### PR TITLE
Add Dalli support

### DIFF
--- a/lib/new_relic/agent/instrumentation/memcache.rb
+++ b/lib/new_relic/agent/instrumentation/memcache.rb
@@ -3,6 +3,7 @@
 # See:
 #     http://www.deveiate.org/code/Ruby-MemCache/ (Gem: Ruby-MemCache)
 #     http://seattlerb.rubyforge.org/memcache-client/ (Gem: memcache-client)
+#     http://github.com/mperham/dalli (Gem: dalli)
 unless NewRelic::Control.instance['disable_memcache_instrumentation']
 
   def self.instrument_method(the_class, method_name)
@@ -35,6 +36,7 @@ unless NewRelic::Control.instance['disable_memcache_instrumentation']
   %w[get get_multi set add incr decr delete replace append prepend cas].each do | method_name |
     instrument_method(::MemCache, method_name) if defined? ::MemCache
     instrument_method(::Memcached, method_name) if defined? ::Memcached
+    instrument_method(::Dalli::Client, method_name) if defined? ::Dalli::Client
   end
 
 end


### PR DESCRIPTION
Hi, I'm the maintainer of the memcache-client gem and the author of the new Dalli gem.  I've deprecated memcache-client and won't be supporting it past 2010.  Instead I'm moving everyone to Dalli, which is a drop-in replacement for :mem_cache_store in Rails.

http://github.com/mperham/dalli

Included are the changes necessary to instrument Dalli.  I had to refactor the memcache tests a bit but they will work with either memcache-client or Dalli.
