### PR TITLE
Use Rails.env and Rails.root instead of deprecated RAILS_ROOT and RAILS_ENV

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -33,5 +33,5 @@ end
 
 #ClassLoadingWatcher.flag_const_missing = nil
 # 
-# ::RAILS_DEFAULT_LOGGER.warn "RPM detected environment: #{NewRelic::Control.instance.local_env.to_s}, RAILS_ENV: #{RAILS_ENV}"
+# ::RAILS_DEFAULT_LOGGER.warn "RPM detected environment: #{NewRelic::Control.instance.local_env.to_s}, Rails.env: #{Rails.env}"
 # ::RAILS_DEFAULT_LOGGER.warn "Enabled? #{NewRelic::Control.instance.agent_enabled?}"

--- a/lib/new_relic/agent.rb
+++ b/lib/new_relic/agent.rb
@@ -162,7 +162,7 @@ module NewRelic
     # newrelic.yml, such as app_name.  In addition, the option +log+
     # will take a logger that will be used instead of the standard
     # file logger.  The setting for the newrelic.yml section to use
-    # (ie, RAILS_ENV) can be overridden with an :env argument.
+    # (ie, Rails.env) can be overridden with an :env argument.
     #
     def manual_start(options={})
       raise unless Hash === options

--- a/lib/new_relic/control.rb
+++ b/lib/new_relic/control.rb
@@ -31,7 +31,7 @@ module NewRelic
     include Instrumentation
 
     # The env is the setting used to identify which section of the newrelic.yml
-    # to load.  This defaults to a framework specific value, such as ENV['RAILS_ENV']
+    # to load.  This defaults to a framework specific value, such as ENV['Rails.env']
     # but can be overridden as long as you set it before calling #init_plugin
     attr_writer :env
 

--- a/lib/new_relic/control/frameworks/rails.rb
+++ b/lib/new_relic/control/frameworks/rails.rb
@@ -4,10 +4,10 @@
 class NewRelic::Control::Frameworks::Rails < NewRelic::Control
 
   def env
-    @env ||= RAILS_ENV.dup
+    @env ||= Rails.env.dup
   end
   def root
-    RAILS_ROOT
+    Rails.root
   end
 
   # In versions of Rails prior to 2.0, the rails config was only available to
@@ -92,7 +92,7 @@ class NewRelic::Control::Frameworks::Rails < NewRelic::Control
         ::Rails.configuration.action_controller.allow_concurrency == true
       end
     end
-    local_env.append_environment_value('Rails Env') { ENV['RAILS_ENV'] }
+    local_env.append_environment_value('Rails Env') { ENV['Rails.env'] }
     if rails_version >= NewRelic::VersionNumber.new('2.1.0')
       local_env.append_gem_list do
         ::Rails.configuration.gems.map do | gem |

--- a/lib/new_relic/control/frameworks/ruby.rb
+++ b/lib/new_relic/control/frameworks/ruby.rb
@@ -2,11 +2,11 @@
 # Looks for a newrelic.yml file in several locations
 # including ./, ./config, $HOME/.newrelic and $HOME/.
 # It loads the settings from the newrelic.yml section
-# based on the value of RUBY_ENV or RAILS_ENV.
+# based on the value of RUBY_ENV or Rails.env.
 class NewRelic::Control::Frameworks::Ruby < NewRelic::Control
 
   def env
-    @env ||= ENV['RUBY_ENV'] || ENV['RAILS_ENV'] || ENV['RACK_ENV'] || 'development'
+    @env ||= ENV['RUBY_ENV'] || ENV['Rails.env'] || ENV['RACK_ENV'] || 'development'
   end
   def root
     @root ||= ENV['APP_ROOT'] || Dir['.']

--- a/lib/new_relic/control/frameworks/sinatra.rb
+++ b/lib/new_relic/control/frameworks/sinatra.rb
@@ -4,7 +4,7 @@ require 'new_relic/control/frameworks/ruby'
 class NewRelic::Control::Frameworks::Sinatra < NewRelic::Control::Frameworks::Ruby
 
   def env
-    @env ||= ENV['RACK_ENV'] || ENV['RAILS_ENV'] || 'development'
+    @env ||= ENV['RACK_ENV'] || ENV['Rails.env'] || 'development'
   end
 
   # This is the control used when starting up in the context of

--- a/lib/new_relic/local_environment.rb
+++ b/lib/new_relic/local_environment.rb
@@ -112,7 +112,7 @@ module NewRelic
       # The name of the database adapter for the current environment.
       if defined? ::ActiveRecord
         append_environment_value 'Database adapter' do
-          ActiveRecord::Base.configurations[RAILS_ENV]['adapter']
+          ActiveRecord::Base.configurations[Rails.env]['adapter']
         end
         append_environment_value 'Database schema version' do
           ActiveRecord::Migrator.current_version

--- a/newrelic.yml
+++ b/newrelic.yml
@@ -34,7 +34,7 @@ common: &default_settings
   # to map this instance into multiple apps, like "AJAX Requests" and
   # "All UI" then specify a semicolon separated list of up to three
   # distinct names, or a yaml list.  Defaults to the 
-  # capitalized RAILS_ENV or RACK_ENV (i.e., Production, Staging, etc)
+  # capitalized Rails.env or RACK_ENV (i.e., Production, Staging, etc)
   #
   # Example:
   #
@@ -198,7 +198,7 @@ common: &default_settings
 # Application Environments
 # ------------------------------------------
 # Environment specific settings are in this section.
-# For Rails applications, RAILS_ENV is used to determine the environment
+# For Rails applications, Rails.env is used to determine the environment
 # For Java applications, pass -Dnewrelic.environment <environment> to set
 # the environment
 

--- a/test/config/newrelic.yml
+++ b/test/config/newrelic.yml
@@ -24,7 +24,7 @@ test:
     - a
     - b
     - c
-  log_file_path: <%= RAILS_ROOT %>/log
+  log_file_path: <%= Rails.root %>/log
 
   # Some fixtures for newrelic.yml parsing tests
   erb_value: <%= 'hey'*3 %>

--- a/test/new_relic/agent/active_record_instrumentation_test.rb
+++ b/test/new_relic/agent/active_record_instrumentation_test.rb
@@ -40,7 +40,7 @@ class ActiveRecordInstrumentationTest < Test::Unit::TestCase
   # call.  the others are ignored.
   def test_query_cache
     # Not sure why we get a transaction error with sqlite
-    return if ActiveRecord::Base.configurations[RAILS_ENV]['adapter'] =~ /sqlite/  
+    return if ActiveRecord::Base.configurations[Rails.env]['adapter'] =~ /sqlite/  
     ActiveRecordFixtures::Order.cache do
       m = ActiveRecordFixtures::Order.create :id => 0, :name => 'jeff'
       ActiveRecordFixtures::Order.find(:all)
@@ -67,10 +67,10 @@ class ActiveRecordInstrumentationTest < Test::Unit::TestCase
       ActiveRecord/find
       ActiveRecord/ActiveRecordFixtures::Order/find
       ]
-    expected += %W[Database/SQL/insert] if ActiveRecord::Base.configurations[RAILS_ENV]['adapter'] =~ /jdbc/  
-    expected += %W[ActiveRecord/create] unless  ActiveRecord::Base.configurations[RAILS_ENV]['adapter'] =~ /jdbc/  
-    expected += %W[Database/SQL/other] unless  ActiveRecord::Base.configurations[RAILS_ENV]['adapter'] =~ /jdbc|sqlite/  
-    expected += %W[ActiveRecord/ActiveRecordFixtures::Order/create] unless ActiveRecord::Base.configurations[RAILS_ENV]['adapter'] =~ /jdbc/  
+    expected += %W[Database/SQL/insert] if ActiveRecord::Base.configurations[Rails.env]['adapter'] =~ /jdbc/  
+    expected += %W[ActiveRecord/create] unless  ActiveRecord::Base.configurations[Rails.env]['adapter'] =~ /jdbc/  
+    expected += %W[Database/SQL/other] unless  ActiveRecord::Base.configurations[Rails.env]['adapter'] =~ /jdbc|sqlite/  
+    expected += %W[ActiveRecord/ActiveRecordFixtures::Order/create] unless ActiveRecord::Base.configurations[Rails.env]['adapter'] =~ /jdbc/  
     expected += %W[ActiveRecord/save ActiveRecord/ActiveRecordFixtures::Order/save] if NewRelic::Control.instance.rails_version < '2.1.0'   
     compare_metrics expected, metrics
     assert_equal 1, NewRelic::Agent.get_stats("ActiveRecord/ActiveRecordFixtures::Order/find").call_count
@@ -100,12 +100,12 @@ class ActiveRecordInstrumentationTest < Test::Unit::TestCase
     expected_metrics += %W[
     Database/SQL/other 
     Database/SQL/show
-    ] unless ActiveRecord::Base.configurations[RAILS_ENV]['adapter'] =~ /jdbc|sqlite/  
+    ] unless ActiveRecord::Base.configurations[Rails.env]['adapter'] =~ /jdbc|sqlite/  
     expected_metrics += %W[
     ActiveRecord/create
     ActiveRecord/ActiveRecordFixtures::Shipment/create
     ActiveRecord/ActiveRecordFixtures::Order/create
-    ] unless ActiveRecord::Base.configurations[RAILS_ENV]['adapter'] =~ /jdbc/  
+    ] unless ActiveRecord::Base.configurations[Rails.env]['adapter'] =~ /jdbc/  
     
     compare_metrics expected_metrics, metrics
     # This number may be different with different db adapters, not sure
@@ -141,7 +141,7 @@ class ActiveRecordInstrumentationTest < Test::Unit::TestCase
   end
   
   def test_show_sql
-    return if ActiveRecord::Base.configurations[RAILS_ENV]['adapter'] =~ /sqlite/  
+    return if ActiveRecord::Base.configurations[Rails.env]['adapter'] =~ /sqlite/  
     list = ActiveRecordFixtures::Order.connection.execute "show tables"
     metrics = NewRelic::Agent.instance.stats_engine.metrics
     compare_metrics %W[
@@ -262,7 +262,7 @@ class ActiveRecordInstrumentationTest < Test::Unit::TestCase
   
   def test_rescue_handling
     # Not sure why we get a transaction error with sqlite
-    return if ActiveRecord::Base.configurations[RAILS_ENV]['adapter'] =~ /sqlite/  
+    return if ActiveRecord::Base.configurations[Rails.env]['adapter'] =~ /sqlite/  
     begin
       ActiveRecordFixtures::Order.transaction do
         raise ActiveRecord::ActiveRecordError.new('preserve-me!') 
@@ -278,7 +278,7 @@ class ActiveRecordInstrumentationTest < Test::Unit::TestCase
   private
   
   def isPostgres?
-    ActiveRecordFixtures::Order.configurations[RAILS_ENV]['adapter'] =~ /postgres/
+    ActiveRecordFixtures::Order.configurations[Rails.env]['adapter'] =~ /postgres/
   end
   def isMysql?
     ActiveRecordFixtures::Order.connection.class.name =~ /mysql/i 

--- a/test/new_relic/agent/testable_agent.rb
+++ b/test/new_relic/agent/testable_agent.rb
@@ -2,7 +2,7 @@
 ##require 'new_relic/agent'
 
 
-RAILS_ROOT='.' if !defined? RAILS_ROOT
+Rails.root='.' if !defined? Rails.root
 
 
 class String

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,5 @@
 module NewRelic; TEST = true; end unless defined? NewRelic::TEST
-ENV['RAILS_ENV'] = 'test'
+ENV['Rails.env'] = 'test'
 NEWRELIC_PLUGIN_DIR = File.expand_path(File.join(File.dirname(__FILE__),".."))
 $LOAD_PATH << File.join(NEWRELIC_PLUGIN_DIR,"test")
 $LOAD_PATH << File.join(NEWRELIC_PLUGIN_DIR,"ui/helpers")
@@ -14,7 +14,7 @@ if ENV['SKIP_RAILS']
   while dirs.any? && !File.directory?((dirs+%w[log]).join('/'))
     dirs.pop
   end
-  RAILS_ROOT = dirs.any? ? dirs.join("/") : "#{File.dirname(__FILE__)}/.." unless defined?(RAILS_ROOT)
+  Rails.root = dirs.any? ? dirs.join("/") : "#{File.dirname(__FILE__)}/.." unless defined?(Rails.root)
   $LOAD_PATH << File.join(NEWRELIC_PLUGIN_DIR, "lib")
   require File.join(NEWRELIC_PLUGIN_DIR, "lib/newrelic_rpm")
 else


### PR DESCRIPTION
DEPRECATION WARNING: RAILS_ENV is deprecated. Please use ::Rails.env. (called from /Users/raphaelwc/Ruby Projects/ngforms/config/environment.rb:5)
