### PR TITLE
remove debugging puts from rails3 instrumentation

### DIFF
--- a/lib/new_relic/agent/instrumentation/rails3/action_controller.rb
+++ b/lib/new_relic/agent/instrumentation/rails3/action_controller.rb
@@ -36,7 +36,6 @@ module NewRelic
 end
 
 if defined?(ActionController) && defined?(ActionController::Base)
-  puts "ApplicationController is defined"
   class ActionController::Base
     include NewRelic::Agent::Instrumentation::ControllerInstrumentation
     include NewRelic::Agent::Instrumentation::Rails3::ActionController


### PR DESCRIPTION
there's a random puts still in one of the hooks to rails 3 so whenever I run rails console or rails server, I see "ApplicationController is defined".
