### PR TITLE
DJ agent init should not be unconditional

### DIFF
--- a/lib/new_relic/delayed_job_injection.rb
+++ b/lib/new_relic/delayed_job_injection.rb
@@ -19,7 +19,7 @@ Delayed::Worker.class_eval do
     dispatcher_instance_id = worker_name || "host:#{Socket.gethostname} pid:#{Process.pid}" rescue "pid:#{Process.pid}"
     say "RPM Monitoring DJ worker #{dispatcher_instance_id}"
     NewRelic::DelayedJobInjection.worker_name = worker_name
-    NewRelic::Agent.manual_start :dispatcher => :delayed_job, :dispatcher_instance_id => dispatcher_instance_id
+    NewRelic::Control.instance.init_plugin :dispatcher => :delayed_job, :dispatcher_instance_id => dispatcher_instance_id
   end
 
   alias initialize_without_new_relic initialize


### PR DESCRIPTION
Due to the use of manual_start, the RPM agent cannot be disabled by the usual means (NEWRELIC_ENABLE=false, etc) when running delayed_job.  This patch skips manual_start and calls init_plugin directly with the proper options.
