### PR TITLE
Expand path for 1.9.2

### DIFF
--- a/lib/new_relic/control/instrumentation.rb
+++ b/lib/new_relic/control/instrumentation.rb
@@ -83,7 +83,7 @@ module NewRelic
 
         # Instrumentation for the key code points inside rails for monitoring by NewRelic.
         # note this file is loaded only if the newrelic agent is enabled (through config/newrelic.yml)
-        instrumentation_path = File.join(File.dirname(__FILE__), '..', 'agent','instrumentation')
+        instrumentation_path = File.expand_path(File.join(File.dirname(__FILE__), '..', 'agent','instrumentation'))
         @instrumentation_files <<
         File.join(instrumentation_path, '*.rb') <<
         File.join(instrumentation_path, app.to_s, '*.rb')


### PR DESCRIPTION
Ruby 1.9.2 would not load several of the instrumentation due to the path not being expanded.

10/12/10 20:43:22 -0400 Gibbs.local (4621)] ERROR : Error loading instrumentation file '/Users/tjsingleton/.rvm/gems/ruby-1.9.2-p0@crunch/gems/newrelic_rpm-2.13.2/lib/new_relic/control/../agent/instrumentation/active_record_instrumentation.rb': can't convert Pathname into String
