### PR TITLE
Add Trinidad as a dispatcher and fix GlassFish check

### DIFF
--- a/lib/new_relic/local_environment.rb
+++ b/lib/new_relic/local_environment.rb
@@ -205,10 +205,18 @@ module NewRelic
       return unless defined?(::JRuby) &&
         (((com.sun.grizzly.jruby.rack.DefaultRackApplicationFactory rescue nil) &&
           defined?(com::sun::grizzly::jruby::rack::DefaultRackApplicationFactory)) ||
-         ((org.jruby.rack.DefaultRackApplicationFactory rescue nil) &&
-          defined?(org::jruby::rack::DefaultRackApplicationFactory)) ||
-         defined?(::GlassFish::Server))
+          (jruby_rack? && defined?(::GlassFish::Server)))
       @dispatcher = :glassfish
+    end
+
+    def check_for_trinidad
+      return unless defined?(::JRuby) && jruby_rack? && defined?(::Trinidad::Server)
+      @dispatcher = :trinidad
+    end
+
+    def jruby_rack?
+      ((org.jruby.rack.DefaultRackApplicationFactory rescue nil) &&
+          defined?(org::jruby::rack::DefaultRackApplicationFactory))
     end
 
     def check_for_webrick


### PR DESCRIPTION
Hi, 

I just added Trinidad as a dispatcher for JRuby, this commit also fixes the check for GlassFish because it was assuming that every server that used JRuby-Rack was a GlassFish server.

I didn't find how to write a test to check this behavior, please let me know if there is something else that I need to add.
