### PR TITLE
Replaced RAILS_ENV with NewRelic::Control.instance.env

### DIFF
--- a/lib/new_relic/local_environment.rb
+++ b/lib/new_relic/local_environment.rb
@@ -112,7 +112,7 @@ module NewRelic
       # The name of the database adapter for the current environment.
       if defined? ::ActiveRecord
         append_environment_value 'Database adapter' do
-          ActiveRecord::Base.configurations[RAILS_ENV]['adapter']
+          ActiveRecord::Base.configurations[NewRelic::Control.instance.env]['adapter']
         end
         append_environment_value 'Database schema version' do
           ActiveRecord::Migrator.current_version


### PR DESCRIPTION
...to prevent Rails 3 from writing an deprecation warning to the logs.

Thanks for your great service!
