### PR TITLE
Update to local_environment for detection of TorqueBox

### DIFF
--- a/lib/new_relic/local_environment.rb
+++ b/lib/new_relic/local_environment.rb
@@ -197,7 +197,7 @@ module NewRelic
 
     def check_for_torquebox
       return unless defined?(::JRuby) &&
-         ( Java::OrgTorqueboxRailsWebDeployers::RailsRackDeployer rescue nil)
+         ( org.torquebox::TorqueBox rescue nil)
       @dispatcher = :torquebox
     end
 


### PR DESCRIPTION
Just a quick update in the class to search for in order to detect TorqueBox AS as the local environment.  Plus, using slightly more idiomatic JRuby.

Everything works-as-expected within TorqueBox with this change.
