### PR TITLE
Fix for the Delayed::Job transaction tracer name

### DIFF
--- a/lib/new_relic/agent/instrumentation/delayed_job_instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/delayed_job_instrumentation.rb
@@ -12,8 +12,8 @@ DependencyDetection.defer do
   executes do
     Delayed::Job.class_eval do
       include NewRelic::Agent::Instrumentation::ControllerInstrumentation
-      if self.instance_methods.include?('name')
-        add_transaction_tracer "invoke_job", :category => 'OtherTransaction/DelayedJob', :path => '#{self.name}'
+      if self.instance_methods.include?('name') || self.instance_methods.include?(:name)
+        add_transaction_tracer "invoke_job", :category => 'OtherTransaction/DelayedJob', :name => '#{self.name}'
       else
         add_transaction_tracer "invoke_job", :category => 'OtherTransaction/DelayedJob'
       end


### PR DESCRIPTION
I am using Ruby 1.9.2 and Rails 3.0.x and the Delayed::Job tracer always has the name of invoke_job, even when the Delayed::Job instance has a name.  The reason this happens is that Delayed::Job.instance_methods returns an array of symbols instead of an array of strings.  To fix this I have included an updated delayed_job_instrumentation.  I chose to use an OR statement, instead of entirely replacing the conditional, in the case that there are other versions of Ruby that return an array of strings for their instance_methods implementation.
