### PR TITLE
Fix for the Delayed::Job transaction tracer name for Ruby 1.9.2

### DIFF
--- a/lib/new_relic/agent/instrumentation/delayed_job_instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/delayed_job_instrumentation.rb
@@ -12,7 +12,7 @@ DependencyDetection.defer do
   executes do
     Delayed::Job.class_eval do
       include NewRelic::Agent::Instrumentation::ControllerInstrumentation
-      if self.instance_methods.include?('name')
+      if self.instance_methods.include?('name') || self.instance_methods.include?(:name)
         add_transaction_tracer "invoke_job", :category => 'OtherTransaction/DelayedJob', :path => '#{self.name}'
       else
         add_transaction_tracer "invoke_job", :category => 'OtherTransaction/DelayedJob'


### PR DESCRIPTION
I am using Ruby 1.9.2 and the Delayed::Job transaction tracer always has the name of invoke_job, even when the Delayed::Job instance has a name. The reason this happens is that Delayed::Job.instance_methods returns an array of symbols instead of an array of strings. To fix this I have included an updated delayed_job_instrumentation. I chose to use an OR statement, instead of entirely replacing the conditional, because in Ruby 1.8.7 the instance_methods function returns an array of strings. This commit is compatible with both Ruby 1.8.7 and Ruby 1.9.2.
