### PR TITLE
Prevent activation of the ActiveMerchant instrumentation when only ActiveShipping is included in the project

### DIFF
--- a/lib/new_relic/agent/instrumentation/active_merchant.rb
+++ b/lib/new_relic/agent/instrumentation/active_merchant.rb
@@ -1,6 +1,6 @@
 DependencyDetection.defer do
   depends_on do
-    defined?(ActiveMerchant)
+    defined?(ActiveMerchant) && defined?(ActiveMerchant::Billing)
   end
 
   executes do


### PR DESCRIPTION
Currently the ActiveMerchant instrumentation activates when
ActiveShipping is included in the project because they share the
ActiveMerchant namespace. Adding a check for ActiveMerchant::Billing
prevents the exception from occurring.
