### PR TITLE
Check for existence of the Merb::BootLoader constant

### DIFF
--- a/lib/newrelic_rpm.rb
+++ b/lib/newrelic_rpm.rb
@@ -18,7 +18,7 @@
 # directly.
 #
 require 'new_relic/control'
-if defined? Merb
+if defined?(Merb) && defined?(Merb::BootLoader)
   module NewRelic
     class MerbBootLoader < Merb::BootLoader
       after Merb::BootLoader::ChooseAdapter


### PR DESCRIPTION
The NewRelic gem improperly assumes that because Merb is defined
it should add Merb instrumentation. This can cause an exception in
apps that are pulling in a piece of Merb, like the Merb Router.
