### PR TITLE
[delayed_job] Add queue wait time instrumentation

### DIFF
--- a/lib/new_relic/agent/instrumentation/delayed_job_instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/delayed_job_instrumentation.rb
@@ -17,7 +17,7 @@ DependencyDetection.defer do
       else
         add_transaction_tracer "invoke_job", :category => 'OtherTransaction/DelayedJob'
       end
-    end
+    end    
   end
 
   executes do
@@ -39,6 +39,21 @@ DependencyDetection.defer do
         end
       end
     end
+  end
+  
+  executes do
+    Delayed::Job.class_eval do
+      def invoke_job_with_queue_wait
+        total_time = self.class.db_time_now - created_at
+        raise "Queue wait time is < 0. Your clocks may be out of sync." if total_time < 0
+        
+        NewRelic::Agent.get_stats("Background/WaitTime").trace_call(total_time)
+        
+        invoke_job_without_queue_wait
+      end
+      
+      alias_method_chain :invoke_job, :queue_wait
+    end    
   end
 end
 


### PR DESCRIPTION
Patch to add a Background/WaitTime metric to the delayed job instrumentation. This is possibly the most useful metric when determining queue performance. I'm open to other ways of recording the metric if there's a better way to approach it.
