### PR TITLE
support for mysql2

### DIFF
--- a/lib/new_relic/agent/instrumentation/rails/active_record_instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/rails/active_record_instrumentation.rb
@@ -17,6 +17,7 @@ module NewRelic
 
           # Capture db config if we are going to try to get the explain plans
           if (defined?(ActiveRecord::ConnectionAdapters::MysqlAdapter) && self.is_a?(ActiveRecord::ConnectionAdapters::MysqlAdapter)) ||
+              (defined?(ActiveRecord::ConnectionAdapters::Mysql2Adapter) && self.is_a?(ActiveRecord::ConnectionAdapters::Mysql2Adapter)) ||
               (defined?(ActiveRecord::ConnectionAdapters::PostgreSQLAdapter) && self.is_a?(ActiveRecord::ConnectionAdapters::PostgreSQLAdapter))
             supported_config = @config
           end

--- a/lib/new_relic/agent/instrumentation/rails3/active_record_instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/rails3/active_record_instrumentation.rb
@@ -19,6 +19,7 @@ module NewRelic
 
           # Capture db config if we are going to try to get the explain plans
           if (defined?(ActiveRecord::ConnectionAdapters::MysqlAdapter) && self.is_a?(ActiveRecord::ConnectionAdapters::MysqlAdapter)) ||
+              (defined?(ActiveRecord::ConnectionAdapters::Mysql2Adapter) && self.is_a?(ActiveRecord::ConnectionAdapters::Mysql2Adapter)) ||
               (defined?(ActiveRecord::ConnectionAdapters::PostgreSQLAdapter) && self.is_a?(ActiveRecord::ConnectionAdapters::PostgreSQLAdapter))
             supported_config = @config
           end


### PR DESCRIPTION
The mysql2 gem is quite popular these days. In the context of ActiveRecord, the ActiveRecord::ConnectionAdapters::Mysql2Adapter is very similar to the original ActiveRecord::ConnectionAdapters::MysqlAdapter, so for NewRelic it's as simple as adding it to the list of supported adapters.
