### PR TITLE
Fix RAILS_DEFAULT_LOGGER deprecation warnings

### DIFF
--- a/lib/new_relic/control/frameworks/rails.rb
+++ b/lib/new_relic/control/frameworks/rails.rb
@@ -17,6 +17,9 @@ module NewRelic
             super
           end
         end
+        def logger
+          ::RAILS_DEFAULT_LOGGER
+        end
 
         # In versions of Rails prior to 2.0, the rails config was only available to
         # the init.rb, so it had to be passed on from there.
@@ -71,13 +74,13 @@ module NewRelic
 
         def log!(msg, level=:info)
           super unless should_log?
-          ::RAILS_DEFAULT_LOGGER.send(level, msg)
+          logger.send(level, msg)
         rescue Exception => e
           super
         end
 
         def to_stdout(message)
-          ::RAILS_DEFAULT_LOGGER.info(message)
+          logger.info(message)
         rescue Exception => e
           super
         end


### PR DESCRIPTION
Hi,
I added a quick patch to fix deprecation warnings we were seeing in Rails 3, along the lines of : 

```
DEPRECATION WARNING: RAILS_DEFAULT_LOGGER is deprecated. Please use ::Rails.logger. (called from log! at /Users/jon/.rvm/gems/ruby-1.9.2-p180/bundler/gems/rpm-c265ab00cf38/lib/new_relic/control/frameworks/rails.rb:74)
```

It just adds a Rails#logger method to hide the RAILS_DEFAULT_LOGGER constant in, since there's already a Rails3#logger method.
