### PR TITLE
Active record logger takes an optional binds arguments

### DIFF
--- a/lib/new_relic/agent/instrumentation/rails3/active_record_instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/rails3/active_record_instrumentation.rb
@@ -13,9 +13,9 @@ module NewRelic
           end
         end
 
-        def log_with_newrelic_instrumentation(sql, name, &block)
+        def log_with_newrelic_instrumentation(sql, name, binds = [], &block)
 
-          return log_without_newrelic_instrumentation(sql, name, &block) unless NewRelic::Agent.is_execution_traced?
+          return log_without_newrelic_instrumentation(sql, name, binds, &block) unless NewRelic::Agent.is_execution_traced?
 
           # Capture db config if we are going to try to get the explain plans
           if (defined?(ActiveRecord::ConnectionAdapters::MysqlAdapter) && self.is_a?(ActiveRecord::ConnectionAdapters::MysqlAdapter)) ||


### PR DESCRIPTION
See https://github.com/rails/rails/blob/master/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb#L216

Without this, all exec_query calls (and therefore, all calls to any SQL database) fail because there's one missing argument.
