### PR TITLE
ShimAgent out of sync with Agent

### DIFF
--- a/lib/new_relic/agent/shim_agent.rb
+++ b/lib/new_relic/agent/shim_agent.rb
@@ -17,11 +17,11 @@ module NewRelic
       end
       def after_fork *args; end
       def start *args; end
-      def shutdown; end
+      def shutdown *args; end
       def serialize; end
-      def merge_data_from(*args); end
-      def push_trace_execution_flag(*args); end
-      def pop_trace_execution_flag(*args); end
+      def merge_data_from *args; end
+      def push_trace_execution_flag *args; end
+      def pop_trace_execution_flag *args; end
       def browser_timing_header; "" end
       def browser_timing_footer; "" end
     end


### PR DESCRIPTION
We're getting a ArgumentError because the ShimAgent doesn't accept arguments... this fails all jobs.

wrong number of arguments (1 for 0)

~/.rvm/gems/ruby-1.9.2-p180/gems/newrelic_rpm-3.1.0/lib/new_relic/agent/shim_agent.rb:20:in 'shutdown'
~/.rvm/gems/ruby-1.9.2-p180/gems/newrelic_rpm-3.1.0/lib/new_relic/agent.rb:209:in 'shutdown'
~/.rvm/gems/ruby-1.9.2-p180/gems/rpm_contrib-2.1.3/lib/rpm_contrib/instrumentation/resque.rb:12:in 'around_perform_with_monitoring'
~/.rvm/gems/ruby-1.9.2-p180/gems/resque-1.17.1/lib/resque/job.rb:143:in 'block (2 levels) in perform'
~/.rvm/gems/ruby-1.9.2-p180/gems/resque-1.17.1/lib/resque/job.rb:151:in 'call'
