### PR TITLE
Fixed a double logging and deprecation warning with Rails 3 logging support.

### DIFF
--- a/lib/new_relic/control/frameworks/rails.rb
+++ b/lib/new_relic/control/frameworks/rails.rb
@@ -70,8 +70,11 @@ module NewRelic
         end
 
         def log!(msg, level=:info)
-          super unless should_log?
-          ::RAILS_DEFAULT_LOGGER.send(level, msg)
+          if should_log?
+            ::RAILS_DEFAULT_LOGGER.send(level, msg)
+          else
+            super
+          end
         rescue Exception => e
           super
         end

--- a/lib/new_relic/control/frameworks/rails3.rb
+++ b/lib/new_relic/control/frameworks/rails3.rb
@@ -30,8 +30,11 @@ module NewRelic
 
 
         def log!(msg, level=:info)
-          super unless should_log?
-          logger.send(level, msg)
+          if should_log?
+            logger.send(level, msg)
+          else
+            super
+          end
         rescue Exception => e
           super
         end


### PR DESCRIPTION
Rails3 logging calls Rails logging when should_log? is false.  This causes deprecation warings and double logging.
