### PR TITLE
silence deprecation warning for RAILS_DEFAULT_LOGGER and rails 3.0.x

### DIFF
--- a/lib/new_relic/control/frameworks/rails.rb
+++ b/lib/new_relic/control/frameworks/rails.rb
@@ -71,13 +71,15 @@ module NewRelic
 
         def log!(msg, level=:info)
           super unless should_log?
-          ::RAILS_DEFAULT_LOGGER.send(level, msg)
+          logger = ::Rails.respond_to?(:logger) ? Rails.logger : ::RAILS_DEFAULT_LOGGER
+          logger.send(level, msg)
         rescue Exception => e
           super
         end
 
         def to_stdout(message)
-          ::RAILS_DEFAULT_LOGGER.info(message)
+          logger = ::Rails.respond_to?(:logger) ? Rails.logger : ::RAILS_DEFAULT_LOGGER
+          logger.info(message)
         rescue Exception => e
           super
         end


### PR DESCRIPTION
Seeing this deprecation warning while running gemcutter on rails 3.0.9:

```
DEPRECATION WARNING: RAILS_DEFAULT_LOGGER is deprecated. Please use ::Rails.logger. (called from /Users/gabrielhorner/code/repo/gemcutter/config/environment.rb:5)
```
