### PR TITLE
Speed up developer_mode? checks

### DIFF
--- a/lib/new_relic/agent/agent.rb
+++ b/lib/new_relic/agent/agent.rb
@@ -541,7 +541,7 @@ module NewRelic
           # disable transaction sampling if disabled by the server
           # and we're not in dev mode
           def check_transaction_sampler_status
-            if control.developer_mode? || @should_send_samples
+            if control.developer_mode_installed? || @should_send_samples
               @transaction_sampler.enable
             else
               @transaction_sampler.disable

--- a/lib/new_relic/agent/transaction_sampler.rb
+++ b/lib/new_relic/agent/transaction_sampler.rb
@@ -94,14 +94,13 @@ module NewRelic
 
         builder.trace_entry(scope, time.to_f)
 
-        capture_segment_trace if NewRelic::Control.instance.developer_mode?
+        capture_segment_trace if NewRelic::Control.instance.developer_mode_installed?
       end
 
       # in developer mode, capture the stack trace with the segment.
       # this is cpu and memory expensive and therefore should not be
       # turned on in production mode
       def capture_segment_trace
-        return unless NewRelic::Control.instance.developer_mode?
         segment = builder.current_segment
         if segment
           # Strip stack frames off the top that match /new_relic/agent/
@@ -177,7 +176,7 @@ module NewRelic
       # Samples take up a ton of memory, so we only store a lot of
       # them in developer mode - we truncate to @max_samples
       def store_sample_for_developer_mode(sample)
-        return unless NewRelic::Control.instance.developer_mode?
+        return unless NewRelic::Control.instance.developer_mode_installed?
         @samples = [] unless @samples
         @samples << sample
         truncate_samples

--- a/lib/new_relic/control/instance_methods.rb
+++ b/lib/new_relic/control/instance_methods.rb
@@ -88,6 +88,14 @@ module NewRelic
         NewRelic::Agent.agent.start
       end
 
+      def developer_mode_installed!
+        @developer_mode_installed = true
+      end
+
+      def developer_mode_installed?
+        @developer_mode_enabled
+      end
+
       # True if dev mode or monitor mode are enabled, and we are running
       # inside a valid dispatcher like mongrel or passenger.  Can be overridden
       # by NEWRELIC_ENABLE env variable, monitor_daemons config option when true, or
@@ -143,6 +151,7 @@ module NewRelic
       def initialize local_env, config_file_override=nil
         @local_env = local_env
         @instrumentation_files = []
+        @developer_mode_installed = false
         newrelic_file = config_file_override || config_file
         # Next two are for populating the newrelic.yml via erb binding, necessary
         # when using the default newrelic.yml file

--- a/lib/new_relic/rack/developer_mode.rb
+++ b/lib/new_relic/rack/developer_mode.rb
@@ -18,6 +18,7 @@ module NewRelic
 
       def initialize(app)
         @app = app
+        NewRelic::Control.instance.developer_mode_installed!
       end
 
       def call(env)

--- a/test/new_relic/agent/agent/start_worker_thread_test.rb
+++ b/test/new_relic/agent/agent/start_worker_thread_test.rb
@@ -24,7 +24,7 @@ class NewRelic::Agent::Agent::StartWorkerThreadTest < Test::Unit::TestCase
 
   def test_check_transaction_sampler_status_enabled
     control = mocked_control
-    control.expects(:developer_mode?).returns(false)
+    control.expects(:developer_mode_installed?).returns(false)
     @should_send_samples = true
     @transaction_sampler = mock('transaction_sampler')
     @transaction_sampler.expects(:enable)
@@ -33,7 +33,7 @@ class NewRelic::Agent::Agent::StartWorkerThreadTest < Test::Unit::TestCase
 
   def test_check_transaction_sampler_status_devmode
     control = mocked_control
-    control.expects(:developer_mode?).returns(true)
+    control.expects(:developer_mode_installed?).returns(true)
     @should_send_samples = false
     @transaction_sampler = mock('transaction_sampler')
     @transaction_sampler.expects(:enable)
@@ -42,7 +42,7 @@ class NewRelic::Agent::Agent::StartWorkerThreadTest < Test::Unit::TestCase
 
   def test_check_transaction_sampler_status_disabled
     control = mocked_control
-    control.expects(:developer_mode?).returns(false)
+    control.expects(:developer_mode_installed?).returns(false)
     @should_send_samples = false
     @transaction_sampler = mock('transaction_sampler')
     @transaction_sampler.expects(:disable)

--- a/test/new_relic/agent/transaction_sampler_test.rb
+++ b/test/new_relic/agent/transaction_sampler_test.rb
@@ -115,7 +115,7 @@ class NewRelic::Agent::TransactionSamplerTest < Test::Unit::TestCase
   end
 
   def test_notice_push_scope_with_builder
-    NewRelic::Control.instance.expects(:developer_mode?).returns(false)
+    NewRelic::Control.instance.expects(:developer_mode_installed?).returns(false)
     builder = mock('builder')
     builder.expects(:trace_entry).with('a scope', 100.0)
     @sampler.expects(:builder).returns(builder).twice
@@ -124,7 +124,7 @@ class NewRelic::Agent::TransactionSamplerTest < Test::Unit::TestCase
   end
 
   def test_notice_push_scope_in_dev_mode
-    NewRelic::Control.instance.expects(:developer_mode?).returns(true)
+    NewRelic::Control.instance.expects(:developer_mode_installed?).returns(true)
 
     builder = mock('builder')
     builder.expects(:trace_entry).with('a scope', 100.0)
@@ -230,7 +230,7 @@ class NewRelic::Agent::TransactionSamplerTest < Test::Unit::TestCase
   end
 
   def test_store_sample_for_developer_mode_in_dev_mode
-    NewRelic::Control.instance.expects(:developer_mode?).returns(true)
+    NewRelic::Control.instance.expects(:developer_mode_installed?).returns(true)
     sample = mock('sample')
     @sampler.expects(:truncate_samples)
     @sampler.store_sample_for_developer_mode(sample)
@@ -238,7 +238,7 @@ class NewRelic::Agent::TransactionSamplerTest < Test::Unit::TestCase
   end
 
   def test_store_sample_for_developer_mode_no_dev
-    NewRelic::Control.instance.expects(:developer_mode?).returns(false)
+    NewRelic::Control.instance.expects(:developer_mode_installed?).returns(false)
     sample = mock('sample')
     @sampler.store_sample_for_developer_mode(sample)
     assert_equal([], @sampler.instance_variable_get('@samples'))


### PR DESCRIPTION
Every `TransactionSampler#notice_push_scope` checks whether developer mode is enabled.

This is a quick settings check, but it's in a hot path. Distinguishing "developer mode setting is enabled in config" from "developer mode is currently installed" makes it a simple flag check.
