### PR TITLE
Speed up is_execution_traced? checks

### DIFF
--- a/lib/new_relic/agent.rb
+++ b/lib/new_relic/agent.rb
@@ -326,7 +326,8 @@ module NewRelic
 
     # Check to see if we are capturing metrics currently on this thread.
     def is_execution_traced?
-      Thread.current[:newrelic_untraced].nil? || Thread.current[:newrelic_untraced].last != false
+      untraced = Thread.current[:newrelic_untrace]
+      untraced.nil? || untraced.last != false
     end
     
     # helper method to check the thread local to determine whether the


### PR DESCRIPTION
Cuts out a duplicate `Thread.current#[]` from this very high traffic method.
