### PR TITLE
Suppress New Relic Agent not running message in test environment

### DIFF
--- a/lib/new_relic/control/frameworks/rails.rb
+++ b/lib/new_relic/control/frameworks/rails.rb
@@ -41,7 +41,7 @@ module NewRelic
           if !agent_enabled?
             # Might not be running if it does not think mongrel, thin, passenger, etc
             # is running, if it things it's a rake task, or if the agent_enabled is false.
-            log! "New Relic Agent not running."
+            log! "New Relic Agent not running." unless env == "test"
           else
             log! "Starting the New Relic Agent."
             install_developer_mode rails_config if developer_mode?


### PR DESCRIPTION
We get a lot of "New Relic Agent not running" messages in our test output in the latest version. This is a simple change to not log the message when the agent's not enabled and the Rails env is test.
