### PR TITLE
in NewRelic::Control::Frameworks::Rails#log! and to_stdout, reference top-level Rails constant to access the framework's logger

### DIFF
--- a/lib/new_relic/control/frameworks/rails.rb
+++ b/lib/new_relic/control/frameworks/rails.rb
@@ -87,7 +87,7 @@ module NewRelic
 
         def log!(msg, level=:info)
           if should_log?
-            logger = ::Rails.respond_to?(:logger) ? Rails.logger : ::RAILS_DEFAULT_LOGGER
+            logger = ::Rails.respond_to?(:logger) ? ::Rails.logger : ::RAILS_DEFAULT_LOGGER
             logger.send(level, msg)
           else
             super
@@ -97,7 +97,7 @@ module NewRelic
         end
 
         def to_stdout(message)
-          logger = ::Rails.respond_to?(:logger) ? Rails.logger : ::RAILS_DEFAULT_LOGGER
+          logger = ::Rails.respond_to?(:logger) ? ::Rails.logger : ::RAILS_DEFAULT_LOGGER
           logger.info(message)
         rescue Exception => e
           super


### PR DESCRIPTION
There's a problem with the rails2 integration, the log! and to_stdout methods reference Rails.logger, which raises an exception as there is no class method of that name in NewRelic::Control::Frameworks::Rails. This exception is then caught and the methods of the superclass are called instead. This in turn leads to unwanted output in STDOUT, e.g. rake tasks and the rails console now report "New Relic Agent not running." to STDOUT, which normally would only show up in the production.log.
