### PR TITLE
Don't check dependencies in delayed_job_injection.rb if Rails is defined

### DIFF
--- a/lib/new_relic/delayed_job_injection.rb
+++ b/lib/new_relic/delayed_job_injection.rb
@@ -43,4 +43,9 @@ DependencyDetection.defer do
     end
   end
 end
-DependencyDetection.detect!
+
+# If Rails is defined, this gets called in an after_initialize hook
+# see NewRelic::Control::Frameworks::Rails#init_config
+unless defined?(Rails)
+  DependencyDetection.detect!
+end


### PR DESCRIPTION
This was causing NewRelic::Control to be instantiated (in the depends_on block) before Rails had initialized.

DependencyDetection.detect! is called in the Rails#init_config method anyway so no need to call it here.

I was unable to run the tests for this:

```
lewis@mac-local:~/github/rpm (master)$ rake test:newrelic 
(in /Users/lewis/github/rpm)
rake aborted!
Don't know how to build task 'environment'
```
