### PR TITLE
DataMapper: prevent ArgumentError (invalid byte sequence in UTF-8) when using binary values in query

### DIFF
--- a/lib/new_relic/agent/instrumentation/data_mapper.rb
+++ b/lib/new_relic/agent/instrumentation/data_mapper.rb
@@ -197,7 +197,7 @@ module NewRelic
         # the proper call scope.
         def log_with_newrelic_instrumentation(msg)
           return unless NewRelic::Agent.is_execution_traced?
-          return unless operation = case msg.query
+          return unless operation = case msg.query.force_encoding(Encoding::ASCII_8BIT)
                                     when /^\s*select/i          then 'find'
                                     when /^\s*(update|insert)/i then 'save'
                                     when /^\s*delete/i          then 'destroy'


### PR DESCRIPTION
prevent ArgumentError (invalid byte sequence in UTF-8) when using binary values in query
