### PR TITLE
DEPRECATION WARNING: RAILS_ROOT

### DIFF
--- a/lib/new_relic/control/frameworks/rails.rb
+++ b/lib/new_relic/control/frameworks/rails.rb
@@ -11,8 +11,8 @@ module NewRelic
           @env ||= RAILS_ENV.dup
         end
         def root
-          if defined?(RAILS_ROOT) && RAILS_ROOT.to_s != ''
-            RAILS_ROOT.to_s
+          if defined?(Rails.root) && Rails.root.to_s != ''
+            Rails.root.to_s
           else
             super
           end


### PR DESCRIPTION
When we start server, run specs, cukes, etc. we get the following:

DEPRECATION WARNING: RAILS_ROOT is deprecated. Please use ::Rails.root.to_s. (called from rescue in block in <top (required)> at /var/rails/t1d/shared/bundle/ruby/1.9.1/bundler/gems/rpm_contrib-1c7d10c775c0/lib/rpm_contrib/instrumentation.rb:13)

After searching the stack, we have found this file to be the blame.  We are running rails 3 which makes me curious why this file would be running.  Please let me know if this is not an accurate blame.

Thanks.

Matt
