### PR TITLE
Fix rails3 env override

### DIFF
--- a/lib/new_relic/control/frameworks/rails3.rb
+++ b/lib/new_relic/control/frameworks/rails3.rb
@@ -10,7 +10,7 @@ module NewRelic
       class Rails3 < NewRelic::Control::Frameworks::Rails
 
         def env
-          ::Rails.env.to_s
+          @env ||= ::Rails.env.to_s
         end
         
         # Rails can return an empty string from this method, causing


### PR DESCRIPTION
Rails 3 framework control, unlike the others, doesn't honor the setting of @env.

Which means that things like this won't work:

```
NewRelic::Control.instance.env = HostCheck.instrumentation_environment
```

This commit brings the Rails 3 framework control in line with the other frameworks.
