### PR TITLE
Fix for NullPointerException in JRuby when running in 1.9 mode

### DIFF
--- a/lib/new_relic/language_support.rb
+++ b/lib/new_relic/language_support.rb
@@ -27,13 +27,16 @@ module NewRelic::LanguageSupport
     def self.included(base)
       # need to use syck rather than psych when possible
       if defined?(::YAML::ENGINE)
-        base.class_eval do
-          def load_newrelic_yml(*args)
-            yamler = ::YAML::ENGINE.yamler
-            ::YAML::ENGINE.yamler = 'syck'
-            val = super
-            ::YAML::ENGINE.yamler = yamler
-            val
+        unless NewRelic::LanguageSupport.using_engine?('jruby') &&
+                NewRelic::LanguageSupport.using_version?('1.9')
+          base.class_eval do
+            def load_newrelic_yml(*args)
+              yamler = ::YAML::ENGINE.yamler
+              ::YAML::ENGINE.yamler = 'syck'
+              val = super
+              ::YAML::ENGINE.yamler = yamler
+              val
+            end
           end
         end
       end


### PR DESCRIPTION
In the latest version of JRuby running in 1.9 mode, you'll get a NullPointerException when requiring newrelic_rpm due to NewRelic::LanguageSupport::Control forcing YAML::ENGINE.yamler to 'syck' when parsing the new_relic.yml config file.

syck support in JRuby is poor/non-existent when running in 1.9 mode (see https://github.com/padrino/padrino-framework/issues/649#issuecomment-2083545).
