### PR TITLE
Reading /proc/* files directly with ruby IO methods could cause reads to block forever

### DIFF
--- a/lib/new_relic/agent/samplers/memory_sampler.rb
+++ b/lib/new_relic/agent/samplers/memory_sampler.rb
@@ -124,9 +124,11 @@ module NewRelic
           def get_memory
             # We do not read the file directly because of a kernel bug in linux prior to 2.6.30
             # that makes ruby IO hang on select() calls to /proc/* files forever
-            File.popen("cat #{proc_status_file}").readlines.each do |line|
-              if line =~ /RSS:\s*(\d+) kB/i
-                return $1.to_f / 1024.0
+            File.popen("cat #{proc_status_file}") do |pipe|
+              pipe.readlines.each do |line|
+                if line =~ /RSS:\s*(\d+) kB/i
+                  return $1.to_f / 1024.0
+                end
               end
             end
             raise "Unable to find RSS in #{proc_status_file}"

--- a/lib/new_relic/local_environment.rb
+++ b/lib/new_relic/local_environment.rb
@@ -108,7 +108,9 @@ module NewRelic
       @processors = append_environment_value('Processors') do
         # We do not read the file directly because of a kernel bug in linux prior to 2.6.30
         # that makes ruby IO hang on select() calls to /proc/* files forever
-        processors = File.popen('cat /proc/cpuinfo').readlines.select { |line| line =~ /^processor\s*:/ }.size
+        processors = File.popen('cat /proc/cpuinfo') do |pipe|
+          pipe.readlines.select { |line| line =~ /^processor\s*:/ }.size
+        end
         raise "Cannot determine the number of processors in /proc/cpuinfo" unless processors > 0
         processors
       end


### PR DESCRIPTION
Hello,

There is a problem in linux kernels prior to 2.6.30 (RHEL5 and Centos 5 latest kernels for example) that causes all reads from /proc/\* and /sys/\* files to block forever. There are many ruby projects (puppet, ohai, etc) that experienced this issue and put in place all kinds of fixes to work the problem around.

My patch fixed the issue by using File.popen("can /proc/file").readlines instead of File.readlines("/proc/file") which means eliminating Ruby's IO.select calls from the equation.

For your reference, tickets in other ruby projects:

Puppet: http://projects.puppetlabs.com/issues/7141
OHAI: http://tickets.opscode.com/browse/OHAI-196

The patch in linux kernel:
http://kerneltrap.org/mailarchive/git-commits-head/2009/4/17/5510664

Redhat bug:
https://bugzilla.redhat.com/show_bug.cgi?id=604887

Thanks,

Oleksiy Kovyrin
Technical Operations
LivingSocial.com
