### PR TITLE
Fix SQL explains in developer mode

### DIFF
--- a/lib/new_relic/rack/developer_mode.rb
+++ b/lib/new_relic/rack/developer_mode.rb
@@ -83,9 +83,9 @@ module NewRelic
           @obfuscated_sql = @segment.obfuscated_sql
         end
 
-        explanations = @segment.explain_sql
+        headers, explanations = @segment.explain_sql
         if explanations
-          @explanation = explanations.first
+          @explanation = explanations
           if !@explanation.blank?
             first_row = @explanation.first
             # Show the standard headers if it looks like a mysql explain plan


### PR DESCRIPTION
After the database metrics were added to the Newrelic web service,
we've been seeing errors when trying to view explains and backtraces
in developer mode. This change adjusts the array manipulation that
developer mode's explain_sql action uses to match the new format
returned by @segment.explain_sql.
