### PR TITLE
Don't inject JavaScript instrumentation code when downloading HTML pages

### DIFF
--- a/lib/new_relic/rack/browser_monitoring.rb
+++ b/lib/new_relic/rack/browser_monitoring.rb
@@ -15,13 +15,13 @@ module NewRelic::Rack
         # NewRelic::Agent::TransactionInfo.get.force_persist = true
         # NewRelic::Agent::TransactionInfo.get.capture_deep_tt = true
       # end
-      
+
       # if req.params['nr_capture_tt']
         # NewRelic::Agent::TransactionInfo.get.force_persist = true
       # end
-      
+
       result = @app.call(env)   # [status, headers, response]
-      
+
       if (NewRelic::Agent.browser_timing_header != "") && should_instrument?(result[0], result[1])
         response_string = autoinstrument_source(result[2], result[1])
 
@@ -37,24 +37,25 @@ module NewRelic::Rack
     end
 
     def should_instrument?(status, headers)
-      status == 200 && headers["Content-Type"] && headers["Content-Type"].include?("text/html")
+      status == 200 && headers["Content-Type"] && headers["Content-Type"].include?("text/html") &&
+        !headers['Content-Disposition'].to_s.include?('attachment')
     end
 
     def autoinstrument_source(response, headers)
       source = nil
       response.each {|fragment| source ? (source << fragment.to_s) : (source = fragment.to_s)}
       return nil unless source
-      
+
       body_start = source.index("<body")
       body_close = source.rindex("</body>")
 
       if body_start && body_close
         footer = NewRelic::Agent.browser_timing_footer
         header = NewRelic::Agent.browser_timing_header
-                  
+
         if source.include?('X-UA-Compatible')
           # put at end of header if UA-Compatible meta tag found
-          head_pos = source.index("</head>")          
+          head_pos = source.index("</head>")
         elsif head_open = source.index("<head")
           # put at the beginning of the header
           head_pos = source.index(">", head_open) + 1
@@ -71,5 +72,5 @@ module NewRelic::Rack
       source
     end
   end
-  
+
 end

--- a/test/new_relic/rack/browser_monitoring_test.rb
+++ b/test/new_relic/rack/browser_monitoring_test.rb
@@ -15,7 +15,7 @@ end
 if middleware_supported?
 class BrowserMonitoringTest < Test::Unit::TestCase
   include Rack::Test::Methods
-  
+
   class TestApp
     def self.doc=(other)
       @@doc = other
@@ -38,11 +38,11 @@ EOL
     end
     include NewRelic::Agent::Instrumentation::Rack
   end
-  
+
   def app
     NewRelic::Rack::BrowserMonitoring.new(TestApp.new)
   end
-  
+
   def setup
     super
     clear_cookies
@@ -54,36 +54,40 @@ EOL
     NewRelic::Agent.instance.stubs(:beacon_configuration).returns(config)
     NewRelic::Agent.stubs(:is_transaction_traced?).returns(true)
   end
-  
+
   def teardown
     super
     clear_cookies
     mocha_teardown
     TestApp.doc = nil
   end
-  
+
   def test_make_sure_header_is_set
     assert NewRelic::Agent.browser_timing_header.size > 0
   end
-  
+
   def test_make_sure_footer_is_set
     assert NewRelic::Agent.browser_timing_footer.size > 0
   end
-  
+
   def test_should_only_instrument_successfull_html_requests
     assert app.should_instrument?(200, {'Content-Type' => 'text/html'})
     assert !app.should_instrument?(500, {'Content-Type' => 'text/html'})
     assert !app.should_instrument?(200, {'Content-Type' => 'text/xhtml'})
   end
 
+  def test_should_not_instrument_when_content_disposition
+    assert !app.should_instrument?(200, {'Content-Type' => 'text/html', 'Content-Disposition' => 'attachment; filename=test.html'})
+  end
+
   def test_insert_timing_header_right_after_open_head_if_no_meta_tags
     get '/'
-    
+
     assert(last_response.body.include?("head>#{NewRelic::Agent.browser_timing_header}"),
            last_response.body)
     TestApp.doc = nil
-  end  
-  
+  end
+
   def test_insert_timing_header_right_before_head_close_if_ua_compatible_found
     TestApp.doc = <<-EOL
 <html>
@@ -98,30 +102,30 @@ EOL
 </html>
 EOL
     get '/'
-    
+
     assert(last_response.body.include?("#{NewRelic::Agent.browser_timing_header}</head>"),
            last_response.body)
   end
-  
+
   def test_insert_timing_footer_right_before_html_body_close
     get '/'
-    
+
     assert_match(/.*NREUMQ\.push.*new Date\(\)\.getTime\(\),"","","","",""\]\)<\/script><\/body>/,
                  last_response.body)
   end
-  
+
   def test_should_not_throw_exception_on_empty_reponse
     TestApp.doc = ''
     get '/'
 
     assert last_response.ok?
   end
-  
+
   def test_token_is_set_in_footer_when_set_by_cookie
     token = '1234567890987654321'
     set_cookie "NRAGENT=tk=#{token}"
     get '/'
-    
+
     assert(last_response.body.include?(token), last_response.body)
   end
 


### PR DESCRIPTION
The patch disables JS instrumentation when a `Content-Disposition=attachment` header is present, which means the file is being downloaded instead of displayed in the browser.
