### PR TITLE
Allow calls to #add_method_tracer to specify multiple metric names.

### DIFF
--- a/lib/new_relic/agent/method_tracer.rb
+++ b/lib/new_relic/agent/method_tracer.rb
@@ -378,7 +378,7 @@ module NewRelic
 
             "def #{_traced_method_name(method_name, metric_name_code)}(*args, &block)
               #{options[:code_header]}
-              result = #{klass}.trace_execution_scoped(\"#{metric_name_code}\",
+              result = #{klass}.trace_execution_scoped(#{Array(metric_name_code).inspect},
                         :metric => #{options[:metric]},
                         :forced => #{options[:force]},
                         :deduct_call_time_from_parent => #{options[:deduct_call_time_from_parent]},


### PR DESCRIPTION
CAUTION:  As I haven't provided tests[1], you shouldn't actually merge this pull request.  This was just the easiest way to point you to the idea.

See https://support.newrelic.com/requests/6896 (private support ticket) for more context.
## 

[1] I didn't see any instructions on setting up a testing environment for the gem, and it wasn't immediately obvious; I need to get back to actual work sometime soon, so I didn't pursue it further.
