### PR TITLE
Fix: undefined method for Rails 1.x

### DIFF
--- a/lib/new_relic/agent/instrumentation/rails/action_controller.rb
+++ b/lib/new_relic/agent/instrumentation/rails/action_controller.rb
@@ -74,11 +74,11 @@ DependencyDetection.defer do
   end
   
   depends_on do
-    defined?(Rails) && Rails::VERSION::MAJOR.to_i == 2
+    defined?(Rails) && Rails::VERSION::MAJOR.to_s =~ /^(1|2)/
   end
   
   executes do
-    NewRelic::Agent.logger.debug 'Installing Rails 2 Controller instrumentation'
+    NewRelic::Agent.logger.debug 'Installing Rails 1 - 2 Controller instrumentation'
   end
   
   executes do


### PR DESCRIPTION
The Rails 1.x view instrumentation requires `newrelic_metric_path`
but it is only defined when the detected Rails version is 2.

Change-Id: Ice521b65c26e2849aa5275b11de451a8cc93e3e5
