### PR TITLE
Lazily load action-controller

### DIFF
--- a/lib/new_relic/control/frameworks/rails.rb
+++ b/lib/new_relic/control/frameworks/rails.rb
@@ -158,9 +158,11 @@ module NewRelic
         def install_shim
           super
           require 'new_relic/agent/instrumentation/controller_instrumentation'
-          ::ActionController::Base.class_eval {
-            include NewRelic::Agent::Instrumentation::ControllerInstrumentation::Shim
-          }
+          if ActiveSupport.respond_to?(:on_load) # rails 3+
+            ActiveSupport.on_load(:action_controller) { include NewRelic::Agent::Instrumentation::ControllerInstrumentation::Shim }
+          else
+            ActionController::Base.class_eval { include NewRelic::Agent::Instrumentation::ControllerInstrumentation::Shim }
+          end
         end
 
       end


### PR DESCRIPTION
Hi,
I've spent the past week or two trying to cut down on my Rails app's launch time, and have managed to improve 'rails runner 0' from 22s to 15s.  Still not ideal, but it's an improvement...

A big part of the reason for the slowness is due to plugins referencing parts of Rails that don't necessarily need to be loaded, so, eg, ActiveRecord::Base gets pulled in even though I'm just trying to run 'rake routes'.  As of Rails 3.0, this can be avoided using on_load hooks.

What do you think to the attached commit, which waits until ActionController::Base has been loaded before trying to inject instrumentation into it?
