### PR TITLE
Add ability to set custom hostname

### DIFF
--- a/lib/new_relic/agent/agent.rb
+++ b/lib/new_relic/agent/agent.rb
@@ -425,7 +425,6 @@ module NewRelic
         def start
           return if already_started? || disabled?
           @started = true
-          @local_host = determine_host
           log_dispatcher
           log_app_names
           config_transaction_tracer
@@ -686,6 +685,11 @@ module NewRelic
             control['send_environment_info'] != false ? control.local_env.snapshot : []
           end
 
+          # Who am I? Well, this method can tell you your hostname.
+          def determine_host
+            control['hostname'] || Socket.gethostname
+          end
+
           # These validation settings are used for cases where a
           # dynamic server is spun up for clients - partners can
           # include a seed and token to indicate that the host is
@@ -702,7 +706,7 @@ module NewRelic
           def connect_settings
             {
               :pid => $$,
-              :host => @local_host,
+              :host => determine_host,
               :app_name => control.app_names,
               :language => 'ruby',
               :agent_version => NewRelic::VERSION::STRING,
@@ -966,11 +970,6 @@ module NewRelic
           else
             disconnect
           end
-        end
-
-        # Who am I? Well, this method can tell you your hostname.
-        def determine_host
-          Socket.gethostname
         end
 
         # Delegates to the control class to determine the root

--- a/test/new_relic/agent/agent/connect_test.rb
+++ b/test/new_relic/agent/agent/connect_test.rb
@@ -158,11 +158,25 @@ class NewRelic::Agent::Agent::ConnectTest < Test::Unit::TestCase
     control.expects(:settings)
     self.expects(:validate_settings)
     self.expects(:environment_for_connect)
+    self.expects(:determine_host)
     keys = %w(pid host app_name language agent_version environment settings validate)
     value = connect_settings
     keys.each do |k|
       assert(value.has_key?(k.to_sym), "should include the key #{k}")
     end
+  end
+
+  def test_determine_host_default
+    control = mocked_control
+    control.expects(:'[]').with('hostname').once.returns(nil)
+    Socket.expects(:gethostname).once.returns('hostname')
+    assert_equal('hostname', determine_host)
+  end
+
+  def test_determine_host_set_in_config
+    control = mocked_control
+    control.expects(:'[]').with('hostname').once.returns('custom-hostname')
+    assert_equal('custom-hostname', determine_host)
   end
 
   def test_configure_error_collector_base


### PR DESCRIPTION
I've added the ability to set a custom hostname by setting "hostname: whatever" within newrelic.yml

Use case:

Due to restrictions we have on some of our servers, we can't change the hostname of the machine. We're able to override the hostname for the system monitoring by setting "hostname=whatever", but lack this facility for rpm. We want to have the server monitoring integrated properly with the application monitoring but since it's based on hostnames, it's not linking up properly.

I've written tests for both the custom hostname case and default hostname case.
