### PR TITLE
Fix for Rails 3 view instrumentation

### DIFF
--- a/lib/new_relic/agent/instrumentation/rails3/action_controller.rb
+++ b/lib/new_relic/agent/instrumentation/rails3/action_controller.rb
@@ -162,7 +162,7 @@ DependencyDetection.defer do
     class ActionView::TemplateRenderer
       def render_template(*args)
         template = args.first
-        NewRelic::Agent.trace_execution_scoped "View/#{template.virtual_path}/Rendering" do
+        NewRelic::Agent.trace_execution_scoped "View/#{template.respond_to?(:virtual_path) ? template.virtual_path : "Text"}/Rendering" do
           super
         end
       end


### PR DESCRIPTION
Fix view instrumentation for Rails >= 3.1.0.  Rails changed their rendering interface in 3.1 and the gem is trying to hook on to non-existent classes/methods. Also fixed the old implementation to work on Rails 3.0.*.

In Rails >= 3.1, ActionView::Partials::PartialRenderer was moved to ActionView::PartialRenderer.  Also, the internal method _render_template is no longer used.

The "rails3_view" was checking for the presence of ActionView::Partials while also enforcing Rails >= 3.1 which is an impossible case.  I changed this one to check that Rails == 3.0.\* and should work as it was originally written.
