### PR TITLE
Changed the authorization header in deployment notification command

### DIFF
--- a/lib/new_relic/commands/deployments.rb
+++ b/lib/new_relic/commands/deployments.rb
@@ -53,7 +53,7 @@ class NewRelic::Command::Deployments < NewRelic::Command
       uri = "/deployments.xml"
 
       raise "license_key was not set in newrelic.yml for #{config.env}" if config['license_key'].nil?
-      request = Net::HTTP::Post.new(uri, {'x-license-key' => config['license_key']})
+      request = Net::HTTP::Post.new(uri, {'x-api-key' => config['license_key']})
       request.content_type = "application/octet-stream"
 
       request.set_form_data(create_params)


### PR DESCRIPTION
Changed the authorization header in deployment notification command from x-license-key to x-api-key (otherwise you're getting Forbidden error back from the server).
