### PR TITLE
Update lib/new_relic/agent/instrumentation/data_mapper.rb

### DIFF
--- a/lib/new_relic/agent/instrumentation/data_mapper.rb
+++ b/lib/new_relic/agent/instrumentation/data_mapper.rb
@@ -115,7 +115,7 @@ DependencyDetection.defer do
       add_method_tracer :destroy,  'ActiveRecord/#{self.class.name[/[^:]*$/]}/destroy'
       add_method_tracer :destroy!, 'ActiveRecord/#{self.class.name[/[^:]*$/]}/destroy'
 
-      add_method_tracer :update,   'ActiveRecord/all', :push_scope => false
+      add_method_tracer :update,   'ActiveRecord/save', :push_scope => false
       add_method_tracer :update!,  'ActiveRecord/save', :push_scope => false
       add_method_tracer :save,     'ActiveRecord/save', :push_scope => false
       add_method_tracer :save!,    'ActiveRecord/save', :push_scope => false
@@ -175,6 +175,11 @@ DependencyDetection.defer do
       add_method_tracer :select,  'ActiveRecord/#{self.class.name[/[^:]*$/]}/select'
       add_method_tracer :execute, 'ActiveRecord/#{self.class.name[/[^:]*$/]}/execute'
 
+      add_method_tracer :select,    'ActiveRecord/find', :push_scope => false
+      add_method_tracer :select,    'ActiveRecord/all', :push_scope => false
+
+      add_method_tracer :execute,    'ActiveRecord/save', :push_scope => false
+      add_method_tracer :execute,    'ActiveRecord/all', :push_scope => false
     end
   end
 end


### PR DESCRIPTION
Our project using DataMapper 1.1 does not display any database time on the App Server 'Overview' graph or on the 'Database throughput' and 'Database response time' graphs on the Database page.

Per the comments at the top of data_mapper.rb, this seems to be because the various DataMapper methods need to be instrumented with `:push_scope => false` for 'ActiveRecord/all', 'ActiveRecord/find', etc.

We now have this change in production with our app and we are once again seeing the DataMapper instrumentation that we had with RPM 2.x

I believe similar instrumentation should be added for the DataObjectsAdapter methods as well as lazy_load, but it was less clear to me whether that would double count some time in the graphs so I left that out of this pull request.
