### PR TITLE
Silence "Resolved #{host} to #{ip}" log message

### DIFF
--- a/lib/new_relic/control/server_methods.rb
+++ b/lib/new_relic/control/server_methods.rb
@@ -53,7 +53,7 @@ module NewRelic
         return host if verify_certificate?
         return nil if host.nil? || host.downcase == "localhost"
         ip = resolve_ip_address(host)
-        log.info "Resolved #{host} to #{ip}"
+        log.debug "Resolved #{host} to #{ip}"
         ip
       end
 


### PR DESCRIPTION
Having upgraded our app from `newrelic_rpm` v3.3.1 to v3.4.0, we're now getting unwanted messages to `STDOUT` saying `Resolved collector.newrelic.com to 204.93.223.153` on app boot. This is problematic as it causes our cron jobs to email us this every time they run, which is both unnecessary and annoying.

This commit downgrades the log level for this message from `info` to `debug` and so suppresses its output.
