### PR TITLE
Fixed reference to @service.request_timeout to @request_timeout. 

### DIFF
--- a/lib/new_relic/agent/new_relic_service.rb
+++ b/lib/new_relic/agent/new_relic_service.rb
@@ -167,7 +167,7 @@ module NewRelic
             response = http.request(request)
           end
         rescue Timeout::Error
-          log.warn "Timed out trying to post data to New Relic (timeout = #{@request_timeout} seconds)" unless @service.request_timeout < 30
+          log.warn "Timed out trying to post data to New Relic (timeout = #{@request_timeout} seconds)" unless @request_timeout < 30
           raise
         end
         if response.is_a? Net::HTTPServiceUnavailable


### PR DESCRIPTION
This was raising an error with the following details:

```
ERROR : Error running task in Agent Worker Loop 'undefined method `request_timeout' for nil:NilClass': /apps/crm/shared/bundle/ruby/1.9.1/gems/newrelic_rpm-3.4.0/lib/new_relic/agent/new_relic_service.rb:170:in `rescue in send_request'
```

I believe the reference to @service should be referencing self.
