### PR TITLE
Fix memory sampler to make it work on the latest osx servers.

### DIFF
--- a/lib/new_relic/agent/samplers/memory_sampler.rb
+++ b/lib/new_relic/agent/samplers/memory_sampler.rb
@@ -35,7 +35,7 @@ module NewRelic
         end
 
         def self.supported_on_this_platform?
-          defined?(JRuby) or platform =~ /linux|darwin9|darwin10|freebsd|solaris/
+          defined?(JRuby) or platform =~ /linux|darwin|freebsd|solaris/
         end
 
         def self.platform


### PR DESCRIPTION
Snow leopard and upward just report "Darwin" on an uname -a. Because of this rpm unnecessarily disables the memory sampler. This patch fixes this.
