### PR TITLE
IN_PHUSION_PASSENGER deprecated in Phusion Passenger 3.9.0, causes :dispatcher not to be found/set

### DIFF
--- a/lib/new_relic/agent/instrumentation/passenger_instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/passenger_instrumentation.rb
@@ -2,18 +2,18 @@ DependencyDetection.defer do
   @name = :passenger
   
   depends_on do
-    defined?(PhusionPassenger)
+    defined?(::PhusionPassenger)
   end
 
   executes do
     NewRelic::Agent.logger.debug "Installing Passenger event hooks."
 
-    PhusionPassenger.on_event(:stopping_worker_process) do
+    ::PhusionPassenger.on_event(:stopping_worker_process) do
       NewRelic::Agent.logger.debug "Passenger stopping this process, shutdown the agent."
       NewRelic::Agent.instance.shutdown
     end
 
-    PhusionPassenger.on_event(:starting_worker_process) do |forked|
+    ::PhusionPassenger.on_event(:starting_worker_process) do |forked|
       # We want to reset the stats from the stats engine in case any carried
       # over into the spawned process.  Don't clear them in case any were
       # cached.  We do this even in conservative spawning.
@@ -24,7 +24,7 @@ end
 
 DependencyDetection.defer do
   depends_on do
-    defined?(::Passenger) && defined?(::Passenger::AbstractServer) || defined?(::IN_PHUSION_PASSENGER)
+    defined?(::Passenger) && defined?(::Passenger::AbstractServer)
   end
 
   executes do

--- a/lib/new_relic/local_environment.rb
+++ b/lib/new_relic/local_environment.rb
@@ -397,7 +397,7 @@ module NewRelic
     end
 
     def check_for_passenger
-      if (defined?(::Passenger) && defined?(::Passenger::AbstractServer)) || defined?(::IN_PHUSION_PASSENGER)
+      if (defined?(::Passenger) && defined?(::Passenger::AbstractServer)) || defined?(::PhusionPassenger)
         @dispatcher = :passenger
       end
     end


### PR DESCRIPTION
Per Phusion (Hongli Lai): "The IN_PHUSION_PASSENGER constant is a
private implementation detail and was never meant to be part of the
public API."

3.9.0 (4.0.0 Beta 1) has removed defining the constant
IN_PHUSION_PASSENGER.

This commit looks for the proper ::PhusionPassenger, which is also
compatible with older versions.

As a workaround before implementing this, I have been doing:
"IN_PHUSION_PASSENGER = true if defined?(::PhusionPassenger)"
