### PR TITLE
use java_import instead of include_class

### DIFF
--- a/lib/new_relic/agent/instrumentation/metric_frame.rb
+++ b/lib/new_relic/agent/instrumentation/metric_frame.rb
@@ -64,8 +64,8 @@ module NewRelic
         if defined? JRuby
           begin
             require 'java'
-            include_class 'java.lang.management.ManagementFactory'
-            include_class 'com.sun.management.OperatingSystemMXBean'
+            java_import 'java.lang.management.ManagementFactory'
+            java_import 'com.sun.management.OperatingSystemMXBean'
             @@java_classes_loaded = true
           rescue => e
           end


### PR DESCRIPTION
... because "include_class is deprecated", and complains about it.
