### PR TITLE
change jruby include_class to java_import to remove deprecation warnings

### DIFF
--- a/lib/new_relic/agent/instrumentation/metric_frame.rb
+++ b/lib/new_relic/agent/instrumentation/metric_frame.rb
@@ -54,8 +54,8 @@ module NewRelic
         if defined? JRuby
           begin
             require 'java'
-            include_class 'java.lang.management.ManagementFactory'
-            include_class 'com.sun.management.OperatingSystemMXBean'
+            java_import 'java.lang.management.ManagementFactory'
+            java_import 'com.sun.management.OperatingSystemMXBean'
             @@java_classes_loaded = true
           rescue => e
           end


### PR DESCRIPTION
JRuby 1.7.0 deprecated include_class, and recommends using java_import
instead. This fixes the warnings for using include_class.
