### PR TITLE
no longer use deprecated include_class calls

### DIFF
--- a/lib/new_relic/agent/instrumentation/metric_frame.rb
+++ b/lib/new_relic/agent/instrumentation/metric_frame.rb
@@ -54,8 +54,8 @@ module NewRelic
         if defined? JRuby
           begin
             require 'java'
-            include_class 'java.lang.management.ManagementFactory'
-            include_class 'com.sun.management.OperatingSystemMXBean'
+            java_import 'java.lang.management.ManagementFactory'
+            java_import 'com.sun.management.OperatingSystemMXBean'
             @@java_classes_loaded = true
           rescue => e
           end


### PR DESCRIPTION
jruby 1.7.0 has deprecated `include_class`. i changed this to use `import_java` instead.
