### PR TITLE
Fixed passing environment to manual_start()

### DIFF
--- a/lib/new_relic/control/instance_methods.rb
+++ b/lib/new_relic/control/instance_methods.rb
@@ -45,6 +45,7 @@ module NewRelic
       #
       def init_plugin(options={})
         begin
+          env = options[:env] || env
           path = @newrelic_file || Agent.config[:config_path]
           yaml = Agent::Configuration::YamlSource.new(path, env)
           Agent.config.replace_or_add_config(yaml, 1)


### PR DESCRIPTION
Fixed bug where NewRelic::Agent.manual_start({:env => "custom_env_name"}) did not propagate to the yaml reading code as per the documentation. Instead, the instance member called `env' is always used.

See: http://newrelic.github.com/rpm/NewRelic/Agent.html#method-i-manual_start description for details on using the :env symbol.
