### PR TITLE
Fix initialization for Rails 4

### DIFF
--- a/lib/newrelic_rpm.rb
+++ b/lib/newrelic_rpm.rb
@@ -28,7 +28,7 @@ if defined?(Merb) && defined?(Merb::BootLoader)
     end
   end
 elsif defined? Rails
-  if Rails.respond_to?(:version) && Rails.version =~ /^3/
+  if Rails.respond_to?(:version) && Rails.version > '3'
     module NewRelic
       class Railtie < Rails::Railtie
 


### PR DESCRIPTION
The current version prevents the server from starting when using Rails 4.

/Users/jon/.rvm/gems/ruby-1.9.3-p0@card-game/bundler/gems/rails-0d7b0f0183ce/railties/lib/rails.rb:37:in `configuration': undefined method`config' for nil:NilClass (NoMethodError)
    from /Users/jon/.rvm/gems/ruby-1.9.3-p0@card-game/gems/newrelic_rpm-3.5.0.1/lib/newrelic_rpm.rb:44:in `<top (required)>'
    from /Users/jon/.rvm/gems/ruby-1.9.3-p0@card-game/gems/bundler-1.2.1/lib/bundler/runtime.rb:68:in`require'
    from /Users/jon/.rvm/gems/ruby-1.9.3-p0@card-game/gems/bundler-1.2.1/lib/bundler/runtime.rb:68:in `block (2 levels) in require'
    from /Users/jon/.rvm/gems/ruby-1.9.3-p0@card-game/gems/bundler-1.2.1/lib/bundler/runtime.rb:66:in`each'
    from /Users/jon/.rvm/gems/ruby-1.9.3-p0@card-game/gems/bundler-1.2.1/lib/bundler/runtime.rb:66:in `block in require'
    from /Users/jon/.rvm/gems/ruby-1.9.3-p0@card-game/gems/bundler-1.2.1/lib/bundler/runtime.rb:55:in`each'
    from /Users/jon/.rvm/gems/ruby-1.9.3-p0@card-game/gems/bundler-1.2.1/lib/bundler/runtime.rb:55:in `require'
    from /Users/jon/.rvm/gems/ruby-1.9.3-p0@card-game/gems/bundler-1.2.1/lib/bundler.rb:128:in`require'
    from /Users/jon/Sites/card-game/config/application.rb:11:in `<top (required)>'
    from /Users/jon/.rvm/gems/ruby-1.9.3-p0@card-game/bundler/gems/rails-0d7b0f0183ce/railties/lib/rails/commands.rb:83:in`require'
    from /Users/jon/.rvm/gems/ruby-1.9.3-p0@card-game/bundler/gems/rails-0d7b0f0183ce/railties/lib/rails/commands.rb:83:in `block in <top (required)>'
    from /Users/jon/.rvm/gems/ruby-1.9.3-p0@card-game/bundler/gems/rails-0d7b0f0183ce/railties/lib/rails/commands.rb:80:in`tap'
    from /Users/jon/.rvm/gems/ruby-1.9.3-p0@card-game/bundler/gems/rails-0d7b0f0183ce/railties/lib/rails/commands.rb:80:in `<top (required)>'
    from script/rails:6:in`require'
    from script/rails:6:in `<main>'
