### PR TITLE
Switch to java_import from include_class

### DIFF
--- a/lib/new_relic/agent/instrumentation/metric_frame.rb
+++ b/lib/new_relic/agent/instrumentation/metric_frame.rb
@@ -54,8 +54,8 @@ module NewRelic
         if defined? JRuby
           begin
             require 'java'
-            include_class 'java.lang.management.ManagementFactory'
-            include_class 'com.sun.management.OperatingSystemMXBean'
+            java_import 'java.lang.management.ManagementFactory'
+            java_import 'com.sun.management.OperatingSystemMXBean'
             @@java_classes_loaded = true
           rescue => e
           end


### PR DESCRIPTION
When using the gem under jruby 1.7.0, we see the warnings:

``` bash
$ rake
include_class is deprecated. Use java_import.
```

In jruby 1.7.0, include_class has been deprecated (http://jira.codehaus.org/browse/JRUBY-3797). 

This pull request replaces include_class with java_import.
