### PR TITLE
Capistrano  newrelic:notice_deployment bugfix

### DIFF
--- a/lib/new_relic/commands/deployments.rb
+++ b/lib/new_relic/commands/deployments.rb
@@ -62,7 +62,7 @@ class NewRelic::Command::Deployments < NewRelic::Command
           NewRelic::Agent.config[:license_key].empty?
         raise "license_key was not set in newrelic.yml for #{control.env}"
       end
-      request = Net::HTTP::Post.new(uri, {'x-license-key' => NewRelic::Agent.config[:license_key]})
+      request = Net::HTTP::Post.new(uri, {'x-api-key' => NewRelic::Agent.config[:license_key]})
       request.content_type = "application/octet-stream"
 
       request.set_form_data(create_params)


### PR DESCRIPTION
I was receving following message after calling `cap newrelic:notice_deployment`

   *\* Uploading deployment to New Relic
   *\* Deployment not recorded: Forbidden

I figured out that `x-licence-key` header is used in call to newrelic API, when i changed it to `x-api-key` as mentioned in [documentation](https://newrelic.com/docs/docs/getting-started-with-the-new-relic-rest-api) it started working.
