### PR TITLE
Bug: Fix Sinatra Request header access.

### DIFF
--- a/lib/new_relic/agent/instrumentation/sinatra.rb
+++ b/lib/new_relic/agent/instrumentation/sinatra.rb
@@ -49,6 +49,11 @@ module NewRelic
           end
         end
 
+        # Define Request Header accessor for Sinatra
+        def newrelic_request_headers
+          request.env
+        end
+
         module NewRelic
           extend self
           

--- a/test/new_relic/agent/instrumentation/sinatra_test.rb
+++ b/test/new_relic/agent/instrumentation/sinatra_test.rb
@@ -1,0 +1,25 @@
+require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..', 'test_helper'))
+require 'new_relic/agent/instrumentation/sinatra'
+
+class NewRelic::Agent::Instrumentation::SinatraTest < Test::Unit::TestCase
+  class SinatraTestApp
+    def initialize(response)
+      @response = response
+    end
+
+    def dispatch!
+      @response = response
+    end
+
+    include NewRelic::Agent::Instrumentation::Sinatra
+    alias dispatch_without_newrelic dispatch!
+    alias dispatch! dispatch_with_newrelic
+  end
+
+  def test_newrelic_request_headers
+    app = SinatraTestApp.new([200, {}, ["OK"]])
+    expected_headers = {:fake => :header}
+    app.expects(:request).returns(mock('request', :env => expected_headers))
+    assert_equal app.send(:newrelic_request_headers), expected_headers
+  end
+end


### PR DESCRIPTION
Bug: RPM Queue Wait tracking isn't recorded via Sinatra instrumentation.

The root cause of this is HTTP request headers not being accessible properly to the Controller instrumentation mixin.

This pull request properly exposes request headers for Sinatra instrumentation by mapping the sinatra header hash in an over-written `newrelic_request_headers ()` method.
