### PR TITLE
Easier support servers that pass time values with milliseconds resolution

### DIFF
--- a/lib/new_relic/agent/instrumentation/queue_time.rb
+++ b/lib/new_relic/agent/instrumentation/queue_time.rb
@@ -10,7 +10,7 @@ module NewRelic
           HEROKU_QUEUE_HEADER = 'HTTP_X_HEROKU_QUEUE_WAIT_TIME'
           APP_HEADER = 'HTTP_X_APPLICATION_START'
 
-          HEADER_REGEX = /([^\s\/,(t=)]+)? ?t=([0-9]+)/
+          HEADER_REGEX = /([^\s\/,(t=)]+)? ?t=([0-9\.]+)/
           SERVER_METRIC = 'WebFrontend/WebServer/'
           MIDDLEWARE_METRIC = 'Middleware/'
           # no individual queue metric - more than one queue?!
@@ -93,7 +93,7 @@ module NewRelic
         def get_matches_from_header(header, env)
           return [] if env.nil?
           get_matches(env[header]).map do |name, time|
-            convert_to_name_time_pair(name, time)
+            convert_to_name_time_pair(name, time.sub('.', ''))
           end
         end
 

--- a/test/new_relic/agent/instrumentation/queue_time_test.rb
+++ b/test/new_relic/agent/instrumentation/queue_time_test.rb
@@ -118,6 +118,20 @@ class NewRelic::Agent::Instrumentation::QueueTimeTest < Test::Unit::TestCase
     check_metric_time('WebFrontend/WebServer/serverb', 1.0, 0.1)
   end
 
+  def test_parse_server_time_accepting_milliseconds_resolution_separator_char
+    env = {'HTTP_X_REQUEST_START' => "t=1000.000000"}
+    create_test_start_time(env)
+    env['HTTP_X_QUEUE_START'] = "t=1001.000000"
+    assert_calls_metrics('WebFrontend/WebServer/all') do
+      assert_equal(Time.at(1000), parse_server_time_from(env))
+    end
+    assert_calls_metrics('WebFrontend/QueueTime') do
+      assert_equal(Time.at(1001), parse_queue_time_from(env))
+    end
+    check_metric_time('WebFrontend/WebServer/all', 2.0, 0.1)
+    check_metric_time('WebFrontend/QueueTime', 1.0, 0.1)
+  end
+
   # test for backwards compatibility with old header
   def test_parse_server_time_from_with_no_server_name
     env = {'HTTP_X_REQUEST_START' => "t=#{convert_to_microseconds(Time.at(1001))}"}


### PR DESCRIPTION
Support HTTP header values for X-Request-Start and/or X-Queue-Start values such as "t=1002.000000". Note the dot character for the milliseconds resolution.

Specifically this makes configuring nginx a lot simpler and no patching of nginx is required as described in https://newrelic.com/docs/features/tracking-front-end-time

Using nginx 1.3.9 it then simply becomes: 

```
proxy_set_header X-Queue-Start "t=${msec}000"                                      
```
