### PR TITLE
Fix sinatra dependency check.

### DIFF
--- a/lib/new_relic/agent/instrumentation/sinatra.rb
+++ b/lib/new_relic/agent/instrumentation/sinatra.rb
@@ -5,7 +5,8 @@ DependencyDetection.defer do
 
   depends_on do
     defined?(::Sinatra) && defined?(::Sinatra::Base) &&
-      Sinatra::Base.private_method_defined?(:dispatch!)
+      Sinatra::Base.private_method_defined?(:dispatch!) &&
+      Sinatra::Base.private_method_defined?(:process_route)
   end
 
   executes do


### PR DESCRIPTION
The process_route method was added in sinatra 1.1 and we were using 1.0.

it seems like it would be nice to support multiple versions but not sure how.
