### PR TITLE
Error detected for old versions of ruby and rescue at Browser Monitoring

### DIFF
--- a/lib/new_relic/agent/transaction_info.rb
+++ b/lib/new_relic/agent/transaction_info.rb
@@ -63,7 +63,7 @@ module NewRelic
       end
 
       def self.get_token(request)
-        return nil unless request
+        return nil if request.blank?
         
         agent_flag = request.cookies['NRAGENT']
         if agent_flag and agent_flag.instance_of? String 


### PR DESCRIPTION
For some cases, using old versions of ruby and resque request is an empty hash {}
In those cases an exception is raised and the jobs fails.

Detected on Environment:
ree-1.8.7
resque-1.17.1
