### PR TITLE
Rails root

### DIFF
--- a/lib/new_relic/control/frameworks/rails.rb
+++ b/lib/new_relic/control/frameworks/rails.rb
@@ -10,20 +10,20 @@ module NewRelic
         def env
           @env ||= RAILS_ENV.dup
         end
-        def root
-          root =
-            if defined?(::Rails) && ::Rails::VERSION::MAJOR == 3
-              ::Rails.root
-            elsif defined?(RAILS_ROOT)
-              RAILS_ROOT
-            end
 
-          if root.to_s != ''
+        def root
+          root = rails_root.to_s
+          if !root.empty?
             root
           else
             super
           end
         end
+
+        def rails_root
+          RAILS_ROOT if defined?(RAILS_ROOT)
+        end
+
         def logger
           ::RAILS_DEFAULT_LOGGER
         end

--- a/lib/new_relic/control/frameworks/rails3.rb
+++ b/lib/new_relic/control/frameworks/rails3.rb
@@ -14,6 +14,10 @@ module NewRelic
           @env ||= ::Rails.env.to_s
         end
 
+        def rails_root
+          ::Rails.root
+        end
+
         def logger
           ::Rails.logger
         end


### PR DESCRIPTION
This fixes a deprecation warning in our Rails 3 application, where NewRelic is loaded as part of the Gemfile, before Rails has initialised (and configured `::Rails.root`).

I realise it's not ideal to be moving Rails3-specific code from the `Framework::Rails3` class up to the `Framework::Rails` class.  But I don't really see a more elegant way to avoid using the deprecated `RAILS_ROOT` constant and triggering the warning.  Also, there's plenty of precedent for the `::Rails::VERSION::MAJOR == 3` approach elsewhere in the rpm code.

Let me know if there's a better way to do this.  Obviously the deprecation warning is incorrect in this case, but we just want to eliminate the useless extra noise it creates.
