### PR TITLE
Ruby 2.0 compatibility fix

### DIFF
--- a/lib/new_relic/agent/instrumentation/rails3/action_controller.rb
+++ b/lib/new_relic/agent/instrumentation/rails3/action_controller.rb
@@ -149,7 +149,7 @@ DependencyDetection.defer do
 
       def render_with_newrelic(context, options)
         # This is needed for rails 3.2 compatibility
-        @details = extract_details(options) if respond_to? :extract_details
+        @details = extract_details(options) if respond_to? :extract_details, true
         identifier = determine_template(options) ? determine_template(options).identifier : nil
         str = "View/#{NewRelic::Agent::Instrumentation::Rails3::ActionView::NewRelic.template_metric(identifier, options)}/Rendering"
         trace_execution_scoped str do


### PR DESCRIPTION
In ruby 2.0 protected methods are no longer searched when `respond_to?` is invoked with only method name (http://tenderlovemaking.com/2012/09/07/protected-methods-and-ruby-2-0.html).

I've fixed new relic compatibility with ruby 2.0 when using rails 3 by simply setting second argument to `respond_to?` as `true` so it will search private and **protected** methods.

Fix is backward compatible with ruby 1.9 and ruby 1.8.
