### PR TITLE
Minor fix to Google pie chart helper

### DIFF
--- a/ui/helpers/google_pie_chart.rb
+++ b/ui/helpers/google_pie_chart.rb
@@ -1,3 +1,4 @@
+require 'cgi'
 
 # A wrapper around the google charts service.
 class GooglePieChart


### PR DESCRIPTION
Added 

``` ruby
require 'cgi'
```

to the file `ui/helpers/google_pie_chart.rb` in order to fix a `NameError` that occurred in developer mode when viewing details summary.

Travis tests pass for all environments except ree; that environment seems to be missing bundler, which has nothing to do with my change.  See test results at 
https://travis-ci.org/nihonjinrxs/rpm

Update: Travis.ci has updated their REE build in RVM, and all tests now pass. https://travis-ci.org/nihonjinrxs/rpm
