### PR TITLE
fix missing @details under ruby2 due to change in respond_to? behavior

### DIFF
--- a/lib/new_relic/agent/instrumentation/rails3/action_controller.rb
+++ b/lib/new_relic/agent/instrumentation/rails3/action_controller.rb
@@ -149,7 +149,7 @@ DependencyDetection.defer do
 
       def render_with_newrelic(context, options)
         # This is needed for rails 3.2 compatibility
-        @details = extract_details(options) if respond_to? :extract_details
+        @details = extract_details(options) if respond_to?(:extract_details, true)
         identifier = determine_template(options) ? determine_template(options).identifier : nil
         str = "View/#{NewRelic::Agent::Instrumentation::Rails3::ActionView::NewRelic.template_metric(identifier, options)}/Rendering"
         trace_execution_scoped str do


### PR DESCRIPTION
The newrelic instrumentation currently breaks rails applications running under ruby 2.0 release candidates, due to this change in behavior of 'respond_to?':
http://tenderlovemaking.com/2012/09/07/protected-methods-and-ruby-2-0.html

This patch passes in 'true' as the second argument to 'respond_to?' to fix the issue under ruby2 (and should be innocuous under ruby versions < 2).
