### PR TITLE
Fix instrumentation include for Sintra

### DIFF
--- a/lib/new_relic/agent/instrumentation/sinatra.rb
+++ b/lib/new_relic/agent/instrumentation/sinatra.rb
@@ -19,6 +19,7 @@ DependencyDetection.defer do
 
   executes do
     ::Sinatra::Base.class_eval do
+      include ::NewRelic::Agent::Instrumentation::ControllerInstrumentation
       include NewRelic::Agent::Instrumentation::Sinatra
       alias dispatch_without_newrelic dispatch!
       alias dispatch! dispatch_with_newrelic
@@ -38,8 +39,6 @@ module NewRelic
       # to match them.  HTTP operations are not distinguished.  Multiple matches
       # will all be tracked as separate actions.
       module Sinatra
-        include ::NewRelic::Agent::Instrumentation::ControllerInstrumentation
-
         def dispatch_with_newrelic
           # We're trying to determine the transaction name via Sinatra's
           # process_route, but calling it here misses Sinatra's normal error handling.


### PR DESCRIPTION
The `NewRelic::Agent::Instrumentation::ControllerInstrumentation` module does an `extend` on the `included` hook. At present, it is extending onto the `NewRelic::Agent::Instrumentation::Sinatra` module, but those class methods should be added to the `::Sinatra::Base` class.

This fixes that issue by moving the include of the `ControllerInstrumentation` into the `Sinatra::Base.class_eval` block.
