### PR TITLE
Fixed \A and \z not being stripped from Sinatra

### DIFF
--- a/lib/new_relic/agent/instrumentation/sinatra.rb
+++ b/lib/new_relic/agent/instrumentation/sinatra.rb
@@ -94,7 +94,7 @@ module NewRelic
               end
             end
 
-            name.gsub!(%r{^[/^]*(.*?)[/\$\?]*$}, '\1')
+            name.gsub!(%r{^[/^\\A]*(.*?)[/\$\?\\z]*$}, '\1')
             if verb
               name = verb + ' ' + name
             end


### PR DESCRIPTION
Sinatra 1.4.x (at least, might be earlier) uses \A and \z for its route regex. Turning `get "/ping"` into `/\A\/ping\z/` which the instrumentation does not strip properly because it's only looking for `^$`.

Which is what the changed line will fix so it instead returns "ping" not "\Aping\z"
