### PR TITLE
Use Rails::VERSION::MAJOR instead of Rails.version 

### DIFF
--- a/lib/new_relic/agent/instrumentation/rails3/errors.rb
+++ b/lib/new_relic/agent/instrumentation/rails3/errors.rb
@@ -26,7 +26,7 @@ DependencyDetection.defer do
   @name = :rails3_error
   
   depends_on do
-    defined?(::Rails) && ::Rails.respond_to?(:version) && ::Rails.version.to_i == 3
+    defined?(::Rails) && ::Rails::VERSION::MAJOR.to_i == 3
   end
 
   depends_on do

--- a/lib/new_relic/agent/instrumentation/rails4/errors.rb
+++ b/lib/new_relic/agent/instrumentation/rails4/errors.rb
@@ -26,7 +26,7 @@ DependencyDetection.defer do
   @name = :rails4_error
   
   depends_on do
-    defined?(::Rails) && ::Rails.respond_to?(:version) && ::Rails.version.to_i == 4
+    defined?(::Rails) && ::Rails::VERSION::MAJOR.to_i == 4
   end
 
   depends_on do

--- a/lib/newrelic_rpm.rb
+++ b/lib/newrelic_rpm.rb
@@ -32,7 +32,7 @@ if defined?(Merb) && defined?(Merb::BootLoader)
     end
   end
 elsif defined? Rails
-  if Rails.respond_to?(:version) && Rails.version > '3'
+  if Rails::VERSION::MAJOR.to_i >= 3
     module NewRelic
       class Railtie < Rails::Railtie
 
@@ -42,7 +42,7 @@ elsif defined? Rails
       end
     end
   else
-    # After verison 2.0 of Rails we can access the configuration directly.
+    # After version 2.0 of Rails we can access the configuration directly.
     # We need it to add dev mode routes after initialization finished.
     config = nil
     config = Rails.configuration if Rails.respond_to?(:configuration)

--- a/test/config/test_control.rb
+++ b/test/config/test_control.rb
@@ -6,8 +6,8 @@ require 'new_relic/control/frameworks/rails'
 require 'new_relic/control/frameworks/rails3'
 require 'new_relic/control/frameworks/rails4'
 
-if defined?(::Rails) && ::Rails.respond_to?(:version)
-  parent_class = case ::Rails.version.to_i
+if defined?(::Rails)
+  parent_class = case ::Rails::VERSION::MAJOR.to_i
   when 4
     NewRelic::Control::Frameworks::Rails4
   when 3

--- a/test/new_relic/agent/instrumentation/active_record_instrumentation_test.rb
+++ b/test/new_relic/agent/instrumentation/active_record_instrumentation_test.rb
@@ -211,7 +211,7 @@ class NewRelic::Agent::Instrumentation::ActiveRecordInstrumentationTest < Test::
   end
 
   def test_join_metrics_sqlite
-    return if (defined?(Rails) && Rails.respond_to?(:version) && Rails.version.to_i == 3)
+    return if (defined?(Rails) && Rails::VERSION::MAJOR.to_i == 3)
     return if defined?(JRuby)
     return unless isSqlite?
 
@@ -249,7 +249,7 @@ class NewRelic::Agent::Instrumentation::ActiveRecordInstrumentationTest < Test::
   end
 
   def test_join_metrics_standard
-    return if (defined?(Rails) && Rails.respond_to?(:version) && Rails.version.to_i >= 3)
+    return if (defined?(Rails) && Rails::VERSION::MAJOR.to_i >= 3)
     return if defined?(JRuby) || isSqlite?
 
     expected_metrics = %W[
@@ -549,7 +549,7 @@ class NewRelic::Agent::Instrumentation::ActiveRecordInstrumentationTest < Test::
   private
 
   def rails3?
-    (defined?(Rails) && Rails.respond_to?(:version) && Rails.version.to_i >= 3)
+    (defined?(Rails) && Rails::VERSION::MAJOR.to_i >= 3)
   end
 
   def rails_env


### PR DESCRIPTION
Last week in rails master branch was changed the Rails.version method. Now it returns a Gem::Version object instead of a String ( rails/rails@c07e1515f7c66f5599cbb3c7e9fe42e166bf3edc ).

Due to this change the comparison of Rails.version with a String and Rails.version.to_i are failing.

I have updated the gem to use Rails::VERSION::MAJOR, already used in several places in this gem.
