### PR TITLE
Since Rails 4 .version returns a Gem::Version

### DIFF
--- a/lib/newrelic_rpm.rb
+++ b/lib/newrelic_rpm.rb
@@ -32,7 +32,7 @@ if defined?(Merb) && defined?(Merb::BootLoader)
     end
   end
 elsif defined? Rails
-  if Rails.respond_to?(:version) && Rails.version > '3'
+  if Rails.respond_to?(:version) && Rails.version.to_s > '3'
     module NewRelic
       class Railtie < Rails::Railtie
 


### PR DESCRIPTION
We convert it `to_s` to be compatible with both < 4 and >= 4
