### PR TITLE
Rails.version must force .to_s after rails 4

### DIFF
--- a/lib/new_relic/agent/instrumentation/rails3/errors.rb
+++ b/lib/new_relic/agent/instrumentation/rails3/errors.rb
@@ -24,9 +24,9 @@ end
 
 DependencyDetection.defer do
   @name = :rails3_error
-  
+
   depends_on do
-    defined?(::Rails) && ::Rails.respond_to?(:version) && ::Rails.version.to_i == 3
+    defined?(::Rails) && ::Rails.respond_to?(:version) && ::Rails.version.to_s.to_i == 3
   end
 
   depends_on do

--- a/lib/new_relic/agent/instrumentation/rails4/errors.rb
+++ b/lib/new_relic/agent/instrumentation/rails4/errors.rb
@@ -24,9 +24,9 @@ end
 
 DependencyDetection.defer do
   @name = :rails4_error
-  
+
   depends_on do
-    defined?(::Rails) && ::Rails.respond_to?(:version) && ::Rails.version.to_i == 4
+    defined?(::Rails) && ::Rails.respond_to?(:version) && ::Rails.version.to_s.to_i == 4
   end
 
   depends_on do

--- a/lib/newrelic_rpm.rb
+++ b/lib/newrelic_rpm.rb
@@ -32,7 +32,7 @@ if defined?(Merb) && defined?(Merb::BootLoader)
     end
   end
 elsif defined? Rails
-  if Rails.respond_to?(:version) && Rails.version > '3'
+  if Rails.respond_to?(:version) && Rails.version.to_s > '3'
     module NewRelic
       class Railtie < Rails::Railtie
 


### PR DESCRIPTION
Rails.version now return a Gem::Version instance. If we want a string
from it, we should call .to_s method. this is also backwards compatible

ref https://github.com/rails/jquery-rails/pull/117
ref https://github.com/rails/rails/pull/8501
