### PR TITLE
Do not attempt to resolve host IP address if proxy is in use

### DIFF
--- a/lib/new_relic/control/server_methods.rb
+++ b/lib/new_relic/control/server_methods.rb
@@ -53,6 +53,8 @@ module NewRelic
         # here we leave it as a host name since the cert verification
         # needs it in host form
         return host if Agent.config[:ssl] && Agent.config[:verify_certificate]
+        # We won't talk directly to the host, so no need to resolve if proxy configured
+        return host if Agent.config[:proxy_host]
         return nil if host.nil? || host.downcase == "localhost"
         ip = resolve_ip_address(host)
 


### PR DESCRIPTION
In an environment where hosts need to go through a proxy to get to newrelic, sometimes they don't have DNS at all.  

The DNS resolution here is whiny about failure, which becomes a problem downstream (suddenly rake tasks produce output, which makes noise for logs, etc).

So don't even try to resolve the host if proxy is specified.
