### PR TITLE
Handle batch submission of queries with incompatible encodings

### DIFF
--- a/lib/new_relic/agent/transaction_sampler.rb
+++ b/lib/new_relic/agent/transaction_sampler.rb
@@ -295,7 +295,11 @@ module NewRelic
       # segment - i.e. traced method calls multiple sql queries
       def append_new_message(old_message, message)
         if old_message
-          old_message + ";\n" + message
+          begin
+            old_message + ";\n" + message
+          rescue EncodingError
+            old_message + ";\n" + message.encode(old_message.encoding, invalid: :replace, undef: :replace)
+          end
         else
           message
         end


### PR DESCRIPTION
We've experienced an error where a query with a BLOB, encoded as
ASCII-8BIT is concatenated to a UTF-8 query (with UTF-8 multibyte
characters present). This is an invalid conversion and raises an
EncodingError. This commit rescues that error and forcibly converts
the second query to the first's encoding.

This may or may not be a complete solution. I haven't taken the time to understand RPM's architecture enough to figure out how to test this adequately.

It seems odd to me that this would cause problems. It doesn't seem like it should be an uncommon case. Did we do something wrong?
