### PR TITLE
Restore a MetricFrame

### DIFF
--- a/lib/new_relic/agent/instrumentation/controller_instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/controller_instrumentation.rb
@@ -2,6 +2,7 @@
 # This file is distributed under New Relic's license terms.
 # See https://github.com/newrelic/rpm/blob/master/LICENSE for complete details.
 
+require 'new_relic/agent/instrumentation/metric_frame'
 require 'new_relic/agent/transaction'
 require 'new_relic/agent/instrumentation/queue_time'
 module NewRelic


### PR DESCRIPTION
restoring require statment, otherwise we will get a
uninitialized constant NewRelic::Agent::Instrumentation::MetricFrame
