### PR TITLE
Load rum.js asynchronously

### DIFF
--- a/lib/new_relic/agent/beacon_configuration.rb
+++ b/lib/new_relic/agent/beacon_configuration.rb
@@ -73,6 +73,7 @@ EOS
           js << <<-EOS
 var e=document.createElement("script");
 e.type="text/javascript";
+e.async=true;
 e.src=(("http:"===document.location.protocol)?"http:":"https:") + "//" +
   "#{Agent.config[:episodes_file]}";
 document.body.appendChild(e);


### PR DESCRIPTION
This page - https://newrelic.com/docs/features/how-does-real-user-monitoring-work - seems to suggest that rum.js can and/or should be loading asynchronously.  How about the attached commit?
