### PR TITLE
Fix Authlogic constant name 

### DIFF
--- a/lib/new_relic/agent/instrumentation/authlogic.rb
+++ b/lib/new_relic/agent/instrumentation/authlogic.rb
@@ -17,7 +17,9 @@ DependencyDetection.defer do
   
   executes do
     Authlogic::Session::Base.class_eval do
-      add_method_tracer :find, 'Custom/Authlogic/find'
+      class << self
+        add_method_tracer :find, 'Custom/Authlogic/find'
+      end
     end
   end
 end


### PR DESCRIPTION
Fixed authlogic constant name, as it is silently failing loading of the instrumentation.
