### PR TITLE
Remove ActiveSupport::Concern warnings when including MethodTracer in Rails

### DIFF
--- a/lib/new_relic/agent/instrumentation/controller_instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/controller_instrumentation.rb
@@ -310,7 +310,7 @@ module NewRelic
             return yield if !(NewRelic::Agent.is_execution_traced? || options[:force])
             options[:metric] = true if options[:metric].nil?
             options[:deduct_call_time_from_parent] = true if options[:deduct_call_time_from_parent].nil?
-            _, expected_scope = NewRelic::Agent::MethodTracer::InstanceMethods::TraceExecutionScoped.trace_execution_scoped_header(options, txn.start_time.to_f)
+            _, expected_scope = NewRelic::Agent::MethodTracer::TraceExecutionScoped.trace_execution_scoped_header(options, txn.start_time.to_f)
 
             begin
               NewRelic::Agent::BusyCalculator.dispatcher_start txn.start_time
@@ -337,7 +337,7 @@ module NewRelic
             metric_names = Array(recorded_metrics(txn))
             txn_name = metric_names.shift
 
-            NewRelic::Agent::MethodTracer::InstanceMethods::TraceExecutionScoped.trace_execution_scoped_footer(txn.start_time.to_f, txn_name, metric_names, expected_scope, options, end_time.to_f)
+            NewRelic::Agent::MethodTracer::TraceExecutionScoped.trace_execution_scoped_footer(txn.start_time.to_f, txn_name, metric_names, expected_scope, options, end_time.to_f)
             NewRelic::Agent::BusyCalculator.dispatcher_finish(end_time)
             txn.record_apdex(end_time) unless ignore_apdex?
             txn = Transaction.stop(txn_name, end_time)

--- a/lib/new_relic/control/instance_methods.rb
+++ b/lib/new_relic/control/instance_methods.rb
@@ -71,7 +71,7 @@ module NewRelic
         # An artifact of earlier implementation, we put both #add_method_tracer and #trace_execution
         # methods in the module methods.
         Module.send :include, NewRelic::Agent::MethodTracer::ClassMethods
-        Module.send :include, NewRelic::Agent::MethodTracer::InstanceMethods
+        Module.send :include, NewRelic::Agent::MethodTracer
         init_config(options)
         NewRelic::Agent.agent = NewRelic::Agent::Agent.instance
         if Agent.config[:agent_enabled] && !NewRelic::Agent.instance.started?

--- a/test/new_relic/agent/method_tracer/instance_methods/trace_execution_scoped_test.rb
+++ b/test/new_relic/agent/method_tracer/instance_methods/trace_execution_scoped_test.rb
@@ -3,9 +3,9 @@
 # See https://github.com/newrelic/rpm/blob/master/LICENSE for complete details.
 
 require File.expand_path(File.join(File.dirname(__FILE__),'..','..','..','..','test_helper'))
-class NewRelic::Agent::MethodTracer::InstanceMethods::TraceExecutionScopedTest < Test::Unit::TestCase
+class NewRelic::Agent::MethodTracer::TraceExecutionScopedTest < Test::Unit::TestCase
   require 'new_relic/agent/method_tracer'
-  include NewRelic::Agent::MethodTracer::InstanceMethods::TraceExecutionScoped
+  include NewRelic::Agent::MethodTracer::TraceExecutionScoped
 
   def setup
     NewRelic::Agent.agent.stats_engine.clear_stats
@@ -219,7 +219,7 @@ class NewRelic::Agent::MethodTracer::InstanceMethods::TraceExecutionScopedTest <
   end
 
   def test_log_errors_with_error
-    expects_logging(:error, 
+    expects_logging(:error,
       includes("Caught exception in name."),
       instance_of(RuntimeError))
 

--- a/test/new_relic/agent/method_tracer_test.rb
+++ b/test/new_relic/agent/method_tracer_test.rb
@@ -94,7 +94,7 @@ class NewRelic::Agent::MethodTracerTest < Test::Unit::TestCase
 
   def test_record_metrics_does_not_raise_outside_transaction
     assert_nothing_raised do
-      NewRelic::Agent::MethodTracer::InstanceMethods::TraceExecutionScoped.record_metrics('a', ['b'], 12, 10, :metric => true)
+      NewRelic::Agent::MethodTracer::TraceExecutionScoped.record_metrics('a', ['b'], 12, 10, :metric => true)
     end
     expected = { :call_count => 1, :total_call_time => 12, :total_exclusive_time => 10 }
     assert_metrics_recorded('a' => expected, 'b' => expected)


### PR DESCRIPTION
In Rails 3.2+, when including NewRelic::Agent::MethodTracer
and any concern based on ActiveSupport::Concern in the same class,
ActiveSupport::Concern is displaying warnings like:

```
DEPRECATION WARNING: The InstanceMethods module inside ActiveSupport::Concern will be no longer included automatically. Please define instance methods directly in TheClass instead.
```

For `TheClass` defined as:

```
class TheClass
  include SomeConcern
  include ::NewRelic::Agent::MethodTracer

  add_method_tracer :some_method
end
```

given the ancestors of `TheClass`:

```
[TheClass,
NewRelic::Agent::MethodTracer::InstanceMethods,
NewRelic::Agent::MethodTracer,
SomeConcern,
Object, Kernel]
```

there’s no need for a `NewRelic::Agent::MethodTracer::InstanceMethods`
since methods on `NewRelic::Agent::MethodTracer` are already in the chain.

http://engineering.appfolio.com/2013/06/17/ruby-mixins-activesupportconcern/
