### PR TITLE
Suggests a quality spec

### DIFF
--- a/test/quality_spec.rb
+++ b/test/quality_spec.rb
@@ -1,4 +1,9 @@
-require "pry"
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/rpm/blob/master/LICENSE for complete details.
+
+# This spec will illuminate files with trailing white space
+# as well as files with hard tab characters.
 if defined?(Encoding) && Encoding.default_external != "UTF-8"
   Encoding.default_external = "UTF-8"
 end


### PR DESCRIPTION
Hi, I noticed some commits that targeted trailing white space.  This spec is from the [bundler](https://github.com/bundler/bundler/blob/master/spec/quality_spec.rb) project.  The spec illuminates files with trailing white space or with hard tab characters.

You can easily exclude certain files from these checks (see [here](https://github.com/rthbound/rpm/compare/suggests_quality_spec?expand=1#L0R47))

```
$ rspec test/quality_spec.rb 
F

Failures:

  1) The library itself has no malformed whitespace
     Failure/Error: expect(error_messages.compact).to be_well_formed
       .project has tab characters on lines 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22
       bin/mongrel_rpm has spaces on the EOL on lines 31
       cert/oldsite.pem has spaces on the EOL on lines 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28
       cert/site.pem has spaces on the EOL on lines 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27
       test/new_relic/agent/method_interrobang_test.rb has tab characters on lines 10, 12, 13, 14, 16, 17, 18, 20, 21, 23, 24, 25, 26, 28, 29, 30, 31
       test/script/ci_agent-tests_runner.sh has tab characters on lines 18, 19, 29, 31, 32
       ui/views/layouts/newrelic_default.rhtml has tab characters on lines 7, 8, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47
       ui/views/newrelic/_explain_plans.rhtml has tab characters on lines 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14
       ui/views/newrelic/_segment.rhtml has tab characters on lines 6, 7, 8, 9
       ui/views/newrelic/_segment_row.rhtml has tab characters on lines 2, 3, 5, 6, 7, 8, 9, 10, 11
       ui/views/newrelic/_show_sample_detail.rhtml has tab characters on lines 2, 3, 4, 5, 8, 9
       ui/views/newrelic/_show_sample_sql.rhtml has tab characters on lines 9, 10, 11, 12, 15, 18, 19, 20, 23
       ui/views/newrelic/_sql_row.rhtml has tab characters on lines 4, 6, 7, 14, 15
       ui/views/newrelic/_table.rhtml has tab characters on lines 2, 3, 4, 5, 6, 7, 8, 11
       ui/views/newrelic/explain_sql.rhtml has tab characters on lines 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 32, 33, 34, 35, 38
       ui/views/newrelic/file/stylesheets/style.css has tab characters on lines 25, 55, 57, 70, 71, 72, 73, 74, 75, 76, 79, 80, 81, 84, 85, 86, 89, 93, 94, 95, 96, 97, 101, 102, 109, 110, 118, 123, 125, 130, 135, 136, 139, 142, 145, 146, 147, 148, 152, 159, 160, 163, 164, 167, 170, 171, 172, 178, 179, 183, 187, 188, 189, 190, 194, 195, 204, 208, 209, 210, 215, 220, 221, 226, 227, 232, 233, 237, 238, 239, 240, 241, 246, 251, 252, 253, 254, 255, 260, 261, 262, 263, 264, 269, 274, 275, 280, 281, 282, 283, 288, 300, 301, 305, 309, 310, 321, 322, 323, 324, 325, 334, 335, 346, 351, 356, 357, 358, 364, 365, 366, 367, 373, 374, 375, 376, 377, 378, 388, 389, 394, 395, 400, 401, 408, 409, 410, 415, 420, 421, 425, 426, 430, 433, 437, 438, 439, 440, 441, 442, 446, 447, 448, 449, 450, 451, 456, 464, 465, 466, 471, 475, 480, 485
       ui/views/newrelic/index.rhtml has tab characters on lines 3, 22, 23, 38, 39, 40, 42, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 63, 64, 65, 66, 67, 68, 69, 70
       ui/views/newrelic/index.rhtml has spaces on the EOL on lines 28, 47, 66
       ui/views/newrelic/show_sample.rhtml has tab characters on lines 64, 65, 66, 67, 68, 69, 70, 71, 72, 74, 75, 76, 77, 78, 79
       ui/views/newrelic/show_sample.rhtml has spaces on the EOL on lines 28, 41, 58, 73
       ui/views/newrelic/threads.rhtml has tab characters on lines 6, 7, 8, 9, 10, 11, 28, 29, 30, 31, 32, 33
     # ./test/quality_spec.rb:51:in `block (2 levels) in <top (required)>'

Finished in 0.27194 seconds
1 example, 1 failure

Failed examples:

rspec ./test/quality_spec.rb:41 # The library itself has no malformed whitespace
```
