### PR TITLE
remove indirection and possible race case when initializing the agent

### DIFF
--- a/lib/new_relic/agent/agent.rb
+++ b/lib/new_relic/agent/agent.rb
@@ -747,7 +747,7 @@ module NewRelic
           def connect_settings
             {
               :pid => $$,
-              :host => @local_host,
+              :host => determine_host,
               :app_name => Agent.config.app_names,
               :language => 'ruby',
               :agent_version => NewRelic::VERSION::STRING,


### PR DESCRIPTION
Hi New Relic,

We had a problem when initializing a background process, where newrelic would continually error out.

The logs we were seeing were:

```
[08/08/13 13:02:29 +0000 ip-10-98-147-237 (2869)] ERROR : Error establishing connection with New Relic Service at collector.newrelic.com:443:
[08/08/13 13:02:29 +0000 ip-10-98-147-237 (2868)] ERROR : RuntimeError: Hostname passed in connect command cannot be nil.
```

After digging into the source code I determined that `@local_host` was not set by the time the `connect` method ran.  After studying the code for a little bit, I thought that `@local_host` introduced indirection and was not 100% necessary.  So, rather than using that variable, I instead chose to use `determine_host`, which is responsible for populating `@local_host` anyways.  Misdirection removed!
