### PR TITLE
Fix header_str in parallel fetches

### DIFF
--- a/lib/new_relic/agent/instrumentation/curb.rb
+++ b/lib/new_relic/agent/instrumentation/curb.rb
@@ -73,9 +73,13 @@ DependencyDetection.defer do
 
       # We override this method in order to ensure access to header_str even
       # though we use an on_header callback
-      def header_str
-        self._nr_header_str
+      def nr_header_str
+        self._nr_header_str || self.origin_header_str
       end
+
+      alias_method :origin_header_str, :header_str
+      alias_method :header_str, :nr_header_str
+
     end # class Curl::Easy
 
 

--- a/test/multiverse/suites/curb/curb_test.rb
+++ b/test/multiverse/suites/curb/curb_test.rb
@@ -109,16 +109,23 @@ class CurbTest < MiniTest::Unit::TestCase
 
 
   def test_works_with_parallel_fetches
+    header_results = []
     results = []
     other_url = "http://localhost:#{$fake_server.port}/"
 
     in_transaction("test") do
       Curl::Multi.get( [default_url,other_url] ) do |easy|
+        header_results << easy.header_str
         results << easy.body_str
       end
 
       results.each do |res|
         assert_match %r/<head>/i, res
+      end
+
+      header_results.each do |res|
+        assert_match(/^HTTP\/1\.1 200 OK\s+$/, res)
+        assert_match(/^Content-Length: \d+\s+$/, res)
       end
 
       last_segment = find_last_transaction_segment()


### PR DESCRIPTION
Hi guys,

We had a problem when using newrelic_rpm 3.6.6.147 with Feedzirra.
It works with 3.6.5.130.

Our code is like this

``` Ruby
Feedzirra::fetch_and_parse(url).entries.each do
    #Code
end
```

We pass the correct url but result of fetch_and_parse method is always nil. This is the reason
- header_str method of Curl::Easy class always returns nil in parallel fetches in 3.6.6.147. because, install_header_callback method is not called.

I think it should be returns original header_str in this case. I fixed the code like that.
How do you think? or did I do something wrong?
