### PR TITLE
Don't rescue everything... :)

### DIFF
--- a/lib/new_relic/commands/deployments.rb
+++ b/lib/new_relic/commands/deployments.rb
@@ -91,7 +91,7 @@ class NewRelic::Command::Deployments < NewRelic::Command
       raise NewRelic::Command::CommandFailure.new(err_string)
     rescue NewRelic::Command::CommandFailure
       raise
-    rescue => e
+    rescue StandardError => e
       err "Unexpected error attempting to connect to #{control.api_server}"
       info "#{e}: #{e.backtrace.join("\n   ")}"
       raise NewRelic::Command::CommandFailure.new(e.to_s)


### PR DESCRIPTION
Howdy Gang,

I was actually looking to see why them gem needs to use sudo to notify of a deploy (not sure if it was a configuration issue of mine or yours). While investigating, I noticed that you were catching everything.

Using StandardError instead makes sure it's actually an error instead of capturing anything under the sun (signals/interrupts).

... I think I learned that from Sam, actually.

Anyway, if you all have a specific reason for doing it, do share, because I'm curious...
