### PR TITLE
Specify Content-Type as HTML in rack developer mode.

### DIFF
--- a/lib/new_relic/rack/developer_mode.rb
+++ b/lib/new_relic/rack/developer_mode.rb
@@ -141,7 +141,7 @@ module NewRelic
           body = render_without_layout(view, binding)
         end
         if add_rack_array
-          ::Rack::Response.new(body).finish
+          ::Rack::Response.new(body, 200, {'Content-Type' => 'text/html'}).finish
         else
           body
         end


### PR DESCRIPTION
I was using developer mode in Chrome. Chrome rendered the page as plain text, but Safari rendered it as HTML. I curled `/newrelic`, and noticed `Content-Type` was missing. I dug around and found that [in Rack 1.5, the `Content-Type` in Rack responses does not default to text/html](https://github.com/rack/rack/commit/3623d04526b953a63bfb3e72de2d6920a042563f#L2L24). So to be consistent, `Content-Type` should be explicitly set.
