### PR TITLE
Fix a bug in the browser monitoring js injection when the head_pos is 0.

### DIFF
--- a/lib/new_relic/rack/browser_monitoring.rb
+++ b/lib/new_relic/rack/browser_monitoring.rb
@@ -76,7 +76,7 @@ module NewRelic::Rack
         # is really weird and we should punt.
         if head_pos && (head_pos < body_close)
           # rebuild the source
-          source = source[0..(head_pos-1)] <<
+          source = source[0, head_pos] <<
             header <<
             source[head_pos..(body_close-1)] <<
             footer <<


### PR DESCRIPTION
If you have no head tag, and the browser monitoring code detects your <body> tag at position 0, then the content in source would be duplicated (see that the changed line would be source[0 .. -1] which == source). This fixes that problem.
