### PR TITLE
Fix a bug in the browser monitoring js injection when the head_pos is 0.

### DIFF
--- a/lib/new_relic/rack/browser_monitoring.rb
+++ b/lib/new_relic/rack/browser_monitoring.rb
@@ -76,9 +76,9 @@ module NewRelic::Rack
         # is really weird and we should punt.
         if head_pos && (head_pos < body_close)
           # rebuild the source
-          source = source[0..(head_pos-1)] <<
+          source = source[0...head_pos] <<
             header <<
-            source[head_pos..(body_close-1)] <<
+            source[head_pos...body_close] <<
             footer <<
             source[body_close..-1]
         else

--- a/test/rum/no_html_and_no_header.result.html
+++ b/test/rum/no_html_and_no_header.result.html
@@ -1,0 +1,3 @@
+|||I AM THE RUM HEADER|||<body>
+  This isn't great HTML but it's what we've got.
+|||I AM THE RUM FOOTER|||</body>

--- a/test/rum/no_html_and_no_header.source.html
+++ b/test/rum/no_html_and_no_header.source.html
@@ -1,0 +1,3 @@
+<body>
+  This isn't great HTML but it's what we've got.
+</body>


### PR DESCRIPTION
If you have no head tag, and the browser monitoring code detects your tag at position 0, then the content in source would be duplicated (see that the changed line would be source[0 .. -1] which == source). This fixes that problem.
