### PR TITLE
fix http_put_with_newrelic

### DIFF
--- a/lib/new_relic/agent/instrumentation/curb.rb
+++ b/lib/new_relic/agent/instrumentation/curb.rb
@@ -44,9 +44,9 @@ DependencyDetection.defer do
       alias_method :http_post_without_newrelic, :http_post
       alias_method :http_post, :http_post_with_newrelic
 
-      def http_put_with_newrelic(url, data, &blk)
+      def http_put_with_newrelic(*args, &blk)
         self._nr_http_verb = :PUT
-        http_put_with_newrelic(url, data, &blk)
+        http_put_without_newrelic(*args, &blk)
       end
       alias_method :http_put_without_newrelic, :http_put
       alias_method :http_put, :http_put_with_newrelic


### PR DESCRIPTION
http_put_with_newrelic self references and accepts the wrong number of arguments. It is teh broken, this fixes it
