### PR TITLE
Adding sidekiq parameters to instrumentation middleware

### DIFF
--- a/lib/new_relic/agent/instrumentation/sidekiq.rb
+++ b/lib/new_relic/agent/instrumentation/sidekiq.rb
@@ -21,6 +21,7 @@ DependencyDetection.defer do
         perform_action_with_newrelic_trace(
           :name => 'perform',
           :class_name => msg['class'],
+          :params => { :args => msg['args'] },
           :category => 'OtherTransaction/SidekiqJob') do
           yield
         end


### PR DESCRIPTION
When we see slow sidekiq jobs in newrelic, we can't see any of the parameters to see how they could affect the performance of the job. 

Note: we were unable to see this info in any of the multiverse tests for sidekiq, so are unclear on how to write a proper test for this functionality.
