### PR TITLE
http_put_with_newrelic recursively calling itself?

### DIFF
--- a/lib/new_relic/agent/instrumentation/curb.rb
+++ b/lib/new_relic/agent/instrumentation/curb.rb
@@ -46,7 +46,7 @@ DependencyDetection.defer do
 
       def http_put_with_newrelic(url, data, &blk)
         self._nr_http_verb = :PUT
-        http_put_with_newrelic(url, data, &blk)
+        http_put_without_newrelic(url, data, &blk)
       end
       alias_method :http_put_without_newrelic, :http_put
       alias_method :http_put, :http_put_with_newrelic


### PR DESCRIPTION
I ran into this issue in production when I was trying to use the Tire gem (I know its deprecated, that's unrelated) and saw this in my log:

```
newrelic_rpm-3.6.8.164/lib/new_relic/agent/instrumentation/curb.rb:47:in `http_put_with_newrelic': wrong number of arguments (1 for 2) (ArgumentError)
    from tire-d50635905458/lib/tire/http/clients/curb.rb:39:in `put'
```

If you look below, you will see that it seems like `http_put_with_newrelic` will end up calling itself recursively, is this a mistake?

I don't think this will solve my error, but it still seems like an issue.
