### PR TITLE
Fix for Merb instrumentation

### DIFF
--- a/lib/new_relic/agent/instrumentation/merb/controller.rb
+++ b/lib/new_relic/agent/instrumentation/merb/controller.rb
@@ -32,12 +32,14 @@ DependencyDetection.defer do
         self.send attr_name
       end
 
-      protected
       # determine the path that is used in the metric name for
       # the called controller action
       def newrelic_metric_path
         "#{controller_name}/#{action_name}"
       end
+
+      protected
+
       alias_method :perform_action_without_newrelic_trace, :_dispatch
       alias_method :_dispatch, :perform_action_with_newrelic_trace
     end


### PR DESCRIPTION
With the advent of 3.6, #newrelic_metric_path is called from the TransactionNamer object. In the Merb::Controller instrumentation, this method is protected. Thus triggering an exception when called. Making it a public method, fixes the issue.

(Since Merb isn't supported anymore, I haven't gone to great lengths to create something more elaborate.)
