### PR TITLE
Add support for Puma 2.8.0

### DIFF
--- a/lib/new_relic/agent/instrumentation/puma.rb
+++ b/lib/new_relic/agent/instrumentation/puma.rb
@@ -17,7 +17,8 @@ DependencyDetection.defer do
   end
 
   executes do
-    Puma.cli_config.options[:worker_boot] << Proc.new do
+    option_name = [:worker_boot, :before_worker_boot].detect {|option| Puma.cli_config.options.has_key? option }
+    Puma.cli_config.options[option_name] << Proc.new do
       ::NewRelic::Agent.after_fork(:force_reconnect => true)
     end
   end


### PR DESCRIPTION
Puma 2.8.0 renamed the `worker_boot` option to
`before_worker_boot`[1]. This commit detects which option name is in
use and adds a hook to the correct one.

1: https://github.com/puma/puma/commit/e5150f07927e96aa5aae8a65db116472de1d9d63
