### PR TITLE
refer to the correct env var NEWRELIC_AGENT_ENABLED

### DIFF
--- a/lib/new_relic/agent/autostart.rb
+++ b/lib/new_relic/agent/autostart.rb
@@ -13,7 +13,7 @@ module NewRelic
     # the console during interactive sessions.
     #
     # It should be possible to override Autostart logic with an explicit
-    # configuration, for example the NEWRELIC_ENABLE environment variable or
+    # configuration, for example the NEWRELIC_AGENT_ENABLED environment variable or
     # agent_enabled key in newrelic.yml
     module Autostart
       extend self

--- a/lib/new_relic/control/instance_methods.rb
+++ b/lib/new_relic/control/instance_methods.rb
@@ -50,7 +50,7 @@ module NewRelic
       def init_plugin(options={})
         env = options[:env] || self.env
         Agent.logger.info("Starting the New Relic agent in #{env.inspect} environment.")
-        Agent.logger.info("To prevent agent startup add a NEWRELIC_ENABLE=false environment variable or modify the #{env.inspect} section of your newrelic.yml.")
+        Agent.logger.info("To prevent agent startup add a NEWRELIC_AGENT_ENABLED=false environment variable or modify the #{env.inspect} section of your newrelic.yml.")
 
         yaml = Agent::Configuration::YamlSource.new(@config_file_path, env)
         Agent.config.replace_or_add_config(yaml, 1)


### PR DESCRIPTION
In turns out that the documentation in https://docs.newrelic.com/docs/ruby/forcing-the-ruby-agent-to-start and the logs are referring to the non-working environment variable `NEWRELIC_ENABLE`. However, from my own testing and from "lib/new_relic/control/instance_methods.rb" line 76, it seems that the correct var is `NEWRELIC_AGENT_ENABLED`.
