### PR TITLE
Made Rails presence check more defensive

### DIFF
--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -55,7 +55,7 @@ module NewRelic
             case
             when defined?(::NewRelic::TEST) then :test
             when defined?(::Merb) && defined?(::Merb::Plugins) then :merb
-            when defined?(::Rails)
+            when defined?(::Rails::VERSION)
               case Rails::VERSION::MAJOR
               when 0..2
                 :rails

--- a/lib/newrelic_rpm.rb
+++ b/lib/newrelic_rpm.rb
@@ -32,7 +32,7 @@ if defined?(Merb) && defined?(Merb::BootLoader)
       end
     end
   end
-elsif defined? Rails
+elsif defined?(Rails::VERSION)
   if Rails::VERSION::MAJOR.to_i >= 3
     module NewRelic
       class Railtie < Rails::Railtie

--- a/test/new_relic/control_test.rb
+++ b/test/new_relic/control_test.rb
@@ -23,14 +23,14 @@ class NewRelic::ControlTest < Minitest::Test
 
   def test_root
     assert File.directory?(NewRelic::Control.newrelic_root), NewRelic::Control.newrelic_root
-    if defined?(Rails)
+    if defined?(Rails::VERSION)
       assert File.directory?(File.join(NewRelic::Control.newrelic_root, "lib")), NewRelic::Control.newrelic_root +  "/lib"
     end
   end
 
   def test_info
     NewRelic::Agent.manual_start
-    if defined?(Rails)
+    if defined?(Rails::VERSION)
       assert_match /jdbc|postgres|mysql|sqlite/, NewRelic::EnvironmentReport.new["Database adapter"]
     end
   end


### PR DESCRIPTION
It will be safer to check for the presence of pair Rails and VERSION constants, so newrelic gem will not crash applications which have only a Rails module, not Rails itself.
