### PR TITLE
Allow sinatra apps to set the newrelic environment independently of RACK_ENV

### DIFF
--- a/lib/new_relic/control/frameworks/sinatra.rb
+++ b/lib/new_relic/control/frameworks/sinatra.rb
@@ -11,7 +11,7 @@ module NewRelic
       class Sinatra < NewRelic::Control::Frameworks::Ruby
 
         def env
-          @env ||= ENV['NEWRELIC_ENV'] || ENV['RACK_ENV'] || ENV['RAILS_ENV'] || 'development'
+          @env ||= ENV['NEW_RELIC_ENV'] || ENV['RACK_ENV'] || ENV['RAILS_ENV'] || 'development'
         end
 
         def init_config(options={})


### PR DESCRIPTION
I am developing a Padrino/Sinatra app that runs in unicorn, where RACK_ENV is supposed to be 'development', 'deployment' or 'none'. (See [unicorn manpage](http://manpages.ubuntu.com/manpages/raring/man1/unicorn.1.html#contenttoc8)).

Then I have no way to use a different environment variable to load the `newrelic.yml` file in the right environment.

Also, some other Padrino apps use `ENV['PADRINO_ENV']` for configuration.

With this change it would be easy to assign any trivial environment if it needs to, for example:

``` ruby
ENV['NEWRELIC_ENV'] = ENV['PADRINO_ENV']
require 'newrelic_rpm' # will load newrelic.yml with the PADRINO_ENV environment
```
