### PR TITLE
Fix some inconsistencies with logging the Rails version.

### DIFF
--- a/lib/new_relic/agent/instrumentation/rails3/errors.rb
+++ b/lib/new_relic/agent/instrumentation/rails3/errors.rb
@@ -34,7 +34,7 @@ DependencyDetection.defer do
   end
 
   executes do
-    ::NewRelic::Agent.logger.info 'Installing Rails3 Error instrumentation'
+    ::NewRelic::Agent.logger.info 'Installing Rails 3 Error instrumentation'
   end
 
   executes do

--- a/lib/new_relic/agent/instrumentation/rails4/errors.rb
+++ b/lib/new_relic/agent/instrumentation/rails4/errors.rb
@@ -33,7 +33,7 @@ DependencyDetection.defer do
   end
 
   executes do
-    ::NewRelic::Agent.logger.info 'Installing Rails4 Error instrumentation'
+    ::NewRelic::Agent.logger.info 'Installing Rails 4 Error instrumentation'
   end
 
   executes do


### PR DESCRIPTION
Most of the logging [refers to 'Rails 3' and 'Rails 4'](http://cl.ly/WWie), whereas the
`errors.rb` files would print 'Rails3' and 'Rails4'. A minor fix, but a good one (if you ask me).
