### PR TITLE
Adjust rails 4 rake task

### DIFF
--- a/install.rb
+++ b/install.rb
@@ -2,7 +2,7 @@
 # This file is distributed under New Relic's license terms.
 # See https://github.com/newrelic/rpm/blob/master/LICENSE for complete details.
 
-if __FILE__ == $0 || $0 =~ /script\/plugin/
+if __FILE__ == $0 || $0 =~ /script\/plugin/ || File.basename($0) == 'rake'
   $LOAD_PATH << File.expand_path(File.join(File.dirname(__FILE__), 'lib'))
   require 'new_relic/cli/command'
   begin


### PR DESCRIPTION
`bin/rake newrelic:install` does not work.
[lib/tasks/install.rake](https://github.com/newrelic/rpm/blob/04640bb21110aa43503140bb7ef99a2587bbd84f/lib/tasks/install.rake)  calls [install.rb](https://github.com/newrelic/rpm/blob/04640bb21110aa43503140bb7ef99a2587bbd84f/install.rb), but this does not meet [the condition](https://github.com/newrelic/rpm/blob/04640bb21110aa43503140bb7ef99a2587bbd84f/install.rb#L5).

This is my `__FILE__` and `$0`:

```
(byebug)  __FILE__
"/Users/sane/.anyenv/envs/rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/newrelic_rpm-3.9.0.229/install.rb"
(byebug) $0
"/Users/sane/.anyenv/envs/rbenv/versions/2.1.2/bin/rake"
```

I add `bin/rake`, Any suggestions?

My env:

```
Bundler 1.6.2
Ruby 2.1.2 (2014-05-08 patchlevel 95) [x86_64-darwin13.0]
Rubygems 2.2.2
newrelic_rpm (3.9.0.229)
rake (10.3.2)
rails (4.1.4)
```
