### PR TITLE
Allow to change logger formatter.

### DIFF
--- a/lib/new_relic/agent/agent_logger.rb
+++ b/lib/new_relic/agent/agent_logger.rb
@@ -172,6 +172,10 @@ module NewRelic
       def gather_startup_logs
         StartupLogger.instance.dump(self)
       end
+
+      def log_formatter=(formatter)
+        @log.formatter = formatter
+      end
     end
 
     # In an effort to not lose messages during startup, we trap them in memory

--- a/test/new_relic/agent/agent_logger_test.rb
+++ b/test/new_relic/agent/agent_logger_test.rb
@@ -337,6 +337,17 @@ class AgentLoggerTest < Minitest::Test
     )
   end
 
+  def test_can_overwrite_log_formatter
+    log_message   = 'How are you?'
+    log_formatter = Proc.new { |s, t, p, m| m.reverse }
+
+    logger = create_basic_logger
+    logger.log_formatter = log_formatter
+    logger.warn log_message
+
+    assert_logged log_message.reverse
+  end
+
   #
   # Helpers
   #


### PR DESCRIPTION
In Heroku, logging time are provided by logplex(?).
so I want to remove datetime as like `07/28/14 06:57:45 +0000` from newrelic agent logging.

```
2014-07-28T06:57:45.391666+00:00 app[web.1]: ** [NewRelic][07/28/14 06:57:45 +0000 web.1 (2)] INFO : Starting the New Relic agent in "production" environment.
2014-07-28T06:57:45.391678+00:00 app[web.1]: ** [NewRelic][07/28/14 06:57:45 +0000 web.1 (2)] INFO : To prevent agent startup add a NEWRELIC_AGENT_ENABLED=false environment variable or modify the "production" section of your newrelic.yml.
2014-07-28T06:57:45.391714+00:00 app[web.1]: ** [NewRelic][07/28/14 06:57:45 +0000 web.1 (2)] INFO : Reading configuration from config/newrelic.yml
2014-07-28T06:57:45.395774+00:00 app[web.1]: ** [NewRelic][07/28/14 06:57:45 +0000 web.1 (2)] INFO : Environment: production
```
