### PR TITLE
Fixes multiple newrelic deploy notifications

### DIFF
--- a/lib/new_relic/recipes/capistrano3.rb
+++ b/lib/new_relic/recipes/capistrano3.rb
@@ -9,7 +9,7 @@ namespace :newrelic do
   # notifies New Relic of a deployment
   desc "Record a deployment in New Relic (newrelic.com)"
   task :notice_deployment do
-    on roles(:app) do
+    run_locally do
       rails_env = fetch(:newrelic_rails_env, fetch(:rails_env, "production"))
 
       require 'new_relic/cli/command.rb'


### PR DESCRIPTION
The use of `on roles(:app)` here is unnecessary. The body of this block doesn't actually include any `execute`, `upload`, or `capture` commands, and thus doesn't actually ever execute on the remote servers. What happens instead is for every `:app` server you have, you locally notify NewRelic of the deployment, resulting in N-1 duplicate notifications for N app servers.

I simply changed this `run_locally` which is intended for locally executing code. This way you get at most one deployment notification.
