### PR TITLE
Fix invalid variable name

### DIFF
--- a/lib/new_relic/agent/configuration/yaml_source.rb
+++ b/lib/new_relic/agent/configuration/yaml_source.rb
@@ -89,7 +89,7 @@ module NewRelic
         def process_yaml(file, env, config)
           if file
             confighash = with_yaml_engine { YAML.load(file) }
-            ::NewRelic::Agent.logger.error("Config (#{path}) doesn't include a '#{env}' environment!") unless confighash.key?(env)
+            ::NewRelic::Agent.logger.error("Config (#{file}) doesn't include a '#{env}' environment!") unless confighash.key?(env)
 
             config = confighash[env] || {}
           end


### PR DESCRIPTION
When an environment is not included in a config the following error is printed in newrelic.log:

```
NameError: undefined local variable or method `path' for #<NewRelic::Agent::Configuration::YamlSource:74268300 {}>
```
