### PR TITLE
Check if the rack_env is set

### DIFF
--- a/lib/new_relic/recipes/capistrano3.rb
+++ b/lib/new_relic/recipes/capistrano3.rb
@@ -10,7 +10,7 @@ namespace :newrelic do
   desc "Record a deployment in New Relic (newrelic.com)"
   task :notice_deployment do
     run_locally do
-      rails_env = fetch(:newrelic_rails_env, fetch(:rails_env, "production"))
+      environment = fetch(:newrelic_rails_env, fetch(:rack_env, fetch(:rails_env, "production")))
 
       require 'new_relic/cli/command.rb'
 
@@ -30,7 +30,7 @@ namespace :newrelic do
 
         new_revision = rev
         deploy_options = {
-          :environment => rails_env,
+          :environment => environment,
           :revision    => new_revision,
           :changelog   => changelog,
           :description => description,


### PR DESCRIPTION
I have a rack app build with ruby, it does not make sens for me to add set the `rails_env`. The same applies for my other apps that are not build on top of rails. I propose checking for the `rack_env` first.
