### PR TITLE
Add support for Resque Pool when started via Rake task

### DIFF
--- a/lib/new_relic/local_environment.rb
+++ b/lib/new_relic/local_environment.rb
@@ -146,14 +146,10 @@ module NewRelic
     end
 
     def check_for_resque
-      using_resque = (
-        defined?(::Resque) &&
-        (ENV['QUEUE'] || ENV['QUEUES']) &&
-        (File.basename($0) == 'rake' && ARGV.include?('resque:work'))
-      ) || (
-        defined?(::Resque::Pool) &&
-        (File.basename($0) == 'resque-pool')
-      )
+      using_resque = defined?(::Resque) &&
+        ((ENV['QUEUE'] || ENV['QUEUES']) && (File.basename($0) == 'rake' && ARGV.include?('resque:work'))) ||
+        (defined?(::Resque::Pool) && File.basename($0) == 'resque-pool') ||
+        (File.basename($0) == 'rake' && ARGV.include?('resque:pool'))
 
       @discovered_dispatcher = :resque if using_resque
     end


### PR DESCRIPTION
When [Resque Pool is started through a rake task](https://github.com/nevans/resque-pool#other-features), NewRelic's RPM local environment inspection is [failing to configure the `:resque` detector](https://github.com/newrelic/rpm/blob/master/lib/new_relic/local_environment.rb#L154-L156).

Here's an attempt of making best effort a little bit better ;)
