### PR TITLE
do not wrap middleware proxy if target is a Proc

### DIFF
--- a/lib/new_relic/agent/instrumentation/middleware_proxy.rb
+++ b/lib/new_relic/agent/instrumentation/middleware_proxy.rb
@@ -41,7 +41,8 @@ module NewRelic
         def self.needs_wrapping?(target)
           (
             !target.respond_to?(:_nr_has_middleware_tracing) &&
-            !is_sinatra_app?(target)
+            !is_sinatra_app?(target) &&
+            !target.is_a?(Proc)
           )
         end
 


### PR DESCRIPTION
Grape will add an endpoint with Proc object, but on newrelic we always see Proc#call as transaction name

https://github.com/xinminlabs/newrelic-grape/issues/17

After digging rpm source code, I found it's MiddlewareProxy which adds Proc#call transaction to newrelic, but which is unnecessary.

I overridden MiddlewareProxy.needs_wrapping? method, https://github.com/xinminlabs/newrelic-grape/blob/master/lib/newrelic-grape/instrument.rb#L62, return false if target is a Proc object, if you could merge this pull request, then I can remove the monkey patch from newrelic-grape
