### PR TITLE
Replace single quotes with double quotes in doc example

### DIFF
--- a/lib/new_relic/agent/method_tracer.rb
+++ b/lib/new_relic/agent/method_tracer.rb
@@ -287,7 +287,7 @@ module NewRelic
         # metric associated with the call, so if you want to use interpolation
         # evaluated at call time, then single quote the value like this:
         #
-        #     add_method_tracer :foo, 'Custom/#{self.class.name}/foo'
+        #     add_method_tracer :foo, "Custom/#{self.class.name}/foo"
         #
         # This would name the metric according to the class of the runtime
         # intance, as opposed to the class where +foo+ is defined.
@@ -316,7 +316,7 @@ module NewRelic
         #   add_method_tracer :foo
         #
         #   # With a custom metric name
-        #   add_method_tracer :foo, 'Custom/#{self.class.name}/foo'
+        #   add_method_tracer :foo, "Custom/#{self.class.name}/foo"
         #
         #   # Instrument foo only for custom dashboards (not in transaction
         #   # traces or breakdown charts)


### PR DESCRIPTION
Ruby doesn't interpolate in single quotes
