### PR TITLE
Do not shutdown Agent after performing if Resque forks are disabled.

### DIFF
--- a/lib/new_relic/agent/instrumentation/resque.rb
+++ b/lib/new_relic/agent/instrumentation/resque.rb
@@ -41,7 +41,8 @@ DependencyDetection.defer do
               end
             ensure
               NewRelic::Agent.shutdown if NewRelic::LanguageSupport.can_fork? &&
-                                          (!Resque.respond_to?(:inline) || !Resque.inline)
+                                          (!Resque.respond_to?(:inline) || !Resque.inline) &&
+                                          ENV['FORK_PER_JOB'] != 'false'
             end
           end
         end

--- a/test/multiverse/suites/resque/instrumentation_test.rb
+++ b/test/multiverse/suites/resque/instrumentation_test.rb
@@ -70,6 +70,14 @@ class ResqueTest < Minitest::Test
     assert NewRelic::Agent.instance.started?
   end
 
+  def test_agent_still_running_after_non_forked_job
+    fork_per_job = ENV['FORK_PER_JOB']
+    ENV['FORK_PER_JOB'] = 'false'
+    run_jobs
+    assert NewRelic::Agent.instance.started?
+    ENV['FORK_PER_JOB'] = fork_per_job
+  end
+
   def test_doesnt_capture_args_by_default
     run_jobs
     assert_no_params_on_jobs


### PR DESCRIPTION
If `ENV['FORK_PER_JOB'] = 'false'`, Resque does not fork to perform each job. The existing behavior ensures that the Agent is shut down after performing each job. This causes Resque workers to report data for one job after starting up, and then ignore the rest until the workers are restarted again.

This change just adds a check to make sure that the Agent is not shut down in this situation, just like when `Resque.inline` is enabled.

This started out as an issue on the community forums:
https://discuss.newrelic.com/t/new-relic-agent-not-reporting-from-resque-worker/7800
