### PR TITLE
Renamed TransactionNamer.name class method.

### DIFF
--- a/lib/new_relic/agent/instrumentation/controller_instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/controller_instrumentation.rb
@@ -213,7 +213,7 @@ module NewRelic
         end
 
         class TransactionNamer
-          def self.name(txn, traced_obj, category, options={})
+          def self.txn_name(txn, traced_obj, category, options={})
             "#{prefix_for_category(txn, category)}#{path_name(traced_obj, options)}"
           end
 
@@ -354,7 +354,7 @@ module NewRelic
 
           category    = trace_options[:category] || :controller
           txn_options = create_transaction_options(trace_options, available_params)
-          txn_options[:transaction_name] = TransactionNamer.name(nil, self, category, trace_options)
+          txn_options[:transaction_name] = TransactionNamer.txn_name(nil, self, category, trace_options)
           txn_options[:apdex_start_time] = detect_queue_start_time(state)
 
           begin

--- a/test/new_relic/agent/instrumentation/controller_instrumentation_test.rb
+++ b/test/new_relic/agent/instrumentation/controller_instrumentation_test.rb
@@ -145,53 +145,53 @@ module NewRelic::Agent::Instrumentation
 
     def test_transaction_name_calls_newrelic_metric_path
       @object.stubs(:newrelic_metric_path).returns('some/wacky/path')
-      assert_equal('Controller/some/wacky/path', @txn_namer.name(nil, @object, :controller))
+      assert_equal('Controller/some/wacky/path', @txn_namer.txn_name(nil, @object, :controller))
     end
 
     def test_transaction_name_applies_category_and_path
       assert_equal('Controller/metric/path',
-                   @txn_namer.name(nil,
-                                   @object,
-                                   :controller,
-                                   :path => 'metric/path'))
+                   @txn_namer.txn_name(nil,
+                                       @object,
+                                       :controller,
+                                       :path => 'metric/path'))
       assert_equal('OtherTransaction/Background/metric/path',
-                   @txn_namer.name(nil,
-                                   @object,
-                                   :task,
-                                   :path => 'metric/path'))
+                   @txn_namer.txn_name(nil,
+                                       @object,
+                                       :task,
+                                       :path => 'metric/path'))
       assert_equal('Controller/Rack/metric/path',
-                   @txn_namer.name(nil,
-                                   @object,
-                                   :rack,
-                                   :path => 'metric/path'))
+                   @txn_namer.txn_name(nil,
+                                       @object,
+                                       :rack,
+                                       :path => 'metric/path'))
       assert_equal('Controller/metric/path',
-                   @txn_namer.name(nil,
-                                   @object,
-                                   :uri,
-                                   :path => 'metric/path'))
+                   @txn_namer.txn_name(nil,
+                                       @object,
+                                       :uri,
+                                       :path => 'metric/path'))
       assert_equal('Controller/Sinatra/metric/path',
-                   @txn_namer.name(nil,
-                                   @object,
-                                   :sinatra,
-                                   :path => 'metric/path'))
+                   @txn_namer.txn_name(nil,
+                                       @object,
+                                       :sinatra,
+                                       :path => 'metric/path'))
       assert_equal('Blarg/metric/path',
-                   @txn_namer.name(nil,
-                                   @object,
-                                   'Blarg',
-                                   :path => 'metric/path'))
+                   @txn_namer.txn_name(nil,
+                                       @object,
+                                       'Blarg',
+                                       :path => 'metric/path'))
     end
 
     def test_transaction_name_uses_class_name_if_path_not_specified
       assert_equal('Controller/NewRelic::Agent::Instrumentation::ControllerInstrumentationTest::TestObject',
-                   @txn_namer.name(nil, @object, :controller))
+                   @txn_namer.txn_name(nil, @object, :controller))
     end
 
     def test_transaction_name_applies_action_name_if_specified_and_not_path
       assert_equal('Controller/NewRelic::Agent::Instrumentation::ControllerInstrumentationTest::TestObject/action',
-                     @txn_namer.name(nil,
-                                     @object,
-                                     :controller,
-                                     :name => 'action'))
+                     @txn_namer.txn_name(nil,
+                                         @object,
+                                         :controller,
+                                         :name => 'action'))
     end
 
     def test_transaction_path_name


### PR DESCRIPTION
The TransactionNamer class is rather poorly-behaved; it overrides the built-in `name` method with something completely different, thus preventing anyone from asking the class object what it's called. Observe:

```
1.9.3-p484 :001 > String.name
 => "String" 
1.9.3-p484 :002 > NewRelic.name
 => "NewRelic" 
1.9.3-p484 :003 > NewRelic::Agent::Instrumentation::ControllerInstrumentation::TransactionNamer.name
ArgumentError: wrong number of arguments (0 for 3)
```

Not a hypothetical problem; it bit me while I was instrumenting classes to find a memory leak. The fix is simple -- just rename the method.
