### PR TITLE
Subtract request buffering from queue time

### DIFF
--- a/lib/new_relic/agent/instrumentation/action_controller_subscriber.rb
+++ b/lib/new_relic/agent/instrumentation/action_controller_subscriber.rb
@@ -91,7 +91,7 @@ module NewRelic
 
         def queue_start(request)
           if request && request.respond_to?(:env)
-            QueueTime.parse_frontend_timestamp(request.env, Time.now)
+            QueueTime.frontend_timestamp(request.env, Time.now)
           end
         end
       end

--- a/lib/new_relic/agent/instrumentation/controller_instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/controller_instrumentation.rb
@@ -462,7 +462,7 @@ module NewRelic
         def detect_queue_start_time(request)
           headers = newrelic_request_headers(request)
 
-          QueueTime.parse_frontend_timestamp(headers) if headers
+          QueueTime.frontend_timestamp(headers) if headers
         end
       end
     end

--- a/lib/new_relic/agent/instrumentation/middleware_tracing.rb
+++ b/lib/new_relic/agent/instrumentation/middleware_tracing.rb
@@ -39,7 +39,7 @@ module NewRelic
         end
 
         def merge_first_middleware_options(opts, env)
-          opts[:apdex_start_time] = QueueTime.parse_frontend_timestamp(env)
+          opts[:apdex_start_time] = QueueTime.frontend_timestamp(env)
           # this case is for the rare occasion that an app is using Puma::Rack
           # without having ::Rack as a dependency
           opts[:request] = ::Rack::Request.new(env) if defined? ::Rack


### PR DESCRIPTION
Follow up from https://github.com/newrelic/rpm/issues/342

- When enabled, this will subtract time spent waiting for the HTTP request body to be received from the queue time.
- Enabled with config `queue_time_subtract_buffering` set to true.
- Currently only supported for Puma.
- Other common Ruby web servers don't expose buffering time.

If we adjust the queue time within `QueueTime`, then it will update queue time, response time, and the apdex calculation.  Please let me know what should be changed.  When we figure out the implementation, then I can update and add tests.  Thank you!

Here's some info on common Ruby web servers:

### Webrick
Webrick doesn't buffer large requests.  I also didn't see any passed headers that log the buffering time.

### Thin
Thin can buffer large requests but I didn't see any passed headers that log buffering time.

### Unicorn
I didn't see any passed headers that log buffering time.  It looks like it's recommended to use with nginx to buffer requests.  I don't know nginx but wondering if it's possible set a header when a request has finish buffering so we could calculate here what the buffering time is.

### Phusion Passenger
Phusion Passenger also uses nginx.  I didn't see any headers logging the request buffer time.  Also wondering if it would be possible to set a header in nginx when a request has completed buffering so we could then calculate the buffering time here.