### PR TITLE
Prevent connecting agent thread from hanging on shutdown

### DIFF
--- a/lib/new_relic/agent/agent.rb
+++ b/lib/new_relic/agent/agent.rb
@@ -953,6 +953,10 @@ module NewRelic
         rescue NewRelic::Agent::UnrecoverableAgentException => e
           handle_unrecoverable_agent_error(e)
         rescue StandardError, Timeout::Error, NewRelic::Agent::ServerConnectionException => e
+          # Allow a killed (aborting) thread to continue exiting during shutdown.
+          # See: https://github.com/newrelic/newrelic-ruby-agent/issues/340
+          raise if Thread.current.status == 'aborting'
+
           log_error(e)
           if opts[:keep_retrying]
             note_connect_failure


### PR DESCRIPTION
# Overview

A bug in `Net::HTTP`'s Gzip decoder can cause the (un-catchable) thread-kill exception to be replaced with a (catchable) `Zlib` exception, which prevents a connecting agent thread from exiting during shutdown, causing the Ruby process to hang indefinitely.

This workaround checks for an 'aborting' thread in the #connect exception handler and re-raises the exception, allowing a killed thread to continue exiting.

# Related Github Issue

Fixes #340.

# See also:
https://bugs.ruby-lang.org/issues/13882#note-4

# Testing
Includes a test (failing on `main`, passing on this PR) that minimally reproduces the issue described in https://github.com/newrelic/newrelic-ruby-agent/issues/340#issuecomment-661304946.