### PR TITLE
removed all versions of ruby except 2.6 for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,15 +50,7 @@ branches:
 
 rvm:
   # Run slowest builds first to try and optimize overall cycle time.
-  - jruby-9.2.6.0
-  - 2.7.0
   - 2.6.1
-  - 2.5.3
-  - 2.4.2
-  - 2.3.5
-  - 2.2.8
-  - 2.1.10
-  - 2.0.0-p648
 
 jdk:
   - oraclejdk8
@@ -99,50 +91,8 @@ env:
     - TYPE=NULLVERSE
 
 matrix:
-  allow_failures:
-    - rvm: jruby-9.2.6.0
-      env: TYPE=FUNCTIONAL GROUP=agent
   fast_finish: true
   exclude:
-    # Unsupported Rails/Ruby combinations
-    # 2.7
-    - rvm: 2.7.0
-      env: TYPE=UNIT ENVIRONMENT=rails30
-    - rvm: 2.7.0
-      env: TYPE=UNIT ENVIRONMENT=rails31
-    - rvm: 2.7.0
-      env: TYPE=UNIT ENVIRONMENT=rails32
-    - rvm: 2.7.0
-      env: TYPE=UNIT ENVIRONMENT=rails40
-    - rvm: 2.7.0
-      env: TYPE=UNIT ENVIRONMENT=rails41
-
-    - rvm: 2.7.0
-      env: TYPE=UNIT ENVIRONMENT=rails42  # rails (= 4.2.11) depends on bundler (< 2.0, >= 1.3.0)
-    - rvm: 2.7.0
-      env: TYPE=UNIT ENVIRONMENT=rails50  # rails (= 5.0.0) depends on bundler (< 2.0, >= 1.3.0)
-    - rvm: 2.7.0
-      env: TYPE=UNIT ENVIRONMENT=rails51  # rails (= 5.1.0) depends on bundler (< 2.0, >= 1.3.0)
-    - rvm: 2.7.0
-      env: TYPE=UNIT ENVIRONMENT=rails52  # rails (= 5.2.0) depends on bundler (< 2.0, >= 1.3.0)
-    - rvm: 2.7.0
-      env: TYPE=FUNCTIONAL GROUP=api      # blocked: https://github.com/solnic/coercible/issues/27
-    - rvm: 2.7.0
-      env: TYPE=FUNCTIONAL GROUP=sinatra  # padrino (~> 0.14.0) depends on bundler (~> 1.0)
-
-    - rvm: 2.7.0
-      env: TYPE=UNIT ENVIRONMENT=rails42  # rails (= 4.2.11) depends on bundler (< 2.0, >= 1.3.0)
-    - rvm: 2.7.0
-      env: TYPE=UNIT ENVIRONMENT=rails50  # rails (= 5.0.0) depends on bundler (< 2.0, >= 1.3.0)
-    - rvm: 2.7.0
-      env: TYPE=UNIT ENVIRONMENT=rails51  # rails (= 5.1.0) depends on bundler (< 2.0, >= 1.3.0)
-    - rvm: 2.7.0
-      env: TYPE=UNIT ENVIRONMENT=rails52  # rails (= 5.2.0) depends on bundler (< 2.0, >= 1.3.0)
-    - rvm: 2.7.0
-      env: TYPE=FUNCTIONAL GROUP=api      # blocked: https://github.com/solnic/coercible/issues/27
-    - rvm: 2.7.0
-      env: TYPE=FUNCTIONAL GROUP=sinatra  # padrino (~> 0.14.0) depends on bundler (~> 1.0)
-
     # 2.6
     - rvm: 2.6.1
       env: TYPE=UNIT ENVIRONMENT=rails30
@@ -154,87 +104,3 @@ matrix:
       env: TYPE=UNIT ENVIRONMENT=rails40
     - rvm: 2.6.1
       env: TYPE=UNIT ENVIRONMENT=rails41
-
-    # 2.5
-    - rvm: 2.5.3
-      env: TYPE=UNIT ENVIRONMENT=rails30
-    - rvm: 2.5.3
-      env: TYPE=UNIT ENVIRONMENT=rails31
-    - rvm: 2.5.3
-      env: TYPE=UNIT ENVIRONMENT=rails32
-    - rvm: 2.5.3
-      env: TYPE=UNIT ENVIRONMENT=rails40
-    - rvm: 2.5.3
-      env: TYPE=UNIT ENVIRONMENT=rails41
-
-    # 2.4
-    - rvm: 2.4.2
-      env: TYPE=UNIT ENVIRONMENT=rails30
-    - rvm: 2.4.2
-      env: TYPE=UNIT ENVIRONMENT=rails31
-    - rvm: 2.4.2
-      env: TYPE=UNIT ENVIRONMENT=rails32
-    - rvm: 2.4.2
-      env: TYPE=UNIT ENVIRONMENT=rails40
-    - rvm: 2.4.2
-      env: TYPE=UNIT ENVIRONMENT=rails41
-    - rvm: 2.4.2
-      env: TYPE=UNIT ENVIRONMENT=rails60
-
-    # 2.3
-    - rvm: 2.3.5
-      env: TYPE=UNIT ENVIRONMENT=rails60
-
-    # 2.2
-    - rvm: 2.2.8
-      env: TYPE=UNIT ENVIRONMENT=rails60
-
-    # 2.1
-    - rvm: 2.1.10
-      env: TYPE=UNIT ENVIRONMENT=rails50
-    - rvm: 2.1.10
-      env: TYPE=UNIT ENVIRONMENT=rails51
-    - rvm: 2.1.10
-      env: TYPE=UNIT ENVIRONMENT=rails52
-    - rvm: 2.1.10
-      env: TYPE=UNIT ENVIRONMENT=rails60
-
-    # 2.0
-    - rvm: 2.0.0-p648
-      env: TYPE=UNIT ENVIRONMENT=rails50
-    - rvm: 2.0.0-p648
-      env: TYPE=UNIT ENVIRONMENT=rails51
-    - rvm: 2.0.0-p648
-      env: TYPE=UNIT ENVIRONMENT=rails52
-    - rvm: 2.0.0-p648
-      env: TYPE=UNIT ENVIRONMENT=rails60
-
-    # jruby 9.2.6.0 (Compatible with MRI 2.5)
-    - rvm: jruby-9.2.6.0
-      env: TYPE=UNIT ENVIRONMENT=rails30
-    - rvm: jruby-9.2.6.0
-      env: TYPE=UNIT ENVIRONMENT=rails31
-    - rvm: jruby-9.2.6.0
-      env: TYPE=UNIT ENVIRONMENT=rails32
-    - rvm: jruby-9.2.6.0
-      env: TYPE=UNIT ENVIRONMENT=rails40
-    - rvm: jruby-9.2.6.0
-      env: TYPE=UNIT ENVIRONMENT=rails41
-    - rvm: jruby-9.2.6.0
-      env: TYPE=UNIT ENVIRONMENT=rails60
-    - rvm: jruby-9.2.6.0
-      env: TYPE=UNIT ENVIRONMENT=rails52
-
-    # Excluding unsupported Rubies for grpc
-    - rvm: 2.0.0-p648
-      env: TYPE=FUNCTIONAL GROUP=infinite_tracing
-    - rvm: 2.1.10
-      env: TYPE=FUNCTIONAL GROUP=infinite_tracing
-    - rvm: 2.2.8
-      env: TYPE=FUNCTIONAL GROUP=infinite_tracing
-    - rvm: 2.3.5
-      env: TYPE=FUNCTIONAL GROUP=infinite_tracing
-    - rvm: 2.4.2
-      env: TYPE=FUNCTIONAL GROUP=infinite_tracing
-    - rvm: jruby-9.2.6.0
-      env: TYPE=FUNCTIONAL GROUP=infinite_tracing


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
Removed all versions of ruby except one, 2.6, from the travis matrix. We're moving over to github actions right now and can decrease the resources used on travis.

# Related Github Issue
https://github.com/newrelic/newrelic-ruby-agent/issues/365
