### PR TITLE
Decrease allocations for span attributes

### DIFF
--- a/lib/new_relic/agent/transaction/segment.rb
+++ b/lib/new_relic/agent/transaction/segment.rb
@@ -17,12 +17,15 @@ module NewRelic
 
         def initialize name=nil, unscoped_metrics=nil, start_time=nil
           @unscoped_metrics = unscoped_metrics
-          @attributes = Attributes.new(NewRelic::Agent.instance.attribute_filter)
           super name, start_time
         end
 
+        def attributes
+          @attributes ||= Attributes.new(NewRelic::Agent.instance.attribute_filter)
+        end
+
         def add_agent_attribute(key, value, default_destinations=AttributeFilter::DST_SPAN_EVENTS)
-          @attributes.add_agent_attribute(key, value, default_destinations)
+          attributes.add_agent_attribute(key, value, default_destinations)
         end
 
         def self.merge_untrusted_agent_attributes(attributes, prefix, default_destinations)
@@ -33,8 +36,9 @@ module NewRelic
           end
         end
 
-        def merge_untrusted_agent_attributes(attributes, prefix, default_destinations)
-          @attributes.merge_untrusted_agent_attributes(attributes, prefix, default_destinations)
+        def merge_untrusted_agent_attributes(agent_attributes, prefix, default_destinations)
+          return if agent_attributes.nil?
+          attributes.merge_untrusted_agent_attributes(agent_attributes, prefix, default_destinations)
         end
 
         def add_custom_attributes(p)

--- a/lib/new_relic/agent/transaction/segment.rb
+++ b/lib/new_relic/agent/transaction/segment.rb
@@ -13,7 +13,7 @@ module NewRelic
         # unscoped_metrics can be nil, a string, or array. we do this to save
         # object allocations. if allocations weren't important then we would
         # initialize it as an array that would be empty, have one item, or many items.
-      attr_reader :unscoped_metrics, :attributes, :custom_transaction_attributes
+        attr_reader :unscoped_metrics, :custom_transaction_attributes
 
         def initialize name=nil, unscoped_metrics=nil, start_time=nil
           @unscoped_metrics = unscoped_metrics

--- a/test/performance/README.md
+++ b/test/performance/README.md
@@ -13,29 +13,6 @@ There are two main goals driving the development of this framework:
 
 ## Examples
 
-### Invoking via rake task
-
-Basic performance test invocations can be done using a rake task provided in the
-newrelic_rpm Rakefile.
-
-Run all performance tests, reporting results to the console:
-
-```
-$ rake test:performance
-```
-
-Run one specific suite:
-
-```
-$ rake test:performance[TransactionTracingPerfTests]
-```
-
-Run one specific suite and test (test name matching is via regex):
-
-```
-$ rake test:performance[TransactionTracingPerfTests,test_short_transactions]
-```
-
 ### Invoking via the runner directly
 
 More advanced options can be specified by invoking the runner script directly.

--- a/test/performance/README.md
+++ b/test/performance/README.md
@@ -13,6 +13,29 @@ There are two main goals driving the development of this framework:
 
 ## Examples
 
+### Invoking via rake task
+
+Basic performance test invocations can be done using a rake task provided in the
+newrelic_rpm Rakefile.
+
+Run all performance tests, reporting results to the console:
+
+```
+$ rake test:performance
+```
+
+Run one specific suite:
+
+```
+$ rake test:performance[TransactionTracingPerfTests]
+```
+
+Run one specific suite and test (test name matching is via regex):
+
+```
+$ rake test:performance[TransactionTracingPerfTests,test_short_transactions]
+```
+
 ### Invoking via the runner directly
 
 More advanced options can be specified by invoking the runner script directly.


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
Previously, our segments were always creating an attributes object in the initializer. Moving the creation of the attributes object to when it is actually being used decreased allocations by 21% in a basic middleware performance test.
Results:
```
+--------------------------------------------+-----------+-----------+-------+---------------+--------------+--------------+
| name                                       | before    | after     | delta | allocs_before | allocs_after | allocs_delta |
|--------------------------------------------+-----------+-----------+-------+---------------+--------------+--------------|
| RackMiddleware#test_basic_middleware_stack | 446.70 µs | 425.91 µs | -4.7% |           302 |          236 |       -21.9% |
+--------------------------------------------+-----------+-----------+-------+---------------+--------------+--------------+
```
