### PR TITLE
Fix test that fails when run in certain environments

### DIFF
--- a/test/multiverse/suites/agent_only/utilization_data_collection_test.rb
+++ b/test/multiverse/suites/agent_only/utilization_data_collection_test.rb
@@ -68,8 +68,12 @@ class UtilizationDataCollectionTest < Minitest::Test
     NewRelic::Agent::Utilization::GCP.any_instance.stubs(:detect).returns(false)
 
     # this will trigger the agent to connect and send utilization data
-    setup_agent
-
+    setup_agent({
+      'utilization.detect_aws': false,
+      'utilization.detect_gcp': false,
+      'utilization.detect_azure': false,
+      'utilization.detect_pcf': false
+    })
     assert_equal expected, single_connect_posted.utilization
   end
 


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
Previously, this test was failing in certain situations because it assumes there is no vendor information available in the environment. When the test runs in an environment where the information is available (like github actions), the test failed. This change ensures that no vendor information is gathered by the agent. 
