### PR TITLE
PR 359: Prevent reconnect attempts during shutdowns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # New Relic Ruby Agent Release Notes #
 
+  * **Prevent connecting agent thread from hanging on shutdown**
+
+    A bug in `Net::HTTP`'s Gzip decoder can cause the (un-catchable)
+    thread-kill exception to be replaced with a (catchable) `Zlib` exception,
+    which prevents a connecting agent thread from exiting during shutdown,
+    causing the Ruby process to hang indefinitely.
+    This workaround checks for an `aborting` thread in the `#connect` exception handler
+    and re-raises the exception, allowing a killed thread to continue exiting.
+  
+    Thanks to Will Jordan (@wjordan) for chasing this one down and patching with tests.
+
   * **Fix error messages about Rake instrumentation**
 
     When running a Rails application with rake tasks, customers could see the following error in logs resulting from

--- a/lib/new_relic/agent/agent.rb
+++ b/lib/new_relic/agent/agent.rb
@@ -953,6 +953,10 @@ module NewRelic
         rescue NewRelic::Agent::UnrecoverableAgentException => e
           handle_unrecoverable_agent_error(e)
         rescue StandardError, Timeout::Error, NewRelic::Agent::ServerConnectionException => e
+          # Allow a killed (aborting) thread to continue exiting during shutdown.
+          # See: https://github.com/newrelic/newrelic-ruby-agent/issues/340
+          raise if Thread.current.status == 'aborting'
+
           log_error(e)
           if opts[:keep_retrying]
             note_connect_failure

--- a/test/new_relic/agent/agent_test.rb
+++ b/test/new_relic/agent/agent_test.rb
@@ -745,14 +745,14 @@ module NewRelic
         Thread.new do
           # Write HTTP response with partial gzip content, leaving connection open.
           gzip = Zlib.gzip('Hello World!')
-          headers = <<~HTTP
-            HTTP/1.1 200
-            Content-Encoding: gzip
-            Content-Length: #{gzip.length}
-            #{gzip.byteslice(0..-2)}
-          HTTP
+          headers = [
+            "HTTP/1.1 200",
+            "Content-Encoding: gzip",
+            "Content-Length: #{gzip.length}",
+            gzip.byteslice(0..-2),
+        ].join("\r\n")
 
-          server.accept.write headers
+          server.accept.write headers.chomp
         end
 
         @agent.unstub(:start_worker_thread)

--- a/test/new_relic/agent/agent_test.rb
+++ b/test/new_relic/agent/agent_test.rb
@@ -745,13 +745,14 @@ module NewRelic
         Thread.new do
           # Write HTTP response with partial gzip content, leaving connection open.
           gzip = Zlib.gzip('Hello World!')
-          server.accept.write <<~HTTP.gsub("\n", "\r\n").chomp
+          headers = <<~HTTP
             HTTP/1.1 200
             Content-Encoding: gzip
             Content-Length: #{gzip.length}
-
             #{gzip.byteslice(0..-2)}
           HTTP
+
+          server.accept.write headers
         end
 
         @agent.unstub(:start_worker_thread)


### PR DESCRIPTION
Please see #359 for discussion on the original PR. Our CI is in a bit of an intermediate state right now as we migrate to GitHub actions, so we created a branch to make sure this passed our internal Travis CI, which it does. Reopening so we can continue to evaluate our options for fixing this issue.

Thank you again for your submission, @wjordan!