### PR TITLE
Check Rake::VERSION is defined before checking for supported versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,23 @@
 # New Relic Ruby Agent Release Notes #
 
+  * **Fix error messages about Rake instrumentation**
+
+    When running a Rails application with rake tasks, customers could see the following error in logs resulting from
+    a small part of rake functionality being loaded with the Rails test runner:
+
+    ```
+    ERROR : Error while detecting rake_instrumentation:
+    ERROR : NameError: uninitialized constant Rake::VERSION
+    ```
+
+    Such error messages should no longer appear in this context.
+
+    Thanks to @CamilleDrapier for pointing out this issue.
+
   ## v6.12.0
 
-  * The New Relic Ruby Agent is now open source under the [Apache 2 license](LICENSE) 
-    and you can now observe the project roadmap. See our [Contributing guide](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) 
+  * The New Relic Ruby Agent is now open source under the [Apache 2 license](LICENSE)
+    and you can now observe the project roadmap. See our [Contributing guide](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md)
     and [Code of Conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md) for details on contributing!
 
   * **Security: Updated all uses of Rake to >= 12.3.3**
@@ -11,32 +25,32 @@
     All versions of Rake testing prior to 12.3.3 were removed to address
     [CVE-2020-8130](https://nvd.nist.gov/vuln/detail/CVE-2020-8130).
     No functionality in the agent was removed nor deprecated with this change, and older versions
-    of rake are expected to continue to work as they have in the past.  However, versions of 
+    of rake are expected to continue to work as they have in the past.  However, versions of
     rake < 12.3.3 are no longer tested nor supported.
 
   * **Bugfix: fixes an error capturing content length in middleware on multi-part responses**
 
-    In the middleware tracing, the `Content-Length` header is sometimes returned as an array of 
-    values when content is a multi-part response.  Previously, the agent would fail with 
-    "NoMethodError: undefined method `to_i` for Array" Error.  This bug is now fixed and 
+    In the middleware tracing, the `Content-Length` header is sometimes returned as an array of
+    values when content is a multi-part response.  Previously, the agent would fail with
+    "NoMethodError: undefined method `to_i` for Array" Error.  This bug is now fixed and
     multi-part content lengths are summed for a total when an `Array` is present.
-    
+
   * **Added support for auto-instrumenting Mongo gem versions 2.6 to 2.12**
-  
+
   * **Bugfix: MongoDB instrumentation did not handle CommandFailed events when noticing errors**
 
     The mongo gem sometimes returns a CommandFailed object instead of a CommandSucceeded object with
     error attributes populated.  The instrumentation did not handle noticing errors on CommandFailed
     objects and resulted in logging an error and backtrace to the log file.
 
-    Additionally, a bug in recording the metric for "findAndModify" as all lowercased "findandmodify" 
+    Additionally, a bug in recording the metric for "findAndModify" as all lowercased "findandmodify"
     for versions 2.1 through 2.5 was fixed.
 
   * **Bugfix: Priority Sampler causes crash in high throughput environents in rare cases**
 
     Previously, the priority sampling buffer would, in rare cases, generate an error in high-throughput
     environments once capacity is reached and the sampling algorthym engages.  This issue is fixed.
-    
+
   * **Additional Transaction Information applied to Span Events**
 
     When Distributed Tracing and/or Infinite Tracing are enabled, the Agent will now incorporate additional information from the Transaction Event on to the root Span Event of the transaction.

--- a/lib/new_relic/agent/instrumentation/rake.rb
+++ b/lib/new_relic/agent/instrumentation/rake.rb
@@ -8,6 +8,7 @@ DependencyDetection.defer do
 
   depends_on do
     defined?(::Rake) &&
+      defined?(::Rake::VERSION) &&
       ::NewRelic::Agent.config[:'disable_rake'] == false &&
       ::NewRelic::Agent.config[:'rake.tasks'].any? &&
       ::NewRelic::Agent::Instrumentation::RakeInstrumentation.should_install?


### PR DESCRIPTION
# Overview
When running a Rails application with rake tasks, customers could see the following error:

```
ERROR : Error while detecting rake_instrumentation:
ERROR : NameError: uninitialized constant Rake::VERSION
```
This is because a very small piece of Rake is loaded with [the Rails test runner](https://github.com/rails/rails/blob/9734dfa1a1a2d5909652dcbb80947a92ce42c431/railties/lib/rails/test_unit/runner.rb#L5).

On this branch, we're checking to see if `Rake::VERSION` exists before going further with determining whether to install rake instrumentation. This does not seem to have any ill effects on our normal rake instrumentation.

# Related Github Issue
#338 - thanks to @CamilleDrapier for reporting this!

# Testing
Verified in my logs that the error does not appear, and there was no breakage of existing tests when run locally. Let me know, dear reviewer, if you'd like us to add a specific test for this.

Also, I manually tested that I could still see instrumented rake tasks with this fix in place, but I'd appreciate the reviewer double-checking that before merging.