### PR TITLE
Use System Certificates by default

### DIFF
--- a/lib/new_relic/agent/new_relic_service.rb
+++ b/lib/new_relic/agent/new_relic_service.rb
@@ -359,7 +359,7 @@ module NewRelic
           NewRelic::Agent.logger.warn("Couldn't find CA bundle from configured ca_bundle_path: #{path_override}") unless File.exist? path_override
           path_override
         else
-          Agent.record_metric("Supportability/Ruby/BundledCertsRequired", 0.0)
+          ::NewRelic::Agent.increment_metric("Supportability/Ruby/BundledCertsRequired")
           File.expand_path(File.join(control.newrelic_root, 'cert', 'cacert.pem'))
         end
       end

--- a/lib/new_relic/agent/new_relic_service.rb
+++ b/lib/new_relic/agent/new_relic_service.rb
@@ -359,7 +359,7 @@ module NewRelic
           NewRelic::Agent.logger.warn("Couldn't find CA bundle from configured ca_bundle_path: #{path_override}") unless File.exist? path_override
           path_override
         else
-          ::NewRelic::Agent.increment_metric("Supportability/Ruby/BundledCertsRequired")
+          ::NewRelic::Agent.increment_metric("Supportability/Ruby/Certificate/BundleRequired ")
           File.expand_path(File.join(control.newrelic_root, 'cert', 'cacert.pem'))
         end
       end

--- a/lib/new_relic/agent/new_relic_service.rb
+++ b/lib/new_relic/agent/new_relic_service.rb
@@ -292,6 +292,7 @@ module NewRelic
         conn.use_ssl     = true
         conn.verify_mode = OpenSSL::SSL::VERIFY_PEER
         if @use_bundled_certs || NewRelic::Agent.config[:ca_bundle_path]
+          Agent.record_metric("Supportability/Ruby/BundledCertsRequired", 0.0)
           conn.cert_store  = ssl_cert_store
         else
           ::NewRelic::Agent.logger.debug("Using default security certificates")

--- a/lib/new_relic/agent/new_relic_service.rb
+++ b/lib/new_relic/agent/new_relic_service.rb
@@ -291,14 +291,18 @@ module NewRelic
         # installed
         conn.use_ssl     = true
         conn.verify_mode = OpenSSL::SSL::VERIFY_PEER
+        set_cert_store(conn)
+      rescue StandardError, LoadError
+        msg = "SSL is not available in the environment; please install SSL support."
+        raise UnrecoverableAgentException.new(msg)
+      end
+
+      def set_cert_store(conn)
         if @use_bundled_certs || NewRelic::Agent.config[:ca_bundle_path]
           conn.cert_store  = ssl_cert_store
         else
           ::NewRelic::Agent.logger.debug("Using default security certificates")
         end
-      rescue StandardError, LoadError
-        msg = "SSL is not available in the environment; please install SSL support."
-        raise UnrecoverableAgentException.new(msg)
       end
 
       def start_connection(conn)

--- a/lib/new_relic/agent/new_relic_service.rb
+++ b/lib/new_relic/agent/new_relic_service.rb
@@ -292,7 +292,6 @@ module NewRelic
         conn.use_ssl     = true
         conn.verify_mode = OpenSSL::SSL::VERIFY_PEER
         if @use_bundled_certs || NewRelic::Agent.config[:ca_bundle_path]
-          Agent.record_metric("Supportability/Ruby/BundledCertsRequired", 0.0)
           conn.cert_store  = ssl_cert_store
         else
           ::NewRelic::Agent.logger.debug("Using default security certificates")
@@ -360,6 +359,7 @@ module NewRelic
           NewRelic::Agent.logger.warn("Couldn't find CA bundle from configured ca_bundle_path: #{path_override}") unless File.exist? path_override
           path_override
         else
+          Agent.record_metric("Supportability/Ruby/BundledCertsRequired", 0.0)
           File.expand_path(File.join(control.newrelic_root, 'cert', 'cacert.pem'))
         end
       end

--- a/lib/new_relic/agent/new_relic_service.rb
+++ b/lib/new_relic/agent/new_relic_service.rb
@@ -359,7 +359,7 @@ module NewRelic
           NewRelic::Agent.logger.warn("Couldn't find CA bundle from configured ca_bundle_path: #{path_override}") unless File.exist? path_override
           path_override
         else
-          ::NewRelic::Agent.increment_metric("Supportability/Ruby/Certificate/BundleRequired ")
+          ::NewRelic::Agent.increment_metric("Supportability/Ruby/Certificate/BundleRequired")
           File.expand_path(File.join(control.newrelic_root, 'cert', 'cacert.pem'))
         end
       end

--- a/lib/new_relic/agent/new_relic_service.rb
+++ b/lib/new_relic/agent/new_relic_service.rb
@@ -346,7 +346,7 @@ module NewRelic
         conn = create_http_connection
         start_connection(conn)
         conn
-      rescue Timeout::Error => e
+      rescue Timeout::Error
         if @use_bundled_certs == false
           ::NewRelic::Agent.logger.info("Unable to connect. Falling back to bundled security certificates")
           @use_bundled_certs = true

--- a/lib/new_relic/agent/new_relic_service.rb
+++ b/lib/new_relic/agent/new_relic_service.rb
@@ -294,7 +294,7 @@ module NewRelic
         if @use_bundled_certs || NewRelic::Agent.config[:ca_bundle_path]
           conn.cert_store  = ssl_cert_store
         else
-          ::NewRelic::Agent.logger.info("Using default security certificates")
+          ::NewRelic::Agent.logger.debug("Using default security certificates")
         end
       rescue StandardError, LoadError
         msg = "SSL is not available in the environment; please install SSL support."
@@ -344,7 +344,7 @@ module NewRelic
         conn
       rescue Timeout::Error => e
         if @use_bundled_certs == false
-          ::NewRelic::Agent.logger.debug("Unable to connect. Falling back to bundled security certificates")
+          ::NewRelic::Agent.logger.info("Unable to connect. Falling back to bundled security certificates")
           @use_bundled_certs = true
           retry 
         else


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
The ruby agent previously used a root SSL/TLS certificate bundle by default. Now the agent will attempt to use the default system certificate, but will fall back to the bundled cert if there is an issue (and log that this occurred). 


# Related Github Issue
Requirement for https://github.com/newrelic/newrelic-ruby-agent/issues/351

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
Github Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 
