### PR TITLE
Add issue template config to clarify troubleshooting tickets

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Troubleshooting
+    url:  https://github.com/newrelic/newrelic-ruby-agent#support
+    about: checkout the README for troubleshooting directions

--- a/.github/ISSUE_TEMPLATE/troubleshooting.md
+++ b/.github/ISSUE_TEMPLATE/troubleshooting.md
@@ -1,12 +1,5 @@
----
-name: Troubleshooting
-about: Troubleshooting and getting help
-title: ''
-labels: ''
-assignees: ''
+<!-- ⚠️⚠️STOP⚠️⚠️ -- PLEASE READ! -->
 
----
-
-We use GitHub to track feature requests and bug reports. Please do not submit issues for questions about how to configure, use features, troubleshoot, or best practices for using New Relic software.
+We use GitHub to track feature requests and bug reports. Please **do not** submit issues for questions about how to configure, use features, troubleshoot, or best practices for using New Relic software.
 
 See the README.md support section in this repository for more details on self-service troubleshooting tooling, links to our comprehensive documentation, and how to get further support.


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
Adding an issue template so that troubleshooting tickets are redirected to the appropriate places. When creating a ticket now there is no longer an option to create a troubleshooting ticket, instead it redirects them to the support section of our README. 