### PR TITLE
Add Retry to running tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,8 +124,12 @@ jobs:
       - name: Bundler install
         run: bundle install 
 
-      - name: rake test
-        run:  bundle exec rake test:env[${{ matrix.rails }}] TESTOPTS="--verbose"
+      - name: Run Unit Tests
+        uses: nick-invision/retry@v1.0.0
+        with:
+          timeout_minutes: 20
+          max_attempts: 2
+          command:  bundle exec rake test:env[${{ matrix.rails }}] TESTOPTS="--verbose"
         env:
           DB_PORT: 3306
           MYSQL_PASSWORD: root
@@ -192,8 +196,12 @@ jobs:
       - name: Start mysql
         run: sudo systemctl start mysql
 
-      - name: Run unit tests
-        run: bundle exec rake test:multiverse[group=${{ matrix.multiverse }},verbose]
+      - name: Run Multiverse Tests
+        uses: nick-invision/retry@v1.0.0
+        with:
+          timeout_minutes: 20
+          max_attempts: 2
+          command:  bundle exec rake test:multiverse[group=${{ matrix.multiverse }},verbose]
         env:
           DB_PORT: 3306
           MYSQL_PASSWORD: root

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,7 +199,7 @@ jobs:
       - name: Run Multiverse Tests
         uses: nick-invision/retry@v1.0.0
         with:
-          timeout_minutes: 20
+          timeout_minutes: 30
           max_attempts: 2
           command:  bundle exec rake test:multiverse[group=${{ matrix.multiverse }},verbose]
         env:

--- a/.github/workflows/infinite_tracing_tests.yml
+++ b/.github/workflows/infinite_tracing_tests.yml
@@ -8,7 +8,6 @@ on:
   pull_request:
 
 jobs:
-  if: false
   infinite-tracing:
     runs-on: ubuntu-latest
     strategy:
@@ -26,6 +25,9 @@ jobs:
       - name: Bundler install
         run: bundle install
 
-      - name: rake test
-        run: bundle exec rake test:multiverse[group=infinite_tracing,verbose]
-  
+      - name: Run Infinite Tracing Tests
+        uses: nick-invision/retry@v1.0.0
+        with:
+          timeout_minutes: 20
+          max_attempts: 3
+          command:  bundle exec rake test:multiverse[group=infinite_tracing,verbose]

--- a/.github/workflows/infinite_tracing_tests.yml
+++ b/.github/workflows/infinite_tracing_tests.yml
@@ -29,5 +29,5 @@ jobs:
         uses: nick-invision/retry@v1.0.0
         with:
           timeout_minutes: 20
-          max_attempts: 3
+          max_attempts: 4
           command:  bundle exec rake test:multiverse[group=infinite_tracing,verbose]

--- a/.github/workflows/pr_review_checklist.yml
+++ b/.github/workflows/pr_review_checklist.yml
@@ -1,5 +1,5 @@
 name: PR Review Checklist
-on: pull_request_target
+on: pull_request
 jobs:
   sidekick_checklist:
     name: 

--- a/.github/workflows/pr_review_checklist.yml
+++ b/.github/workflows/pr_review_checklist.yml
@@ -2,7 +2,7 @@ name: PR Review Checklist
 
 on: 
   pull_request:
-    types: opened
+    types: [opened]
 
 jobs:
   sidekick_checklist:

--- a/.github/workflows/pr_review_checklist.yml
+++ b/.github/workflows/pr_review_checklist.yml
@@ -1,5 +1,9 @@
 name: PR Review Checklist
-on: pull_request
+
+on: 
+  pull_request:
+    types: opened
+
 jobs:
   sidekick_checklist:
     name: 


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
Infinite tracing tests have frequent intermittent failures that cause our CI to be a bit rocky. The main agent also has some less frequent intermittent failures. Retrying the test runs when failing will help weed out the intermittent failures from true failures. 