### PR TITLE
Close stale issues and pull requests

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,21 @@
+name: "Close stale issues"
+on:
+  schedule:
+  - cron: "0 0 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'This has been marked stale after 30 days with no activity. It will be closed in 5 days if there is no activity.'
+        stale-pr-message: 'Stale pull request message'
+        days-before-stale: 30
+        days-before-close: 5
+        stale-issue-label: 'stale'
+        exempt-issue-labels: 'good first issue,help wanted,in progress,on hold,in review'
+        stale-pr-label: 'stale'
+        exempt-pr-labels: 'on hold,in review'
+


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
Runs the stale action once a day to check for stale issues and pull requests. They will be marked as stale after 30 days, and then closed 5 days after that if there is no activity. 

These labels will prevent an issue from being marked as stale
- good first issue
- help wanted
- in progress
- in review
- on hold

# Github Issue
https://github.com/newrelic/newrelic-ruby-agent/issues/387