### PR TITLE
Ensure preconnect never uses redirect host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # New Relic Ruby Agent Release Notes #
 
+  * **Bugfix: never use redirect host when accessing preconnect endpoint**
+
+    When connecting to New Relic, the Ruby Agent uses the value in `Agent.config[:host]` to post a request to the New Relic preconnect endpoint. This endpoint returns a "redirect host" which is the URL to which agents send data from that point on.
+
+    Previously, if the agent needed to reconnect to the collector, it would incorrectly use this redirect host to call the preconnect
+    endpoint, when it should have used the original configured value in `Agent.config[:host]`. The agent now uses the correct host
+    for all calls to preconnect.
+
   * **Bugfix: `http.url` query parameters spans are now obfuscated**
 
     Previously, the agent was recording the full URL of the external requests, including
@@ -14,7 +22,7 @@
     causing the Ruby process to hang indefinitely.
     This workaround checks for an `aborting` thread in the `#connect` exception handler
     and re-raises the exception, allowing a killed thread to continue exiting.
-  
+
     Thanks to Will Jordan (@wjordan) for chasing this one down and patching with tests.
 
   * **Fix error messages about Rake instrumentation**

--- a/lib/new_relic/agent/new_relic_service.rb
+++ b/lib/new_relic/agent/new_relic_service.rb
@@ -38,7 +38,7 @@ module NewRelic
       def initialize(license_key=nil, collector=control.server)
         @license_key = license_key
         @collector = collector
-        @generic_collector = collector
+        @configured_collector = collector
         @request_timeout = Agent.config[:timeout]
         @ssl_cert_store = nil
         @use_bundled_certs = false
@@ -435,7 +435,7 @@ module NewRelic
         size = data.size
 
         # Preconnect needs to always use the generic collector host, not the redirect host
-        endpoint_specific_collector = (method == :preconnect) ? @generic_collector : @collector
+        endpoint_specific_collector = (method == :preconnect) ? @configured_collector : @collector
 
         uri = remote_method_uri(method)
         full_uri = "#{endpoint_specific_collector}#{uri}"

--- a/lib/new_relic/agent/new_relic_service.rb
+++ b/lib/new_relic/agent/new_relic_service.rb
@@ -434,7 +434,7 @@ module NewRelic
         data, encoding = compress_request_if_needed(data, method)
         size = data.size
 
-        # Preconnect needs to always use the generic collector host, not the redirect host
+        # Preconnect needs to always use the configured collector host, not the redirect host
         endpoint_specific_collector = (method == :preconnect) ? @configured_collector : @collector
 
         uri = remote_method_uri(method)

--- a/test/agent_helper.rb
+++ b/test/agent_helper.rb
@@ -133,6 +133,12 @@ def assert_equal_unordered left, right
   left.each { |element| assert_includes(right, element) }
 end
 
+def assert_log_contains(log, message)
+  lines = log.array
+  failure_message = "Did not find '#{message}' in log. Log contained:\n#{lines.join('')}"
+  assert (lines.any? { |line| line.match(message) }), failure_message
+end
+
 def assert_audit_log_contains audit_log_contents, needle
   # Original request bodies dumped to the log have symbol keys, but once
   # they go through a dump/load, they're strings again, so we strip

--- a/test/multiverse/suites/config_file_loading/config_file_loading_test.rb
+++ b/test/multiverse/suites/config_file_loading/config_file_loading_test.rb
@@ -199,12 +199,6 @@ boom:
     assert_equal 'bazbangbarn', NewRelic::Agent.config[:i_am], "Agent.config did not load bazbangbarn config as requested"
   end
 
-  def assert_log_contains(log, message)
-    lines = log.array
-    failure_message = "Did not find '#{message}' in log. Log contained:\n#{lines.join('')}"
-    assert (lines.any? { |line| line.match(message) }), failure_message
-  end
-
   def refute_log_contains(log, message)
     lines = log.array
     failure_message = "Found unexpected '#{message}' in log. Log contained:\n#{lines.join('')}"

--- a/test/new_relic/agent/new_relic_service_test.rb
+++ b/test/new_relic/agent/new_relic_service_test.rb
@@ -269,7 +269,7 @@ class NewRelicServiceTest < Minitest::Test
   end
 
   def test_preconnect_never_uses_redirect_host
-    # Use generic collector for initial preconnect
+    # Use locally configured collector for initial preconnect
     initial_preconnect_log = with_array_logger(level=:debug) { @service.preconnect }
     assert_log_contains initial_preconnect_log, 'Sending request to somewhere.example.com'
 
@@ -277,7 +277,7 @@ class NewRelicServiceTest < Minitest::Test
     initial_connect_log = with_array_logger(level=:debug) { @service.connect }
     assert_log_contains initial_connect_log, 'Sending request to localhost'
 
-    # If we need to reconnect, preconnect should use the generic collector again
+    # If we need to reconnect, preconnect should use the locally configured collector again
     reconnect_log = with_array_logger(level=:debug) { @service.preconnect }
     assert_log_contains reconnect_log, 'Sending request to somewhere.example.com'
   end

--- a/test/new_relic/agent/new_relic_service_test.rb
+++ b/test/new_relic/agent/new_relic_service_test.rb
@@ -22,7 +22,7 @@ class NewRelicServiceTest < Minitest::Test
     @service.stubs(:create_http_connection).returns(@http_handle)
   end
 
-  def teardown 
+  def teardown
     NewRelic::Agent.config.reset_to_defaults
     reset_buffers_and_caches
   end
@@ -266,6 +266,20 @@ class NewRelicServiceTest < Minitest::Test
 
     @service.connect
     assert_equal 666, @service.agent_id
+  end
+
+  def test_preconnect_never_uses_redirect_host
+    # Use generic collector for initial preconnect
+    initial_preconnect_log = with_array_logger(level=:debug) { @service.preconnect }
+    assert_log_contains initial_preconnect_log, 'Sending request to somewhere.example.com'
+
+    # Connect has set the redirect host as the collector
+    initial_connect_log = with_array_logger(level=:debug) { @service.connect }
+    assert_log_contains initial_connect_log, 'Sending request to localhost'
+
+    # If we need to reconnect, preconnect should use the generic collector again
+    reconnect_log = with_array_logger(level=:debug) { @service.preconnect }
+    assert_log_contains reconnect_log, 'Sending request to somewhere.example.com'
   end
 
   def test_preconnect_with_no_token_and_no_lasp


### PR DESCRIPTION
# Overview
Stealing shamelessly from @astormnewrelic's [excellent explanation of this issue](https://github.com/newrelic/node-newrelic/issues/462). 😄 

When connecting to New Relic, the Ruby Agent uses the value in `Agent.config[:host]` to post a request to the New Relic preconnect endpoint. This endpoint returns a "redirect host", which (at the time of this writing) often looks like one of the following:

```
collector-00n.newrelic.com
gov-collector-00n.newrelic.com
```
This URL becomes the URL that agents will send data to.

There is a bug in the Ruby Agent related to this functionality. If the agent needs to reconnect to the collector, it will incorrectly use this redirect host to call the preconnect endpoint, when instead it should use the original configured value in `Agent.config[:host]`.

The root cause of this bug is the agent using a single `@collector` for all endpoints, which at the beginning is the configured host and after connect is permanently reset to the redirect host.

This PR stores the original configured host separately and always uses it in the case of preconnect only.

# Testing
I've included a new test for this which checks the logs to make sure we are sending things to the correct host.

This also involved moving `assert_log_contains` into our test helpers.