### PR TITLE
Add roadmap to list of stale action excluded labels

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,7 +15,7 @@ jobs:
         days-before-stale: 30
         days-before-close: 5
         stale-issue-label: 'stale'
-        exempt-issue-labels: 'good first issue,help wanted,in progress,on hold,in review'
+        exempt-issue-labels: 'good first issue,help wanted,in progress,on hold,in review,roadmap'
         stale-pr-label: 'stale'
         exempt-pr-labels: 'on hold,in review'
 


### PR DESCRIPTION
A simple change to make sure issues on our roadmap are not marked as stale.