### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Install rotp
-      run: gem install rotp
+      run: sudo gem install rotp
     - name: Configure gem credentials
       run: |
         if [ -f ~/.gem/credentials ]; then


### PR DESCRIPTION
A simple fix to make sure we can install the rotp gem as part of our release workflow.