### PR TITLE
Pin timers gem to 4.1.1. for Sidekiq ~> 3.5.3 multiverse

### DIFF
--- a/test/multiverse/suites/sidekiq/Envfile
+++ b/test/multiverse/suites/sidekiq/Envfile
@@ -64,6 +64,7 @@ if RUBY_VERSION < '2.4.0' && RUBY_PLATFORM != 'java'
     gem 'connection_pool', '2.2.2'
     gem 'sidekiq', '~> 3.5.3'
     gem 'rack'
+    gem 'timers', '4.1.1'
     gem 'newrelic_rpm', :require => false, :path => File.expand_path('../../../../')
   RB
 end


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
Sidekiq multiverse tests started failing today because of an incompatibility between a new version of the `timers` gem and Ruby 2.0.0. Pinned `timers` in the Envfile to fix.