### PR TITLE
WIP version that implements prepend version of method tracer

### DIFF
--- a/test/new_relic/agent/method_tracer_test.rb
+++ b/test/new_relic/agent/method_tracer_test.rb
@@ -418,6 +418,23 @@ class NewRelic::Agent::MethodTracerTest < Minitest::Test
 
     assert_metrics_not_recorded ['X', 'test_txn']
   end
+  
+  class ComponentRenderer
+    def render_component(component_name, options = {})
+      puts component_name
+      puts options
+    end
+  end
+  
+  class ComponentRenderer2 < ComponentRenderer
+    prepend ::NewRelic::Agent::MethodTracer
+  
+    add_method_tracer :render_component
+  end
+  
+  def test_ruby27_warnings_on_method_signatures
+    ComponentRenderer2.new.render_component(:test, { props: { test: 1 } })
+  end
 
   def check_time(t1, t2)
     assert_in_delta t2, t1, 0.001


### PR DESCRIPTION
# Overview
We have a recurring issue with Ruby 2.7 where using add_method_tracer is challenging to get right in all scenarios and argument combinations.  Ruby 2.7 is deprecating automatic keyword arguments and attempting to replicate method signatures causes warnings emitted to the log file.

This work in progress demonstrates using prepend instead of append as the method to latch onto methods the users wish to trace in their apps.  

TODO: 
* Continue fleshing out the solution and adapting test framework to test `prepended` version as fully as the `included` version.
* Extract the `included` version out to its own file and prepare to deprecate it with next major release.
* Clean up implementation of `prepended` version as needed to fully replicate `included`'s functionality.

# Related Github Issue
* See issue #349 

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
Github Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 
