### PR TITLE
Remove reference to repo-specific CoC from gemspec

### DIFF
--- a/newrelic_rpm.gemspec
+++ b/newrelic_rpm.gemspec
@@ -28,7 +28,6 @@ EOS
     "LICENSE",
     "README.md",
     "CONTRIBUTING.md",
-    "CODE_OF_CONDUCT.md",
     "newrelic.yml"
   ]
 


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
Another small fix to our release workflow: removing the outdated reference to a repo-specific Code of Conduct (we're now using the organization-level one) from the agent's gemspec.