### PR TITLE
simply reports a cache reserve failure error for bundle install cache…

### DIFF
--- a/.github/actions/build-ruby/index.js
+++ b/.github/actions/build-ruby/index.js
@@ -463,7 +463,12 @@ async function setupTestEnvironment(rubyVersion) {
   else {
     await exec.exec('bundle', ['install'])
     await io.cp(`${workspacePath}/Gemfile.lock`, `${filePath}/Gemfile.lock`)
-    await saveBundleToCache(rubyVersion)
+    try {
+      await saveBundleToCache(rubyVersion)
+    }
+    catch (error) {
+      console.log('Failed to save cache' + error.toString())
+    }
   }
 
   core.endGroup()


### PR DESCRIPTION
… so tests don't stop needlessly

_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
https://github.com/newrelic/newrelic-ruby-agent/runs/1088352399?check_suite_focus=true#step:3:230

restores the cache for bundle
then we're writing a cache anyway!?

Reading the code, it looks correct.  This is the specific code involved:

```javascript
async function setupTestEnvironment(rubyVersion) {
  core.startGroup('Setup Test Environment')
  const filePath = gemspecFilePath(rubyVersion)
  const workspacePath = process.env.GITHUB_WORKSPACE
  await restoreBundleFromCache(rubyVersion)
  // restore the Gemfile.lock to working folder if cache-hit
  if (fs.existsSync(`${filePath}/Gemfile.lock`)) {
    await io.cp(`${filePath}/Gemfile.lock`, `${workspacePath}/Gemfile.lock`)
    await exec.exec('bundle', ['install'])
  }
  // otherwise, bundle install and cache it
  else {
    await exec.exec('bundle', ['install'])
    await io.cp(`${workspacePath}/Gemfile.lock`, `${filePath}/Gemfile.lock`)
    await saveBundleToCache(rubyVersion)
  }
  core.endGroup()
}
```
we wait for the bundler cache to be restored.  Then we check if Gemfile.lock exists where the cache was restored.  If it does, we simply bundle install and move along to next thing.  Otherwise, we bundle install, copy over the Gemfile.lock and save that cache.

This is almost definitely a github issue.  We're failing to restore that cache because bundle install is actually fetching and install gems.  When the cache is restored, we'd see a whole bunch of using XXX gem rather than fetching and installing lines emitted.

Yet, the cache clearly exists because when the script attempts to save the cache, it's throwing the unable to reserve error.

# Related Github Issue
Include a link to the related GitHub issue, if applicable

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
Github Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 
