### PR TITLE
Fixes rubygems mfa

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,13 +12,14 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - name: Install rotp
-      run: sudo gem install rotp
-    - name: Install base32
-      run: sudo gem install base32
+    - name: update rubygems
+      run: gem update --system
+    - name: Install rotp and base32
+      run: sudo gem install rotp base32
     - name: Configure gem credentials
       run: |
         echo ::set-env name=GEM_HOST_API_KEY::${{ secrets.RUBYGEMS_API_KEY }}
+        echo ::set-env name=RUBY_GEMS_MFA_KEY::${{ secrets.RUBY_GEMS_MFA_KEY }}
     - name: Build newrelic_rpm gem
       run: gem build newrelic_rpm.gemspec
     - name: Build newrelic-infinite_tracing gem

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
           git push origin ${{ env.VERSION }}
         fi
     - name: Get Rubygems OTP for newrelic_rpm
-      run: echo ::set-env name=RUBYGEMS_OTP::$(ruby ./.github/workflows/scripts/ruby-gems-authenticate.rb ${{ secrets.RUBYGEMS_API_KEY }})
+      run: echo ::set-env name=RUBYGEMS_OTP::$(ruby ./.github/workflows/scripts/ruby-gems-authenticate.rb)
     - name: Publish newrelic_rpm to Rubygems
       run: |
         REMOTE_GEMS=`gem list newrelic_rpm -ra --prerelease | grep ${{ env.VERSION }}, || true`
@@ -48,7 +48,7 @@ jobs:
           echo "Already see newrelic_rpm ${{ env.VERSION }} out on rubygems, skipping push"
         fi
     - name: Get Rubygems OTP for newrelic-infinite_tracing
-      run: echo ::set-env name=RUBYGEMS_OTP::$(ruby ./.github/workflows/scripts/ruby-gems-authenticate.rb ${{ secrets.RUBYGEMS_API_KEY }})
+      run: echo ::set-env name=RUBYGEMS_OTP::$(ruby ./.github/workflows/scripts/ruby-gems-authenticate.rb)
     - name: Publish newrelic-infinite_tracing to Rubygems
       run: |
         REMOTE_GEMS=`gem list newrelic-infinite_tracing -ra --prerelease | grep ${{ env.VERSION }}, || true`

--- a/.github/workflows/scripts/ruby-gems-authenticate.rb
+++ b/.github/workflows/scripts/ruby-gems-authenticate.rb
@@ -1,6 +1,6 @@
 require 'rotp'
 require 'base32'
 
-api_key = Base32.encode ARGV[0]
-totp = ROTP::TOTP.new(api_key)
+mfa_identifier = Base32.encode ENV["RUBY_GEMS_MFA_KEY"]
+totp = ROTP::TOTP.new(mfa_identifier)
 p "#{totp.now}"


### PR DESCRIPTION
Additional fixes for the release workflow
* ensure rubygems is up-to-date
* install rotp and base32 gems in one shot
* set environment var for the MFA key
