### PR TITLE
Prevents original URI objects from be modified when obfuscated.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # New Relic Ruby Agent Release Notes #
 
+  ## NEXT VERSION
+
+  * **Bugfix: obfuscating URLs to external services no longer modifying original URI
+
+    A recent change to the Ruby agent to obfuscate URIs sent to external services had the unintended side-effect of removing query parameters
+    from the original URI.  This is fixed to obfuscate while also preserving the original URI
+
+    Thanks to @VictorJimenezKwast for pinpointing and helpful unit test to demonstrate.
+
   ## v6.13.0
 
   * **Bugfix: never use redirect host when accessing preconnect endpoint**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,10 @@
 
   ## v6.13.1
 
-  * **Bugfix: obfuscating URLs to external services no longer modifying original URI
+  * **Bugfix: obfuscating URLs to external services no longer modifying original URI**
 
     A recent change to the Ruby agent to obfuscate URIs sent to external services had the unintended side-effect of removing query parameters
-    from the original URI.  This is fixed to obfuscate while also preserving the original URI
+    from the original URI.  This is fixed to obfuscate while also preserving the original URI.
 
     Thanks to @VictorJimenezKwast for pinpointing and helpful unit test to demonstrate.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # New Relic Ruby Agent Release Notes #
 
-  ## NEXT VERSION
+  ## v6.13.1
 
   * **Bugfix: obfuscating URLs to external services no longer modifying original URI
 

--- a/lib/new_relic/agent/http_clients/uri_util.rb
+++ b/lib/new_relic/agent/http_clients/uri_util.rb
@@ -28,7 +28,7 @@ module NewRelic
         # accept that the stdlib URI module doesn't handle. If we find that
         # Addressable is around, use that to normalize out our URL's.
         def self.parse_and_normalize_url(url)
-          uri = url
+          uri = url.dup
           unless ::URI === uri
             if defined?(::Addressable::URI)
               address = ::Addressable::URI.parse(url)

--- a/lib/new_relic/version.rb
+++ b/lib/new_relic/version.rb
@@ -12,7 +12,7 @@ module NewRelic
 
     MAJOR = 6
     MINOR = 13
-    TINY  = 0
+    TINY  = 1
 
     begin
       require File.join(File.dirname(__FILE__), 'build')

--- a/test/new_relic/agent/http_clients/uri_util_test.rb
+++ b/test/new_relic/agent/http_clients/uri_util_test.rb
@@ -70,4 +70,16 @@ class URIUtilTest < Minitest::Test
     assert_equal(expected, NewRelic::Agent::HTTPClients::URIUtil.parse_and_normalize_url(URI(original)).to_s)
   end
 
+  def test_obfuscate_should_not_modify_uri_input
+    test_urls = [
+      ::URI.parse("https://foo.com/bar/baz?a=1&b=2#fragment"),
+      "https://foo.com/bar/baz?a=1&b=2#fragment"
+    ]
+
+    test_urls.each do |original|
+      to_obfuscate = original.dup
+      NewRelic::Agent::HTTPClients::URIUtil.obfuscated_uri(to_obfuscate).to_s
+      assert_equal original, to_obfuscate
+    end
+  end
 end


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
Describe the changes present in the pull request

# Related Github Issue
Resolves #450 and #451 

