### PR TITLE
Reduce gem package size

### DIFF
--- a/newrelic_rpm.gemspec
+++ b/newrelic_rpm.gemspec
@@ -39,7 +39,7 @@ EOS
     "homepage_uri"      => "https://newrelic.com/ruby",
   }
 
-  file_list = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features|infinite_tracing)/(?!agent_helper.rb)}) }
+  file_list = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features|infinite_tracing|\.github)/(?!agent_helper.rb)}) }
   build_file_path = 'lib/new_relic/build.rb'
   file_list << build_file_path if File.exist?(build_file_path)
   s.files = file_list


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview


This pull request reduces gem package size.

Currently newrelic_rpm gem package is 4.5MB after unzip. We can confirm the size with `du` command.
For example

```bash
$ cd path/to/installed/dir/lib/ruby/gems/2.7.0/gems
$ du newrelic_rpm-6.13.1/ --summarize -h
4.5M    newrelic_rpm-6.13.1/
```

And `.github` directory occupies half of the size.

```bash
# in the same directory
$ du newrelic_rpm-6.13.1/* --summarize -b | sort -n | tail
7933    newrelic_rpm-6.13.1/README.md
9317    newrelic_rpm-6.13.1/config.dot
11571   newrelic_rpm-6.13.1/LICENSE
13169   newrelic_rpm-6.13.1/bin/
17626   newrelic_rpm-6.13.1/THIRD_PARTY_NOTICES.md
33302   newrelic_rpm-6.13.1/test/
69358   newrelic_rpm-6.13.1/cert/
177295  newrelic_rpm-6.13.1/CHANGELOG.md
1285344 newrelic_rpm-6.13.1/lib/
2178011 newrelic_rpm-6.13.1/.github/
```

But `.github` directory is not necessary for the package users. So this pull request removes the `.github` directory from the gem package.
It reduces 2.2MB package size.


```bash
# In the same directory
$ du newrelic_rpm-6.13.1/ --summarize -h
2.3M    newrelic_rpm-6.13.1/
```

# Related Github Issue

nothing

# Testing

I've confirmed the existing test suites are all green.
