### PR TITLE
fixes dependency check for Redis instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # New Relic Ruby Agent Release Notes #
 
+  ## v6.14.0
+
+  * **Bugfix: dependency detection of Redis now works without raising an exception**
+    
+    Previously, when detecting if Redis was available to instrument, the dependency detection would fail with an Exception raised
+    (with side effect of not attempting to instrument Redis).  This is now fixed with a better dependency check that resolves falsly without raising an `Exception`.
+
   ## v6.13.1
 
   * **Bugfix: obfuscating URLs to external services no longer modifying original URI**

--- a/lib/new_relic/agent/instrumentation/redis.rb
+++ b/lib/new_relic/agent/instrumentation/redis.rb
@@ -37,7 +37,7 @@ DependencyDetection.defer do
   named :redis_instrumentation
 
   depends_on do
-    defined? ::Redis
+    defined? ::Redis::VERSION
   end
 
   depends_on do


### PR DESCRIPTION
# Overview
When attempting to detect Redis, an error is raised and logged:
```
[2020-10-02 14:10:49 -0400 C02ZH0B1LVDT (37897)] INFO : Environment: development
[2020-10-02 14:10:49 -0400 C02ZH0B1LVDT (37897)] INFO : No known dispatcher detected.
[2020-10-02 14:10:49 -0400 C02ZH0B1LVDT (37897)] INFO : Application: Performance Test (development)
[2020-10-02 14:10:49 -0400 C02ZH0B1LVDT (37897)] WARN : Agent configured not to send data in this environment.
[2020-10-02 14:10:49 -0400 C02ZH0B1LVDT (37897)] DEBUG : New Relic Ruby Agent 6.13.1 Initialized: pid = 37897
[2020-10-02 14:10:49 -0400 C02ZH0B1LVDT (37897)] DEBUG : NewRelic::Agent.config[:disable_redis] == false => true
[2020-10-02 14:10:49 -0400 C02ZH0B1LVDT (37897)] ERROR : Error while detecting redis_instrumentation:
[2020-10-02 14:10:49 -0400 C02ZH0B1LVDT (37897)] ERROR : NameError: uninitialized constant Redis::VERSION
[2020-10-02 14:10:49 -0400 C02ZH0B1LVDT (37897)] DEBUG : Debugging backtrace:
.../lib/new_relic/agent/datastores/redis.rb:92:in `is_supported_version?'
  .../lib/new_relic/agent/instrumentation/redis.rb:53:in `block (2 levels) in <top (required)>'
  .../lib/new_relic/dependency_detection.rb:88:in `block in check_dependencies'
  .../lib/new_relic/dependency_detection.rb:86:in `all?'
  .../lib/new_relic/dependency_detection.rb:86:in `check_dependencies'
  .../lib/new_relic/dependency_detection.rb:67:in `dependencies_satisfied?'
  .../lib/new_relic/dependency_detection.rb:28:in `block in detect!'
  .../lib/new_relic/dependency_detection.rb:27:in `each'
  .../lib/new_relic/dependency_detection.rb:27:in `detect!'
  .../lib/new_relic/control/instrumentation.rb:65:in `_install_instrumentation'
  .../lib/new_relic/control/instrumentation.rb:48:in `install_instrumentation'
  .../lib/new_relic/control/instance_methods.rb:76:in `init_plugin'
  .../lib/new_relic/agent.rb:356:in `manual_start'
  .../test/performance/suites/transaction_tracing.rb:82:in `setup'
  .../test/performance/lib/performance/test_case.rb:143:in `run'
  .../test/performance/lib/performance/runner.rb:161:in `run_test_inline'
  .../test/performance/lib/performance/runner.rb:172:in `block in run_test_case'
  .../test/performance/lib/performance/runner.rb:170:in `map'
  .../test/performance/lib/performance/runner.rb:170:in `run_test_case'
  .../test/performance/lib/performance/runner.rb:194:in `block in run_all_test_cases'
  .../test/performance/lib/performance/runner.rb:192:in `each'
  .../test/performance/lib/performance/runner.rb:192:in `run_all_test_cases'
  .../test/performance/lib/performance/runner.rb:204:in `run_and_report'
  .../test/performance/script/runner:131:in `<main>'
```
It is believed that `::Redis` becomes defined in our instrumentation file even though it's not yet installed and activated, thus leading to `::Redis` being present but not `::Redis::VERSION`.  This fix tests for the `::Redis::VERSION` as first step rather than just `::Redis`
