### PR TITLE
tracks retained objects in memory profiler for Performance tests

### DIFF
--- a/lib/new_relic/agent/instrumentation/action_view_subscriber.rb
+++ b/lib/new_relic/agent/instrumentation/action_view_subscriber.rb
@@ -23,12 +23,11 @@ module NewRelic
           log_notification_error(e, name, 'start')
         end
 
-        def finish(name, id, payload) #THREAD_LOCAL_ACCESS
+        def finish(name, id, payload)
           if segment = pop_segment(id)
-
-          if exception = exception_object(payload)
-            segment.notice_error exception
-          end
+            if exception = exception_object(payload)
+              segment.notice_error exception
+            end
             segment.finish
           end
         rescue => e

--- a/lib/new_relic/agent/instrumentation/notifications_subscriber.rb
+++ b/lib/new_relic/agent/instrumentation/notifications_subscriber.rb
@@ -75,7 +75,7 @@ module NewRelic
           # we don't expect this to be called more than once, but we're being
           # defensive.
           return if defined?(exception_object)
-          return unless defined?(::ActiveSupport)
+          return unless defined?(::ActiveSupport::VERSION)
           if ::ActiveSupport::VERSION::STRING < "5.0.0"
             # Earlier versions of Rails did not add the exception itself to the
             # payload asssessible via :exception_object, so we create a stand-in

--- a/lib/new_relic/agent/stats_engine/gc_profiler.rb
+++ b/lib/new_relic/agent/stats_engine/gc_profiler.rb
@@ -99,7 +99,7 @@ module NewRelic
 
           # When using GC::Profiler, it's important to periodically call
           # GC::Profiler.clear in order to avoid unbounded growth in the number
-          # of GC recordds that are stored. However, we actually do this
+          # of GC records that are stored. However, we actually do this
           # internally within MonotonicGCProfiler on calls to #total_time_s,
           # so the reset here is a no-op.
           def reset; end

--- a/lib/new_relic/supportability_helper.rb
+++ b/lib/new_relic/supportability_helper.rb
@@ -14,6 +14,7 @@ module NewRelic
       :accept_distributed_trace_headers,
       :create_distributed_trace_headers,
       :add_custom_attributes,
+      :add_custom_span_attributes,
       :add_instrumentation,
       :add_method_tracer,
       :add_transaction_tracer,

--- a/test/new_relic/agent/monitors/trace_context_request_monitor_test.rb
+++ b/test/new_relic/agent/monitors/trace_context_request_monitor_test.rb
@@ -7,8 +7,10 @@ require File.expand_path '../../../../test_helper', __FILE__
 module NewRelic
   module Agent
     class TraceContextRequestMonitorTest < Minitest::Test
+      include Mocha::API
 
       def setup
+        mocha_setup
         @events  = EventListener.new
         @monitor = DistributedTracing::Monitor.new(@events)
         @config = {
@@ -25,6 +27,7 @@ module NewRelic
       end
 
       def teardown
+        mocha_teardown
         NewRelic::Agent.config.reset_to_defaults
       end
 

--- a/test/new_relic/agent/span_event_primitive_test.rb
+++ b/test/new_relic/agent/span_event_primitive_test.rb
@@ -7,7 +7,7 @@ require File.expand_path(File.join(File.dirname(__FILE__),'..','..','test_helper
 module NewRelic
   module Agent
     module SpanEventPrimitive
-      class SpanEventPrimativeTest < Minitest::Test
+      class SpanEventPrimitiveTest < Minitest::Test
 
         def setup
           @additional_config = { :'distributed_tracing.enabled' => true }

--- a/test/performance/README.md
+++ b/test/performance/README.md
@@ -18,35 +18,42 @@ There are two main goals driving the development of this framework:
 More advanced options can be specified by invoking the runner script directly.
 See `./test/performance/script/runner -h` for a full list of options.
 
+All the examples below assume you have switched to the test/performance folder under the repository's root folder:
+
+```
+$ cd test/performance
+$ script/runner -l
+```
+
 Run all tests, report detailed results in a human-readable form
 
 ```
-$ ./test/performance/script/runner
+$ script/runner
 ```
 
 List all available test suites and names:
 
 ```
-$ ./test/performance/script/runner -l
+$ script/runner -l
 ```
 
 Run a specific test (test name matching is via regex):
 
 ```
-$ ./test/performance/script/runner -n short
+$ script/runner -n short
 ```
 
 To compare results for a specific test between two versions of the code, use the
 `-B` (for Baseline) and `-C` for (for Compare) switches:
 
 ```
-$ ./test/performance/script/runner -n short -B
+$ script/runner -n short -B
 1 tests, 0 failures, 8.199975 s total
 Saved 1 results as baseline.
 
 ... switch to another branch and run again with -C ...
 
-$ ./test/performance/script/runner -n short -C
+$ script/runner -n short -C
 1 tests, 0 failures, 8.220509 s total
 +-----------------------------------------------------+-----------+-----------+-------+---------------+--------------+--------------+
 | name                                                | before    | after     | delta | allocs_before | allocs_after | allocs_delta |
@@ -58,19 +65,19 @@ $ ./test/performance/script/runner -n short -C
 Run all the tests, produce machine readable JSON output (for eventual ingestion into a storage system):
 
 ```
-$ ./test/performance/script/runner -j | json_reformat
+$ script/runner -j | json_reformat
 ```
 
 Run a specific test under a profiler (either stackprof or perftools.rb, depending on your Ruby version):
 
 ```
-$ ./test/performance/script/runner -n short --profile
+$ script/runner -n short --profile
 ```
 
 Run with a set number of iterations, and do object allocation profiling (again to a call-graph dot file):
 
 ```
-$ ./test/performance/script/runner -n short -a -N 1000
+$ script/runner -n short -a -N 1000
 ```
 
 ## Pointing at a different copy of the agent

--- a/test/performance/lib/performance/baseline_compare_reporter.rb
+++ b/test/performance/lib/performance/baseline_compare_reporter.rb
@@ -60,6 +60,7 @@ module Performance
 
         allocations_before = old_result.measurements[:allocations]
         allocations_after  = new_result.measurements[:allocations]
+        allocations_delta_percent = 0
         if allocations_before && allocations_after
           # normalize allocation counts to be per-iteration
           allocations_before /= old_result.iterations
@@ -67,10 +68,22 @@ module Performance
 
           allocations_delta  = allocations_after - allocations_before
           allocations_delta_percent = allocations_delta.to_f / allocations_before * 100
-        else
-          allocations_delta_percent = 0
         end
 
+        retained_before = old_result.measurements[:retained]
+        retained_after  = new_result.measurements[:retained]
+        retained_delta = 0
+        retained_percent = 0
+        if retained_before && retained_after
+          # normalize allocation counts to be per-iteration
+          retained_before /= old_result.iterations
+          retained_after  /= new_result.iterations
+
+          retained_delta  = retained_after - retained_before
+          retained_percent = retained_delta.to_f / retained_before * 100
+        end
+        retained_percent = 0.0 if retained_percent.nan?
+        
         rows << [
           identifier,
           old_result.time_per_iteration,
@@ -78,7 +91,9 @@ module Performance
           percent_delta,
           allocations_before,
           allocations_after,
-          allocations_delta_percent
+          allocations_delta_percent,
+          retained_delta,
+          retained_percent
         ]
       end
 
@@ -95,6 +110,8 @@ module Performance
         column :allocs_before
         column :allocs_after
         column :allocs_delta,  &format_percent_delta
+        column :retained
+        column :retained_delta,  &format_percent_delta
       end
 
       puts table.render

--- a/test/performance/lib/performance/instrumentation/gc_stats.rb
+++ b/test/performance/lib/performance/instrumentation/gc_stats.rb
@@ -27,6 +27,9 @@ module Performance
         allocs_before = @stats_before[:total_allocated_objects] || @stats_before[:total_allocated_object]
         allocs_after  = @stats_after[:total_allocated_objects]  || @stats_after[:total_allocated_object]
         res[:allocations] = allocs_after - allocs_before
+        retained_before = @stats_before[:old_objects] || @stats_before[:old_object]
+        retained_after = @stats_after[:old_objects] || @stats_after[:old_object]
+        res[:retained] = retained_after - retained_before
         res
       end
     end

--- a/test/performance/lib/performance/runner.rb
+++ b/test/performance/lib/performance/runner.rb
@@ -158,7 +158,15 @@ module Performance
       begin
         load_newrelic_rpm
         GC.start
-        test_case.run(method)
+        GC.start
+        GC.start
+        GC.disable
+        result = test_case.run(method)
+        GC.enable
+        GC.start
+        GC.start
+        GC.start
+        result
       rescue => e
         result = Result.new(test_case.class.name, method)
         result.exception = e

--- a/test/performance/script/runner
+++ b/test/performance/script/runner
@@ -9,6 +9,7 @@ require 'rubygems'
 require 'json'
 
 require File.expand_path('../../lib/performance', __FILE__)
+$: << File.expand_path('../../../../lib', __FILE__)
 
 options = {}
 parser = OptionParser.new do |opts|

--- a/test/performance/suites/logging.rb
+++ b/test/performance/suites/logging.rb
@@ -2,13 +2,15 @@
 # This file is distributed under New Relic's license terms.
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 
-class Logging < Performance::TestCase
+require 'new_relic/agent/logging'
+
+class LoggingTest < Performance::TestCase
 
   EXAMPLE_MESSAGE = 'This is an example message'.freeze
 
   def test_logging
     io = StringIO.new
-    logger = ::NewRelic::Logging::DecoratingLogger.new io
+    logger = NewRelic::Agent::Logging::DecoratingLogger.new io
     measure do
       logger.info EXAMPLE_MESSAGE
     end

--- a/test/performance/suites/redis.rb
+++ b/test/performance/suites/redis.rb
@@ -2,8 +2,12 @@
 # This file is distributed under New Relic's license terms.
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 
+require 'redis'
+require 'new_relic/dependency_detection'
+require 'new_relic/agent/instrumentation/redis'
+
 # Primarily just tests allocations around argument formatting
-class Redis < Performance::TestCase
+class RedisTest < Performance::TestCase
   def test_no_args
     with_config(:'transaction_tracer.record_redis_arguments' => true) do
       command = ["lonely_command"]

--- a/test/performance/suites/thread_profiling.rb
+++ b/test/performance/suites/thread_profiling.rb
@@ -22,6 +22,7 @@ class ThreadProfiling < Performance::TestCase
   end
 
   def setup
+    mocha_setup
     require 'new_relic/agent/threading/backtrace_service'
 
     @nthreads = 16
@@ -52,6 +53,8 @@ class ThreadProfiling < Performance::TestCase
   end
 
   def teardown
+    mocha_teardown
+    
     @cvar.broadcast
     @threads.each(&:join)
     mocha_teardown

--- a/test/performance/suites/trace_context.rb
+++ b/test/performance/suites/trace_context.rb
@@ -7,6 +7,15 @@ require 'new_relic/agent/distributed_tracing/trace_context'
 require 'new_relic/agent/transaction/trace_context'
 
 class TraceContext < Performance::TestCase
+  include Mocha::API
+
+  def setup
+    mocha_setup
+  end
+
+  def teardown
+    mocha_teardown
+  end
 
   CONFIG = {
       :'distributed_tracing.enabled' => true,
@@ -22,8 +31,9 @@ class TraceContext < Performance::TestCase
     }
 
     measure do
-      ::NewRelic::Agent::TraceContext.parse carrier: carrier,
-                                            trace_state_entry_key: "33@nr"
+      NewRelic::Agent::DistributedTracing::TraceContext.parse \
+        carrier: carrier,
+        trace_state_entry_key: "33@nr"
     end
   end
 
@@ -35,11 +45,12 @@ class TraceContext < Performance::TestCase
     trace_state = 'k1=asdf,k2=qwerty'
 
     measure do
-      ::NewRelic::Agent::TraceContext.insert carrier: carrier,
-                                             trace_id: trace_id,
-                                             parent_id: parent_id,
-                                             trace_flags: trace_flags,
-                                             trace_state: trace_state
+      NewRelic::Agent::DistributedTracing::TraceContext.insert \
+        carrier: carrier,
+        trace_id: trace_id,
+        parent_id: parent_id,
+        trace_flags: trace_flags,
+        trace_state: trace_state
     end
   end
 
@@ -51,7 +62,7 @@ class TraceContext < Performance::TestCase
     with_config CONFIG do
       in_transaction do |txn|
         measure do
-          txn.insert_trace_context carrier: carrier
+          txn.distributed_tracer.insert_trace_context_header carrier: carrier
         end
       end
     end

--- a/test/performance/suites/trace_context_request_monitor.rb
+++ b/test/performance/suites/trace_context_request_monitor.rb
@@ -2,6 +2,8 @@
 # This file is distributed under New Relic's license terms.
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 
+require 'mocha/api'
+
 require 'new_relic/coerce'
 require 'new_relic/constants'
 require 'new_relic/supportability_helper'
@@ -9,6 +11,7 @@ require 'new_relic/agent/monitors'
 require 'new_relic/agent/distributed_tracing'
 
 class TraceContextRequestMonitor < Performance::TestCase
+  include Mocha::API
 
   CONFIG = {
     :'cross_application_tracer.enabled' => false,
@@ -18,6 +21,14 @@ class TraceContextRequestMonitor < Performance::TestCase
     :primary_application_id             => "46954",
     :trusted_account_key                => "99999"
   }
+
+  def setup
+    mocha_setup
+  end
+
+  def teardown
+    mocha_teardown
+  end
 
   def test_on_before_call
     carrier = {
@@ -30,7 +41,7 @@ class TraceContextRequestMonitor < Performance::TestCase
     NewRelic::Agent.config.add_config_for_testing(CONFIG)
 
     @events = NewRelic::Agent::EventListener.new
-    @request_monitor = NewRelic::Agent::TraceContextRequestMonitor.new(@events)
+    @request_monitor = NewRelic::Agent::Monitors.new(@events)
 
     @events.notify(:initial_configuration_complete)
 

--- a/test/performance/suites/transaction_tracing.rb
+++ b/test/performance/suites/transaction_tracing.rb
@@ -25,6 +25,10 @@ class TransactionTracingPerfTests < Performance::TestCase
         NewRelic::Agent.add_custom_attributes(BOO => HOO, OH => NO)
       end
 
+      def span_with_attributes
+        method_5
+      end
+
       def long_transaction(n)
         n.times do
           method_1
@@ -50,6 +54,10 @@ class TransactionTracingPerfTests < Performance::TestCase
       def method_4
       end
 
+      def method_5
+        NewRelic::Agent.add_custom_span_attributes(BOO => HOO, OH => NO)
+      end
+
       if instrument
         include NewRelic::Agent::Instrumentation::ControllerInstrumentation
         include NewRelic::Agent::MethodTracer
@@ -58,6 +66,7 @@ class TransactionTracingPerfTests < Performance::TestCase
         add_method_tracer :method_2
         add_method_tracer :method_3
         add_method_tracer :method_4
+        add_method_tracer :method_5
 
         add_transaction_tracer :short_transaction
         add_transaction_tracer :long_transaction
@@ -91,6 +100,10 @@ class TransactionTracingPerfTests < Performance::TestCase
 
   def test_with_custom_attributes
     measure { @dummy.transaction_with_attributes }
+  end
+
+  def test_spans_with_custom_attributes
+    measure { @dummy.span_with_attributes }
   end
 
   def test_failure


### PR DESCRIPTION
# Overview

To have a repeatable process for tracking and detecting memory leaks, the performance tests were improved to 
track GC.stats[:old_objects] with capability to baseline then compare.  Performance tests were enhanced to
flush stats for old_objects by running major GC sweeps three times, disabling GC during test runs, then re-enabling and running 3 times after the test run.  This ensures consistent tracking and baselining.

The `test/performance/README.md` was also updated for correctness as running the tests while homed to the repo's root folder did not quite work as advertised.  The performance test now also correctly loads the Ruby agent before running whereas before would complain about not finding specific files.

Minor typos, misspellings, etc. were fixed in comments.