### PR TITLE
Add checks for nil middleware class in use_with_newrelic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # New Relic Ruby Agent Release Notes #
 
+  ## v6.14.0
+
+  * **Bugfix: Gracefully handles NilClass as a Middleware Class when instrumenting**
+
+    Previously, if a NilClass is passed as the Middleware Class to instrument when processing the middleware stack,
+    the agent would fail to fully load and instrument the middleware stack.  This fix gracefully skips over nil classes.
+    
   ## v6.13.1
 
   * **Bugfix: obfuscating URLs to external services no longer modifying original URI**

--- a/lib/new_relic/agent/instrumentation/rack.rb
+++ b/lib/new_relic/agent/instrumentation/rack.rb
@@ -99,27 +99,31 @@ module NewRelic
             else
               run_without_newrelic(app, *args, **kwargs)
             end
-          end          
+          end
         end
 
         if RUBY_VERSION < "2.7.0"
           def use_with_newrelic(middleware_class, *args, &blk)
-            if ::NewRelic::Agent::Instrumentation::RackHelpers.middleware_instrumentation_enabled?
-              wrapped_middleware_class = ::NewRelic::Agent::Instrumentation::MiddlewareProxy.for_class(middleware_class)
-              use_without_newrelic(wrapped_middleware_class, *args, &blk)
-            else
-              use_without_newrelic(middleware_class, *args, &blk)
+            unless middleware_class.nil?
+              if ::NewRelic::Agent::Instrumentation::RackHelpers.middleware_instrumentation_enabled?
+                wrapped_middleware_class = ::NewRelic::Agent::Instrumentation::MiddlewareProxy.for_class(middleware_class)
+                use_without_newrelic(wrapped_middleware_class, *args, &blk)
+              else
+                use_without_newrelic(middleware_class, *args, &blk)
+              end
             end
           end
         else
           def use_with_newrelic(middleware_class, *args, **kwargs, &blk)
-            if ::NewRelic::Agent::Instrumentation::RackHelpers.middleware_instrumentation_enabled?
-              wrapped_middleware_class = ::NewRelic::Agent::Instrumentation::MiddlewareProxy.for_class(middleware_class)
-              use_without_newrelic(wrapped_middleware_class, *args, **kwargs, &blk)
-            else
-              use_without_newrelic(middleware_class, *args, **kwargs, &blk)
+            unless middleware_class.nil?
+              if ::NewRelic::Agent::Instrumentation::RackHelpers.middleware_instrumentation_enabled?
+                wrapped_middleware_class = ::NewRelic::Agent::Instrumentation::MiddlewareProxy.for_class(middleware_class)
+                use_without_newrelic(wrapped_middleware_class, *args, **kwargs, &blk)
+              else
+                use_without_newrelic(middleware_class, *args, **kwargs, &blk)
+              end
             end
-          end  
+          end
         end
 
         # We patch this method for a reason that actually has nothing to do with

--- a/lib/new_relic/agent/instrumentation/rack.rb
+++ b/lib/new_relic/agent/instrumentation/rack.rb
@@ -104,24 +104,22 @@ module NewRelic
 
         if RUBY_VERSION < "2.7.0"
           def use_with_newrelic(middleware_class, *args, &blk)
-            unless middleware_class.nil?
-              if ::NewRelic::Agent::Instrumentation::RackHelpers.middleware_instrumentation_enabled?
-                wrapped_middleware_class = ::NewRelic::Agent::Instrumentation::MiddlewareProxy.for_class(middleware_class)
-                use_without_newrelic(wrapped_middleware_class, *args, &blk)
-              else
-                use_without_newrelic(middleware_class, *args, &blk)
-              end
+            return if middleware_class.nil?
+            if ::NewRelic::Agent::Instrumentation::RackHelpers.middleware_instrumentation_enabled?
+              wrapped_middleware_class = ::NewRelic::Agent::Instrumentation::MiddlewareProxy.for_class(middleware_class)
+              use_without_newrelic(wrapped_middleware_class, *args, &blk)
+            else
+              use_without_newrelic(middleware_class, *args, &blk)
             end
           end
         else
           def use_with_newrelic(middleware_class, *args, **kwargs, &blk)
-            unless middleware_class.nil?
-              if ::NewRelic::Agent::Instrumentation::RackHelpers.middleware_instrumentation_enabled?
-                wrapped_middleware_class = ::NewRelic::Agent::Instrumentation::MiddlewareProxy.for_class(middleware_class)
-                use_without_newrelic(wrapped_middleware_class, *args, **kwargs, &blk)
-              else
-                use_without_newrelic(middleware_class, *args, **kwargs, &blk)
-              end
+            return if middleware_class.nil?
+            if ::NewRelic::Agent::Instrumentation::RackHelpers.middleware_instrumentation_enabled?
+              wrapped_middleware_class = ::NewRelic::Agent::Instrumentation::MiddlewareProxy.for_class(middleware_class)
+              use_without_newrelic(wrapped_middleware_class, *args, **kwargs, &blk)
+            else
+              use_without_newrelic(middleware_class, *args, **kwargs, &blk)
             end
           end
         end


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
This PR skips all middleware processing in the case that a `nil` value exists in the middleware chain. Sorry the diff is rendering weird - the only actual change is checking for `nil` here.

# Related Issue
Here's the [internal ticket](https://newrelic.atlassian.net/browse/GTSE-3080) where the bug was reported through support. The customer was seeing `nil` passed in as a middleware (reason unknown on their end), resulting in error messages such as `NoMethodError: undefined method `new' for nil:NilClass`.

This is confirmed to have solved the customer's issue and we should get this fix into our next release.

# Testing
This is a very small change so I have not added a test, but I'm happy to do so if it seems advisable, dear reviewer.