### PR TITLE
Use connection_db_config if it's available

### DIFF
--- a/lib/new_relic/environment_report.rb
+++ b/lib/new_relic/environment_report.rb
@@ -71,7 +71,13 @@ module NewRelic
     report_on('OS'                ) { ::NewRelic::Agent::SystemInfo.ruby_os_identifier     }
     report_on('Database adapter'  ) do
       begin
-        ActiveRecord::Base.configurations.configs_for(env_name: NewRelic::Control.instance.env, spec_name: "primary").config['adapter']
+        if ::ActiveRecord::Base.respond_to?(:connection_db_config)
+          ActiveRecord::Base.configurations.configs_for(env_name: NewRelic::Control.instance.env, name: "primary")
+            .connection_db_config.configuration_hash['adapter']
+        else
+          ActiveRecord::Base.configurations.configs_for(env_name: NewRelic::Control.instance.env, spec_name: "primary").config['adapter']
+        end
+
       rescue NoMethodError
         ActiveRecord::Base.configurations[NewRelic::Control.instance.env]['adapter']
       end


### PR DESCRIPTION
# Overview

This PR is really just to silence this Rails 6.1 deprecation warning

```
DEPRECATION WARNING: The kwarg `spec_name` is deprecated in favor of `name`. `spec_name` will be removed in Rails 6.2 (called from block in <class:EnvironmentReport> at /Users/tomgilligan/.asdf/installs/ruby/2.6.1/lib/ruby/gems/2.6.0/gems/newrelic_rpm-6.13.1/lib/new_relic/environment_report.rb:74)
DEPRECATION WARNING: DatabaseConfig#config will be removed in 6.2.0 in favor of DatabaseConfigurations#configuration_hash which returns a hash with symbol keys (called from block in <class:EnvironmentReport> at /Users/tomgilligan/.asdf/installs/ruby/2.6.1/lib/ruby/gems/2.6.0/gems/newrelic_rpm-6.13.1/lib/new_relic/environment_report.rb:74)
```

# Testing

No tests introduced thus far.  Probably it'd be nice to introduce a Rails 6.1 environment for testing but it's still pre-release so maybe that's a bit premature?