### PR TITLE
Create assignproj.yml

### DIFF
--- a/.github/workflows/assignproj.yml
+++ b/.github/workflows/assignproj.yml
@@ -1,0 +1,21 @@
+name: Auto Assign to Project
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+env:
+  GITHUB_TOKEN: ${{ secrets.RUBY_GITHUB_TOKEN }}
+
+jobs:
+  assign_one_project:
+    runs-on: ubuntu-latest
+    name: Assign to One Project
+    steps:
+    - name: Assign NEW issues and NEW pull requests to project 2
+      uses: srggrs/assign-one-project-github-action@1.2.0
+      if: github.event.action == 'opened'
+      with:
+        project: 'https://github.com/orgs/newrelic/projects/17'
+        column_name: 'Triage'

--- a/.github/workflows/assignproj.yml
+++ b/.github/workflows/assignproj.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     types: [opened]
 env:
-  GITHUB_TOKEN: ${{ secrets.RUBY_GITHUB_TOKEN }}
+  MY_GITHUB_TOKEN: ${{ secrets.RUBY_GITHUB_TOKEN }}
 
 jobs:
   assign_one_project:


### PR DESCRIPTION
Auto assigns project to an issue on create

_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
Add GHA to automatically associate the issue to the correct engineering project.

# Related Github Issue
Include a link to the related GitHub issue, if applicable

# Testing
Need to add SECRET with a TOKEN to pass.
1) Create a new issue.
2) Verify that it is automatically assigned to the correct Ruby engineering project and it shows up on Triage Column.
