### PR TITLE
Updated the memory sampler to recognize macOS Big Sur

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 
     Previously, if a NilClass is passed as the Middleware Class to instrument when processing the middleware stack,
     the agent would fail to fully load and instrument the middleware stack.  This fix gracefully skips over nil classes.
+
+  * **Memory Sampler updated to recognize macOS Big Sur**
+
+    Previously, the agent was unable to recognize the platform macOS Big Sur in the memory sampler, resulting in an error being logged. The memory sampler is now able to recognize Big Sur. 
     
   ## v6.13.1
 

--- a/lib/new_relic/agent/samplers/memory_sampler.rb
+++ b/lib/new_relic/agent/samplers/memory_sampler.rb
@@ -29,7 +29,7 @@ module NewRelic
             end
           elsif platform =~ /darwin9/ # 10.5
             @sampler = ShellPS.new("ps -o rsz")
-          elsif platform =~ /darwin1\d+/ # >= 10.6
+          elsif platform =~ /darwin(1|2)\d+/ # >= 10.6
             @sampler = ShellPS.new("ps -o rss")
           elsif platform =~ /freebsd/
             @sampler = ShellPS.new("ps -o rss")


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
Updated the regex in the memory sampler to recognize the new macos, Big Sur. Big sur platform output is `x86_64-darwin20`, so adding 1 or 2 catches this new OS as well. 

# Related Github Issue
https://github.com/newrelic/newrelic-ruby-agent/issues/474

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
Github Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 
