### PR TITLE
Enable rake task to work with Ruby 3.0.0-preview1

### DIFF
--- a/infinite_tracing/newrelic-infinite_tracing.gemspec
+++ b/infinite_tracing/newrelic-infinite_tracing.gemspec
@@ -1,6 +1,8 @@
 #-*- coding: utf-8 -*-
 # frozen_string_literal: true
 
+require 'fileutils'
+
 agent_lib = File.expand_path('../../lib', __FILE__)
 $LOAD_PATH.unshift(agent_lib) unless $LOAD_PATH.include?(agent_lib)
 


### PR DESCRIPTION


# Overview

`rake` command for this repository fails with Ruby 3.0.0-preview1 (and the latest dev version of Ruby).


```bash
$ rbenv shell 3.0.0-preview1
$ ruby -v
ruby 3.0.0preview1 (2020-09-25 master 0096d2b895) [x86_64-linux]

$ bundle exec rake -T
bundler: failed to load command: rake (/home/pocke/.rbenv/versions/3.0.0-preview1/bin/rake)
Bundler::GemspecError: 
[!] There was an error while loading `newrelic-infinite_tracing.gemspec`: uninitialized constant FileUtils
Did you mean?  FileTest. Bundler cannot continue.

 #  from /home/pocke/ghq/github.com/newrelic/newrelic-ruby-agent/infinite_tracing/newrelic-infinite_tracing.gemspec:20
 #  -------------------------------------------
 #        dest_full_filename = File.join(subfolder, File.basename(filename))
 >        FileUtils.cp source_full_filename, dest_full_filename
 #      end
 #  -------------------------------------------

  /home/pocke/.rbenv/versions/3.0.0-preview1/lib/ruby/3.0.0/bundler.rb:645:in `rescue in eval_gemspec'
  /home/pocke/.rbenv/versions/3.0.0-preview1/lib/ruby/3.0.0/bundler.rb:636:in `eval_gemspec'
  /home/pocke/.rbenv/versions/3.0.0-preview1/lib/ruby/3.0.0/bundler.rb:574:in `block in load_gemspec_uncached'
  /home/pocke/.rbenv/versions/3.0.0-preview1/lib/ruby/3.0.0/bundler/shared_helpers.rb:52:in `chdir'
  /home/pocke/.rbenv/versions/3.0.0-preview1/lib/ruby/3.0.0/bundler/shared_helpers.rb:52:in `block in chdir'
  /home/pocke/.rbenv/versions/3.0.0-preview1/lib/ruby/3.0.0/bundler/shared_helpers.rb:51:in `synchronize'
  /home/pocke/.rbenv/versions/3.0.0-preview1/lib/ruby/3.0.0/bundler/shared_helpers.rb:51:in `chdir'
  /home/pocke/.rbenv/versions/3.0.0-preview1/lib/ruby/3.0.0/bundler.rb:573:in `load_gemspec_uncached'
  /home/pocke/.rbenv/versions/3.0.0-preview1/lib/ruby/3.0.0/bundler.rb:559:in `load_gemspec'
  /home/pocke/.rbenv/versions/3.0.0-preview1/lib/ruby/3.0.0/bundler/source/path.rb:160:in `load_gemspec'
  /home/pocke/.rbenv/versions/3.0.0-preview1/lib/ruby/3.0.0/bundler/source/path.rb:175:in `block in load_spec_files'
  /home/pocke/.rbenv/versions/3.0.0-preview1/lib/ruby/3.0.0/bundler/source/path.rb:174:in `each'
  /home/pocke/.rbenv/versions/3.0.0-preview1/lib/ruby/3.0.0/bundler/source/path.rb:174:in `load_spec_files'
  /home/pocke/.rbenv/versions/3.0.0-preview1/lib/ruby/3.0.0/bundler/source/path.rb:105:in `local_specs'
  /home/pocke/.rbenv/versions/3.0.0-preview1/lib/ruby/3.0.0/bundler/source/path.rb:113:in `specs'
  /home/pocke/.rbenv/versions/3.0.0-preview1/lib/ruby/3.0.0/bundler/definition.rb:606:in `specs_for_source_changed?'
  /home/pocke/.rbenv/versions/3.0.0-preview1/lib/ruby/3.0.0/bundler/definition.rb:591:in `specs_changed?'
  /home/pocke/.rbenv/versions/3.0.0-preview1/lib/ruby/3.0.0/bundler/definition.rb:635:in `block in converge_paths'
  /home/pocke/.rbenv/versions/3.0.0-preview1/lib/ruby/3.0.0/bundler/definition.rb:634:in `any?'
  /home/pocke/.rbenv/versions/3.0.0-preview1/lib/ruby/3.0.0/bundler/definition.rb:634:in `converge_paths'
  /home/pocke/.rbenv/versions/3.0.0-preview1/lib/ruby/3.0.0/bundler/definition.rb:124:in `initialize'
  /home/pocke/.rbenv/versions/3.0.0-preview1/lib/ruby/3.0.0/bundler/dsl.rb:232:in `new'
  /home/pocke/.rbenv/versions/3.0.0-preview1/lib/ruby/3.0.0/bundler/dsl.rb:232:in `to_definition'
  /home/pocke/.rbenv/versions/3.0.0-preview1/lib/ruby/3.0.0/bundler/dsl.rb:13:in `evaluate'
  /home/pocke/.rbenv/versions/3.0.0-preview1/lib/ruby/3.0.0/bundler/definition.rb:34:in `build'
  /home/pocke/.rbenv/versions/3.0.0-preview1/lib/ruby/3.0.0/bundler.rb:195:in `definition'
  /home/pocke/.rbenv/versions/3.0.0-preview1/lib/ruby/3.0.0/bundler.rb:143:in `setup'
  /home/pocke/.rbenv/versions/3.0.0-preview1/lib/ruby/3.0.0/bundler/setup.rb:20:in `block in <top (required)>'
  /home/pocke/.rbenv/versions/3.0.0-preview1/lib/ruby/3.0.0/bundler/ui/shell.rb:136:in `with_level'
  /home/pocke/.rbenv/versions/3.0.0-preview1/lib/ruby/3.0.0/bundler/ui/shell.rb:88:in `silence'
  /home/pocke/.rbenv/versions/3.0.0-preview1/lib/ruby/3.0.0/bundler/setup.rb:20:in `<top (required)>'
```

Previously `FileUtils` is loaded by Bundler, but now `FileUtils` module is no longer loaded in the latest bundler.
`FileUtils` module is [vendored](https://github.com/rubygems/rubygems/blob/53a1673b8edae04f0190c30506facd6b4c1e1f72/bundler/lib/bundler/vendor/fileutils/lib/fileutils.rb) as `Bundler::FileUtils` and bundler uses it. So bundler doesn't define `FileUtils` at the top level now.


So we need to write `require 'fileutils'` explicitly even if we use Bundler. 


This is a related pull request https://github.com/rubygems/bundler/pull/5613, but it is a bit old. I'm not sure why FileUtils is loaded in Ruby 2.7 or less. :thinking: 




# Related Github Issue

nothing

# Testing

I don't add any unit test, but I confirmed `bundle exec rake -T` works with Ruby 3.0.0-preview1.
