### PR TITLE
request headers are now logged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
   ## v6.14.0
 
+  * **Feature: captures incoming and outgoing request headers for distributed tracing**
+
+    HTTP request headers will be logged when log level is at least debug level.  Similarly, request headers 
+    for exchanges with New Relic servers are now audit logged when audit logging is enabled.
+
   * **Bugfix: dependency detection of Redis now works without raising an exception**
     
     Previously, when detecting if Redis was available to instrument, the dependency detection would fail with an Exception raised

--- a/lib/new_relic/agent/audit_logger.rb
+++ b/lib/new_relic/agent/audit_logger.rb
@@ -26,6 +26,16 @@ module NewRelic
         !@log.nil?
       end
 
+      def log_request_headers(uri, headers)
+        return unless enabled? && allowed_endpoint?(uri)
+        @log.info("REQUEST HEADERS: #{headers}")
+      rescue StandardError, SystemStackError, SystemCallError => e
+        ::NewRelic::Agent.logger.warn("Failed writing request headers to audit log", e)
+      rescue Exception => e
+        ::NewRelic::Agent.logger.warn("Failed writing request headers to audit log with exception. Re-raising in case of interrupt.", e)
+        raise
+      end
+
       def log_request(uri, data, marshaller)
         return unless enabled? && allowed_endpoint?(uri)
 

--- a/lib/new_relic/agent/distributed_tracing/cross_app_tracing.rb
+++ b/lib/new_relic/agent/distributed_tracing/cross_app_tracing.rb
@@ -52,14 +52,14 @@ module NewRelic
         result
       end
 
-      def insert_cross_app_header request
+      def insert_cross_app_header headers
         return unless CrossAppTracing.cross_app_enabled?
         @is_cross_app_caller = true
         txn_guid  = transaction.guid
         trip_id   = cat_trip_id
         path_hash = cat_path_hash
 
-        insert_request_headers request, txn_guid, trip_id, path_hash
+        insert_request_headers headers, txn_guid, trip_id, path_hash
       end
 
       def add_message_cat_headers headers

--- a/lib/new_relic/agent/new_relic_service.rb
+++ b/lib/new_relic/agent/new_relic_service.rb
@@ -526,6 +526,7 @@ module NewRelic
         else
           request = Net::HTTP::Post.new(opts[:uri], headers)
         end
+        @audit_logger.log_request_headers(opts[:uri], headers)
         request['user-agent'] = user_agent
         request.content_type = "application/octet-stream"
         request.body = opts[:data]

--- a/lib/new_relic/agent/transaction/message_broker_segment.rb
+++ b/lib/new_relic/agent/transaction/message_broker_segment.rb
@@ -93,6 +93,7 @@ module NewRelic
           if headers && transaction && action == :produce && record_metrics?
             transaction.distributed_tracer.insert_distributed_trace_header headers
             transaction.distributed_tracer.insert_cat_headers headers
+            transaction.distributed_tracer.log_request_headers headers
           end
         rescue => e
           NewRelic::Agent.logger.error "Error during message header processing", e

--- a/test/new_relic/agent/transaction/external_request_segment_test.rb
+++ b/test/new_relic/agent/transaction/external_request_segment_test.rb
@@ -28,6 +28,10 @@ module NewRelic::Agent
         def host_from_header
           self['host']
         end
+
+        def to_s
+          headers.to_s # so logging request headers works as expected
+        end
       end
 
       TRANSACTION_GUID = 'BEC1BC64675138B9'


### PR DESCRIPTION
# Overview
HTTP request headers will be logged when log level is at least debug level.  

Similarly, request headers for exchanges with New Relic servers are now audit logged when audit logging is enabled.

# Related Github Issue
This resolves #472
