### PR TITLE
restores .erb to the search paths for config files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
   ## v6.14.0
 
+  * **Bugfix: `newrelic.yml.erb` added to the configuration search path**
+
+    Previously, when a user specifies a `newrelic.yml.erb` and no `newrelic.yml` file, the agent fails to find
+    the `.erb` file because it was not in the list of files searched at startup.  The Ruby agent has long supported this as a
+    means of configuring the agent programatically.  The `newrelic.yml.erb` filename is restored to the search
+    path and will be utilized if present.  NOTE:  `newrelic.yml` still takes precedence over `newrelic.yml.erb`  If found,
+    the `.yml` file is used instead of the `.erb` file.  Search directories and order of traversal remain unchanged.
+
   * **Bugfix: dependency detection of Redis now works without raising an exception**
     
     Previously, when detecting if Redis was available to instrument, the dependency detection would fail with an Exception raised

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -48,23 +48,30 @@ module NewRelic
           Proc.new {
             paths = [
               File.join("config","newrelic.yml"),
-              File.join("newrelic.yml")
+              File.join("newrelic.yml"),
+              File.join("config","newrelic.yml.erb"),
+              File.join("newrelic.yml.erb")
             ]
 
             if NewRelic::Control.instance.root
               paths << File.join(NewRelic::Control.instance.root, "config", "newrelic.yml")
               paths << File.join(NewRelic::Control.instance.root, "newrelic.yml")
+              paths << File.join(NewRelic::Control.instance.root, "config", "newrelic.yml.erb")
+              paths << File.join(NewRelic::Control.instance.root, "newrelic.yml.erb")
             end
 
             if ENV["HOME"]
               paths << File.join(ENV["HOME"], ".newrelic", "newrelic.yml")
               paths << File.join(ENV["HOME"], "newrelic.yml")
+              paths << File.join(ENV["HOME"], ".newrelic", "newrelic.yml.erb")
+              paths << File.join(ENV["HOME"], "newrelic.yml.erb")
             end
 
             # If we're packaged for warbler, we can tell from GEM_HOME
             if ENV["GEM_HOME"] && ENV["GEM_HOME"].end_with?(".jar!")
               app_name = File.basename(ENV["GEM_HOME"], ".jar!")
               paths << File.join(ENV["GEM_HOME"], app_name, "config", "newrelic.yml")
+              paths << File.join(ENV["GEM_HOME"], app_name, "config", "newrelic.yml.erb")
             end
 
             paths


### PR DESCRIPTION
# Overview
Adds `newrelic.yml.erb` to the list of directories and files searched at start up.

# Related Github Issue
Resolves #493 