### PR TITLE
fixed overzealous 2.7 changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
   ## v6.14.0
 
+  * **Bugfix: Ruby 2.7+ fix for keyword arguments on Rack apps is unnecessary and removed**
+
+    A common fix for positional and keyword arguments for method parameters was implemented where it was not needed and 
+    led to RackApps getting extra arguments converted to keyword arguments rather than Hash when it expected one.  This 
+    Ruby 2.7+ change was reverted so that Rack apps behave correctly for Ruby >= 2.7.
+    
   * **Bugfix: dependency detection of Redis now works without raising an exception**
     
     Previously, when detecting if Redis was available to instrument, the dependency detection would fail with an Exception raised

--- a/lib/new_relic/agent/instrumentation/middleware_proxy.rb
+++ b/lib/new_relic/agent/instrumentation/middleware_proxy.rb
@@ -27,18 +27,10 @@ module NewRelic
             @middleware_class = middleware_class
           end
 
-          if RUBY_VERSION < "2.7.0"
-            def new(*args, &blk)
-              middleware_instance = @middleware_class.new(*args, &blk)
-              MiddlewareProxy.wrap(middleware_instance)
-            end
-          else
-            def new(*args, **kwargs, &blk)
-              middleware_instance = @middleware_class.new(*args, **kwargs, &blk)
-              MiddlewareProxy.wrap(middleware_instance)
-            end
+          def new(*args, &blk)
+            middleware_instance = @middleware_class.new(*args, &blk)
+            MiddlewareProxy.wrap(middleware_instance)
           end
-
         end
 
         def self.is_sinatra_app?(target)

--- a/lib/new_relic/agent/instrumentation/rack.rb
+++ b/lib/new_relic/agent/instrumentation/rack.rb
@@ -102,25 +102,13 @@ module NewRelic
           end
         end
 
-        if RUBY_VERSION < "2.7.0"
-          def use_with_newrelic(middleware_class, *args, &blk)
-            return if middleware_class.nil?
-            if ::NewRelic::Agent::Instrumentation::RackHelpers.middleware_instrumentation_enabled?
-              wrapped_middleware_class = ::NewRelic::Agent::Instrumentation::MiddlewareProxy.for_class(middleware_class)
-              use_without_newrelic(wrapped_middleware_class, *args, &blk)
-            else
-              use_without_newrelic(middleware_class, *args, &blk)
-            end
-          end
-        else
-          def use_with_newrelic(middleware_class, *args, **kwargs, &blk)
-            return if middleware_class.nil?
-            if ::NewRelic::Agent::Instrumentation::RackHelpers.middleware_instrumentation_enabled?
-              wrapped_middleware_class = ::NewRelic::Agent::Instrumentation::MiddlewareProxy.for_class(middleware_class)
-              use_without_newrelic(wrapped_middleware_class, *args, **kwargs, &blk)
-            else
-              use_without_newrelic(middleware_class, *args, **kwargs, &blk)
-            end
+        def use_with_newrelic(middleware_class, *args, &blk)
+          return if middleware_class.nil?
+          if ::NewRelic::Agent::Instrumentation::RackHelpers.middleware_instrumentation_enabled?
+            wrapped_middleware_class = ::NewRelic::Agent::Instrumentation::MiddlewareProxy.for_class(middleware_class)
+            use_without_newrelic(wrapped_middleware_class, *args, &blk)
+          else
+            use_without_newrelic(middleware_class, *args, &blk)
           end
         end
 


### PR DESCRIPTION
# Overview
When adapting the agent for Ruby 2.7, we were over-zealous in making changes to support Ruby 2.7.  Rack, and therefore, RackApp do not pass keyword arguments, so it was unnecessary change to double-splat the last argument in the rack instrumentation.

# Related Github Issue
Resolves #486 
Resolves #487 
