### PR TITLE
Add prepend option for Net::HTTP instrumentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,7 +193,7 @@ jobs:
       - name: Run Multiverse Tests
         uses: nick-invision/retry@v1.0.0
         with:
-          timeout_minutes: 30
+          timeout_minutes: 40
           max_attempts: 4
           command:  bundle exec rake test:multiverse[group=${{ matrix.multiverse }},verbose]
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
   * **Memory Sampler updated to recognize macOS Big Sur**
 
     Previously, the agent was unable to recognize the platform macOS Big Sur in the memory sampler, resulting in an error being logged. The memory sampler is now able to recognize Big Sur. 
+
+  * **Prepend implementation of Net::HTTP instrumentation available**
+    
+    There is now a config option (`prepend_net_instrumentation`) that will enable the agent to use prepend while instrumenting Net::HTTP. This option is set to false by default.
     
   ## v6.13.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@
 
   * **Prepend implementation of Net::HTTP instrumentation available**
     
-    There is now a config option (`prepend_net_instrumentation`) that will enable the agent to use prepend while instrumenting Net::HTTP. This option is set to false by default.
+    There is now a config option (`prepend_net_instrumentation`) that will enable the agent to use prepend while instrumenting Net::HTTP. This option is set to true by default.
     
   ## v6.13.1
 

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -823,6 +823,13 @@ module NewRelic
           :allowed_from_server => false,
           :description => 'If <code>true</code>, uses Module.prepend rather than alias_method for ActiveRecord instrumentation.'
         },
+        :prepend_net_instrumentation => {
+          :default => false,
+          :public => true,
+          :type => Boolean,
+          :allowed_from_server => false,
+          :description => 'If <code>true</code>, uses Module.prepend rather than alias_method for Net::HTTP instrumentation.'
+        },
         :disable_data_mapper => {
           :default => false,
           :public => true,

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -831,7 +831,7 @@ module NewRelic
           :description => 'If <code>true</code>, uses Module.prepend rather than alias_method for ActiveRecord instrumentation.'
         },
         :prepend_net_instrumentation => {
-          :default => false,
+          :default => true,
           :public => true,
           :type => Boolean,
           :allowed_from_server => false,

--- a/lib/new_relic/agent/instrumentation/net.rb
+++ b/lib/new_relic/agent/instrumentation/net.rb
@@ -16,7 +16,6 @@ DependencyDetection.defer do
   end
 
   executes do
-    # require 'pry'; binding.pry
     if ::NewRelic::Agent.config[:prepend_net_instrumentation]
       if RUBY_VERSION < "2.1.0"
         ::Net::HTTP.send(:prepend, ::NewRelic::Agent::Instrumentation::NetPrepend)

--- a/lib/new_relic/agent/instrumentation/net.rb
+++ b/lib/new_relic/agent/instrumentation/net.rb
@@ -16,8 +16,13 @@ DependencyDetection.defer do
   end
 
   executes do
+    # require 'pry'; binding.pry
     if ::NewRelic::Agent.config[:prepend_net_instrumentation]
-      ::Net::HTTP.prepend ::NewRelic::Agent::Instrumentation::NetPrepend
+      if RUBY_VERSION < "2.1.0"
+        ::Net::HTTP.send(:prepend, ::NewRelic::Agent::Instrumentation::NetPrepend)
+      else
+        ::Net::HTTP.prepend ::NewRelic::Agent::Instrumentation::NetPrepend
+      end
     else 
       class Net::HTTP
         if RUBY_VERSION < "2.7.0"

--- a/lib/new_relic/agent/instrumentation/net.rb
+++ b/lib/new_relic/agent/instrumentation/net.rb
@@ -23,6 +23,7 @@ DependencyDetection.defer do
         ::Net::HTTP.prepend ::NewRelic::Agent::Instrumentation::NetPrepend
       end
     else 
+      NewRelic::Agent.record_metric("Supportability/Instrumentation/NetHTTP/MethodChaining", 0.0)
       class Net::HTTP
         if RUBY_VERSION < "2.7.0"
           def request_with_newrelic_trace(request, *args, &block)

--- a/lib/new_relic/agent/instrumentation/net_prepend.rb
+++ b/lib/new_relic/agent/instrumentation/net_prepend.rb
@@ -2,28 +2,15 @@
 # This file is distributed under New Relic's license terms.
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 
-DependencyDetection.defer do
-  named :net_http
+module NewRelic 
+  module Agent 
+    module Instrumentation
+      module NetPrepend
 
-  depends_on do
-    defined?(Net) && defined?(Net::HTTP)
-  end
-
-  executes do
-    ::NewRelic::Agent.logger.info 'Installing Net instrumentation'
-    require 'new_relic/agent/distributed_tracing/cross_app_tracing'
-    require 'new_relic/agent/http_clients/net_http_wrappers'
-  end
-
-  executes do
-    if ::NewRelic::Agent.config[:prepend_net_instrumentation]
-      ::Net::HTTP.prepend ::NewRelic::Agent::Instrumentation::NetPrepend
-    else 
-      class Net::HTTP
         if RUBY_VERSION < "2.7.0"
-          def request_with_newrelic_trace(request, *args, &block)
+          def request(request, *args, &block)
             wrapped_request = NewRelic::Agent::HTTPClients::NetHTTPRequest.new(self, request)
-    
+  
             segment = NewRelic::Agent::Tracer.start_external_request_segment(
               library: wrapped_request.type,
               uri: wrapped_request.uri,
@@ -38,7 +25,7 @@ DependencyDetection.defer do
               # counting if connection wasn't started (which calls request again).
               NewRelic::Agent.disable_all_tracing do
                 response = NewRelic::Agent::Tracer.capture_segment_error segment do
-                  request_without_newrelic_trace(request, *args, &block)
+                  super
                 end
               end
     
@@ -48,11 +35,11 @@ DependencyDetection.defer do
             ensure
               segment.finish
             end
-          end  
+          end
         else
-          def request_with_newrelic_trace(request, *args, **kwargs, &block)
+          def request(request, *args, **kwargs, &block)
             wrapped_request = NewRelic::Agent::HTTPClients::NetHTTPRequest.new(self, request)
-    
+  
             segment = NewRelic::Agent::Tracer.start_external_request_segment(
               library: wrapped_request.type,
               uri: wrapped_request.uri,
@@ -67,7 +54,7 @@ DependencyDetection.defer do
               # counting if connection wasn't started (which calls request again).
               NewRelic::Agent.disable_all_tracing do
                 response = NewRelic::Agent::Tracer.capture_segment_error segment do
-                  request_without_newrelic_trace(request, *args, **kwargs, &block)
+                  super
                 end
               end
     
@@ -79,11 +66,7 @@ DependencyDetection.defer do
             end
           end
         end
-  
-        alias request_without_newrelic_trace request
-        alias request request_with_newrelic_trace
       end
     end
-
   end
 end

--- a/test/multiverse/lib/multiverse/runner.rb
+++ b/test/multiverse/lib/multiverse/runner.rb
@@ -87,7 +87,7 @@ module Multiverse
       "api"           => ["grape"],
       "background"    => ["delayed_job", "sidekiq"],
       "database"      => ["datamapper", "mongo", "redis", "sequel"],
-      "httpclients"   => ["curb", "excon", "httpclient", "typhoeus", "net_http", "httprb"],
+      "httpclients"   => ["curb", "excon", "httpclient", "typhoeus", "net_http", "net_http_prepend", "httprb"],
       "rails"         => ["active_record", "rails"],
       "serialization" => ["json", "marshalling", "yajl"],
       "sinatra"       => ["sinatra", "padrino"],

--- a/test/multiverse/suites/net_http/config/newrelic.yml
+++ b/test/multiverse/suites/net_http/config/newrelic.yml
@@ -4,6 +4,7 @@ development:
     enabled: true
   apdex_t: 0.5
   monitor_mode: true
+  prepend_net_instrumentation: false
   license_key: bootstrap_newrelic_admin_license_key_000
   ca_bundle_path: ../../../config/test.cert.crt
   app_name: test

--- a/test/multiverse/suites/net_http_prepend/Envfile
+++ b/test/multiverse/suites/net_http_prepend/Envfile
@@ -1,0 +1,6 @@
+gemfile <<-RB
+  gem 'rack'
+  gem 'json', :platforms => [:rbx, :mri_18]
+RB
+
+# vim: ft=ruby

--- a/test/multiverse/suites/net_http_prepend/config/newrelic.yml
+++ b/test/multiverse/suites/net_http_prepend/config/newrelic.yml
@@ -4,7 +4,6 @@ development:
     enabled: true
   apdex_t: 0.5
   monitor_mode: true
-  prepend_net_instrumentation: true
   license_key: bootstrap_newrelic_admin_license_key_000
   ca_bundle_path: ../../../config/test.cert.crt
   app_name: test

--- a/test/multiverse/suites/net_http_prepend/config/newrelic.yml
+++ b/test/multiverse/suites/net_http_prepend/config/newrelic.yml
@@ -1,0 +1,19 @@
+---
+development:
+  error_collector:
+    enabled: true
+  apdex_t: 0.5
+  monitor_mode: true
+  prepend_net_instrumentation: true
+  license_key: bootstrap_newrelic_admin_license_key_000
+  ca_bundle_path: ../../../config/test.cert.crt
+  app_name: test
+  host: localhost
+  api_host: localhost
+  port: <%= $collector && $collector.port %>
+  transaction_tracer:
+    record_sql: obfuscated
+    enabled: true
+    stack_trace_threshold: 0.5
+    transaction_threshold: 1.0
+  capture_params: false

--- a/test/multiverse/suites/net_http_prepend/net_http_prepend.rb
+++ b/test/multiverse/suites/net_http_prepend/net_http_prepend.rb
@@ -4,6 +4,6 @@
 
 require "net_http_test_cases"
 
-class NetHttpTest < Minitest::Test
+class NetHttpPrependTest < Minitest::Test
   include NetHttpTestCases
 end

--- a/test/new_relic/net_http_test_cases.rb
+++ b/test/new_relic/net_http_test_cases.rb
@@ -1,0 +1,129 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+require "net/http"
+require "newrelic_rpm"
+require "http_client_test_cases"
+
+module NetHttpTestCases  
+  include HttpClientTestCases
+
+  #
+  # Support for shared test cases
+  #
+
+  def client_name
+    "Net::HTTP"
+  end
+
+  def timeout_error_class
+    Net::ReadTimeout
+  end
+
+  def simulate_error_response
+    Net::HTTP.any_instance.stubs(:transport_request).raises(timeout_error_class.new)
+    get_response
+  end
+
+  def get_response(url=nil, headers={})
+    uri = default_uri
+    uri = URI.parse(url) unless url.nil?
+    path = uri.path.empty? ? '/' : uri.path
+
+    start(uri) { |http| http.get(path, headers) }
+  end
+
+  def get_wrapped_response url
+    NewRelic::Agent::HTTPClients::NetHTTPResponse.new get_response url
+  end
+
+  def get_response_multi(url, n)
+    uri = URI(url)
+    responses = []
+
+    start(uri) do |conn|
+      n.times do
+        req = Net::HTTP::Get.new(url)
+        responses << conn.request(req)
+      end
+    end
+
+    responses
+  end
+
+  def head_response
+    start(default_uri) { |http| http.head(default_uri.path) }
+  end
+
+  def post_response
+    start(default_uri) { |http| http.post(default_uri.path, "") }
+  end
+
+  def put_response
+    start(default_uri) { |http| http.put(default_uri.path, "") }
+  end
+
+  def delete_response
+    start(default_uri) { |http| http.delete(default_uri.path) }
+  end
+
+  def create_http(uri)
+    http = Net::HTTP.new(uri.host, uri.port)
+    if use_ssl?
+      http.use_ssl = true
+      http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+    end
+    http
+  end
+
+  def start(uri, &block)
+    http = create_http(uri)
+    http.start(&block)
+  end
+
+  def request_instance
+    http = Net::HTTP.new(default_uri.host, default_uri.port)
+    request = Net::HTTP::Get.new(default_uri.request_uri)
+    NewRelic::Agent::HTTPClients::NetHTTPRequest.new(http, request)
+  end
+
+  def response_instance(headers = {})
+    response = Net::HTTPResponse.new(nil, nil, nil)
+    headers.each do |k,v|
+      response[k] = v
+    end
+    NewRelic::Agent::HTTPClients::NetHTTPResponse.new response
+  end
+
+  #
+  # Net::HTTP specific tests
+  #
+  def test_get__simple
+    # Don't check this specific condition against SSL, since API doesn't support it
+    return if use_ssl?
+
+    in_transaction do
+      Net::HTTP.get default_uri
+    end
+
+    assert_metrics_recorded([
+      'External/all',
+      'External/localhost/Net::HTTP/GET',
+      'External/allOther',
+      'External/localhost/all'
+    ])
+  end
+
+  # https://newrelic.atlassian.net/browse/RUBY-835
+  def test_direct_get_request_doesnt_double_count
+    http = create_http(default_uri)
+    in_transaction do
+      http.request(Net::HTTP::Get.new(default_uri.request_uri))
+    end
+
+    assert_metrics_recorded(
+      'External/localhost/Net::HTTP/GET' => { :call_count => 1 })
+  end
+end


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
This change adds a new config option to enable the instrumentation of Net::HTTP to use prepend rather than monkey patching. 

# Related Github Issue
https://github.com/newrelic/newrelic-ruby-agent/issues/347

# Testing
Added a new test suite `net_http_prepend`. I pulled out all of the existing work in net_http test suite into a helper module and included that in both `net_http_prepend` and `net_http`. These needed to be in separate suites because the instrumentation is set up when the agent starts, and cannot switch instrumentation implementations while running.
