### PR TITLE
Updates for our github action workflows

### DIFF
--- a/.github/workflows/assignproj.yml
+++ b/.github/workflows/assignproj.yml
@@ -11,6 +11,7 @@ env:
 jobs:
   assign_one_project:
     runs-on: ubuntu-latest
+    continue-on-error: true
     name: Assign to One Project
     steps:
     - name: Assign NEW issues and NEW pull requests to project 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,13 +172,6 @@ jobs:
       matrix:
         multiverse: [agent, api, background, background_2, database, httpclients, rails, rest, serialization, sinatra]
         ruby-version: [2.0.0-p648, 2.1.10, 2.2.10, 2.3.8, 2.4.10, 2.5.8, 2.6.6, 2.7.1, jruby-9.2.12.0]
-        include:
-          - ruby-version: "2.7.1"
-            multiverse: infinite_tracing
-          - ruby-version: "2.6.6"
-            multiverse: infinite_tracing
-          - ruby-version: "2.5.8"
-            multiverse: infinite_tracing
         exclude:
           - ruby-version: "2.7.1"
             multiverse: api
@@ -206,6 +199,32 @@ jobs:
         env:
           DB_PORT: 3306
           MYSQL_PASSWORD: root
+
+      - name: Annotate errors
+        if: ${{ failure() }}
+        uses: ./.github/actions/annotate
+
+  infinite_tracing:
+    needs: build-ruby
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby-version: [2.5.8, 2.6.6, 2.7.1]
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build Ruby ${{ matrix.ruby-version }}
+        uses: ./.github/actions/build-ruby
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+
+      - name: Run Multiverse Tests
+        uses: nick-invision/retry@v1.0.0
+        with:
+          timeout_minutes: 40
+          max_attempts: 6
+          command:  bundle exec rake test:multiverse[group=infinite_tracing,verbose]
 
       - name: Annotate errors
         if: ${{ failure() }}

--- a/.github/workflows/pr_review_checklist.yml
+++ b/.github/workflows/pr_review_checklist.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   sidekick_checklist:
-    name: 
+    continue-on-error: true
     runs-on: ubuntu-latest
     steps:
       - name: Checklist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,22 +14,28 @@ jobs:
         fetch-depth: 0
     - name: update rubygems
       run: gem update --system
+
     - name: Install onetimepass
       run: pip install onetimepass
+
     - name: Configure gem credentials
       run: |
-        echo ::set-env name=GEM_HOST_API_KEY::${{ secrets.RUBYGEMS_API_KEY }}
-        echo ::set-env name=RUBYGEMS_MFA_KEY::${{ secrets.RUBYGEMS_MFA_KEY }}
+        echo "GEM_HOST_API_KEY=${{ secrets.RUBYGEMS_API_KEY }}" >> $GITHUB_ENV
+        echo "RUBYGEMS_MFA_KEY=${{ secrets.RUBYGEMS_MFA_KEY }}" >> $GITHUB_ENV
+
     - name: Build newrelic_rpm gem
       run: gem build newrelic_rpm.gemspec
+
     - name: Build newrelic-infinite_tracing gem
       run: |
         cd infinite_tracing
         gem build newrelic-infinite_tracing.gemspec
         cd ..
+
     - name: Determine version
       run: |
-        echo ::set-env name=VERSION::$(ls newrelic_rpm-*.gem | ruby -pe 'sub(/newrelic_rpm\-(.*).gem/, "\\1")')
+        echo "VERSION=$(ls newrelic_rpm-*.gem | ruby -pe 'sub(/newrelic_rpm\-(.*).gem/, "\\1")')" >> $GITHUB_ENV
+
     - name: Tag new version
       run: |
         if [ $(git tag -l ${{ env.VERSION }}) ]; then
@@ -40,12 +46,14 @@ jobs:
         fi
 
     - name: Obtain OTP to publish newrelic_rpm to rubygems.org
-      run: echo ::set-env name=RUBYGEMS_OTP::$(python ./.github/workflows/scripts/rubygems-authenticate.py RUBYGEMS_MFA_KEY)
+      run: echo "RUBYGEMS_OTP=$(python ./.github/workflows/scripts/rubygems-authenticate.py RUBYGEMS_MFA_KEY)" >> $GITHUB_ENV
+
     - name: Publish newrelic_rpm to rubygems.org
       run: ruby ./.github/workflows/scripts/rubygems-publish.rb newrelic_rpm
 
     - name: Obtain OTP to publish newrelic-infinite_tracing to rubygems.org
-      run: echo ::set-env name=RUBYGEMS_OTP::$(python ./.github/workflows/scripts/rubygems-authenticate.py RUBYGEMS_MFA_KEY)
+      run: echo "RUBYGEMS_OTP=$(python ./.github/workflows/scripts/rubygems-authenticate.py RUBYGEMS_MFA_KEY)" >> $GITHUB_ENV
+
     - name: Publish newrelic-infinite_tracing to rubygems.org
       run: ruby ./.github/workflows/scripts/rubygems-publish.rb infinite_tracing/newrelic-infinite_tracing
 


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
- Changed release workflow so it is no longer using the deprecated `set-env`, and is now using [`$GITHUB_ENV`](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable). 
- Pulled infinite tracing tests into a separate job in the same CI workflow. This enables us to bump up the retry limits for only infinite tracing, which has the most intermittent failures. This makes it so that we don't have to wait even longer in the case of real failures in other parts of the agent unrelated to infinite tracing. 
- added [`continue-on-error`](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idcontinue-on-error) to workflows that run on pull requests, but are not testing. This includes adding the workflows for PR checklist commenting and assigning to the project board. 

# Related Github Issue
https://github.com/newrelic/newrelic-ruby-agent/issues/471 https://github.com/newrelic/newrelic-ruby-agent/issues/463
