### PR TITLE
Don't overwrite existing sidekiq trace info.

### DIFF
--- a/lib/new_relic/agent/instrumentation/sidekiq.rb
+++ b/lib/new_relic/agent/instrumentation/sidekiq.rb
@@ -46,7 +46,7 @@ DependencyDetection.defer do
       end
       class Client
         def call(_worker_class, job, *_)
-          job[NewRelic::NEWRELIC_KEY] = distributed_tracing_headers if ::NewRelic::Agent.config[:'distributed_tracing.enabled']
+          job[NewRelic::NEWRELIC_KEY] ||= distributed_tracing_headers if ::NewRelic::Agent.config[:'distributed_tracing.enabled']
           yield
         end
 


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
We are using Shoryuken to pull from SQS and push to Sidekiq. This is a small slice of logic that we don't want monitored with with New Relic, but we do want to connect the distributed tracing that is happening from the Ruby application on the other side of SNS. Our Shoryuken worker is putting the key in place and it is being overwritten by sidekiq.

I can have our application delete the New Relic client sidekiq middleware within shoryuken, but I figured it'd be sharing what I ran into here as well.

Maybe `::NewRelic::Agent.config[:'distributed_tracing.enabled']` should be false if `::NewRelic::Agent.config[:agent_enabled]` is false?

# Related Github Issue
N/A

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
Github Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 
