### PR TITLE
resolve infinite recursion when airbrake is present

### DIFF
--- a/lib/new_relic/agent/instrumentation/net.rb
+++ b/lib/new_relic/agent/instrumentation/net.rb
@@ -16,7 +16,9 @@ DependencyDetection.defer do
   end
 
   def monkey_patched
-    defined?(::Airbrake) || source_location_for(Net::HTTP, "request") =~ /airbrake/i
+    defined?(::Airbrake) || 
+    defined?(::Rack::MiniProfiler) ||
+    source_location_for(Net::HTTP, "request") =~ /airbrake|profiler/i
   end
 
   executes do

--- a/lib/new_relic/agent/instrumentation/net.rb
+++ b/lib/new_relic/agent/instrumentation/net.rb
@@ -15,8 +15,12 @@ DependencyDetection.defer do
     require 'new_relic/agent/http_clients/net_http_wrappers'
   end
 
+  def monkey_patched
+    defined?(::Airbrake) || source_location_for(Net::HTTP, "request") =~ /airbrake/i
+  end
+
   executes do
-    if ::NewRelic::Agent.config[:prepend_net_instrumentation]
+    if ::NewRelic::Agent.config[:prepend_net_instrumentation] && !monkey_patched
       if RUBY_VERSION < "2.1.0"
         ::Net::HTTP.send(:prepend, ::NewRelic::Agent::Instrumentation::NetPrepend)
       else
@@ -24,66 +28,36 @@ DependencyDetection.defer do
       end
     else 
       NewRelic::Agent.record_metric("Supportability/Instrumentation/NetHTTP/MethodChaining", 0.0)
+
       class Net::HTTP
-        if RUBY_VERSION < "2.7.0"
-          def request_with_newrelic_trace(request, *args, &block)
-            wrapped_request = NewRelic::Agent::HTTPClients::NetHTTPRequest.new(self, request)
-    
-            segment = NewRelic::Agent::Tracer.start_external_request_segment(
-              library: wrapped_request.type,
-              uri: wrapped_request.uri,
-              procedure: wrapped_request.method
-            )
-    
-            begin
-              response = nil
-              segment.add_request_headers wrapped_request
-    
-              # RUBY-1244 Disable further tracing in request to avoid double
-              # counting if connection wasn't started (which calls request again).
-              NewRelic::Agent.disable_all_tracing do
-                response = NewRelic::Agent::Tracer.capture_segment_error segment do
-                  request_without_newrelic_trace(request, *args, &block)
-                end
+        def request_with_newrelic_trace(request, *args, &block)
+          wrapped_request = NewRelic::Agent::HTTPClients::NetHTTPRequest.new(self, request)
+  
+          segment = NewRelic::Agent::Tracer.start_external_request_segment(
+            library: wrapped_request.type,
+            uri: wrapped_request.uri,
+            procedure: wrapped_request.method
+          )
+  
+          begin
+            response = nil
+            segment.add_request_headers wrapped_request
+  
+            # RUBY-1244 Disable further tracing in request to avoid double
+            # counting if connection wasn't started (which calls request again).
+            NewRelic::Agent.disable_all_tracing do
+              response = NewRelic::Agent::Tracer.capture_segment_error segment do
+                request_without_newrelic_trace(request, *args, &block)
               end
-    
-              wrapped_response = NewRelic::Agent::HTTPClients::NetHTTPResponse.new response
-              segment.process_response_headers wrapped_response
-              response
-            ensure
-              segment.finish
             end
-          end  
-        else
-          def request_with_newrelic_trace(request, *args, **kwargs, &block)
-            wrapped_request = NewRelic::Agent::HTTPClients::NetHTTPRequest.new(self, request)
-    
-            segment = NewRelic::Agent::Tracer.start_external_request_segment(
-              library: wrapped_request.type,
-              uri: wrapped_request.uri,
-              procedure: wrapped_request.method
-            )
-    
-            begin
-              response = nil
-              segment.add_request_headers wrapped_request
-    
-              # RUBY-1244 Disable further tracing in request to avoid double
-              # counting if connection wasn't started (which calls request again).
-              NewRelic::Agent.disable_all_tracing do
-                response = NewRelic::Agent::Tracer.capture_segment_error segment do
-                  request_without_newrelic_trace(request, *args, **kwargs, &block)
-                end
-              end
-    
-              wrapped_response = NewRelic::Agent::HTTPClients::NetHTTPResponse.new response
-              segment.process_response_headers wrapped_response
-              response
-            ensure
-              segment.finish
-            end
+  
+            wrapped_response = NewRelic::Agent::HTTPClients::NetHTTPResponse.new response
+            segment.process_response_headers wrapped_response
+            response
+          ensure
+            segment.finish
           end
-        end
+        end  
   
         alias request_without_newrelic_trace request
         alias request request_with_newrelic_trace

--- a/lib/new_relic/dependency_detection.rb
+++ b/lib/new_relic/dependency_detection.rb
@@ -68,7 +68,7 @@ module DependencyDetection
     end
 
     def source_location_for klass, method_name
-      Object.instance_method(:method).bind(klass.allocate).call(method_name).source_location
+      Object.instance_method(:method).bind(klass.allocate).call(method_name).source_location.to_s
     end
   
     def execute

--- a/lib/new_relic/dependency_detection.rb
+++ b/lib/new_relic/dependency_detection.rb
@@ -67,6 +67,10 @@ module DependencyDetection
       !executed and check_dependencies
     end
 
+    def source_location_for klass, method_name
+      Object.instance_method(:method).bind(klass.allocate).call(method_name).source_location
+    end
+  
     def execute
       @executes.each do |x|
         begin


### PR DESCRIPTION
# Overview
resolves #510 where infinite recursion error occurs when both the Ruby agent and Airbrake are loaded in a Rails project.  Airbrake and the Ruby agent both are monkey patching the Net::HTTP#request method in order to benchmark.  When prepend method of patching is used, we end up with an infinite recursion issue since the two approaches cannot be used together.

# Related Github Issue
Closes #510 


