### PR TITLE
Remove warnings from tests in ruby 3.0.0-preview1

### DIFF
--- a/lib/new_relic/cli/commands/deployments.rb
+++ b/lib/new_relic/cli/commands/deployments.rb
@@ -7,7 +7,6 @@
 
 require 'yaml'
 require 'net/http'
-require 'rexml/document'
 require 'new_relic/agent/hostname'
 
 # We need to use the Control object but we don't want to load

--- a/test/new_relic/agent_test.rb
+++ b/test/new_relic/agent_test.rb
@@ -476,7 +476,7 @@ module NewRelic
       end
     end
 
-    DEPRECATED_CONSTANTS = [:Tms]
+    DEPRECATED_CONSTANTS = [:Tms, :Passwd, :Group]
 
     def test_modules_and_classes_return_name_properly
       valid = [Module, Class]


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
Removed all instances of require 'rexml/document' in the agent.
Added Passwd and Group to our deprecated constants list in our agent test

# Related Github Issue
closes #491 
