### PR TITLE
multiple bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
   ## v6.15.0
 
+  * **Bugfix: Fixes cases where errors are reported for spans with no other attributes**
+
+    Previously, in cases where a span does not have any agent/custom attributes on it, but an error
+    is noticed and recorded against the span, a `FrozenError: can't modify frozen Hash` is thrown.
+    This is now fixed and errors are now correctly recorded against such span events.
+
+  * **Bugfix: `DistributedTracing.insert_distributed_trace_headers` Supportability metric now recorded**
+    
+    Previously, API calls to `DistributedTracing.insert_distributed_trace_headers` would lead to an exception
+    about the missing supportability metric rather than flowing through the API implementation as intended.
+    This would potentially lead to broken distributed traces as the trace headers were not inserted on the API call.
+    `DistributedTracing.insert_distributed_trace_headers` now correctly records the supportability metric and
+    inserts the distributed trace headers as intended.
+
+  * **Bugfix: child completions after parent completes sometimes throws exception attempting to access nil parent**
+
+    In scenarios where the child segment/span is completing after the parent in jRuby, the parent may have already
+    been freed and no longer accessible.  This would lead to attempting to calll `descendant_complete` on a Nil
+    object.  This is fixed to protect against calling the `descendant_complete` in such cases.
+    
   * **Feature: implements `force_install_exit_handler` config flag**
     
     The `force_install_exit_handler` configuration flag allows an application to instruct the agent to install it's 

--- a/lib/new_relic/agent/span_event_primitive.rb
+++ b/lib/new_relic/agent/span_event_primitive.rb
@@ -165,16 +165,18 @@ module NewRelic
         end
       end
 
+      def merge_and_freeze_attributes agent_attributes, error_attributes
+        return agent_attributes.freeze unless error_attributes
+        return error_attributes.freeze if agent_attributes.equal?(NewRelic::EMPTY_HASH)
+        agent_attributes.merge!(error_attributes).freeze
+      end
+
       def agent_attributes segment
-        attributes = segment.attributes
-        agent_attributes = attributes.agent_attributes_for(NewRelic::Agent::AttributeFilter::DST_SPAN_EVENTS)
+        agent_attributes = segment.attributes
+          .agent_attributes_for(NewRelic::Agent::AttributeFilter::DST_SPAN_EVENTS)
         error_attributes = error_attributes(segment)
-        if agent_attributes || error_attributes
-          agent_attributes.merge!(error_attributes) if error_attributes
-          agent_attributes.freeze
-        else
-          NewRelic::EMPTY_HASH
-        end
+        return NewRelic::EMPTY_HASH unless agent_attributes || error_attributes
+        merge_and_freeze_attributes(agent_attributes, error_attributes)
       end
 
       def parent_guid segment

--- a/lib/new_relic/agent/transaction/abstract_segment.rb
+++ b/lib/new_relic/agent/transaction/abstract_segment.rb
@@ -167,7 +167,7 @@ module NewRelic
 
           if finished?
             transaction.async = true
-            parent.descendant_complete self, segment
+            parent.descendant_complete(self, segment) if parent
           end
         end
 

--- a/lib/new_relic/supportability_helper.rb
+++ b/lib/new_relic/supportability_helper.rb
@@ -11,6 +11,7 @@ module NewRelic
     # transaction, just to eke out a bit less performance hit
     #
     API_SUPPORTABILITY_METRICS = [
+      :insert_distributed_trace_headers,
       :accept_distributed_trace_headers,
       :create_distributed_trace_headers,
       :add_custom_attributes,

--- a/test/new_relic/agent/span_event_primitive_test.rb
+++ b/test/new_relic/agent/span_event_primitive_test.rb
@@ -30,13 +30,23 @@ module NewRelic
         end
 
         def test_error_attributes_returns_populated_attributes_when_error_present
-            segment, _ = capture_segment_with_error
+          segment, _ = capture_segment_with_error
 
           eh = SpanEventPrimitive::error_attributes(segment)
           assert segment.noticed_error, "segment.noticed_error should NOT be nil!"
           assert eh.is_a?(Hash), "expected a Hash when error present on segment"
           assert_equal "oops!", eh["error.message"]
           assert_equal "RuntimeError", eh["error.class"]
+        end
+
+        def test_error_attributes_are_merged_with_agent_attributes_when_error_present
+          segment, _ = capture_segment_with_error
+          segment.attributes.stubs(:agent_attributes_for).returns(NewRelic::EMPTY_HASH)
+          _, _, attrs = SpanEventPrimitive.for_segment(segment)
+          assert segment.noticed_error, "segment.noticed_error should NOT be nil!"
+          assert attrs.is_a?(Hash), "expected a Hash when error present on segment"
+          assert_equal "oops!", attrs["error.message"]
+          assert_equal "RuntimeError", attrs["error.class"]
         end
 
         def test_does_not_add_error_attributes_in_high_security


### PR DESCRIPTION
# Overview
Multiple bugs were encountered and fixed while exploring issue with why certain Sidekiq processes were not recording calls to external services.  Principally, when an error is noticed and recording such against a span/segment that does not have any custom attributes, a Cannot modify Frozen Hash exception would result and agent attributes for the span/segment would not be collected.  It is not known at this time whether these bugfixes resolve the original observation of not seeing external calls/spans in the UI, but nevertheless, these bugs are now fixed.

# Related Github Issue
* closes #518 
* closes #519 
* closes #520 

