### PR TITLE
Add connect response data to infinite trace metadata

### DIFF
--- a/infinite_tracing/CHANGELOG.md
+++ b/infinite_tracing/CHANGELOG.md
@@ -1,4 +1,7 @@
 # New Relic Infinite Tracing for Ruby Agent Release Notes #
+
+  ## v6.15.0
+  * Adds data from the agents connect response `request_headers_map` to the metadata for the connection to the infinite trace observer.
   
   ## v6.12.0
 

--- a/infinite_tracing/lib/infinite_tracing/connection.rb
+++ b/infinite_tracing/lib/infinite_tracing/connection.rb
@@ -97,6 +97,7 @@ module NewRelic::Agent
             "license_key" => license_key,
             "agent_run_token" => agent_id
           }
+          @metadata.merge!(request_headers_map)
         end
       end
 
@@ -136,6 +137,12 @@ module NewRelic::Agent
 
       def license_key
         NewRelic::Agent.config[:license_key]
+      end
+
+      def request_headers_map
+        headers = NewRelic::Agent.agent.service.request_headers_map || NewRelic::EMPTY_HASH
+        # transform_keys only 2.5+, but infinite tracing is 2.5+ only also
+        headers.transform_keys(&:downcase)
       end
 
       # Continues retrying the connection at backoff intervals until a successful connection is made

--- a/infinite_tracing/lib/infinite_tracing/connection.rb
+++ b/infinite_tracing/lib/infinite_tracing/connection.rb
@@ -140,7 +140,7 @@ module NewRelic::Agent
       end
 
       def request_headers_map
-        headers = NewRelic::Agent.agent.service.request_headers_map || NewRelic::EMPTY_HASH
+        headers = NewRelic::Agent.agent.service.instance_variable_get(:@request_headers_map) || NewRelic::EMPTY_HASH
         # transform_keys only 2.5+, but infinite tracing is 2.5+ only also
         headers.transform_keys(&:downcase)
       end

--- a/infinite_tracing/test/infinite_tracing/connection_test.rb
+++ b/infinite_tracing/test/infinite_tracing/connection_test.rb
@@ -18,7 +18,6 @@ module NewRelic
           with_serial_lock do
             timeout_cap do
               with_config localhost_config do
-
                 connection = Connection.instance # instantiate before simulation
                 simulate_connect_to_collector fiddlesticks_config, 0.01 do |simulator|
                   simulator.join # ensure our simulation happens!
@@ -38,7 +37,6 @@ module NewRelic
           with_serial_lock do
             timeout_cap do
               with_config localhost_config do
-
                 simulate_connect_to_collector fiddlesticks_config, 0.0 do |simulator|
                   simulator.join # ensure our simulation happens!
                   connection = Connection.instance # instantiate after simulated connection
@@ -58,7 +56,6 @@ module NewRelic
           with_serial_lock do
             timeout_cap do
               with_config localhost_config do
-
                 simulate_connect_to_collector fiddlesticks_config, 0.01 do |simulator|
                   simulator.join # ensure our simulation happens!
                   connection = Connection.instance
@@ -78,7 +75,6 @@ module NewRelic
           with_serial_lock do
             timeout_cap do
               with_config localhost_config do
-
                 connection = Connection.instance
                 simulate_connect_to_collector fiddlesticks_config, 0.0 do |simulator|
                   simulator.join

--- a/infinite_tracing/test/infinite_tracing/connection_test.rb
+++ b/infinite_tracing/test/infinite_tracing/connection_test.rb
@@ -18,7 +18,6 @@ module NewRelic
           with_serial_lock do
             timeout_cap do
               with_config localhost_config do
-                NewRelic::Agent.agent.service.instance_variable_set(:@request_headers_map, {"NR-UtilizationMetadata"=>"test_metadata"})
 
                 connection = Connection.instance # instantiate before simulation
                 simulate_connect_to_collector fiddlesticks_config, 0.01 do |simulator|
@@ -27,7 +26,6 @@ module NewRelic
 
                   assert_equal "swiss_cheese", metadata["license_key"]
                   assert_equal "fiddlesticks", metadata["agent_run_token"]
-                  assert_equal "test_metadata", metadata["nr-utilizationmetadata"]
                 end
               end
             end
@@ -40,7 +38,6 @@ module NewRelic
           with_serial_lock do
             timeout_cap do
               with_config localhost_config do
-                NewRelic::Agent.agent.service.instance_variable_set(:@request_headers_map, {"NR-UtilizationMetadata"=>"test_metadata"})
 
                 simulate_connect_to_collector fiddlesticks_config, 0.0 do |simulator|
                   simulator.join # ensure our simulation happens!
@@ -49,7 +46,6 @@ module NewRelic
 
                   assert_equal "swiss_cheese", metadata["license_key"]
                   assert_equal "fiddlesticks", metadata["agent_run_token"]
-                  assert_equal "test_metadata", metadata["nr-utilizationmetadata"]
                 end
               end
             end
@@ -62,7 +58,6 @@ module NewRelic
           with_serial_lock do
             timeout_cap do
               with_config localhost_config do
-                NewRelic::Agent.agent.service.instance_variable_set(:@request_headers_map, {"NR-UtilizationMetadata"=>"test_metadata"})
 
                 simulate_connect_to_collector fiddlesticks_config, 0.01 do |simulator|
                   simulator.join # ensure our simulation happens!
@@ -71,7 +66,6 @@ module NewRelic
 
                   assert_equal "swiss_cheese", metadata["license_key"]
                   assert_equal "fiddlesticks", metadata["agent_run_token"]
-                  assert_equal "test_metadata", metadata["nr-utilizationmetadata"]
                 end
               end
             end
@@ -84,7 +78,6 @@ module NewRelic
           with_serial_lock do
             timeout_cap do
               with_config localhost_config do
-                NewRelic::Agent.agent.service.instance_variable_set(:@request_headers_map, {"NR-UtilizationMetadata"=>"test_metadata"})
 
                 connection = Connection.instance
                 simulate_connect_to_collector fiddlesticks_config, 0.0 do |simulator|
@@ -92,17 +85,13 @@ module NewRelic
                   metadata = connection.send :metadata
                   assert_equal "swiss_cheese", metadata["license_key"]
                   assert_equal "fiddlesticks", metadata["agent_run_token"]
-                  assert_equal "test_metadata", metadata["nr-utilizationmetadata"]
 
                   simulate_reconnect_to_collector(reconnect_config)
-                  NewRelic::Agent.agent.service.instance_variable_set(:@request_headers_map, {"NR-UtilizationMetadata_1"=>"test_metadata"})
 
                   metadata = connection.send :metadata
 
                   assert_equal "swiss_cheese", metadata["license_key"]
                   assert_equal "shazbat", metadata["agent_run_token"]
-                  assert_equal "test_metadata", metadata["nr-utilizationmetadata_1"]
-
                 end
               end
             end
@@ -186,6 +175,24 @@ module NewRelic
             end
 
             assert_equal 2, attempts
+          end
+        end
+
+        def test_metadata_includes_request_headers_map
+          with_serial_lock do
+            timeout_cap do
+              with_config localhost_config do
+                NewRelic::Agent.agent.service.instance_variable_set(:@request_headers_map, {"NR-UtilizationMetadata"=>"test_metadata"})
+
+                connection = Connection.instance # instantiate before simulation
+                simulate_connect_to_collector fiddlesticks_config, 0.01 do |simulator|
+                  simulator.join # ensure our simulation happens!
+                  metadata = connection.send :metadata
+
+                  assert_equal "test_metadata", metadata["nr-utilizationmetadata"]
+                end
+              end
+            end
           end
         end
 

--- a/infinite_tracing/test/infinite_tracing/connection_test.rb
+++ b/infinite_tracing/test/infinite_tracing/connection_test.rb
@@ -18,6 +18,7 @@ module NewRelic
           with_serial_lock do
             timeout_cap do
               with_config localhost_config do
+                NewRelic::Agent.agent.service.instance_variable_set(:@request_headers_map, {"NR-UtilizationMetadata"=>"test_metadata"})
 
                 connection = Connection.instance # instantiate before simulation
                 simulate_connect_to_collector fiddlesticks_config, 0.01 do |simulator|
@@ -26,6 +27,7 @@ module NewRelic
 
                   assert_equal "swiss_cheese", metadata["license_key"]
                   assert_equal "fiddlesticks", metadata["agent_run_token"]
+                  assert_equal "test_metadata", metadata["nr-utilizationmetadata"]
                 end
               end
             end
@@ -38,6 +40,7 @@ module NewRelic
           with_serial_lock do
             timeout_cap do
               with_config localhost_config do
+                NewRelic::Agent.agent.service.instance_variable_set(:@request_headers_map, {"NR-UtilizationMetadata"=>"test_metadata"})
 
                 simulate_connect_to_collector fiddlesticks_config, 0.0 do |simulator|
                   simulator.join # ensure our simulation happens!
@@ -46,6 +49,7 @@ module NewRelic
 
                   assert_equal "swiss_cheese", metadata["license_key"]
                   assert_equal "fiddlesticks", metadata["agent_run_token"]
+                  assert_equal "test_metadata", metadata["nr-utilizationmetadata"]
                 end
               end
             end
@@ -58,6 +62,8 @@ module NewRelic
           with_serial_lock do
             timeout_cap do
               with_config localhost_config do
+                NewRelic::Agent.agent.service.instance_variable_set(:@request_headers_map, {"NR-UtilizationMetadata"=>"test_metadata"})
+
                 simulate_connect_to_collector fiddlesticks_config, 0.01 do |simulator|
                   simulator.join # ensure our simulation happens!
                   connection = Connection.instance
@@ -65,6 +71,7 @@ module NewRelic
 
                   assert_equal "swiss_cheese", metadata["license_key"]
                   assert_equal "fiddlesticks", metadata["agent_run_token"]
+                  assert_equal "test_metadata", metadata["nr-utilizationmetadata"]
                 end
               end
             end
@@ -77,18 +84,25 @@ module NewRelic
           with_serial_lock do
             timeout_cap do
               with_config localhost_config do
+                NewRelic::Agent.agent.service.instance_variable_set(:@request_headers_map, {"NR-UtilizationMetadata"=>"test_metadata"})
+
                 connection = Connection.instance
                 simulate_connect_to_collector fiddlesticks_config, 0.0 do |simulator|
                   simulator.join
                   metadata = connection.send :metadata
                   assert_equal "swiss_cheese", metadata["license_key"]
                   assert_equal "fiddlesticks", metadata["agent_run_token"]
+                  assert_equal "test_metadata", metadata["nr-utilizationmetadata"]
 
                   simulate_reconnect_to_collector(reconnect_config)
+                  NewRelic::Agent.agent.service.instance_variable_set(:@request_headers_map, {"NR-UtilizationMetadata_1"=>"test_metadata"})
+
                   metadata = connection.send :metadata
 
                   assert_equal "swiss_cheese", metadata["license_key"]
                   assert_equal "shazbat", metadata["agent_run_token"]
+                  assert_equal "test_metadata", metadata["nr-utilizationmetadata_1"]
+
                 end
               end
             end

--- a/lib/new_relic/agent/new_relic_service.rb
+++ b/lib/new_relic/agent/new_relic_service.rb
@@ -33,7 +33,7 @@ module NewRelic
       CONNECTION_ERRORS = [Timeout::Error, EOFError, SystemCallError, SocketError].freeze
 
       attr_accessor :request_timeout
-      attr_reader :collector, :marshaller, :agent_id, :request_headers_map
+      attr_reader :collector, :marshaller, :agent_id
 
       def initialize(license_key=nil, collector=control.server)
         @license_key = license_key

--- a/lib/new_relic/agent/new_relic_service.rb
+++ b/lib/new_relic/agent/new_relic_service.rb
@@ -33,7 +33,7 @@ module NewRelic
       CONNECTION_ERRORS = [Timeout::Error, EOFError, SystemCallError, SocketError].freeze
 
       attr_accessor :request_timeout
-      attr_reader :collector, :marshaller, :agent_id
+      attr_reader :collector, :marshaller, :agent_id, :request_headers_map
 
       def initialize(license_key=nil, collector=control.server)
         @license_key = license_key


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
Adds the key-value pairs from `request_headers_map` (in the agents connect response) to the metadata used in connecting to the infinite trace observer. The keys are all downcased per the spec.

# Related Github Issue
closes #508 

# Testing
All the existing connection tests on metadata have been updated to include these changes
