### PR TITLE
509 handle failed precondition response

### DIFF
--- a/infinite_tracing/lib/infinite_tracing/client.rb
+++ b/infinite_tracing/lib/infinite_tracing/client.rb
@@ -77,6 +77,7 @@ module NewRelic::Agent
 
         case error
         when GRPC::Unavailable then restart
+        when GRPC::FailedPrecondition then restart
         when GRPC::Unimplemented then suspend
         else
           # Set exponential backoff to false so we'll reconnect at periodic (15 second) intervals instead
@@ -152,8 +153,6 @@ module NewRelic::Agent
       def record_span_batches exponential_backoff
         RecordStatusHandler.new self, Connection.record_span_batches(self, buffer.batch_enumerator, exponential_backoff)
       end
-
     end
-
   end
 end

--- a/infinite_tracing/test/infinite_tracing/connection_test.rb
+++ b/infinite_tracing/test/infinite_tracing/connection_test.rb
@@ -142,7 +142,7 @@ module NewRelic
                 active_client = client
               end
               refute_kind_of SuspendedStreamingBuffer, active_client.buffer
-              refute active_client.suspended?, "expected client to be suspended."
+              refute active_client.suspended?, "expected client to not be suspended."
 
               assert_equal total_spans, segments.size
               assert_equal 0, spans.size
@@ -152,7 +152,7 @@ module NewRelic
 
               assert_metrics_recorded({
                 "Supportability/InfiniteTracing/Span/Seen" => {:call_count => total_spans},
-                "Supportability/InfiniteTracing/Span/gRPC/FAILED_PRECONDITION" => {:call_count => 10}
+                "Supportability/InfiniteTracing/Span/gRPC/FAILED_PRECONDITION" => {:call_count => 5}
               })
             end
           end

--- a/infinite_tracing/test/infinite_tracing/connection_test.rb
+++ b/infinite_tracing/test/infinite_tracing/connection_test.rb
@@ -132,6 +132,32 @@ module NewRelic
           end
         end
 
+        def test_handling_failed_precondition_server_response
+          with_serial_lock do
+            timeout_cap do
+              total_spans = 5
+              active_client = nil
+
+              spans, segments = emulate_streaming_to_failed_precondition(total_spans) do |client, segments|
+                active_client = client
+              end
+              refute_kind_of SuspendedStreamingBuffer, active_client.buffer
+              refute active_client.suspended?, "expected client to be suspended."
+
+              assert_equal total_spans, segments.size
+              assert_equal 0, spans.size
+
+              assert_metrics_recorded "Supportability/InfiniteTracing/Span/Sent"
+              assert_metrics_recorded "Supportability/InfiniteTracing/Span/Response/Error"
+
+              assert_metrics_recorded({
+                "Supportability/InfiniteTracing/Span/Seen" => {:call_count => total_spans},
+                "Supportability/InfiniteTracing/Span/gRPC/FAILED_PRECONDITION" => {:call_count => 10}
+              })
+            end
+          end
+        end
+
         def test_handling_ok_and_close_server_response
           timeout_cap 5 do
             with_detailed_trace do 
@@ -147,10 +173,7 @@ module NewRelic
 
               refute_metrics_recorded "Supportability/InfiniteTracing/Span/Response/Error"
 
-              assert_metrics_recorded({
-                "Supportability/InfiniteTracing/Span/Seen" => {:call_count => total_spans},
-                "Supportability/InfiniteTracing/Span/Sent" => {:call_count => total_spans},
-              })
+              assert_metrics_recorded("Supportability/InfiniteTracing/Span/Sent")
             end
           end
         end

--- a/infinite_tracing/test/support/fake_trace_observer.rb
+++ b/infinite_tracing/test/support/fake_trace_observer.rb
@@ -87,6 +87,14 @@ if NewRelic::Agent::InfiniteTracing::Config.should_load?
       end
     end
 
+    class FailedPreconditionInfiniteTracer < BaseInfiniteTracer
+      def record_span(record_spans)
+        @lock.synchronize { @noticed.signal }
+        msg = "I don't exist!"
+        raise GRPC::BadStatus.new(GRPC::Core::StatusCodes::FAILED_PRECONDITION, msg)
+      end
+    end
+
     class FakeTraceObserverServer
       attr_reader :trace_observer, :worker
 

--- a/infinite_tracing/test/support/fake_trace_observer.rb
+++ b/infinite_tracing/test/support/fake_trace_observer.rb
@@ -88,10 +88,16 @@ if NewRelic::Agent::InfiniteTracing::Config.should_load?
     end
 
     class FailedPreconditionInfiniteTracer < BaseInfiniteTracer
+      def initialize
+        super
+        @count = 0
+      end
+
       def record_span(record_spans)
         @lock.synchronize { @noticed.signal }
         msg = "I don't exist!"
-        raise GRPC::BadStatus.new(GRPC::Core::StatusCodes::FAILED_PRECONDITION, msg)
+        @count += 1
+        raise GRPC::BadStatus.new(GRPC::Core::StatusCodes::FAILED_PRECONDITION, msg) if @count <= 5
       end
     end
 

--- a/infinite_tracing/test/support/fake_trace_observer_helpers.rb
+++ b/infinite_tracing/test/support/fake_trace_observer_helpers.rb
@@ -246,6 +246,10 @@ if NewRelic::Agent::InfiniteTracing::Config.should_load?
             emulate_streaming_with_tracer UnimplementedInfiniteTracer, count, max_buffer_size, &block
           end
 
+          def emulate_streaming_to_failed_precondition count, max_buffer_size=100_000, &block
+            emulate_streaming_with_tracer FailedPreconditionInfiniteTracer, count, max_buffer_size, &block
+          end
+
           def emulate_streaming_with_initial_error count, max_buffer_size=100_000, &block
             emulate_streaming_with_tracer ErroringInfiniteTracer, count, max_buffer_size, &block
           end


### PR DESCRIPTION
# Overview
Implements handing FAILED_PRECONDITION responses from the server.

# Related Github Issue
Closes #509
