### PR TITLE
Upgrade ruby 3 preview version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy: 
       matrix: 
-        ruby-version: [2.0.0-p648, 2.1.10, 2.2.10, 2.3.8, 2.4.10, 2.5.8, 2.6.6, 2.7.1, 3.0.0-preview1, jruby-9.2.12.0]
+        ruby-version: [2.0.0-p648, 2.1.10, 2.2.10, 2.3.8, 2.4.10, 2.5.8, 2.6.6, 2.7.1, 3.0.0-preview2, jruby-9.2.12.0]
     steps:
       - uses: actions/checkout@v2
 
@@ -28,27 +28,27 @@ jobs:
       fail-fast: false
       matrix: 
         rails: [norails, rails60, rails52, rails51, rails42, rails41, rails40, rails32, rails31, rails30]
-        ruby-version: [2.0.0-p648, 2.1.10, 2.2.10, 2.3.8, 2.4.10, 2.5.8, 2.6.6, 2.7.1, 3.0.0-preview1, jruby-9.2.12.0]
+        ruby-version: [2.0.0-p648, 2.1.10, 2.2.10, 2.3.8, 2.4.10, 2.5.8, 2.6.6, 2.7.1, 3.0.0-preview2, jruby-9.2.12.0]
         exclude:
-          - ruby-version: "3.0.0-preview1"
+          - ruby-version: "3.0.0-preview2"
             rails: rails30
-          - ruby-version: "3.0.0-preview1"
+          - ruby-version: "3.0.0-preview2"
             rails: rails31
-          - ruby-version: "3.0.0-preview1"
+          - ruby-version: "3.0.0-preview2"
             rails: rails32
-          - ruby-version: "3.0.0-preview1"
+          - ruby-version: "3.0.0-preview2"
             rails: rails40
-          - ruby-version: "3.0.0-preview1"
+          - ruby-version: "3.0.0-preview2"
             rails: rails41
-          - ruby-version: "3.0.0-preview1"
+          - ruby-version: "3.0.0-preview2"
             rails: rails42
-          - ruby-version: "3.0.0-preview1"
+          - ruby-version: "3.0.0-preview2"
             rails: rails50
-          - ruby-version: "3.0.0-preview1"
+          - ruby-version: "3.0.0-preview2"
             rails: rails51
-          - ruby-version: "3.0.0-preview1"
+          - ruby-version: "3.0.0-preview2"
             rails: rails52
-          - ruby-version: "3.0.0-preview1"
+          - ruby-version: "3.0.0-preview2"
             rails: rails60
           - ruby-version: "2.7.1"
             rails: rails30
@@ -191,15 +191,15 @@ jobs:
       fail-fast: false
       matrix:
         multiverse: [agent, api, background, background_2, database, httpclients, rails, rails_extras, rest, serialization, sinatra]
-        ruby-version: [2.0.0-p648, 2.1.10, 2.2.10, 2.3.8, 2.4.10, 2.5.8, 2.6.6, 2.7.1, 3.0.0-preview1, jruby-9.2.12.0]
+        ruby-version: [2.0.0-p648, 2.1.10, 2.2.10, 2.3.8, 2.4.10, 2.5.8, 2.6.6, 2.7.1, 3.0.0-preview2, jruby-9.2.12.0]
         exclude:
-          - ruby-version: "3.0.0-preview1"
+          - ruby-version: "3.0.0-preview2"
             multiverse: api
-          - ruby-version: "3.0.0-preview1"
+          - ruby-version: "3.0.0-preview2"
             multiverse: sinatra
-          - ruby-version: "3.0.0-preview1"
+          - ruby-version: "3.0.0-preview2"
             multiverse: rails
-          - ruby-version: "3.0.0-preview1"
+          - ruby-version: "3.0.0-preview2"
             multiverse: rails_extras
           - ruby-version: "2.7.1"
             multiverse: api


### PR DESCRIPTION
A new preview for ruby 3 has been released, `3.0.0-preview2`. This PR updates all CI running on preview1 to preview2.