### PR TITLE
Default net_prepend_instrumentation to false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@
     graceful shutdown exit handler, which will send any locally cached data to the New Relic collector prior to the 
     application shutting down.  This useful for when the primary framework has an embedded Sinatra application that 
     is otherwise detected and skips installing the exit hook for graceful shutdowns.
+
+  * **Default prepend_net_instrumentation to false**
+
+    Previously, this was defaulted to true. PMany gems are still using monkey patching on Net::HTTP, which causes compatibility issues with using prepend. Defaulting this to false will minimize instances of unexpected compatibilty issues.
     
   ## v6.14.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,14 +31,14 @@
 
   * **Default prepend_net_instrumentation to false**
 
-    Previously, this was defaulted to true. PMany gems are still using monkey patching on Net::HTTP, which causes compatibility issues with using prepend. Defaulting this to false will minimize instances of unexpected compatibilty issues.
+    Previously, `prepend_net_instrumentation` defaulted to true. However, many gems are still using monkey patching on Net::HTTP, which causes compatibility issues with using prepend. Defaulting this to false minimizes instances of 
+    unexpected compatibilty issues.
     
   ## v6.14.0
 
   * **Bugfix: Method tracers no longer cloning arguments**
   
-    Previously, when calling add_method_tracer with certain combination of arguments, it would lead to the wrapped method's arguments
-    being cloned rather than passed to the original method for manipulation as intended.  This has been fixed.
+    Previously, when calling add_method_tracer with certain combination of arguments, it would lead to the wrapped method's arguments being cloned rather than passed to the original method for manipulation as intended.  This has been fixed.
 
   * **Bugfix: Delayed Job instrumentation fixed for Ruby 2.7+**
 

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -843,7 +843,7 @@ module NewRelic
           :description => 'If <code>true</code>, uses Module.prepend rather than alias_method for ActiveRecord instrumentation.'
         },
         :prepend_net_instrumentation => {
-          :default => true,
+          :default => false,
           :public => true,
           :type => Boolean,
           :allowed_from_server => false,

--- a/test/multiverse/suites/net_http_prepend/config/newrelic.yml
+++ b/test/multiverse/suites/net_http_prepend/config/newrelic.yml
@@ -4,6 +4,7 @@ development:
     enabled: true
   apdex_t: 0.5
   monitor_mode: true
+  prepend_net_instrumentation: true
   license_key: bootstrap_newrelic_admin_license_key_000
   ca_bundle_path: ../../../config/test.cert.crt
   app_name: test


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
We've had a few issues come through where prepend instrumentation on Net::HTTP is causing compatibility issues with gems that are still using monkey patching on the same objects. For now, we should change the default behavior back to monkey patching to prevent unexpected problems to arise for customers using gems that monkey patch. We should revisit this change when we do our major shift to prepend in our next major release. 

# Related Github Issue
https://github.com/newrelic/newrelic-ruby-agent/issues/530
https://github.com/newrelic/newrelic-ruby-agent/issues/510