### PR TITLE
Fix database adapter lookup for Rails 6.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: Continuous Integration
 
-on: 
-  push: 
+on:
+  push:
     branches:
       - main
       - dev
@@ -10,8 +10,8 @@ on:
 jobs:
   build-ruby:
     runs-on: ubuntu-latest
-    strategy: 
-      matrix: 
+    strategy:
+      matrix:
         ruby-version: [2.0.0-p648, 2.1.10, 2.2.10, 2.3.8, 2.4.10, 2.5.8, 2.6.6, 2.7.1, 3.0.0, jruby-9.2.12.0]
     steps:
       - uses: actions/checkout@v2
@@ -20,14 +20,14 @@ jobs:
         uses: ./.github/actions/build-ruby
         with:
           ruby-version: ${{ matrix.ruby-version }}
-  
+
   mini-env:
     needs: build-ruby
     runs-on: ubuntu-latest
-    strategy: 
+    strategy:
       fail-fast: false
-      matrix: 
-        rails: [norails, rails60, rails52, rails51, rails42, rails41, rails40, rails32, rails31, rails30]
+      matrix:
+        rails: [norails, rails61, rails60, rails52, rails51, rails42, rails41, rails40, rails32, rails31, rails30]
         ruby-version: [2.0.0-p648, 2.1.10, 2.2.10, 2.3.8, 2.4.10, 2.5.8, 2.6.6, 2.7.1, 3.0.0, jruby-9.2.12.0]
         exclude:
           - ruby-version: "3.0.0"
@@ -50,6 +50,8 @@ jobs:
             rails: rails52
           - ruby-version: "3.0.0"
             rails: rails60
+          - ruby-version: "3.0.0"
+            rails: rails61
           - ruby-version: "2.7.1"
             rails: rails30
           - ruby-version: "2.7.1"
@@ -96,10 +98,16 @@ jobs:
             rails: rails41
           - ruby-version: "2.4.10"
             rails: rails60
+          - ruby-version: "2.4.10"
+            rails: rails61
           - ruby-version: "2.3.8"
             rails: rails60
+          - ruby-version: "2.3.8"
+            rails: rails61
           - ruby-version: "2.2.10"
             rails: rails60
+          - ruby-version: "2.2.10"
+            rails: rails61
           - ruby-version: "2.1.10"
             rails: rails50
           - ruby-version: "2.1.10"
@@ -108,6 +116,8 @@ jobs:
             rails: rails52
           - ruby-version: "2.1.10"
             rails: rails60
+          - ruby-version: "2.1.10"
+            rails: rails61
           - ruby-version: "2.0.0-p648"
             rails: rails50
           - ruby-version: "2.0.0-p648"
@@ -116,6 +126,8 @@ jobs:
             rails: rails52
           - ruby-version: "2.0.0-p648"
             rails: rails60
+          - ruby-version: "2.0.0-p648"
+            rails: rails61
           - ruby-version: "jruby-9.2.12.0"
             rails: rails30
           - ruby-version: "jruby-9.2.12.0"
@@ -128,6 +140,8 @@ jobs:
             rails: rails41
           - ruby-version: "jruby-9.2.12.0"
             rails: rails60
+          - ruby-version: "jruby-9.2.12.0"
+            rails: rails61
           - ruby-version: "jruby-9.2.12.0"
             rails: rails52
     steps:
@@ -173,18 +187,18 @@ jobs:
         ports:
           - 5672:5672
         options: >-
-          --health-cmd "rabbitmqctl node_health_check" 
-          --health-interval 10s 
-          --health-timeout 5s 
+          --health-cmd "rabbitmqctl node_health_check"
+          --health-interval 10s
+          --health-timeout 5s
           --health-retries 5
       memcached:
         image: memcached:latest
         ports:
           - 11211:11211
         options: >-
-          --health-cmd "timeout 5 bash -c 'cat < /dev/null > /dev/udp/127.0.0.1/11211'" 
-          --health-interval 10s 
-          --health-timeout 5s 
+          --health-cmd "timeout 5 bash -c 'cat < /dev/null > /dev/udp/127.0.0.1/11211'"
+          --health-interval 10s
+          --health-timeout 5s
           --health-retries 5
 
     strategy:

--- a/lib/new_relic/agent.rb
+++ b/lib/new_relic/agent.rb
@@ -46,6 +46,7 @@ module NewRelic
     require 'new_relic/agent/error_collector'
     require 'new_relic/agent/sampler'
     require 'new_relic/agent/database'
+    require 'new_relic/agent/database_adapter'
     require 'new_relic/agent/datastores'
     require 'new_relic/agent/pipe_channel_manager'
     require 'new_relic/agent/configuration'

--- a/lib/new_relic/agent/database_adapter.rb
+++ b/lib/new_relic/agent/database_adapter.rb
@@ -1,0 +1,33 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+
+module NewRelic
+  module Agent
+    class DatabaseAdapter
+      VERSIONS = {
+        '6.1.0' => proc { ActiveRecord::Base.connection_db_config.configuration_hash[:adapter] },
+        '4.0.0' => proc { ActiveRecord::Base.connection_config[:adapter] },
+        '3.0.0' => proc { |env| ActiveRecord::Base.configurations[env]['adapter'] }
+      }
+
+      def self.value
+        return unless defined? ActiveRecord::Base
+        new(::NewRelic::Control.instance.env, ActiveRecord::VERSION::STRING).value
+      end
+
+      attr_reader :env, :version
+
+      def initialize(env, version)
+        @env = env
+        @version = Gem::Version.new(version)
+      end
+
+      def value
+        match = VERSIONS.keys.find { |key| version >= Gem::Version.new(key) }
+        return unless match
+        VERSIONS[match].call(env)
+      end
+    end
+  end
+end

--- a/lib/new_relic/environment_report.rb
+++ b/lib/new_relic/environment_report.rb
@@ -69,19 +69,7 @@ module NewRelic
     report_on('Arch'              ) { ::NewRelic::Agent::SystemInfo.processor_arch         }
     report_on('OS version'        ) { ::NewRelic::Agent::SystemInfo.os_version             }
     report_on('OS'                ) { ::NewRelic::Agent::SystemInfo.ruby_os_identifier     }
-    report_on('Database adapter'  ) do
-      begin
-        if ::ActiveRecord::Base.respond_to?(:connection_db_config)
-          ActiveRecord::Base.configurations.configs_for(env_name: NewRelic::Control.instance.env, name: "primary")
-            .connection_db_config.configuration_hash['adapter']
-        else
-          ActiveRecord::Base.configurations.configs_for(env_name: NewRelic::Control.instance.env, spec_name: "primary").config['adapter']
-        end
-
-      rescue NoMethodError
-        ActiveRecord::Base.configurations[NewRelic::Control.instance.env]['adapter']
-      end
-    end
+    report_on('Database adapter'  ) { ::NewRelic::Agent::DatabaseAdapter.value }
     report_on('Framework'       ) { Agent.config[:framework].to_s  }
     report_on('Dispatcher'      ) { Agent.config[:dispatcher].to_s }
     report_on('Environment'     ) { NewRelic::Control.instance.env }

--- a/test/environments/rails61/Gemfile
+++ b/test/environments/rails61/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gem 'rake', '~> 12.3.3'
 
-gem 'rails', '~> 5.1.0'
+gem 'rails', '6.1.0'
 
 gem 'minitest', '5.2.3'
 gem 'mocha', '~> 1.1.0', :require => false
@@ -11,18 +11,16 @@ gem 'rack-test'
 gem 'sprockets', '3.7.2'
 
 platforms :jruby do
-  gem "activerecord-jdbcmysql-adapter", "~> 51.0"
-  gem "activerecord-jdbcsqlite3-adapter", "~> 51.0"
-  gem "jruby-openssl"
+  gem 'jruby-openssl'
 end
 
 platforms :ruby, :rbx do
-  gem "mysql2"
-  gem 'sqlite3', '~> 1.3.13'
+  gem 'mysql2'
+  gem 'sqlite3', '~> 1.4'
 end
 
-gem "newrelic_rpm", :path => "../../.."
+gem 'newrelic_rpm', :path => '../../..'
 
+gem 'hometown', '~> 0.2.5'
 gem 'pry', '~> 0.12.2'
 gem 'pry-nav'
-gem 'hometown', '~> 0.2.5'

--- a/test/environments/rails61/Rakefile
+++ b/test/environments/rails61/Rakefile
@@ -1,0 +1,11 @@
+# Add your own tasks in files placed in lib/tasks ending in .rake,
+# for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
+
+require File.expand_path('../config/application', __FILE__)
+require 'rake'
+
+RpmTestApp::Application.load_tasks
+require 'tasks/all'
+
+Rake::Task["default"].clear
+task :default => [:'test:newrelic']

--- a/test/environments/rails61/config/application.rb
+++ b/test/environments/rails61/config/application.rb
@@ -1,0 +1,19 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+
+require File.expand_path('../boot', __FILE__)
+
+require 'rails/all'
+require 'active_record/base'
+
+Bundler.require(:default, Rails.env) if defined?(Bundler)
+
+module RpmTestApp
+  class Application < Rails::Application
+    config.encoding = "utf-8"
+    config.filter_parameters += [:password]
+    config.secret_key_base = '414fd9af0cc192729b2b6bffe9e7077c9ac8eed5cbb74c8c4cd628906b716770598a2b7e1f328052753a4df72e559969dc05b408de73ce040c93cac7c51a348e'
+    config.eager_load = false
+  end
+end

--- a/test/environments/rails61/config/boot.rb
+++ b/test/environments/rails61/config/boot.rb
@@ -1,0 +1,10 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+
+require 'rubygems'
+
+# Set up gems listed in the Gemfile.
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
+
+require 'bundler/setup' if File.exists?(ENV['BUNDLE_GEMFILE'])

--- a/test/environments/rails61/config/database.yml
+++ b/test/environments/rails61/config/database.yml
@@ -1,0 +1,26 @@
+mysql: &mysql
+  adapter: mysql2
+  username: root
+  password: <%= ENV['MYSQL_PASSWORD'] %>
+  host: localhost
+  database: <%= db = "#{ENV['RUBY_VERSION']}#{ENV['BRANCH']}"; db.empty? ? "rails_blog" : db %>
+
+sqlite3: &sqlite3
+<% if defined?(JRuby) %>
+  adapter: jdbcsqlite3
+<% else %>
+  adapter: sqlite3
+<% end %>
+  database: db/all.sqlite3
+  pool: 5
+  timeout: 5000
+  host: localhost
+
+development:
+  <<: *sqlite3
+
+test:
+  <<: *sqlite3
+
+production:
+  <<: *sqlite3

--- a/test/environments/rails61/config/environment.rb
+++ b/test/environments/rails61/config/environment.rb
@@ -1,0 +1,6 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+
+require File.expand_path('../application', __FILE__)
+RpmTestApp::Application.initialize!

--- a/test/environments/rails61/db/schema.rb
+++ b/test/environments/rails61/db/schema.rb
@@ -1,0 +1,5 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+
+# File is required to exist by Rails


### PR DESCRIPTION
# Overview
The adapter lookup in Rails 6.1 is raising an error which is caught by the rescue block. However, the lookup in the rescue block is producing a deprecation warning that will be removed in Rails 6.2.
