### PR TITLE
Ruby 3 has removed :global_method_state from VM stats

### DIFF
--- a/lib/new_relic/agent/vm/mri_vm.rb
+++ b/lib/new_relic/agent/vm/mri_vm.rb
@@ -45,9 +45,11 @@ module NewRelic
 
         def gather_ruby_vm_stats(snap)
           if supports?(:method_cache_invalidations)
-            vm_stats = RubyVM.stat
-            snap.method_cache_invalidations = vm_stats[:global_method_state]
-            snap.constant_cache_invalidations = vm_stats[:global_constant_state]
+            snap.method_cache_invalidations = RubyVM.stat[:global_method_state]
+          end
+
+          if supports?(:constant_cache_invalidations)
+            snap.constant_cache_invalidations = RubyVM.stat[:global_constant_state]
           end
         end
 
@@ -66,7 +68,7 @@ module NewRelic
           when :minor_gc_count
             RUBY_VERSION >= '2.1.0'
           when :method_cache_invalidations
-            RUBY_VERSION >= '2.1.0'
+            RUBY_VERSION >= '2.1.0' && RUBY_VERSION < '3.0.0'
           when :constant_cache_invalidations
             RUBY_VERSION >= '2.1.0'
           else


### PR DESCRIPTION
This change fixes the 2 test suites that are currently failing in `dev` for `3.0.0-preview2`.

https://github.com/ruby/ruby/commit/278450de803c59137fff69c4db03cd40c5b5d08a
