### PR TITLE
Ensure transaction nesting max depth is always consistent with length of segments

### DIFF
--- a/lib/new_relic/agent/transaction.rb
+++ b/lib/new_relic/agent/transaction.rb
@@ -464,7 +464,7 @@ module NewRelic
         @ignore_apdex = options[:ignore_apdex] if options.key? :ignore_apdex
         @ignore_enduser = options[:ignore_enduser] if options.key? :ignore_enduser
 
-        nest_initial_segment if nesting_max_depth == 1
+        nest_initial_segment if segments.length == 1
         nested_name = self.class.nested_transaction_name options[:transaction_name]
         segment = create_segment nested_name
         set_default_transaction_name(options[:transaction_name], category)


### PR DESCRIPTION
# Overview
Transaction nesting_max_depth can get out of sync with segments length resulting in an exception when attempting to nest the initial segment which does not exist.

# Related Github Issue
https://github.com/newrelic/newrelic-ruby-agent/issues/545

# Testing
Existing test coverage ensures that the behaviour of nesting_max_depth is unchanged
