### PR TITLE
Remove reference to non-existing create_distributed_trace_headers method

### DIFF
--- a/lib/new_relic/agent/distributed_tracing.rb
+++ b/lib/new_relic/agent/distributed_tracing.rb
@@ -36,10 +36,10 @@ module NewRelic
       #
       # @api public
       #
-      # @deprecated See {#create_distributed_trace_headers} instead.
+      # @deprecated See {#insert_distributed_trace_headers} instead.
       #
       def create_distributed_trace_payload
-        Deprecator.deprecate :create_distributed_trace_payload, :create_distributed_trace_headers
+        Deprecator.deprecate :create_distributed_trace_payload, :insert_distributed_trace_headers
 
         unless Agent.config[:'distributed_tracing.enabled']
           NewRelic::Agent.logger.warn "Not configured to create New Relic distributed trace payload"

--- a/lib/new_relic/supportability_helper.rb
+++ b/lib/new_relic/supportability_helper.rb
@@ -13,7 +13,6 @@ module NewRelic
     API_SUPPORTABILITY_METRICS = [
       :insert_distributed_trace_headers,
       :accept_distributed_trace_headers,
-      :create_distributed_trace_headers,
       :add_custom_attributes,
       :add_custom_span_attributes,
       :add_instrumentation,


### PR DESCRIPTION
# Overview
We did implement custom version of distributed tracing in Sidekiq when it was not available back in time. In the logs, after upgrading newrelic_rpm gem, I've noticed following:

```
[2021-01-26 13:17:16 +0000 host.local (44425)] WARN : The method create_distributed_trace_payload is deprecated.
[2021-01-26 13:17:16 +0000 host.local (44425)] WARN : Please use create_distributed_trace_headers instead.
```

Problem is, `create_distributed_trace_headers` never existed. What we should use is `insert_distributed_trace_headers`.

# Testing
It's not required, no code changes.