### PR TITLE
Remove unused functions in test

### DIFF
--- a/test/new_relic/agent/transaction_sampler_test.rb
+++ b/test/new_relic/agent/transaction_sampler_test.rb
@@ -260,7 +260,6 @@ module NewRelic::Agent
                "expected sample duration = 2, but was: #{slowest.duration.inspect}")
 
         # 1 second duration
-        # run_sample_trace(0,1)
         in_transaction do
           s = Tracer.start_segment name: 'one_second'
           advance_time 1
@@ -434,31 +433,6 @@ module NewRelic::Agent
       (1..count).map do |millis|
         sample_with(opts.merge(:duration => (millis / 1000.0)))
       end
-    end
-
-    def run_long_sample_trace(n)
-      @sampler.on_start_transaction(@state, Time.now)
-      n.times do |i|
-        @sampler.notice_push_frame(@state)
-        yield if block_given?
-        @sampler.notice_pop_frame(@state, "node#{i}")
-      end
-      @sampler.on_finishing_transaction(@state, @txn, Time.now.to_f)
-    end
-
-    def run_sample_trace(start = Time.now.to_f, stop = nil, state = @state)
-      @sampler.on_start_transaction(state, start)
-      @sampler.notice_push_frame(state)
-      @sampler.notice_sql("SELECT * FROM sandwiches WHERE bread = 'wheat'", {}, 0, state)
-      @sampler.notice_push_frame(state)
-      @sampler.notice_sql("SELECT * FROM sandwiches WHERE bread = 'white'", {}, 0, state)
-      yield if block_given?
-      @sampler.notice_pop_frame(state, "ab")
-      @sampler.notice_push_frame(state)
-      @sampler.notice_sql("SELECT * FROM sandwiches WHERE bread = 'french'", {}, 0, state)
-      @sampler.notice_pop_frame(state, "ac")
-      @sampler.notice_pop_frame(state, "a")
-      @sampler.on_finishing_transaction(state, @txn, (stop || Time.now.to_f))
     end
 
     def intrinsic_attributes_from_last_sample


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
While looking at https://github.com/newrelic/newrelic-ruby-agent/pull/575 I noticed the two helper functions are never used anymore.