### PR TITLE
Implement prepend instrumentation for HTTPClient

### DIFF
--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -890,6 +890,14 @@ module NewRelic
 
           :description => "Controls auto-instrumentation of Net::HTTP at start up.  May be one of [auto|prepend|chain|disabled]."
         },
+        :'instrumentation.httpclient' => {
+          :default => instrumentation_value_of(:disable_httpclient),
+          :public => :true,
+          :type => String,
+          :dynamic_name => true,
+          :allowed_from_server => false,
+          :description => "Controls auto-instrumentation of HTTPClient gem at start up.  May be one of [auto|prepend|chain|disabled]."
+        },
         :disable_data_mapper => {
           :default => false,
           :public => true,
@@ -1503,7 +1511,7 @@ module NewRelic
           :type         => Boolean,
           :dynamic_name => true,
           :allowed_from_server => false,
-          :description  => 'If <code>true</code>, disables instrumentation for the httpclient gem.'
+          :description  => deprecated_description(:'instrumentation.httpclient', 'If <code>true</code>, disables instrumentation for the httpclient gem.')
         },
         :disable_net_http => {
           :default      => false,

--- a/lib/new_relic/agent/instrumentation/httpclient.rb
+++ b/lib/new_relic/agent/instrumentation/httpclient.rb
@@ -2,6 +2,9 @@
 # This file is distributed under New Relic's license terms.
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 
+require_relative 'httpclient/chain'
+require_relative 'httpclient/prepend'
+
 DependencyDetection.defer do
   named :httpclient
 
@@ -25,36 +28,10 @@ DependencyDetection.defer do
   end
 
   executes do
-    class HTTPClient
-      def do_get_block_with_newrelic(req, proxy, conn, &block)
-        wrapped_request = NewRelic::Agent::HTTPClients::HTTPClientRequest.new(req)
-        segment = NewRelic::Agent::Tracer.start_external_request_segment(
-          library: wrapped_request.type,
-          uri: wrapped_request.uri,
-          procedure: wrapped_request.method
-        )
-
-        begin
-          response = nil
-          segment.add_request_headers wrapped_request
-
-          NewRelic::Agent::Tracer.capture_segment_error segment do
-            do_get_block_without_newrelic(req, proxy, conn, &block)
-          end
-          response = conn.pop
-          conn.push response
-
-          wrapped_response = ::NewRelic::Agent::HTTPClients::HTTPClientResponse.new(response)
-          segment.process_response_headers wrapped_response
-
-          response
-        ensure
-          segment.finish if segment
-        end
-      end
-
-      alias do_get_block_without_newrelic do_get_block
-      alias do_get_block do_get_block_with_newrelic
+    if use_prepend?
+      prepend_instrument ::HTTPClient, NewRelic::Agent::Instrumentation::HTTPClient::Prepend
+    else
+      chain_instrument NewRelic::Agent::Instrumentation::HTTPClient::Chain
     end
   end
 end

--- a/lib/new_relic/agent/instrumentation/httpclient/chain.rb
+++ b/lib/new_relic/agent/instrumentation/httpclient/chain.rb
@@ -1,0 +1,44 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+
+module NewRelic::Agent::Instrumentation
+  module HTTPClient
+    module Chain 
+      def self.instrument!
+        ::HTTPClient.class_eval do
+          def do_get_block_with_newrelic(req, proxy, conn, &block)
+            wrapped_request = NewRelic::Agent::HTTPClients::HTTPClientRequest.new(req)
+            segment = NewRelic::Agent::Tracer.start_external_request_segment(
+              library: wrapped_request.type,
+              uri: wrapped_request.uri,
+              procedure: wrapped_request.method
+            )
+    
+            begin
+              response = nil
+              segment.add_request_headers wrapped_request
+    
+              NewRelic::Agent::Tracer.capture_segment_error segment do
+                do_get_block_without_newrelic(req, proxy, conn, &block)
+              end
+              response = conn.pop
+              conn.push response
+    
+              wrapped_response = ::NewRelic::Agent::HTTPClients::HTTPClientResponse.new(response)
+              segment.process_response_headers wrapped_response
+    
+              response
+            ensure
+              segment.finish if segment
+            end
+          end
+    
+          alias :do_get_block_without_newrelic :do_get_block
+          alias :do_get_block :do_get_block_with_newrelic
+        end
+      end
+    end
+  end
+end
+

--- a/lib/new_relic/agent/instrumentation/httpclient/prepend.rb
+++ b/lib/new_relic/agent/instrumentation/httpclient/prepend.rb
@@ -1,0 +1,38 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+
+
+module NewRelic::Agent::Instrumentation
+  module HTTPClient
+    module Prepend 
+      def do_get_block(req, proxy, conn, &block)
+        wrapped_request = NewRelic::Agent::HTTPClients::HTTPClientRequest.new(req)
+        segment = NewRelic::Agent::Tracer.start_external_request_segment(
+          library: wrapped_request.type,
+          uri: wrapped_request.uri,
+          procedure: wrapped_request.method
+        )
+
+        begin
+          response = nil
+          segment.add_request_headers wrapped_request
+
+          NewRelic::Agent::Tracer.capture_segment_error segment do
+            super
+          end
+          response = conn.pop
+          conn.push response
+
+          wrapped_response = ::NewRelic::Agent::HTTPClients::HTTPClientResponse.new(response)
+          segment.process_response_headers wrapped_response
+
+          response
+        ensure
+          segment.finish if segment
+        end
+      end
+    end
+  end
+end
+

--- a/test/multiverse/suites/httpclient/Envfile
+++ b/test/multiverse/suites/httpclient/Envfile
@@ -4,6 +4,7 @@ gemfile <<-RB
   gem 'json', :platforms => [:rbx, :mri_18]
   #{ruby3_gem_webrick}
 RB
+instrumentation_methods :chain, :prepend
 
 HTTPCLIENT_VERSIONS = %w(2.8.3
                          2.6.0

--- a/test/multiverse/suites/httpclient/config/newrelic.yml
+++ b/test/multiverse/suites/httpclient/config/newrelic.yml
@@ -6,6 +6,8 @@ development:
   monitor_mode: true
   license_key: bootstrap_newrelic_admin_license_key_000
   ca_bundle_path: ../../../config/test.cert.crt
+  instrumentation:
+    httpclient: <%= $instrumentation_method %>
   app_name: test
   host: localhost
   api_host: localhost


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
Updated HTTPClient gem instrumentation to have both prepend and chain options hooked up and defaults to prepend.

# Related Github Issue
closes #584 