### PR TITLE
Fix required ruby version for infinite tracing

### DIFF
--- a/infinite_tracing/newrelic-infinite_tracing.gemspec
+++ b/infinite_tracing/newrelic-infinite_tracing.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
 
   s.name = "newrelic-infinite_tracing"
   s.version = NewRelic::VERSION::STRING
-  s.required_ruby_version = '>= 2.3.0'
+  s.required_ruby_version = '>= 2.5.0'
   s.required_rubygems_version = Gem::Requirement.new("> 1.3.1") if s.respond_to? :required_rubygems_version=
   s.authors = [ "Rachel Klein", "Tanna McClure", "Michael Lang" ]
   s.date = Time.now.strftime('%Y-%m-%d')


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
The gemspec for infinite tracing had the required minimun ruby version as 2.3, however the correct minimum ruby version is 2.5. Our CI has already been reflecting that we support 2.5+, so this change is just to our gemspec to more accurately reflect the ruby versions infinite tracing is expected to run on.
