### PR TITLE
Exclude ruby 2.2 + Rails 5.2 on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,8 @@ jobs:
             rails: rails60
           - ruby-version: "2.2.10"
             rails: rails61
+          - ruby-version: "2.2.10"
+            rails: rails52
           - ruby-version: "jruby-9.2.12.0"
             rails: rails30
           - ruby-version: "jruby-9.2.12.0"


### PR DESCRIPTION

# Overview
Due to recent changes in rails, rails 5.2 no longer works on ruby 2.2. This adds an exclusion for that combo in our CI.

# Related Github Issue
closes https://github.com/newrelic/newrelic-ruby-agent/issues/634