### PR TITLE
Fix passing keyword arguments in ruby 3.0

### DIFF
--- a/lib/new_relic/agent/instrumentation/middleware_proxy.rb
+++ b/lib/new_relic/agent/instrumentation/middleware_proxy.rb
@@ -27,8 +27,8 @@ module NewRelic
             @middleware_class = middleware_class
           end
 
-          def new(*args, &blk)
-            middleware_instance = @middleware_class.new(*args, &blk)
+          def new(*args, **kwargs, &blk)
+            middleware_instance = @middleware_class.new(*args, **kwargs, &blk)
             MiddlewareProxy.wrap(middleware_instance)
           end
         end


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
`MiddlewareProxy` was passing keyword arguments in a deprecated way, which doesn't work in ruby 3.0.

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
Github Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 
