### PR TITLE
Fix passing keyword arguments in ruby 3.0

### DIFF
--- a/lib/new_relic/agent/instrumentation/middleware_proxy.rb
+++ b/lib/new_relic/agent/instrumentation/middleware_proxy.rb
@@ -32,7 +32,7 @@ module NewRelic
             MiddlewareProxy.wrap(middleware_instance)
           end
 
-          # ruby2_keywords(:new) if respond_to?(:ruby2_keywords, true)
+          ruby2_keywords(:new) if respond_to?(:ruby2_keywords, true)
         end
 
         def self.is_sinatra_app?(target)

--- a/lib/new_relic/agent/instrumentation/middleware_proxy.rb
+++ b/lib/new_relic/agent/instrumentation/middleware_proxy.rb
@@ -27,10 +27,12 @@ module NewRelic
             @middleware_class = middleware_class
           end
 
-          def new(*args, **kwargs, &blk)
-            middleware_instance = @middleware_class.new(*args, **kwargs, &blk)
+          def new(*args, &blk)
+            middleware_instance = @middleware_class.new(*args, &blk)
             MiddlewareProxy.wrap(middleware_instance)
           end
+
+          # ruby2_keywords(:new) if respond_to?(:ruby2_keywords, true)
         end
 
         def self.is_sinatra_app?(target)

--- a/lib/new_relic/agent/instrumentation/middleware_proxy.rb
+++ b/lib/new_relic/agent/instrumentation/middleware_proxy.rb
@@ -27,8 +27,8 @@ module NewRelic
             @middleware_class = middleware_class
           end
 
-          def new(*args, &blk)
-            middleware_instance = @middleware_class.new(*args, &blk)
+          def new(*args, **kwargs, &blk)
+            middleware_instance = @middleware_class.new(*args, **kwargs, &blk)
             MiddlewareProxy.wrap(middleware_instance)
           end
         end

--- a/test/new_relic/agent/instrumentation/middleware_proxy_test.rb
+++ b/test/new_relic/agent/instrumentation/middleware_proxy_test.rb
@@ -56,6 +56,24 @@ class NewRelic::Agent::Instrumentation::MiddlewareProxyTest < Minitest::Test
     assert_equal(['abc', 123], wrapped_instance.target.initialize_args)
   end
 
+  def test_generator_with_keyword_arguments
+    middleware_class = Class.new do
+      attr_reader :foo, :bar
+
+      def initialize(foo, bar:)
+        @foo = foo
+        @bar = bar
+      end
+    end
+
+    generator = NewRelic::Agent::Instrumentation::MiddlewareProxy.for_class(middleware_class)
+
+    wrapped_instance = generator.new('this_is_foo', bar: 'this_is_bar')
+
+    assert_equal('this_is_foo', wrapped_instance.target.foo)
+    assert_equal('this_is_bar', wrapped_instance.target.bar)
+  end
+
   def test_anonymous_class_naming
     middleware_class = Class.new
     wrapped_instance = NewRelic::Agent::Instrumentation::MiddlewareProxy.wrap(middleware_class.new)


### PR DESCRIPTION
# Overview
Passing keyword arguments to `middleware_class` in MiddlewareProxy is broken in ruby 3.0. It's fine, when middleware doesn't require `keyword arguments. Bu when it doesn't they are passed as an hash argument.

Here is an example issue from with honeycomb integration:

<img width="799" alt="Screenshot 2021-04-08 at 11 22 57" src="https://user-images.githubusercontent.com/63880/114002118-e1583680-985c-11eb-9467-f74993d5cc42.png">


# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
Github Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 
