### PR TITLE
record Action Cable events occurring outside of a transaction

### DIFF
--- a/lib/new_relic/agent/instrumentation/action_cable_subscriber.rb
+++ b/lib/new_relic/agent/instrumentation/action_cable_subscriber.rb
@@ -49,7 +49,11 @@ module NewRelic
         end
 
         def metric_name_from_payload(name, payload)
-          "Controller/ActionCable/#{payload[:channel_class]}/#{action_name(name)}"
+          if Tracer.current_transaction
+            "Controller/ActionCable/#{payload[:channel_class]}/#{action_name(name)}"
+          else
+            "Ruby/ActionCable/#{payload[:channel_class]}/#{action_name(name)}"
+          end
         end
 
         DOT_ACTION_CABLE = '.action_cable'.freeze

--- a/lib/new_relic/agent/instrumentation/action_cable_subscriber.rb
+++ b/lib/new_relic/agent/instrumentation/action_cable_subscriber.rb
@@ -19,7 +19,10 @@ module NewRelic
               category: :action_cable
             )
           else
-            Tracer.start_segment(name: metric_name_from_payload(name, payload))
+            Tracer.start_transaction_or_segment(
+              name: metric_name_from_payload(name, payload),
+              category: :action_cable
+            )
           end
           push_segment(id, finishable)
         rescue => e
@@ -46,7 +49,7 @@ module NewRelic
         end
 
         def metric_name_from_payload(name, payload)
-          "Ruby/ActionCable/#{payload[:channel_class]}/#{action_name(name)}"
+          "Controller/ActionCable/#{payload[:channel_class]}/#{action_name(name)}"
         end
 
         DOT_ACTION_CABLE = '.action_cable'.freeze

--- a/lib/new_relic/agent/instrumentation/rails_notifications/action_cable.rb
+++ b/lib/new_relic/agent/instrumentation/rails_notifications/action_cable.rb
@@ -24,7 +24,7 @@ DependencyDetection.defer do
 
   executes do
     # enumerate the specific events we want so that we do not get unexpected additions in the future
-    ActiveSupport::Notifications.subscribe(/(perform_action|transmit)\.action_cable/,
+    ActiveSupport::Notifications.subscribe(/(perform_action|transmit|broadcast)\.action_cable/,
       NewRelic::Agent::Instrumentation::ActionCableSubscriber.new)
 
     ActiveSupport.on_load(:action_cable) do


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
Previously, the agent was assuming certain action cable events would occur within an already existing transaction, but it appears this is typically not the case. This caused the data to be left behind since it was not associated with a transaction. This fix allows the action cable instrumentation to create a transaction if there is no current transaction.

# Related Github Issue
Include a link to the related GitHub issue, if applicable

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
Github Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
