### PR TITLE
Speedup jruby

### DIFF
--- a/test/new_relic/fake_server.rb
+++ b/test/new_relic/fake_server.rb
@@ -76,7 +76,6 @@ module NewRelic
       return unless running?
       @server.shutdown
       @server = nil
-      @thread.pass
       @thread.join if running?
       @started_options = nil
       reset

--- a/test/new_relic/fake_server.rb
+++ b/test/new_relic/fake_server.rb
@@ -76,7 +76,7 @@ module NewRelic
       return unless running?
       @server.shutdown
       @server = nil
-      @thread.join
+      @thread.join if running?
       @started_options = nil
       reset
     end
@@ -88,7 +88,6 @@ module NewRelic
     end
 
     def run_server
-      # Thread.current.abort_on_exception = true
       @server.start
     end
 

--- a/test/new_relic/fake_server.rb
+++ b/test/new_relic/fake_server.rb
@@ -69,7 +69,7 @@ module NewRelic
       @server = WEBrick::HTTPServer.new(@started_options)
       @server.mount "/", ::Rack::Handler.get(:webrick), app
 
-      @thread = Thread.new(&self.method(:run_server))
+      @thread = Thread.new(&self.method(:run_server)).tap{ |t| t.abort_on_exception = true }
     end
 
     def stop
@@ -88,7 +88,7 @@ module NewRelic
     end
 
     def run_server
-      Thread.current.abort_on_exception = true
+      # Thread.current.abort_on_exception = true
       @server.start
     end
 

--- a/test/new_relic/fake_server.rb
+++ b/test/new_relic/fake_server.rb
@@ -76,6 +76,7 @@ module NewRelic
       return unless running?
       @server.shutdown
       @server = nil
+      @thread.pass
       @thread.join if running?
       @started_options = nil
       reset


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
The `httpclient` suite can take well over 30 minutes to run approximately 4 minutes worth of tests with jRuby.  This PR introduces the --dev flag for jRuby environments that brings that overall runtime down to around 6 minutes.

# Related Github Issue
Resolves #637 

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
Github Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
