### PR TITLE
Add recently reported prepend conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # New Relic Ruby Agent Release Notes #
 
+  ## v7.1.0
+
+
+  * **Update known conflicts with use of Module#Prepend**
+    With our release of 7.0.0, we updated our instrumentation to use Module#Prepend by default, instead of method chaining. We have received reports of conflicts and added a check for these known conflicts. If a known conflict with prepend is detected while using the default value of 'auto' for gem instrumentation, the agent will instead install method chaining instrumentation in order to avoid this conflict. This check can by bypassed by setting the instrumentation method for the gem to 'prepend'.
+
+
   ## v7.0.0
 
   * **Ruby Agent 6.x to 7.x Migration Guide Available**

--- a/lib/new_relic/agent/instrumentation/net_http.rb
+++ b/lib/new_relic/agent/instrumentation/net_http.rb
@@ -17,8 +17,9 @@ DependencyDetection.defer do
     require 'new_relic/agent/http_clients/net_http_wrappers'
   end
 
+  # Airbrake uses method chaining on Net::HTTP in versions < 10.0.2 (10.0.2 updated to prepend for Net:HTTP)
   conflicts_with_prepend do
-    defined?(::Airbrake)
+    defined?(::Airbrake) && defined?(::Airbrake::AIRBRAKE_VERSION) && ::Gem::Version.create(::Airbrake::AIRBRAKE_VERSION) < ::Gem::Version.create('10.0.2')
   end
 
   conflicts_with_prepend do

--- a/lib/new_relic/agent/instrumentation/net_http.rb
+++ b/lib/new_relic/agent/instrumentation/net_http.rb
@@ -23,6 +23,10 @@ DependencyDetection.defer do
   end
 
   conflicts_with_prepend do
+    defined?(::ScoutApm)
+  end
+
+  conflicts_with_prepend do
     defined?(::Rack::MiniProfiler)
   end
 

--- a/lib/new_relic/agent/instrumentation/redis.rb
+++ b/lib/new_relic/agent/instrumentation/redis.rb
@@ -18,6 +18,10 @@ DependencyDetection.defer do
     defined?(::Redis) && defined?(::Redis::VERSION)
   end
 
+  conflicts_with_prepend do
+    defined?(::PrometheusExporter)
+  end
+
   depends_on do
     NewRelic::Agent::Datastores::Redis.is_supported_version? &&
       NewRelic::Agent::Datastores::Redis.safe_from_third_party_gem?

--- a/lib/new_relic/agent/instrumentation/resque.rb
+++ b/lib/new_relic/agent/instrumentation/resque.rb
@@ -13,6 +13,11 @@ DependencyDetection.defer do
     defined?(::Resque::Job) && !NewRelic::Agent.config[:disable_resque]
   end
 
+  # Airbrake uses method chaining on Resque::Job
+  conflicts_with_prepend do
+    defined?(::Airbrake)
+  end
+
   executes do
     ::NewRelic::Agent.logger.info 'Installing Resque instrumentation'
   end


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
Adds recently reported prepend conflicts to our checks before installing instrumentation. This will allow the agent to choose chain instrumentation instead of the default of prepend if the config setting is 'auto'. Setting the config value to prepend explicitly will bypass these checks.

# Related Github Issue
https://github.com/newrelic/newrelic-ruby-agent/issues/659 (redis & net_http)
https://github.com/newrelic/newrelic-ruby-agent/issues/656 (resque & net_http)


# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
