### PR TITLE
Use `connection` from sql.active_record payload over `connection_id`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,15 @@
 
   ## v7.1.0
 
-
   * **Update known conflicts with use of Module#Prepend**
     With our release of 7.0.0, we updated our instrumentation to use Module#Prepend by default, instead of method chaining. We have received reports of conflicts and added a check for these known conflicts. If a known conflict with prepend is detected while using the default value of 'auto' for gem instrumentation, the agent will instead install method chaining instrumentation in order to avoid this conflict. This check can by bypassed by setting the instrumentation method for the gem to 'prepend'.
 
+  * **Bugfix: Updated support for ActiveRecord 6.1+ instrumentation**
+
+    Previously, the agent depended on `connection_id` to be present in the Active Support instrumentation for `sql.active_record`
+    to get the current ActiveRecord connection. As of Rails 6.1, `connection_id` has been dropped in favor of providing the connection
+    object through the `connection` value exclusively. This resulted in datastore spans displaying fallback behavior, including showing
+    "ActiveRecord" as the database vendor.
 
   ## v7.0.0
 

--- a/lib/new_relic/agent/instrumentation/active_record_subscriber.rb
+++ b/lib/new_relic/agent/instrumentation/active_record_subscriber.rb
@@ -84,8 +84,6 @@ module NewRelic
         end
 
         def active_record_config(payload)
-          return unless payload[:connection_id]
-
           # handle if the notification payload provides the AR connection
           # available in Rails 6+ & our ActiveRecordNotifications#log extension
           if payload[:connection]
@@ -93,8 +91,8 @@ module NewRelic
             return connection_config if connection_config
           end
 
+          return unless connection_id = payload[:connection_id]
           connection = nil
-          connection_id = payload[:connection_id]
 
           ::ActiveRecord::Base.connection_handler.connection_pool_list.each do |handler|
             connection = handler.connections.detect do |conn|


### PR DESCRIPTION
As of Rails 6.1, ActiveRecord instrumentation does not provide `connection_id` in the payload for "sql.active_record". The agent currently expects this key to be there; in 6.1, this results in no connection config being fetched, and the default vendor falls back to "ActiveRecord" rather than the appropriate database name - other side effects may also be occurring.

The nature of this fix should ensure no behavior changes for the agent in existing Rails installations. `connection` will be used if present; otherwise it will fall back to `connection_id` (the previous behavior).

Also updated the unit test `test_active_record_config_for_event` to cover both pre- and post-Rails 6.1. This test was not working as intended and has been branched into two new tests.

Fixes https://github.com/newrelic/newrelic-ruby-agent/issues/561