### PR TITLE
Add support for CSP nonces when injecting the browser agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
   ## v7.1.0
 
+  * **Add support for CSP nonces when using our API to insert the browser agent**
+    We now support passing in a nonce to our API method `browser_timing_header` to allow the browser agent to run on applications using CSP nonces. This allows users to inject the browser agent themselves and use the nonce required for the script to run. In order to utilize this new feature, you must disable auto instrumentation for the browser agent, and use the API method browser_timing_header to pass the nonce in and inject the script manually.
+    
   * **Update known conflicts with use of Module#Prepend**
     With our release of v7.0.0, we updated our instrumentation to use Module#Prepend by default, instead of method chaining. We have received reports of conflicts and added a check for these known conflicts. If a known conflict with prepend is detected while using the default value of 'auto' for gem instrumentation, the agent will instead install method chaining instrumentation in order to avoid this conflict. This check can be bypassed by setting the instrumentation method for the gem to 'prepend'.
 

--- a/lib/new_relic/agent.rb
+++ b/lib/new_relic/agent.rb
@@ -760,11 +760,11 @@ module NewRelic
     #
     # @api public
     #
-    def browser_timing_header
+    def browser_timing_header(nonce=nil)
       record_api_supportability_metric(:browser_timing_header)
 
       return "" unless agent
-      agent.javascript_instrumentor.browser_timing_header
+      agent.javascript_instrumentor.browser_timing_header(nonce)
     end
 
     # @!endgroup

--- a/lib/new_relic/agent.rb
+++ b/lib/new_relic/agent.rb
@@ -758,6 +758,8 @@ module NewRelic
     # In previous agents there was a corresponding footer required, but all the
     # work is now done by this single method.
     #
+    # @param [String] nonce The nonce to use in the javascript tag for browser instrumentation
+    #
     # @api public
     #
     def browser_timing_header(nonce=nil)

--- a/test/new_relic/rack/browser_monitoring_test.rb
+++ b/test/new_relic/rack/browser_monitoring_test.rb
@@ -198,7 +198,7 @@ EOL
       "Content-Type"   => "text/html"
     }
     headers = headers_from_request(original_headers, "<html><body></body></html>")
-    assert_equal "344", headers["Content-Length"]
+    assert_equal "390", headers["Content-Length"]
   end
 
   def test_content_length_set_when_we_modify_source_containing_unicode
@@ -207,7 +207,7 @@ EOL
       "Content-Type"   => "text/html"
     }
     headers = headers_from_request(original_headers, "<html><body>☃</body></html>")
-    assert_equal "347", headers["Content-Length"]
+    assert_equal "393", headers["Content-Length"]
   end
 
   def test_content_length_set_when_response_is_nil


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
This PR adds support for CSP nonces when injecting the browser agent for our API method `browser_timing_header`. This change was implemented in a way that is in line with the other language agents, based on the updated agent specs for the Browser Monitoring API. 
In order to utilize this change, you must disable auto instrumentation for the browser agent, and use the API method `browser_timing_header` to inject the script manually.
Example:
```
<html>
  <head>
    <%= ::NewRelic::Agent.browser_timing_header("nonce") %>
    ...
  </head>
  <body>
```

# Related Github Issue
closes #332 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
