### PR TITLE
Remove httprb 5.0.0 from test suite

### DIFF
--- a/test/multiverse/suites/httprb/Envfile
+++ b/test/multiverse/suites/httprb/Envfile
@@ -4,12 +4,12 @@ end
 
 instrumentation_methods :chain, :prepend
 
-gemfile <<-RB
-  gem 'http' # latest version
-  gem 'public_suffix', '< 3.0.0' if RUBY_VERSION < "2.1.0"
-  gem 'rack'
-  #{ruby3_gem_webrick}
-RB
+# gemfile <<-RB
+#   gem 'http' # latest version
+#   gem 'public_suffix', '< 3.0.0' if RUBY_VERSION < "2.1.0"
+#   gem 'rack'
+#   #{ruby3_gem_webrick}
+# RB
 
 # NOTE, some versions of HTTP gem implements body with
 # String.new("").force_encoding(@encoding) which won't work 


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
This PR just comments out our testing of latest release of [httprb](https://github.com/httprb/http). 
We typically test the latest release as part of our CI, so that if a gem we instrument releases a new version that breaks our instrumentation we are aware of it. Httprb 5.0.0 was released, and appears to to break our instrumentation. We will need to investigate the changes and update our instrumentation to support this new version. However, in the meantime we will be removing this version from being tested in our CI until we add support for the changes made in that version. 
I just commented out the section where we test the latest version, so that it will be simple to add back later once we are supporting 5.0.0.

# Related Github Issue
closes #675 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
