### PR TITLE
Fix for overwritten bugfix in #564

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
   ## v7.1.0
 
+  * **Bugfix: Fix for missing part of a previous bugfix**
+    Our previous fix of "nil Middlewares injection now prevented and gracefully handled in Sinatra" released in 7.0.0 was partially overwritten by some of the other changes in that release. This release adds back those missing sections of the bugfix, and should resolve the issue for sinatra users. 
+
   * **Update known conflicts with use of Module#Prepend**
     With our release of v7.0.0, we updated our instrumentation to use Module#Prepend by default, instead of method chaining. We have received reports of conflicts and added a check for these known conflicts. If a known conflict with prepend is detected while using the default value of 'auto' for gem instrumentation, the agent will instead install method chaining instrumentation in order to avoid this conflict. This check can be bypassed by setting the instrumentation method for the gem to 'prepend'.
 

--- a/lib/new_relic/agent/instrumentation/sinatra/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/sinatra/instrumentation.rb
@@ -48,6 +48,7 @@ module NewRelic::Agent::Instrumentation
           has_middleware = app.middleware && app.middleware.any? { |info| info && info[0] == clazz }
           app.use(clazz) unless has_middleware
         end
+      end
 
       # Capture last route we've seen. Will set for transaction on route_eval
       def process_route_with_tracing(*args)


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
Unfortunately, part of the bugfix in [this PR](https://github.com/newrelic/newrelic-ruby-agent/pull/564) was accidentally overwritten when we made our prepend changes for 7.0.0. The only effected section of code was in the `lib/new_relic/agent/instrumentation/sinatra.rb` file [here](https://github.com/newrelic/newrelic-ruby-agent/pull/564/files#diff-1590c5124311e7422410bf0489dd50d1c309f71699d69efe6a008ec639900674R104-R112). This code was moved to the file `lib/new_relic/agent/instrumentation/sinatra/instrumentation.rb`, but the new changes were missed in this move. This PR adds back the missing part of the changes present in the original pull request. 

To use this branch, please add this to your gemfile
```
gem 'newrelic_rpm', 
  :git => 'https://github.com/newrelic/newrelic-ruby-agent.git',  
  :branch => 'bugfix/missing_partial_fix'
```


# Related Github Issue
PR - https://github.com/newrelic/newrelic-ruby-agent/pull/564

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
