### PR TITLE
Workaround for 403 response when using the staging collector

### DIFF
--- a/lib/new_relic/agent/new_relic_service.rb
+++ b/lib/new_relic/agent/new_relic_service.rb
@@ -426,7 +426,16 @@ module NewRelic
         size = data.size
 
         # Preconnect needs to always use the configured collector host, not the redirect host
-        endpoint_specific_collector = (method == :preconnect) ? @configured_collector : @collector
+        # endpoint_specific_collector = (method == :preconnect) ? @configured_collector : @collector
+
+        # This is a temporary workaround due to errors occurring on the staging collector. The prod collector does not have the same issue.
+        # The staging collector does not respond correctly when using the configured collector host for preconnect, so must use the redirect host
+        # Once this issue is resolved on the staging collector, use the original line that is commented out above.
+        endpoint_specific_collector = if method == :preconnect && (@configured_collector && @configured_collector.name != 'staging-collector.newrelic.com')
+                                        @configured_collector
+                                      else
+                                        @collector
+                                      end
 
         uri = remote_method_uri(method)
         full_uri = "#{endpoint_specific_collector}#{uri}"

--- a/lib/new_relic/agent/new_relic_service.rb
+++ b/lib/new_relic/agent/new_relic_service.rb
@@ -432,8 +432,10 @@ module NewRelic
         # The staging collector does not respond correctly when using the configured collector host for preconnect, so must use the redirect host
         # Once this issue is resolved on the staging collector, use the original line that is commented out above.
         endpoint_specific_collector = if method == :preconnect && (@configured_collector && @configured_collector.name != 'staging-collector.newrelic.com')
+                                        ::NewRelic::Agent.logger.debug "Using configured collector for preconnect: #{@configured_collector}"
                                         @configured_collector
                                       else
+                                        ::NewRelic::Agent.logger.debug "Using redirect host for collector: #{@collector}"
                                         @collector
                                       end
 


### PR DESCRIPTION
# Overview
This PR is a workaround for the issue happening with the staging collector. The issue this PR addresses only impacts internal New Relic teams that are using the agent to report to the staging collector.
This makes a change to the logic added in PR https://github.com/newrelic/newrelic-ruby-agent/pull/406 when making a preconnect request. The changes present in that pull request work correctly on production, but currently the staging collector is having issues when using the original configured collector. This change will allow the agent to use the redirect host for all preconnect requests rather than the configured collector. 
This change is intended to be a temporary workaround until the issue is resolved with the staging collector. 

# Related Github Issue
closes #657 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
