### PR TITLE
allow distributed_tracing.enabled to be set from server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
   ## v7.1.0
 
+  * **Enable server-side configuration of distributed tracing**
+
+    `distributed_tracing.enabled` may now be set in server-side application configuration.
+
   * **Bugfix: Fix for missing part of a previous bugfix**
     Our previous fix of "nil Middlewares injection now prevented and gracefully handled in Sinatra" released in 7.0.0 was partially overwritten by some of the other changes in that release. This release adds back those missing sections of the bugfix, and should resolve the issue for sinatra users. 
 
@@ -15,7 +19,7 @@
     object through the `connection` value exclusively. This resulted in datastore spans displaying fallback behavior, including showing
     "ActiveRecord" as the database vendor.
 
-  * **Bugfix: Updated support for Resque's FORK_PER_JOB option **
+  * **Bugfix: Updated support for Resque's FORK_PER_JOB option**
 
     Support for Resque's FORK_PER_JOB flag within the Ruby agent was incomplete and nonfunctional. The agent should now behave
     correctly when running in a non-forking Resque worker process.

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2081,7 +2081,7 @@ module NewRelic
           :default     => false,
           :public      => true,
           :type        => Boolean,
-          :allowed_from_server => false,
+          :allowed_from_server => true,
           :description => 'Distributed tracing lets you see the path that a request takes through your distributed system. Enabling distributed tracing changes the behavior of some New Relic features, so carefully consult the [transition guide](/docs/transition-guide-distributed-tracing) before you enable this feature.'
         },
         :trusted_account_key => {


### PR DESCRIPTION
https://github.com/newrelic/newrelic-ruby-agent/issues/670

Enabled SSC for distributed tracing in the Ruby agent. Tested in a sample application, verified that enabling/disabling DT in NR1 sends the signal to force restart the agent, and the configs are correctly updated. *Note: tested in prod as staging reconnect issue is still being investigated.*

Cross-app spec for DT was reviewed. The only change here is to allow `distributed_tracing.enabled` from the server; existing config combinations should continue working as intended.