### PR TITLE
Fix add_transaction_tracer ruby 3 deprecation warning

### DIFF
--- a/lib/new_relic/agent/instrumentation/controller_instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/controller_instrumentation.rb
@@ -179,6 +179,7 @@ module NewRelic
                   #{without_method_name}(*args, &block)
                  end
               end
+              ruby2_keywords(:#{with_method_name}) if respond_to?(:ruby2_keywords, true)
             EOC
 
             visibility = NewRelic::Helper.instance_method_visibility self, method


### PR DESCRIPTION
# Overview
Use `ruby2_keywords` to add ruby 3 support to `NewRelic::Agent::Instrumentation::ControllerInstrumentation.add_transaction_tracer method`, as recommended in this [article](https://eregon.me/blog/2021/02/13/correct-delegation-in-ruby-2-27-3.html).

# Related Github Issue
#671

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
