### PR TITLE
Update md5 use in the sql_sampler to SHA1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,16 @@
 
   ## v7.1.0
 
+  * **Removed MD5 use in the SQL sampler**
+
+    In order to allow the agent to run in FIPS compliant environments, the usage of MD5 for aggregating slow sql traces has been replaced with SHA1. 
+
   * **Bugfix: Fix for missing part of a previous bugfix**
+
     Our previous fix of "nil Middlewares injection now prevented and gracefully handled in Sinatra" released in 7.0.0 was partially overwritten by some of the other changes in that release. This release adds back those missing sections of the bugfix, and should resolve the issue for sinatra users. 
 
   * **Update known conflicts with use of Module#Prepend**
+
     With our release of v7.0.0, we updated our instrumentation to use Module#Prepend by default, instead of method chaining. We have received reports of conflicts and added a check for these known conflicts. If a known conflict with prepend is detected while using the default value of 'auto' for gem instrumentation, the agent will instead install method chaining instrumentation in order to avoid this conflict. This check can be bypassed by setting the instrumentation method for the gem to 'prepend'.
 
   * **Bugfix: Updated support for ActiveRecord 6.1+ instrumentation**

--- a/lib/new_relic/agent/sql_sampler.rb
+++ b/lib/new_relic/agent/sql_sampler.rb
@@ -359,10 +359,10 @@ module NewRelic
       # need to hash the same way in every process, to be able to aggregate slow SQL traces
       def consistent_hash(string)
         if NewRelic::Agent.config[:'slow_sql.use_longer_sql_id']
-          Digest::MD5.hexdigest(string).hex.modulo(2**63-1)
+          Digest::SHA1.hexdigest(string).hex.modulo(2**63-1)
         else
           # from when sql_id needed to fit in an INT(11)
-          Digest::MD5.hexdigest(string).hex.modulo(2**31-1)
+          Digest::SHA1.hexdigest(string).hex.modulo(2**31-1)
         end
       end
     end

--- a/test/new_relic/agent/sql_sampler_test.rb
+++ b/test/new_relic/agent/sql_sampler_test.rb
@@ -344,7 +344,7 @@ class NewRelic::Agent::SqlSamplerTest < Minitest::Test
       marshaller = NewRelic::Agent::NewRelicService::JsonMarshaller.new
       params = "eJyrrgUAAXUA+Q==\n"
 
-      expected = [ 'WebTransaction/Controller/c/a', '/c/a', 526336943,
+      expected = [ 'WebTransaction/Controller/c/a', '/c/a', 1644443586,
                    'select * from test', 'Database/test/select',
                    1, 1500, 1500, 1500, params ]
 


### PR DESCRIPTION
# Overview
In order to allow the agent to run in FIPS compliant servers, we have replaced the uses of md5 with SHA1 when we are hashing the slow sql id in order to aggregate slow sql traces. 
The other use of md5 in the agent is in Cross Application Tracing (CAT), and can not be updated in order to keep it in line with agent specs. This means that CAT can not be used on FIPS compliant servers, distributed tracing should be used instead.

# Related Github Issue
closes #602 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
