### PR TITLE
Replace all uses of Yaml.load with Yaml.safe_load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
   * **Update known conflicts with use of Module#Prepend**
     With our release of v7.0.0, we updated our instrumentation to use Module#Prepend by default, instead of method chaining. We have received reports of conflicts and added a check for these known conflicts. If a known conflict with prepend is detected while using the default value of 'auto' for gem instrumentation, the agent will instead install method chaining instrumentation in order to avoid this conflict. This check can be bypassed by setting the instrumentation method for the gem to 'prepend'.
 
+  * **Updated the agent to load yaml files with safe_load**
+  
+    Replaced all uses of YAML.load with YAML.safe_load
+
   * **Bugfix: Updated support for ActiveRecord 6.1+ instrumentation**
 
     Previously, the agent depended on `connection_id` to be present in the Active Support instrumentation for `sql.active_record`

--- a/lib/new_relic/agent/configuration/yaml_source.rb
+++ b/lib/new_relic/agent/configuration/yaml_source.rb
@@ -99,7 +99,7 @@ module NewRelic
 
         def process_yaml(file, env, config, path)
           if file
-            confighash = YAML.load(file)
+            confighash = YAML.safe_load(file, aliases: true)
             unless confighash.key?(env)
               log_failure("Config file at #{path} doesn't include a '#{env}' section!")
             end

--- a/lib/new_relic/agent/instrumentation/sidekiq.rb
+++ b/lib/new_relic/agent/instrumentation/sidekiq.rb
@@ -60,7 +60,7 @@ DependencyDetection.defer do
 
     class Sidekiq::Extensions::DelayedClass
       def newrelic_trace_args(msg, queue)
-        (target, method_name, _args) = YAML.load(msg['args'][0])
+        (target, method_name, _args) = YAML.safe_load(msg['args'][0], aliases: true)
         {
           :name => method_name,
           :class_name => target.name,

--- a/test/multiverse/suites/active_record/config/database.rb
+++ b/test/multiverse/suites/active_record/config/database.rb
@@ -19,7 +19,7 @@ end
 
 config_raw = File.read(File.join(config_dir, 'database.yml'))
 config_erb = ERB.new(config_raw).result
-config_yml = YAML.load(config_erb)
+config_yml = YAML.safe_load(config_erb, aliases: true)
 
 # Rails 2.x didn't keep the Rails out of ActiveRecord much...
 RAILS_ENV  = "test"


### PR DESCRIPTION
# Overview
This pr addresses issue #679 and replaces all uses of YAML.load with YAML.safe_load, with allowing for aliases in the yaml file.

# Related Github Issue
closes #679 


# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
