### PR TITLE
update rack and puma versions in multiverse

### DIFF
--- a/test/multiverse/suites/rack/Envfile
+++ b/test/multiverse/suites/rack/Envfile
@@ -1,37 +1,20 @@
 instrumentation_methods :chain, :prepend
 
 rack_test_version = RUBY_VERSION < "2.2.0" ? "< 0.8.0" : ">= 0.8.0"
+puma_versions = [nil, '~>3.12.0', '~>4.3.8', '~>5.3.2']
+ruby_rack_versions = { '2.3.0' => '~>2.2.3', '2.2.2' => '~>2.0.3'}
 
-gemfile <<-RB
-  gem 'puma', '~>3.11.0'
-  #{ruby3_gem_webrick}
-RB
-
-gemfile <<-RB
-  gem 'puma', '~>3.11.0'
-  gem 'rack', '~>1.6.0'
-  gem 'rack-test', '#{rack_test_version}'
-  #{ruby3_gem_webrick}
-RB
-
-gemfile <<-RB
-  gem 'puma', '~>3.11.0'
-  #{ruby3_gem_webrick}
-RB
-
-if RUBY_VERSION >= '2.2.2'
-  gemfile <<-RB
-    gem 'puma', '~>3.11.0'
-    gem 'rack', '2.0.3'
-    gem 'rack-test'
-    #{ruby3_gem_webrick}
-  RB
-
-  gemfile <<-RB
-    gem 'rack', '2.0.3'
-    gem 'rack-test'
-    #{ruby3_gem_webrick}
-  RB
+ruby_rack_versions.each do |ruby_version, rack_version|
+  if RUBY_VERSION >= ruby_version
+    puma_versions.each do |puma_version|
+      gemfile <<-RB
+        #{puma_version ? "gem 'puma', '#{puma_version}'" : ''}
+        gem 'rack', '#{rack_version}'
+        gem 'rack-test'
+        #{ruby3_gem_webrick}
+      RB
+    end
+  end
 end
 
 gemfile <<-RB


### PR DESCRIPTION
https://github.com/newrelic/newrelic-ruby-agent/issues/652

Update rack multiverse Envfile for Rack versions 2.0 and 2.2, Puma versions 4 and 5. Added a version check so Rack 2.2 on runs in Ruby 2.3+.

I tried to follow the intent of existing Puma 3.11 tests which run against both Rack 1.6 and Rack 2.0. Only Rack 2.0 and up have Ruby version requirements, and certain tests only run if Puma is present, so I included all of these combinations for Puma 3 and up.

# Reviewer Checklist
- [x] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [x] Confirm all checks passed
- [ ] Add version label prior to acceptance
