### PR TITLE
Fix Rack instrumentation for "kwarg middlewares" in Ruby 3.0

### DIFF
--- a/lib/new_relic/agent/instrumentation/rack/chain.rb
+++ b/lib/new_relic/agent/instrumentation/rack/chain.rb
@@ -31,7 +31,8 @@ module NewRelic::Agent::Instrumentation
             def use_with_newrelic(middleware_class, *args, &block)
               use_with_tracing(middleware_class) { |wrapped_class| use_without_newrelic(wrapped_class, *args, &block) }
             end
-    
+            ruby2_keywords(:use_with_newrelic) if respond_to?(:ruby2_keywords, true)
+
             alias_method :use_without_newrelic, :use
             alias_method :use, :use_with_newrelic
           end

--- a/lib/new_relic/agent/instrumentation/rack/prepend.rb
+++ b/lib/new_relic/agent/instrumentation/rack/prepend.rb
@@ -31,6 +31,7 @@ module NewRelic::Agent::Instrumentation
       def use(middleware_class, *args, &blk)
         use_with_tracing(middleware_class) { |wrapped_class| super(wrapped_class, *args, &blk) }
       end
+      ruby2_keywords(:use) if respond_to?(:ruby2_keywords, true)
     end
   end
 end

--- a/test/multiverse/suites/rack/example_app.rb
+++ b/test/multiverse/suites/rack/example_app.rb
@@ -79,6 +79,23 @@ class MiddlewareTwo
   end
 end
 
+class MiddlewareThree
+  def initialize(app, tag:)
+    @app = app
+    @tag = tag
+  end
+
+  def call(env)
+    advance_time(1)
+    status, headers, body = @app.call(env)
+    headers['MiddlewareThree'] = '3'
+    headers['MiddlewareThreeTag'] = @tag
+
+    advance_time(1)
+    [status, headers, body]
+  end
+end
+
 class ResponseCodeMiddleware
   def initialize(app)
     @app = app

--- a/test/multiverse/suites/rack/rack_auto_instrumentation_test.rb
+++ b/test/multiverse/suites/rack/rack_auto_instrumentation_test.rb
@@ -29,6 +29,7 @@ class RackAutoInstrumentationTest < Minitest::Test
       use MiddlewareTwo, 'the correct tag' do |headers|
         headers['MiddlewareTwoBlockTag'] = 'the block tag'
       end
+      use MiddlewareThree, tag: 'the correct tag'
       use NewRelic::Rack::BrowserMonitoring
       use NewRelic::Rack::AgentHooks
       run ExampleApp.new
@@ -39,6 +40,7 @@ class RackAutoInstrumentationTest < Minitest::Test
     get '/'
     assert last_response.headers['MiddlewareOne']
     assert last_response.headers['MiddlewareTwo']
+    assert last_response.headers['MiddlewareThree']
   end
 
   def test_status_code_is_preserved
@@ -93,6 +95,7 @@ class RackAutoInstrumentationTest < Minitest::Test
         "Controller/Rack/ExampleApp/call",
         "Middleware/Rack/MiddlewareOne/call",
         "Middleware/Rack/MiddlewareTwo/call",
+        "Middleware/Rack/MiddlewareThree/call",
         "Middleware/Rack/NewRelic::Rack::BrowserMonitoring/call",
         "Middleware/Rack/NewRelic::Rack::AgentHooks/call",
         "Nested/Controller/Rack/ExampleApp/call",
@@ -103,6 +106,7 @@ class RackAutoInstrumentationTest < Minitest::Test
         ["Middleware/Rack/NewRelic::Rack::AgentHooks/call",        "Controller/Rack/ExampleApp/call"],
         ["Middleware/Rack/MiddlewareOne/call", "Controller/Rack/ExampleApp/call"],
         ["Middleware/Rack/MiddlewareTwo/call", "Controller/Rack/ExampleApp/call"],
+        ["Middleware/Rack/MiddlewareThree/call", "Controller/Rack/ExampleApp/call"],
         ["Nested/Controller/Rack/ExampleApp/call",    "Controller/Rack/ExampleApp/call"]
       ],
       :ignore_filter => /^Supportability\/EnvironmentReport/
@@ -152,6 +156,12 @@ class RackAutoInstrumentationTest < Minitest::Test
 
     assert_equal('the correct tag', last_response.headers['MiddlewareTwoTag'])
     assert_equal('the block tag',   last_response.headers['MiddlewareTwoBlockTag'])
+  end
+
+  def test_middleware_created_with_kwargs_works
+    get '/'
+
+    assert_equal('the correct tag', last_response.headers['MiddlewareThreeTag'])
   end
 end
 


### PR DESCRIPTION
# Overview

Prior to this change, in Ruby 3.0, using a middleware with keyword arguments would fail with an `ArgumentError`.

This fix is pretty much the same as https://github.com/rack/rack/pull/1505

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
