### PR TITLE
Updates resque prepend conflict check

### DIFF
--- a/lib/new_relic/agent/instrumentation/resque.rb
+++ b/lib/new_relic/agent/instrumentation/resque.rb
@@ -13,9 +13,9 @@ DependencyDetection.defer do
     defined?(::Resque::Job) && !NewRelic::Agent.config[:disable_resque]
   end
 
-  # Airbrake uses method chaining on Resque::Job
+  # Airbrake uses method chaining on Resque::Job on versions < 11.0.3
   conflicts_with_prepend do
-    defined?(::Airbrake)
+    defined?(::Airbrake) && defined?(::Airbrake::AIRBRAKE_VERSION) && ::Gem::Version.create(::Airbrake::AIRBRAKE_VERSION) < ::Gem::Version.create('11.0.3')
   end
 
   executes do


### PR DESCRIPTION
# Overview
Airbrake released a new version, 11.0.3, that updates their use of method chaining on Resque::Job to use Module#prepend instead. I've updated our prepend conflict check for resque to add the new version so that the agent correctly chooses prepend when using the this airbrake version or higher.

# Related Github Issue
https://github.com/newrelic/newrelic-ruby-agent/issues/668

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
Github Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 

# Reviewer Checklist
- [x] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [x] Add version label prior to acceptance
