### PR TITLE
Implement Expected/Ignored errors

### DIFF
--- a/lib/new_relic/agent.rb
+++ b/lib/new_relic/agent.rb
@@ -44,6 +44,7 @@ module NewRelic
     require 'new_relic/agent/sql_sampler'
     require 'new_relic/agent/commands/thread_profiler_session'
     require 'new_relic/agent/error_collector'
+    require 'new_relic/agent/error_filter'   
     require 'new_relic/agent/sampler'
     require 'new_relic/agent/database'
     require 'new_relic/agent/database_adapter'

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -1297,7 +1297,49 @@ module NewRelic
           :public => true,
           :type => String,
           :allowed_from_server => true,
-          :description => 'Specify a comma-delimited list of error classes that the agent should ignore.'
+          :description => 'DEPRECATED; use `error_collector.ignore_classes` instead. Specify a comma-delimited list of error classes that the agent should ignore.'
+        },
+        :'error_collector.ignore_classes' => {
+          :default => [],
+          :public => true,
+          :type => Array,
+          :allowed_from_server => true,
+          :description => 'A list of error classes that the agent should ignore.'
+        },
+        :'error_collector.ignore_messages' => {
+          :default => {},
+          :public => true,
+          :type => Hash,
+          :allowed_from_server => true,
+          :description => 'A map of error classes to a list of messages. When an error of one of the classes specified here occurs, if its error message contains one of the strings corresponding to it here, that error will be ignored.'
+        },
+        :'error_collector.ignore_status_codes' => {
+          :default => '',
+          :public => true,
+          :type => String,
+          :allowed_from_server => true,
+          :description => 'A comma separated list of status codes, possibly including ranges. Errors associated with these status codes, where applicable, will be ignored.'
+        },
+        :'error_collector.expected_classes' => {
+          :default => [],
+          :public => true,
+          :type => Array,
+          :allowed_from_server => true,
+          :description => 'A list of error classes that the agent should treat as expected.'
+        },
+        :'error_collector.expected_messages' => {
+          :default => {},
+          :public => true,
+          :type => Hash,
+          :allowed_from_server => true,
+          :description => 'A map of error classes to a list of messages. When an error of one of the classes specified here occurs, if its error message contains one of the strings corresponding to it here, that error will be treated as expected.'
+        },
+        :'error_collector.expected_status_codes' => {
+          :default => '',
+          :public => true,
+          :type => String,
+          :allowed_from_server => true,
+          :description => 'A comma separated list of status codes, possibly including ranges. Errors associated with these status codes, where applicable, will be treated as expected.'
         },
         :'error_collector.max_backtrace_frames' => {
           :default => 50,

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -1297,6 +1297,7 @@ module NewRelic
           :public => true,
           :type => String,
           :allowed_from_server => true,
+          :dynamic_name => true,
           :description => 'DEPRECATED; use `error_collector.ignore_classes` instead. Specify a comma-delimited list of error classes that the agent should ignore.'
         },
         :'error_collector.ignore_classes' => {
@@ -1304,6 +1305,7 @@ module NewRelic
           :public => true,
           :type => Array,
           :allowed_from_server => true,
+          :dynamic_name => true,
           :description => 'A list of error classes that the agent should ignore.'
         },
         :'error_collector.ignore_messages' => {
@@ -1311,6 +1313,7 @@ module NewRelic
           :public => true,
           :type => Hash,
           :allowed_from_server => true,
+          :dynamic_name => true,
           :description => 'A map of error classes to a list of messages. When an error of one of the classes specified here occurs, if its error message contains one of the strings corresponding to it here, that error will be ignored.'
         },
         :'error_collector.ignore_status_codes' => {
@@ -1318,6 +1321,7 @@ module NewRelic
           :public => true,
           :type => String,
           :allowed_from_server => true,
+          :dynamic_name => true,
           :description => 'A comma separated list of status codes, possibly including ranges. Errors associated with these status codes, where applicable, will be ignored.'
         },
         :'error_collector.expected_classes' => {
@@ -1325,6 +1329,7 @@ module NewRelic
           :public => true,
           :type => Array,
           :allowed_from_server => true,
+          :dynamic_name => true,
           :description => 'A list of error classes that the agent should treat as expected.'
         },
         :'error_collector.expected_messages' => {
@@ -1332,6 +1337,7 @@ module NewRelic
           :public => true,
           :type => Hash,
           :allowed_from_server => true,
+          :dynamic_name => true,
           :description => 'A map of error classes to a list of messages. When an error of one of the classes specified here occurs, if its error message contains one of the strings corresponding to it here, that error will be treated as expected.'
         },
         :'error_collector.expected_status_codes' => {
@@ -1339,6 +1345,7 @@ module NewRelic
           :public => true,
           :type => String,
           :allowed_from_server => true,
+          :dynamic_name => true,
           :description => 'A comma separated list of status codes, possibly including ranges. Errors associated with these status codes, where applicable, will be treated as expected.'
         },
         :'error_collector.max_backtrace_frames' => {

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -1306,7 +1306,7 @@ module NewRelic
           :type => Array,
           :allowed_from_server => true,
           :dynamic_name => true,
-          :description => 'A list of error classes that the agent should ignore.'
+          :description => 'A list of error classes that the agent should ignore. *Note: this setting cannot be set via environment variable.*'
         },
         :'error_collector.ignore_messages' => {
           :default => {},
@@ -1314,7 +1314,7 @@ module NewRelic
           :type => Hash,
           :allowed_from_server => true,
           :dynamic_name => true,
-          :description => 'A map of error classes to a list of messages. When an error of one of the classes specified here occurs, if its error message contains one of the strings corresponding to it here, that error will be ignored.'
+          :description => 'A map of error classes to a list of messages. When an error of one of the classes specified here occurs, if its error message contains one of the strings corresponding to it here, that error will be ignored. *Note: this setting cannot be set via environment variable.*'
         },
         :'error_collector.ignore_status_codes' => {
           :default => '',
@@ -1330,7 +1330,7 @@ module NewRelic
           :type => Array,
           :allowed_from_server => true,
           :dynamic_name => true,
-          :description => 'A list of error classes that the agent should treat as expected.'
+          :description => 'A list of error classes that the agent should treat as expected. *Note: this setting cannot be set via environment variable.*'
         },
         :'error_collector.expected_messages' => {
           :default => {},
@@ -1338,7 +1338,7 @@ module NewRelic
           :type => Hash,
           :allowed_from_server => true,
           :dynamic_name => true,
-          :description => 'A map of error classes to a list of messages. When an error of one of the classes specified here occurs, if its error message contains one of the strings corresponding to it here, that error will be treated as expected.'
+          :description => 'A map of error classes to a list of messages. When an error of one of the classes specified here occurs, if its error message contains one of the strings corresponding to it here, that error will be treated as expected. *Note: this setting cannot be set via environment variable.*'
         },
         :'error_collector.expected_status_codes' => {
           :default => '',

--- a/lib/new_relic/agent/configuration/manager.rb
+++ b/lib/new_relic/agent/configuration/manager.rb
@@ -79,7 +79,6 @@ module NewRelic
           source.freeze
           was_finished = finished_configuring?
 
-          invoke_callbacks(:add, source)
           case source
           when SecurityPolicySource then @security_policy_source = source
           when HighSecuritySource   then @high_security_source   = source
@@ -93,6 +92,7 @@ module NewRelic
           end
 
           reset_cache
+          invoke_callbacks(:add, source)
           log_config(:add, source)
 
           notify_server_source_added if ServerSource === source

--- a/lib/new_relic/agent/configuration/manager.rb
+++ b/lib/new_relic/agent/configuration/manager.rb
@@ -79,6 +79,8 @@ module NewRelic
           source.freeze
           was_finished = finished_configuring?
 
+          invoke_callbacks(:add, source)
+
           case source
           when SecurityPolicySource then @security_policy_source = source
           when HighSecuritySource   then @high_security_source   = source
@@ -92,7 +94,6 @@ module NewRelic
           end
 
           reset_cache
-          invoke_callbacks(:add, source)
           log_config(:add, source)
 
           notify_server_source_added if ServerSource === source
@@ -159,7 +160,6 @@ module NewRelic
         def invoke_callbacks(direction, source)
           return unless source
           source.keys.each do |key|
-
             if @cache[key] != source[key]
               @callbacks[key].each do |proc|
                 if direction == :add

--- a/lib/new_relic/agent/error_collector.rb
+++ b/lib/new_relic/agent/error_collector.rb
@@ -210,6 +210,7 @@ module NewRelic
 
       # See NewRelic::Agent.notice_error for options and commentary
       def notice_error(exception, options={}, span_id=nil)
+        # TODO - Filter ignored/expected errors here. This is where we should set options[:expected]
         return if skip_notice_error?(exception)
 
         tag_exception(exception)

--- a/lib/new_relic/agent/error_collector.rb
+++ b/lib/new_relic/agent/error_collector.rb
@@ -263,7 +263,7 @@ module NewRelic
         noticed_error.line_number = sense_method(exception, :line_number)
         noticed_error.stack_trace = truncate_trace(extract_stack_trace(exception))
 
-        noticed_error.expected = !!options.delete(:expected) || @error_filter.expected?(exception)
+        noticed_error.expected = !!options.delete(:expected) || expected?(exception)
 
         noticed_error.attributes_from_notice_error = options.delete(:custom_params) || {}
 

--- a/lib/new_relic/agent/error_filter.rb
+++ b/lib/new_relic/agent/error_filter.rb
@@ -1,0 +1,13 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+
+module NewRelic
+  module Agent
+
+    # Handles loading of ignored and expected errors from the agent configuration, and
+    # determining at runtime whether an exception is ignored or expected.
+    class ErrorFilter
+    end
+  end
+end

--- a/lib/new_relic/agent/error_filter.rb
+++ b/lib/new_relic/agent/error_filter.rb
@@ -8,84 +8,131 @@ module NewRelic
     # Handles loading of ignored and expected errors from the agent configuration, and
     # determining at runtime whether an exception is ignored or expected.
     class ErrorFilter
+
       def initialize
-        reload
+        @ignore_errors, @ignore_classes, @expected_classes = [], [], []
+        @ignore_messages, @expected_messages = {}, {}
+        @ignore_status_codes, @expected_status_codes = [], []
       end
 
-      # Load ignored/expected errors from current agent config
-      def reload
-        @ignored_classes      = fetch_agent_config(:ignore_classes) || []
-        @ignored_messages     = fetch_agent_config(:ignore_messages) || {}
-        @ignored_status_codes = fetch_agent_config(:ignore_status_codes) || ''
+      def load_all
+        %i(
+          ignore_errors ignore_classes ignore_messages ignore_status_codes
+          expected_classes expected_messages expected_status_codes
+        ).each { |setting| load_from_config(setting) }
+      end
 
-        @expected_classes      = fetch_agent_config(:expected_classes) || []
-        @expected_messages     = fetch_agent_config(:expected_messages) || {}
-        @expected_status_codes = fetch_agent_config(:expected_status_codes) || ''
-
-        # error_collector.ignore_errors is deprecated, but we still support it
-        if @ignored_classes.empty? && ignore_errors = fetch_agent_config(:ignore_errors)
-          @ignored_classes << ignore_errors.split(',').map!(&:strip)
-          @ignored_classes.flatten!
+      def load_from_config(setting, value = nil)
+        errors = nil
+        new_value = value || fetch_agent_config(setting.to_sym)
+        case setting.to_sym
+        when :ignore_errors  # Deprecated; only use if ignore_classes isn't present
+          errors = @ignore_errors = new_value.to_s.split(',').map!(&:strip)
+        when :ignore_classes
+          errors = @ignore_classes = new_value || []
+        when :ignore_messages
+          errors = @ignore_messages = new_value || {}
+        when :ignore_status_codes
+          errors = @ignore_status_codes = parse_status_codes(new_value) || []
+        when :expected_classes
+          errors = @expected_classes = new_value || []
+        when :expected_messages
+          errors = @expected_messages = new_value || {}
+        when :expected_status_codes
+          errors = @expected_status_codes = parse_status_codes(new_value) || []
         end
-
-        log_filters
-      end
-
-      # Takes an Exception object. Depending on whether the Agent is configured
-      # to treat the exception as Ignored, Expected or neither, returns :ignored,
-      # :expected or nil, respectively.
-      def type_for_exception(ex)
-        return nil unless ex.is_a?(Exception)
-        return :ignored if _ignored?(ex)
-        return :expected if _expected?(ex)
-        nil
+        log_filter(setting, errors)
       end
 
       # Define #ignored? and #expected? in this way so that any given exception
-      # cannot be both ignored and expected. Ignoring takes priority.
+      # cannot be both ignored and expected when using type_for_exception.
+      # Ignoring takes priority.
 
-      def ignored?(ex)
-        type_for_exception(ex) == :ignored
+      def ignore?(ex)
+        @ignore_classes.include?(ex.class.name) || 
+          (@ignore_classes.empty? && @ignore_errors.include?(ex.class.name)) ||
+          @ignore_messages.keys.include?(ex.class.name) &&
+          @ignore_messages[ex.class.name].any? { |m| ex.message.include?(m) }
       end
 
       def expected?(ex)
-        type_for_exception(ex) == :expected
+        @expected_classes.include?(ex.class.name) ||
+        @expected_messages.keys.include?(ex.class.name) &&
+        @expected_messages[ex.class.name].any? { |m| ex.message.include?(m) }
       end
 
       def fetch_agent_config(cfg)
         NewRelic::Agent.config[:"error_collector.#{cfg}"]
       end
 
+      def ignore(errors)
+        case errors
+        when Array
+          @ignore_classes += errors
+          log_filter(:ignore_classes, errors)
+        when Hash
+          @ignore_messages.update(errors)
+          log_filter(:ignore_messages, errors)
+        when String
+          if errors.match(/^[\d\,\-]+$/)
+            @ignore_status_codes += parse_status_codes(errors)  # TODO: convert this value to a Hash
+          else
+            new_ignore_classes = errors.split(',').map!(&:strip)
+            @ignore_classes += new_ignore_classes
+            log_filter(:ignore_classes, new_ignore_classes)
+          end
+        end
+      end
+
+      def expect(errors)
+        case errors
+        when Array
+          @expected_classes += errors
+          log_filter(:expected_classes, errors)
+        when Hash
+          @expected_messages.update(errors)
+          log_filter(:expected_messages, errors)
+        when String
+          if errors.match(/^[\d\,\-]+$/)
+            @expected_status_codes += parse_status_codes(errors)
+          else
+            new_expected_classes = errors.split(',').map!(&:strip)
+            @expected_classes += new_expected_classes
+            log_filter(:expected_classes, new_expected_classes)
+          end
+        end
+      end
+
       private
 
-      def _ignored?(ex)
-        @ignored_classes.include?(ex.class.name) ||
-          @ignored_messages.keys.include?(ex.class.name) &&
-          @ignored_messages[ex.class.name].any? { |m| ex.message.include?(m) }
+      def log_filter(setting, errors)
+        case setting
+        when :ignore_errors, :ignore_classes
+          errors.each do |error|
+            ::NewRelic::Agent.logger.debug("Ignoring errors of type '#{error}'")
+          end
+        when :ignore_messages
+          errors.each do |error,messages|
+            ::NewRelic::Agent.logger.debug("Ignoring errors of type '#{error}' with messages: #{messages.join(',')}")
+          end
+        when :ignore_status_codes
+          ::NewRelic::Agent.logger.debug("Ignoring errors associated with status codes: #{errors}")
+        when :expected_classes
+          errors.each do |error|
+            ::NewRelic::Agent.logger.debug("Expecting errors of type '#{error}'")
+          end
+        when :expected_messages
+          errors.each do |error,messages|
+            ::NewRelic::Agent.logger.debug("Expecting errors of type '#{error}' with messages: #{messages.join(',')}")
+          end
+        when :expected_status_codes
+          ::NewRelic::Agent.logger.debug("Expecting errors associated with status codes: #{errors}")
+        end
       end
 
-      def _expected?(ex)
-        @expected_classes.include?(ex.class.name) ||
-          @expected_messages.keys.include?(ex.class.name) &&
-          @expected_messages[ex.class.name].any? { |m| ex.message.include?(m) }
-      end
-
-      def log_filters
-        @ignored_classes.each do |c|
-          ::NewRelic::Agent.logger.debug("Ignoring errors of type '#{c}'")
-        end
-        @ignored_messages.each do |k,v|
-          ::NewRelic::Agent.logger.debug("Ignoring errors of type '#{k}' with messages: " + v.join(', '))
-        end
-        ::NewRelic::Agent.logger.debug("Ignoring status codes #{@ignored_status_codes}") unless @ignored_status_codes.empty?
-
-        @expected_classes.each do |c|
-          ::NewRelic::Agent.logger.debug("Expecting errors of type '#{c}'")
-        end
-        @expected_messages.each do |k,v|
-          ::NewRelic::Agent.logger.debug("Expecting errors of type '#{k}' with messages: " + v.join(', '))
-        end
-        ::NewRelic::Agent.logger.debug("Expecting status codes #{@expected_status_codes}") unless @expected_status_codes.empty?
+      def parse_status_codes(code_string)
+        # TODO: implement
+        []
       end
     end
   end

--- a/lib/new_relic/agent/error_filter.rb
+++ b/lib/new_relic/agent/error_filter.rb
@@ -8,6 +8,54 @@ module NewRelic
     # Handles loading of ignored and expected errors from the agent configuration, and
     # determining at runtime whether an exception is ignored or expected.
     class ErrorFilter
+      def initialize
+        reload
+      end
+
+      # Load ignored/expected errors from current agent config
+      def reload
+        @ignored_classes      = fetch_agent_config(:ignore_classes) || []
+        @ignored_messages     = fetch_agent_config(:ignore_messages) || {}
+        @ignored_status_codes = fetch_agent_config(:ignore_status_codes) || ''
+
+        @expected_classes      = fetch_agent_config(:expected_classes) || []
+        @expected_messages     = fetch_agent_config(:expected_messages) || {}
+        @expected_status_codes = fetch_agent_config(:expected_status_codes) || ''
+
+        # error_collector.ignore_errors is deprecated, but we still support it
+        if @ignored_classes.empty? && ignore_errors = fetch_agent_config(:ignore_errors)
+          @ignored_classes << ignore_errors.split(',').map!(&:strip)
+          @ignored_classes.flatten!
+        end
+      end
+
+      # Takes an Exception object. Depending on whether the Agent is configured
+      # to treat the exception as Ignored, Expected or neither, returns :ignored,
+      # :expected or nil, respectively.
+      def type_for_exception(ex)
+        return nil unless ex.is_a?(Exception)
+        return :ignored if ignored?(ex)
+        return :expected if expected?(ex)
+        nil
+      end
+
+      def fetch_agent_config(cfg)
+        NewRelic::Agent.config[:"error_collector.#{cfg}"]
+      end
+
+      private
+
+      def ignored?(ex)
+        @ignored_classes.include?(ex.class.name) ||
+          @ignored_messages.keys.include?(ex.class.name) &&
+          @ignored_messages[ex.class.name].any? { |m| ex.message.include?(m) }
+      end
+
+      def expected?(ex)
+        @expected_classes.include?(ex.class.name) ||
+          @expected_messages.keys.include?(ex.class.name) &&
+          @expected_messages[ex.class.name].any? { |m| ex.message.include?(m) }
+      end
     end
   end
 end

--- a/lib/new_relic/agent/error_filter.rb
+++ b/lib/new_relic/agent/error_filter.rb
@@ -27,6 +27,22 @@ module NewRelic
           @ignored_classes << ignore_errors.split(',').map!(&:strip)
           @ignored_classes.flatten!
         end
+
+        @ignored_classes.each do |c|
+          ::NewRelic::Agent.logger.debug("Ignoring errors of type '#{c}'")
+        end
+        @ignored_messages.each do |k,v|
+          ::NewRelic::Agent.logger.debug("Ignoring errors of type '#{k}' with messages: " + v.join(', '))
+        end
+        ::NewRelic::Agent.logger.debug("Ignoring status codes #{@ignored_status_codes}") unless @ignored_status_codes.empty?
+
+        @expected_classes.each do |c|
+          ::NewRelic::Agent.logger.debug("Expecting errors of type '#{c}'")
+        end
+        @expected_messages.each do |k,v|
+          ::NewRelic::Agent.logger.debug("Expecting errors of type '#{k}' with messages: " + v.join(', '))
+        end
+        ::NewRelic::Agent.logger.debug("Expecting status codes #{@expected_status_codes}") unless @expected_status_codes.empty?
       end
 
       # Takes an Exception object. Depending on whether the Agent is configured

--- a/lib/new_relic/noticed_error.rb
+++ b/lib/new_relic/noticed_error.rb
@@ -33,7 +33,7 @@ class NewRelic::NoticedError
   ERROR_CLASS_KEY    = "#{ERROR_PREFIX_KEY}.class"
   ERROR_EXPECTED_KEY = "#{ERROR_PREFIX_KEY}.expected"
 
-  def initialize(path, exception, timestamp = Time.now)
+  def initialize(path, exception, timestamp = Time.now, expected = false)
     @exception_id = exception.object_id
     @path = path
 
@@ -58,7 +58,7 @@ class NewRelic::NoticedError
     @attributes_from_notice_error = nil
     @attributes = nil
     @timestamp = timestamp
-    @expected = false
+    @expected = expected
   end
 
   def ==(other)
@@ -104,7 +104,7 @@ class NewRelic::NoticedError
     params[:file_name]        = file_name   if file_name
     params[:line_number]      = line_number if line_number
     params[:stack_trace]      = stack_trace if stack_trace
-    params[:'error.expected'] = expected
+    params[ERROR_EXPECTED_KEY.to_sym] = expected
     params
   end
 

--- a/test/new_relic/agent/error_collector_test.rb
+++ b/test/new_relic/agent/error_collector_test.rb
@@ -318,7 +318,7 @@ module NewRelic::Agent
       def test_skip_notice_error_is_true_if_the_error_is_nil
         error = nil
         with_config(:'error_collector.enabled' => true) do
-          @error_collector.expects(:error_is_ignored?).with(error).returns(false)
+          @error_collector.expects(:error_is_ignored?).with(error, nil).returns(false)
           assert @error_collector.skip_notice_error?(error)
         end
       end
@@ -326,7 +326,7 @@ module NewRelic::Agent
       def test_skip_notice_error_is_true_if_the_error_is_ignored
         error = StandardError.new
         with_config(:'error_collector.enabled' => true) do
-          @error_collector.expects(:error_is_ignored?).with(error).returns(true)
+          @error_collector.expects(:error_is_ignored?).with(error, nil).returns(true)
           assert @error_collector.skip_notice_error?(error)
         end
       end
@@ -334,7 +334,7 @@ module NewRelic::Agent
       def test_skip_notice_error_returns_false_for_non_nil_unignored_errors_with_an_enabled_error_collector
         error = StandardError.new
         with_config(:'error_collector.enabled' => true) do
-          @error_collector.expects(:error_is_ignored?).with(error).returns(false)
+          @error_collector.expects(:error_is_ignored?).with(error, nil).returns(false)
           refute @error_collector.skip_notice_error?(error)
         end
       end
@@ -348,6 +348,13 @@ module NewRelic::Agent
           assert @error_collector.ignore?(error)
         end
         refute @error_collector.ignore?(error)
+      end
+
+      def test_ignore_status_codes
+        error = AnError.new
+        with_config(:'error_collector.ignore_status_codes' => '400-408') do
+          assert @error_collector.ignore?(error, 404)
+        end
       end
 
       def test_expected_classes

--- a/test/new_relic/agent/error_collector_test.rb
+++ b/test/new_relic/agent/error_collector_test.rb
@@ -342,21 +342,25 @@ module NewRelic::Agent
       class ::AnError
       end
 
-      def test_filtered_error_positive
+      def test_ignore_error
+        error = AnError.new
         with_config(:'error_collector.ignore_errors' => 'AnError') do
-          error = AnError.new
-          assert @error_collector.filtered_error?(error)
+          assert @error_collector.ignore?(error)
         end
+        refute @error_collector.ignore?(error)
       end
 
-      def test_filtered_error_negative
+      def test_expected_classes
         error = AnError.new
-        refute @error_collector.filtered_error?(error)
+        with_config(:'error_collector.expected_classes' => ['AnError']) do
+          assert @error_collector.expected?(error)
+        end
+        refute @error_collector.expected?(error)
       end
 
       def test_filtered_by_error_filter_empty
         # should return right away when there's no filter
-        refute @error_collector.filtered_by_error_filter?(nil)
+        refute @error_collector.ignored_by_filter_proc?(nil)
       end
 
       def test_filtered_by_error_filter_positive
@@ -367,7 +371,7 @@ module NewRelic::Agent
         end
 
         error = StandardError.new
-        assert @error_collector.filtered_by_error_filter?(error)
+        assert @error_collector.ignored_by_filter_proc?(error)
 
         assert_equal error, saw_error
       end
@@ -380,7 +384,7 @@ module NewRelic::Agent
         end
 
         error = StandardError.new
-        refute @error_collector.filtered_by_error_filter?(error)
+        refute @error_collector.ignored_by_filter_proc?(error)
 
         assert_equal error, saw_error
       end

--- a/test/new_relic/agent/error_collector_test.rb
+++ b/test/new_relic/agent/error_collector_test.rb
@@ -350,6 +350,17 @@ module NewRelic::Agent
         refute @error_collector.ignore?(error)
       end
 
+      def test_ignored_and_expected_error_is_ignored
+        error = AnError.new
+        with_config(:'error_collector.ignore_classes' => ['AnError'],
+                    :'error_collector.expected_classes' => ['AnError']) do
+          @error_collector.notice_error(AnError.new)
+
+          events = harvest_error_events
+          assert_equal 0, events.length
+        end
+      end
+
       def test_ignore_status_codes
         error = AnError.new
         with_config(:'error_collector.ignore_status_codes' => '400-408') do

--- a/test/new_relic/agent/error_collector_test.rb
+++ b/test/new_relic/agent/error_collector_test.rb
@@ -453,6 +453,7 @@ module NewRelic::Agent
         assert_equal 1, traces.length
         assert_equal 1, events.length
         assert_metrics_not_recorded ['Errors/all']
+        assert_metrics_recorded ['ErrorsExpected/all']
       end
 
       def test_expected_error_not_recorded_as_custom_attribute

--- a/test/new_relic/agent/error_filter_test.rb
+++ b/test/new_relic/agent/error_filter_test.rb
@@ -1,0 +1,41 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+
+require File.expand_path(File.join(File.dirname(__FILE__),'..','..','test_helper'))
+require 'new_relic/agent/configuration/manager'
+
+module NewRelic::Agent
+  class ErrorFilter
+    class ErrorFilterTest < Minitest::Test
+
+      # TODO: setup - read ignored/expected errors from config
+
+      # TODO: test - parses error_collector.ignore_classes as Array; i.e.
+      # - use test config that sets error_collector.ignore_classes = ['TestExceptionA', 'TestExceptionB']
+      # - initialize error_filter object from config
+      # - assert error_filter.for_class('TestExceptionA') == :ignore
+      # - assert error_filter.for_class('TextExceptionC') == nil
+
+      # TODO: test - parses error_collector.ignore_messages as Hash
+      # - as above: error_collector.ignore_messages = {
+      #               'TextExceptionA' => ['message one', 'message two']
+      #             }
+      # - assert error_filter.for_class('TestExceptionA', 'error message one test') == :ignore
+      # - assert error_filter.for_class('TestExceptionA', 'error message three test') == nil
+
+      # TODO: test - parses error_collector.ignore_status_codes as String
+      # - as above: error_collector.ignore_status_codes = "404,507-511"
+      # - assert error_filter.for_status('404') == :ignore
+      # - assert error_filter.for_status('509') == :ignore
+      # - assert error_filter.for_status('500') == nil
+
+      # TODO: test - parses error_collector.ignore_errors as error_collector.ignored_classes
+      #       (compatibility for deprecated config setting; split classes by ',' and store as ignore_classes)
+
+      # TODO: test - parses error_collector.expected_classes as Array
+      # TODO: test - parses error_collector.expected_messages as Hash
+      # TODO: test - parses error_collector.expected_status_codes as String
+    end
+  end
+end

--- a/test/new_relic/agent/error_filter_test.rb
+++ b/test/new_relic/agent/error_filter_test.rb
@@ -17,19 +17,19 @@ module NewRelic::Agent
 
       def test_ignore_classes
         with_config :'error_collector.ignore_classes' => ['TestExceptionA', 'TestExceptionC'] do
-          @error_filter.reload
-          assert @error_filter.ignored?(TestExceptionA.new)
-          refute @error_filter.ignored?(TestExceptionB.new)
+          @error_filter.load_all
+          assert @error_filter.ignore?(TestExceptionA.new)
+          refute @error_filter.ignore?(TestExceptionB.new)
         end
       end
 
       def test_ignore_messages
         with_config :'error_collector.ignore_messages' => {'TestExceptionA' => ['message one', 'message two']} do
-          @error_filter.reload
-          assert @error_filter.ignored?(TestExceptionA.new('message one'))
-          assert @error_filter.ignored?(TestExceptionA.new('message two'))
-          refute @error_filter.ignored?(TestExceptionA.new('message three'))
-          refute @error_filter.ignored?(TestExceptionB.new('message one'))
+          @error_filter.load_all
+          assert @error_filter.ignore?(TestExceptionA.new('message one'))
+          assert @error_filter.ignore?(TestExceptionA.new('message two'))
+          refute @error_filter.ignore?(TestExceptionA.new('message three'))
+          refute @error_filter.ignore?(TestExceptionB.new('message one'))
         end
       end
 
@@ -39,18 +39,18 @@ module NewRelic::Agent
       # - assert error_filter.for_status('509') == :ignore
       # - assert error_filter.for_status('500') == nil
 
-      # compatibility for deprecated config setting; split classes by ',' and store as ignore_classes
+      # compatibility for deprecated config setting
       def test_ignore_errors
         with_config :'error_collector.ignore_errors' => 'TestExceptionA,TestExceptionC' do
-          @error_filter.reload
-          assert @error_filter.ignored?(TestExceptionA.new)
-          refute @error_filter.ignored?(TestExceptionB.new)
+          @error_filter.load_all
+          assert @error_filter.ignore?(TestExceptionA.new)
+          refute @error_filter.ignore?(TestExceptionB.new)
         end
       end
 
       def test_expected_classes
         with_config :'error_collector.expected_classes' => ['TestExceptionA', 'TestExceptionC'] do
-          @error_filter.reload
+          @error_filter.load_all
           assert @error_filter.expected?(TestExceptionA.new)
           refute @error_filter.expected?(TestExceptionB.new)
         end
@@ -58,7 +58,7 @@ module NewRelic::Agent
 
       def test_expected_messages
         with_config :'error_collector.expected_messages' => {'TestExceptionA' => ['message one', 'message two']} do
-          @error_filter.reload
+          @error_filter.load_all
           assert @error_filter.expected?(TestExceptionA.new('message one'))
           assert @error_filter.expected?(TestExceptionA.new('message two'))
           refute @error_filter.expected?(TestExceptionA.new('message three'))

--- a/test/new_relic/agent/error_filter_test.rb
+++ b/test/new_relic/agent/error_filter_test.rb
@@ -18,18 +18,18 @@ module NewRelic::Agent
       def test_ignore_classes
         with_config :'error_collector.ignore_classes' => ['TestExceptionA', 'TestExceptionC'] do
           @error_filter.reload
-          assert_equal :ignored, @error_filter.type_for_exception(TestExceptionA.new)
-          assert_nil @error_filter.type_for_exception(TestExceptionB.new)
+          assert @error_filter.ignored?(TestExceptionA.new)
+          refute @error_filter.ignored?(TestExceptionB.new)
         end
       end
 
       def test_ignore_messages
         with_config :'error_collector.ignore_messages' => {'TestExceptionA' => ['message one', 'message two']} do
           @error_filter.reload
-          assert_equal :ignored, @error_filter.type_for_exception(TestExceptionA.new('message one'))
-          assert_equal :ignored, @error_filter.type_for_exception(TestExceptionA.new('message two'))
-          assert_nil @error_filter.type_for_exception(TestExceptionA.new('message three'))
-          assert_nil @error_filter.type_for_exception(TestExceptionB.new('message one'))
+          assert @error_filter.ignored?(TestExceptionA.new('message one'))
+          assert @error_filter.ignored?(TestExceptionA.new('message two'))
+          refute @error_filter.ignored?(TestExceptionA.new('message three'))
+          refute @error_filter.ignored?(TestExceptionB.new('message one'))
         end
       end
 
@@ -43,26 +43,26 @@ module NewRelic::Agent
       def test_ignore_errors
         with_config :'error_collector.ignore_errors' => 'TestExceptionA,TestExceptionC' do
           @error_filter.reload
-          assert_equal :ignored, @error_filter.type_for_exception(TestExceptionA.new)
-          assert_nil @error_filter.type_for_exception(TestExceptionB.new)
+          assert @error_filter.ignored?(TestExceptionA.new)
+          refute @error_filter.ignored?(TestExceptionB.new)
         end
       end
 
       def test_expected_classes
         with_config :'error_collector.expected_classes' => ['TestExceptionA', 'TestExceptionC'] do
           @error_filter.reload
-          assert_equal :expected, @error_filter.type_for_exception(TestExceptionA.new)
-          assert_nil @error_filter.type_for_exception(TestExceptionB.new)
+          assert @error_filter.expected?(TestExceptionA.new)
+          refute @error_filter.expected?(TestExceptionB.new)
         end
       end
 
       def test_expected_messages
         with_config :'error_collector.expected_messages' => {'TestExceptionA' => ['message one', 'message two']} do
           @error_filter.reload
-          assert_equal :expected, @error_filter.type_for_exception(TestExceptionA.new('message one'))
-          assert_equal :expected, @error_filter.type_for_exception(TestExceptionA.new('message two'))
-          assert_nil @error_filter.type_for_exception(TestExceptionA.new('message three'))
-          assert_nil @error_filter.type_for_exception(TestExceptionB.new('message one'))
+          assert @error_filter.expected?(TestExceptionA.new('message one'))
+          assert @error_filter.expected?(TestExceptionA.new('message two'))
+          refute @error_filter.expected?(TestExceptionA.new('message three'))
+          refute @error_filter.expected?(TestExceptionB.new('message one'))
         end
       end
 


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
This PR implements Expected Errors in the Ruby agent, and allows server-side configuration for ignored/expected error classes and messages. This PR does NOT implement ignoring/expecting errors by status code; this will be addressed in a future PR.

Formerly the error collector only used a single config setting for ignored error classes and stored this in an instance variable. In this PR, the work of loading ignored/expected errors and determining at runtime whether an error is ignored/expected/neither is handled by the `ErrorFilter` class, which is instantiated by the error collector on initialization. Some internal method names in error collector were renamed for clarity.

# Related Github Issue
https://github.com/newrelic/newrelic-ruby-agent/issues/454 https://github.com/newrelic/newrelic-ruby-agent/issues/455 https://github.com/newrelic/newrelic-ruby-agent/issues/456

# Testing
Unit tests for ErrorFilter and updated tests for ErrorCollector are included. Further end-to-end testing may also include:
- test no Errors/* metrics are incremented
- test ErrorsExpected/all is incremented for expected errors
- test nothing is recorded for ignored errors
- test changing SSC properly updates ignored/expected errors in running agent
- add rack multiverse tests for ignored/expected status codes

# Reviewer Checklist
- [x] Perform code review
- [x] Add performance label
- [x] Perform appropriate level of performance testing
- [x] Confirm all checks passed
- [x] Add version label prior to acceptance
