### PR TITLE
Update release workflow to create github release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,14 +38,13 @@ jobs:
       run: |
         echo "VERSION=$(ls newrelic_rpm-*.gem | ruby -pe 'sub(/newrelic_rpm\-(.*).gem/, "\\1")')" >> $GITHUB_ENV
 
-    - name: Tag new version
-      run: |
-        if [ $(git tag -l ${{ env.VERSION }}) ]; then
-          echo "Tag already created for this version"
-        else
-          git tag ${{ env.VERSION }}
-          git push origin ${{ env.VERSION }}
-        fi
+    - name: Create github release
+      uses: softprops/action-gh-release@v1
+      if: $(git tag -l ${{ env.VERSION }}) == false
+      with:
+        tag_name: ${{ env.VERSION }}
+      env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Obtain OTP to publish newrelic_rpm to rubygems.org
       run: echo "RUBYGEMS_OTP=$(python ./.github/workflows/scripts/rubygems-authenticate.py RUBYGEMS_MFA_KEY)" >> $GITHUB_ENV


### PR DESCRIPTION
instead of tagging

_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
Updates our release workflow to use this action https://github.com/softprops/action-gh-release to create a release on github instead of just tagging the release like we've been doing. This should make it clearer to users looking at our release page on github what has been released.
This is something that's hard to try out the whole thing until we are ready to actually release, so if any issues with this change pop up when we release I'll need to deal with them at that time. 

# Related Github Issue
closes #699 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
