### PR TITLE
Ensure blank SSC settings don't overwrite local expected errors

### DIFF
--- a/lib/new_relic/agent/error_collector.rb
+++ b/lib/new_relic/agent/error_collector.rb
@@ -87,6 +87,14 @@ module NewRelic
         @error_filter.expected?(ex, status_code)
       end
 
+      def load_error_filters
+        @error_filter.load_all
+      end
+
+      def reset_error_filters
+        @error_filter.reset
+      end
+
       # Checks the provided error against the error filter, if there
       # is an error filter
       def ignored_by_filter_proc?(error)
@@ -179,9 +187,9 @@ module NewRelic
 
       def skip_notice_error?(exception, status_code = nil)
         disabled? ||
-        error_is_ignored?(exception, status_code) ||
         exception.nil? ||
-        exception_tagged_with?(EXCEPTION_TAG_IVAR, exception)
+        exception_tagged_with?(EXCEPTION_TAG_IVAR, exception) ||
+        error_is_ignored?(exception, status_code)
       end
 
       # calls a method on an object, if it responds to it - used for

--- a/test/multiverse/suites/sinatra/sinatra_error_tracing_test.rb
+++ b/test/multiverse/suites/sinatra/sinatra_error_tracing_test.rb
@@ -41,7 +41,6 @@ class SinatraErrorTracingTest < Minitest::Test
     get '/ignored_boom'
     assert_equal 404, last_response.status
     assert_match %r{Sinatra doesn(&rsquo;|’)t know this ditty\.}, last_response.body
-
     errors = harvest_error_traces!
     assert_equal(0, errors.size)
   end

--- a/test/new_relic/agent/error_collector_test.rb
+++ b/test/new_relic/agent/error_collector_test.rb
@@ -318,7 +318,6 @@ module NewRelic::Agent
       def test_skip_notice_error_is_true_if_the_error_is_nil
         error = nil
         with_config(:'error_collector.enabled' => true) do
-          @error_collector.expects(:error_is_ignored?).with(error, nil).returns(false)
           assert @error_collector.skip_notice_error?(error)
         end
       end

--- a/test/new_relic/agent/error_collector_test.rb
+++ b/test/new_relic/agent/error_collector_test.rb
@@ -368,14 +368,6 @@ module NewRelic::Agent
         end
       end
 
-      def test_expected_classes
-        error = AnError.new
-        with_config(:'error_collector.expected_classes' => ['AnError']) do
-          assert @error_collector.expected?(error)
-        end
-        refute @error_collector.expected?(error)
-      end
-
       def test_filtered_by_error_filter_empty
         # should return right away when there's no filter
         refute @error_collector.ignored_by_filter_proc?(nil)

--- a/test/new_relic/agent/error_filter_test.rb
+++ b/test/new_relic/agent/error_filter_test.rb
@@ -47,7 +47,7 @@ module NewRelic::Agent
       end
 
       def test_ignore_status_codes_by_array
-        with_config :'error_collector.ignore_status_codes' => ['401', '405-409', '501'] do
+        with_config :'error_collector.ignore_status_codes' => ['401', '405-409', 501] do
           @error_filter.load_all
           assert @error_filter.ignore?(TestExceptionA.new, 401)
           assert @error_filter.ignore?(TestExceptionA.new, 501)
@@ -73,7 +73,7 @@ module NewRelic::Agent
         @error_filter.reset
         refute @error_filter.ignore?(TestExceptionA.new)
 
-        @error_filter.ignore('401,405-409', ['500', '505-509'])
+        @error_filter.ignore('401,405-409', [500, '505-509'])
         assert @error_filter.ignore?(TestExceptionA.new, 401)
         assert @error_filter.ignore?(TestExceptionA.new, 407)
         assert @error_filter.ignore?(TestExceptionA.new, 500)
@@ -152,6 +152,14 @@ module NewRelic::Agent
         refute @error_filter.expected?(TestExceptionA.new, 404)
       end
 
+      def test_empty_settings_do_not_overwrite_existing_settings
+        @error_filter.expect(['TestExceptionA'])
+
+        with_config 'error_collector.expected_classes' => [] do
+          @error_filter.load_all
+          assert @error_filter.expected?(TestExceptionA.new)
+        end
+      end
     end
   end
 end

--- a/test/new_relic/multiverse_helpers.rb
+++ b/test/new_relic/multiverse_helpers.rb
@@ -55,6 +55,8 @@ module MultiverseHelpers
     # to clean up before a test too.
     NewRelic::Agent.drop_buffered_data
 
+    NewRelic::Agent.instance.error_collector.load_error_filters
+
     trigger_agent_reconnect(opts)
   end
 
@@ -69,8 +71,8 @@ module MultiverseHelpers
     # Clear out lingering stats we didn't transmit
     NewRelic::Agent.drop_buffered_data
 
-    # Clear the error collector's ignore_filter
-    NewRelic::Agent.instance.error_collector.instance_variable_set(:@ignore_filter, nil)
+    # Clear the error collector's error filters
+    NewRelic::Agent.instance.error_collector.reset_error_filters
 
     # Clean up any thread-local variables starting with 'newrelic'
     NewRelic::Agent::Tracer.clear_state


### PR DESCRIPTION
# Overview
One more Expected Errors change that didn't make it into #704. This commit ensures that if SSC sends an empty array to the agent, this will not overwrite any locally-set expected/ignored errors.

Also fixes Error Filter to accept integers as status codes (as these will be sent by SSC as integers).

# Reviewer Checklist
- [x] Perform code review
- [x] Add performance label
- [x] Perform appropriate level of performance testing
- [x] Confirm all checks passed
- [x] Add version label prior to acceptance
