### PR TITLE
Use `assemble_code_header` in `method_with_push_scope`

### DIFF
--- a/lib/new_relic/agent/method_tracer.rb
+++ b/lib/new_relic/agent/method_tracer.rb
@@ -199,7 +199,7 @@ module NewRelic
           # for a fully traced metric including scoping
           def method_with_push_scope(method_name, metric_name_code, options)
             "def #{_traced_method_name(method_name, metric_name_code)}(#{ARGS_FOR_RUBY_VERSION})
-              #{options[:code_header]}
+              #{assemble_code_header(method_name, metric_name_code, options)}
               result = ::NewRelic::Agent::MethodTracerHelpers.trace_execution_scoped(\"#{metric_name_code}\",
                         :metric => #{options[:metric]}) do
                 #{_untraced_method_name(method_name, metric_name_code)}(#{ARGS_FOR_RUBY_VERSION})


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
Should be a simple update to use the `assemble_code_header` in `NewRelic::Agent::MethodTracer.method_with_push_scope` as it is used in `.method_without_push_scope` for consistency. Should not change any functionality.

Note these methods will likely be refactored in the course of working on #502.

# Related Github Issue
https://github.com/newrelic/newrelic-ruby-agent/issues/716

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
