### PR TITLE
Update rack < 2.1.4 for Rails 6.1 tests

### DIFF
--- a/test/environments/rails61/Gemfile
+++ b/test/environments/rails61/Gemfile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 source 'https://rubygems.org'
 
 gem 'rake', '~> 12.3.3'
@@ -5,8 +6,8 @@ gem 'rake', '~> 12.3.3'
 gem 'rails', '6.1.0'
 
 gem 'minitest', '5.2.3'
-gem 'mocha', '~> 1.1.0', :require => false
-gem 'rack', '< 2.1.0'
+gem 'mocha', '~> 1.1.0', require: false
+gem 'rack', '< 2.1.4'
 gem 'rack-test'
 gem 'sprockets', '3.7.2'
 
@@ -19,7 +20,7 @@ platforms :ruby, :rbx do
   gem 'sqlite3', '~> 1.4'
 end
 
-gem 'newrelic_rpm', :path => '../../..'
+gem 'newrelic_rpm', path: '../../..'
 
 gem 'hometown', '~> 0.2.5'
 gem 'pry', '~> 0.12.2'


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
* Upgrade rack version used in Rails 6.1 tests to 2.1.4 or above to avoid a high severity CVE
* Small syntax changes to the Gemfile to support community standards

# Related Github Issue
https://github.com/newrelic/newrelic-ruby-agent/issues/736

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
Github Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
