### PR TITLE
Remove Ruby 2.0 required kwarg compatibility checks

### DIFF
--- a/lib/new_relic/agent/external.rb
+++ b/lib/new_relic/agent/external.rb
@@ -33,13 +33,9 @@ module NewRelic
       # request as a string, for example, 'GET'.
       #
       # @api public
-      def start_segment(library: nil, uri: nil, procedure: nil)
+      def start_segment(library:, uri:, procedure:)
         Deprecator.deprecate 'External.start_segment',
                              'Tracer#start_external_request_segment'
-
-        raise ArgumentError, 'Argument `library` is required' if library.nil?
-        raise ArgumentError, 'Argument `uri` is required' if uri.nil?
-        raise ArgumentError, 'Argument `procedure` is required' if procedure.nil?
 
         ::NewRelic::Agent.record_api_supportability_metric(:start_segment)
 

--- a/lib/new_relic/agent/http_clients/abstract.rb
+++ b/lib/new_relic/agent/http_clients/abstract.rb
@@ -46,7 +46,7 @@ module NewRelic
       # NOTE: response_object should be non-nil!
       class AbstractResponse # :nodoc:
 
-        def initialize wrapped_response
+        def initialize(wrapped_response)
           if wrapped_response.nil? 
             raise ArgumentError, WHINY_NIL_ERROR % self.class
           end
@@ -65,7 +65,7 @@ module NewRelic
 
         private 
 
-        def get_status_code_using method_name
+        def get_status_code_using(method_name)
           return unless @wrapped_response.respond_to?(method_name)
           code = @wrapped_response.send(method_name).to_i
           code == 0 ? nil : code

--- a/lib/new_relic/agent/messaging.rb
+++ b/lib/new_relic/agent/messaging.rb
@@ -110,20 +110,15 @@ module NewRelic
       #
       # @api public
       #
-      def wrap_message_broker_consume_transaction library: nil,
-                                                  destination_type: nil,
-                                                  destination_name: nil,
+      def wrap_message_broker_consume_transaction(library:,
+                                                  destination_type:,
+                                                  destination_name:,
                                                   headers: nil,
                                                   routing_key: nil,
                                                   queue_name: nil,
                                                   exchange_type: nil,
                                                   reply_to: nil,
-                                                  correlation_id: nil
-
-        # ruby 2.0.0 does not support required kwargs
-        raise ArgumentError, 'missing required argument: library' if library.nil?
-        raise ArgumentError, 'missing required argument: destination_type' if destination_type.nil?
-        raise ArgumentError, 'missing required argument: destination_name' if destination_name.nil?
+                                                  correlation_id: nil)
 
         state = Tracer.state
         return yield if state.current_transaction
@@ -185,17 +180,14 @@ module NewRelic
       #
       # @api public
       #
-      def start_amqp_publish_segment(library: nil,
-                                     destination_name: nil,
+      def start_amqp_publish_segment(library:,
+                                     destination_name:,
                                      headers: nil,
                                      routing_key: nil,
                                      reply_to: nil,
                                      correlation_id: nil,
                                      exchange_type: nil)
 
-        # ruby 2.0.0 does not support required kwargs
-        raise ArgumentError, 'missing required argument: library' if library.nil?
-        raise ArgumentError, 'missing required argument: destination_name' if destination_name.nil?
         raise ArgumentError, 'missing required argument: headers' if headers.nil? && CrossAppTracing.cross_app_enabled?
 
         original_headers = headers.nil? ? nil : headers.dup
@@ -247,19 +239,13 @@ module NewRelic
       #
       # @api public
       #
-      def start_amqp_consume_segment(library: nil,
-                                     destination_name: nil,
-                                     delivery_info: nil,
-                                     message_properties: nil,
+      def start_amqp_consume_segment(library:,
+                                     destination_name:,
+                                     delivery_info:,
+                                     message_properties:,
                                      exchange_type: nil,
                                      queue_name: nil,
                                      start_time: nil)
-
-        # ruby 2.0.0 does not support required kwargs
-        raise ArgumentError, 'missing required argument: library' if library.nil?
-        raise ArgumentError, 'missing required argument: destination_name' if destination_name.nil?
-        raise ArgumentError, 'missing required argument: delivery_info' if delivery_info.nil?
-        raise ArgumentError, 'missing required argument: message_properties' if message_properties.nil?
 
         segment = Tracer.start_message_broker_segment(
           action: :consume,

--- a/lib/new_relic/agent/span_event_aggregator.rb
+++ b/lib/new_relic/agent/span_event_aggregator.rb
@@ -16,7 +16,7 @@ module NewRelic
       enabled_keys :'span_events.enabled',
                    :'distributed_tracing.enabled'
 
-      def record priority: nil, event:nil, &blk
+      def record(priority: nil, event: nil, &blk)
         unless(event || priority && blk)
           raise ArgumentError, "Expected priority and block, or event"
         end
@@ -33,7 +33,7 @@ module NewRelic
       SUPPORTABILITY_TOTAL_SENT = "Supportability/SpanEvent/TotalEventsSent".freeze
       SUPPORTABILITY_DISCARDED  = "Supportability/SpanEvent/Discarded".freeze
 
-      def after_harvest metadata
+      def after_harvest(metadata)
         seen      = metadata[:seen]
         sent      = metadata[:captured]
         discarded = seen - sent

--- a/lib/new_relic/agent/tracer.rb
+++ b/lib/new_relic/agent/tracer.rb
@@ -131,14 +131,10 @@ module NewRelic
         # @api public
         def start_transaction_or_segment(name: nil,
                                          partial_name: nil,
-                                         category: nil,
+                                         category:,
                                          options: {})
-          if name.nil? && partial_name.nil?
-            raise ArgumentError, 'missing required argument: name or partial_name'
-          end
-          if category.nil?
-            raise ArgumentError, 'missing required argument: category'
-          end
+          
+          raise ArgumentError, 'missing required argument: name or partial_name' if name.nil? && partial_name.nil?
 
           if name
             options[:transaction_name] = name
@@ -163,16 +159,12 @@ module NewRelic
 
         # Takes name or partial_name and a category.
         # Returns a transaction instance or nil
-        def start_transaction(name: nil,
+        def start_transaction(category:,
+                              name: nil,
                               partial_name: nil,
-                              category: nil,
                               **options)
-          if name.nil? && partial_name.nil?
-            raise ArgumentError, 'missing required argument: name or partial_name'
-          end
-          if category.nil?
-            raise ArgumentError, 'missing required argument: category'
-          end
+          
+          raise ArgumentError, 'missing required argument: name or partial_name' if name.nil? && partial_name.nil?
 
           return current_transaction if current_transaction
 
@@ -238,13 +230,10 @@ module NewRelic
         #   +finish+ on it at the end of the code you're tracing
         #
         # @api public
-        def start_segment(name:nil,
+        def start_segment(name:,
                           unscoped_metrics:nil,
                           start_time: nil,
                           parent: nil)
-
-          # ruby 2.0.0 does not support required kwargs
-          raise ArgumentError, 'missing required argument: name' if name.nil?
 
           segment = Transaction::Segment.new name, unscoped_metrics, start_time
           start_and_add_segment segment, parent
@@ -341,16 +330,11 @@ module NewRelic
         #   you're tracing
         #
         # @api public
-        def start_external_request_segment(library: nil,
-                                           uri: nil,
-                                           procedure: nil,
+        def start_external_request_segment(library:,
+                                           uri:,
+                                           procedure:,
                                            start_time: nil,
                                            parent: nil)
-
-          # ruby 2.0.0 does not support required kwargs
-          raise ArgumentError, 'missing required argument: library' if library.nil?
-          raise ArgumentError, 'missing required argument: uri' if uri.nil?
-          raise ArgumentError, 'missing required argument: procedure' if procedure.nil?
 
           segment = Transaction::ExternalRequestSegment.new library, uri, procedure, start_time
           start_and_add_segment segment, parent
@@ -377,20 +361,14 @@ module NewRelic
         end
 
         # For New Relic internal use only.
-        def start_message_broker_segment(action: nil,
-                                         library: nil,
-                                         destination_type: nil,
-                                         destination_name: nil,
+        def start_message_broker_segment(action:,
+                                         library:,
+                                         destination_type:,
+                                         destination_name:,
                                          headers: nil,
                                          parameters: nil,
                                          start_time: nil,
                                          parent: nil)
-
-          # ruby 2.0.0 does not support required kwargs
-          raise ArgumentError, 'missing required argument: action' if action.nil?
-          raise ArgumentError, 'missing required argument: library' if library.nil?
-          raise ArgumentError, 'missing required argument: destination_type' if destination_type.nil?
-          raise ArgumentError, 'missing required argument: destination_name' if destination_name.nil?
 
           segment = Transaction::MessageBrokerSegment.new(
             action: action,

--- a/lib/new_relic/agent/transaction/message_broker_segment.rb
+++ b/lib/new_relic/agent/transaction/message_broker_segment.rb
@@ -52,19 +52,13 @@ module NewRelic
                     :library,
                     :headers
 
-        def initialize action: nil,
-                       library: nil,
-                       destination_type: nil,
-                       destination_name: nil,
+        def initialize(action:,
+                       library:,
+                       destination_type:,
+                       destination_name:,
                        headers: nil,
                        parameters: nil,
-                       start_time: nil
-
-          # ruby 2.0.0 does not support required kwargs
-          raise ArgumentError, 'missing required argument: action' if action.nil?
-          raise ArgumentError, 'missing required argument: library' if library.nil?
-          raise ArgumentError, 'missing required argument: destination_type' if destination_type.nil?
-          raise ArgumentError, 'missing required argument: destination_name' if destination_name.nil?
+                       start_time: nil)
 
           @action = action
           @library = library


### PR DESCRIPTION
# Overview
Our agent has code that provides compatibility for required keyword arguments in Ruby versions below 2.1. Since the agent supports Ruby 2.2+, this code is no longer required.

Also added parentheses to method definitions where applicable, for the sake of consistency and readability.

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
