### PR TITLE
Update CAT deprecation message

### DIFF
--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -39,6 +39,8 @@ module NewRelic
         end
       end
 
+      # Marks the config option as deprecated in the documentation once generated.
+      # Does not appear in logs.
       def self.deprecated_description new_setting, description
         link_ref = new_setting.to_s.gsub(".", "-")
         %{Please see: [#{new_setting}](docs/agents/ruby-agent/configuration/ruby-agent-configuration##{link_ref}). \n\n#{description}}
@@ -1483,7 +1485,10 @@ module NewRelic
           :type => Boolean,
           :allowed_from_server => true,
           :deprecated => true,
-          :description => 'Deprecated in favor of distributed_tracing.enabled'
+          :description => deprecated_description(
+            :'distributed_tracing-enabled',
+            'If `true`, enables [cross-application tracing](/docs/agents/ruby-agent/features/cross-application-tracing-ruby/)'
+          )
         },
         :cross_application_tracing => {
           :default => nil,

--- a/lib/new_relic/agent/distributed_tracing/cross_app_tracing.rb
+++ b/lib/new_relic/agent/distributed_tracing/cross_app_tracing.rb
@@ -55,10 +55,6 @@ module NewRelic
       def insert_cross_app_header headers
         return unless CrossAppTracing.cross_app_enabled?
 
-        Deprecator.deprecate('cross_application_tracer.enabled')
-        
-        ::NewRelic::Agent.logger.warn("[DEPRECATED] Cross application tracing is enabled. It has been deprecated in favor of distributed tracing and will be removed in a future release. Enable distributed tracing to continue receiving traces across your applications by updating the 'cross_application_tracer.enabled' configuration to false.")
-
         @is_cross_app_caller = true
         txn_guid  = transaction.guid
         trip_id   = cat_trip_id

--- a/lib/new_relic/agent/monitors/cross_app_monitor.rb
+++ b/lib/new_relic/agent/monitors/cross_app_monitor.rb
@@ -22,6 +22,9 @@ module NewRelic
         CONTENT_LENGTH_HEADER_KEY = 'HTTP_CONTENT_LENGTH'.freeze
 
         def on_finished_configuring(events)
+          Deprecator.deprecate('cross_application_tracer.enabled configuration')
+          ::NewRelic::Agent.logger.warn("[DEPRECATED] Cross application tracing is enabled. It has been deprecated in favor of distributed tracing and will be removed in a future release. Enable distributed tracing to continue receiving traces across external requests removing the 'cross_application_tracer.enabled' configuration.")
+
           register_event_listeners(events)
         end
 
@@ -40,7 +43,7 @@ module NewRelic
         def register_event_listeners(events)
           NewRelic::Agent.logger.
             debug("Wiring up Cross Application Tracing to events after finished configuring")
-
+# DEPRECATION WARNING GOES HERE
           events.subscribe(:before_call) do |env| #THREAD_LOCAL_ACCESS
             if id = decoded_id(env) and should_process_request?(id)
               state = NewRelic::Agent::Tracer.state

--- a/lib/new_relic/agent/monitors/cross_app_monitor.rb
+++ b/lib/new_relic/agent/monitors/cross_app_monitor.rb
@@ -22,7 +22,7 @@ module NewRelic
         CONTENT_LENGTH_HEADER_KEY = 'HTTP_CONTENT_LENGTH'.freeze
 
         def on_finished_configuring(events)
-          Deprecator.deprecate('cross_application_tracer.enabled configuration')
+          Deprecator.deprecate('cross_application_tracer')
           ::NewRelic::Agent.logger.warn(
             "[DEPRECATED] Cross application tracing is enabled. It has been \
             deprecated in favor of distributed tracing and will be removed in a\

--- a/lib/new_relic/agent/monitors/cross_app_monitor.rb
+++ b/lib/new_relic/agent/monitors/cross_app_monitor.rb
@@ -23,7 +23,13 @@ module NewRelic
 
         def on_finished_configuring(events)
           Deprecator.deprecate('cross_application_tracer.enabled configuration')
-          ::NewRelic::Agent.logger.warn("[DEPRECATED] Cross application tracing is enabled. It has been deprecated in favor of distributed tracing and will be removed in a future release. Enable distributed tracing to continue receiving traces across external requests removing the 'cross_application_tracer.enabled' configuration.")
+          ::NewRelic::Agent.logger.warn(
+            "[DEPRECATED] Cross application tracing is enabled. It has been \
+            deprecated in favor of distributed tracing and will be removed in a\
+             future release. Start using distrubted tracing by removing the \
+             'cross_application_tracer.enabled' configuration and setting \
+             'distributed_tracing.enabled' to true."
+          )
 
           register_event_listeners(events)
         end

--- a/test/new_relic/agent/monitors/cross_app_monitor_test.rb
+++ b/test/new_relic/agent/monitors/cross_app_monitor_test.rb
@@ -163,7 +163,7 @@ module NewRelic::Agent
         'OtherTransactionTotalTime',
         'OtherTransactionTotalTime/transaction',
         'Supportability/API/record_metric',
-        'Supportability/Deprecated/cross_application_tracer.enabled configuration'
+        'Supportability/Deprecated/cross_application_tracer'
         ])
     end
 

--- a/test/new_relic/agent/monitors/cross_app_monitor_test.rb
+++ b/test/new_relic/agent/monitors/cross_app_monitor_test.rb
@@ -157,8 +157,14 @@ module NewRelic::Agent
     def test_doesnt_write_metric_if_id_blank
       when_request_runs(for_id(''))
 
-      assert_metrics_recorded_exclusive(['transaction', 'Supportability/API/drop_buffered_data',
-        'OtherTransactionTotalTime', 'OtherTransactionTotalTime/transaction'])
+      assert_metrics_recorded_exclusive([
+        'transaction',
+        'Supportability/API/drop_buffered_data',
+        'OtherTransactionTotalTime',
+        'OtherTransactionTotalTime/transaction',
+        'Supportability/API/record_metric',
+        'Supportability/Deprecated/cross_application_tracer.enabled configuration'
+        ])
     end
 
     def test_setting_response_headers_freezes_transaction_name


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
Update the location of the CAT deprecation message and the accompanying text.

The previous location printed a message to the logs every time an external request is made. By moving the message to `CrossAppMonitor`, it will only be printed when CAT is initialized. 

# Related Github Issue
#551 

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
Github Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
