### PR TITLE
Use monotonically increasing time

### DIFF
--- a/infinite_tracing/test/infinite_tracing/agent_integrations/datastore_segment_test.rb
+++ b/infinite_tracing/test/infinite_tracing/agent_integrations/datastore_segment_test.rb
@@ -20,7 +20,7 @@ module NewRelic
           sql_statement = "select * from table"
 
           span_events = generate_and_stream_segments do
-  
+
             in_web_transaction('wat') do |txn|
               txn.stubs(:sampled?).returns(true)
 
@@ -34,7 +34,7 @@ module NewRelic
               )
 
               segment.notice_sql sql_statement
-              advance_time 1
+              advance_process_time(1)
               segment.finish
 
               timestamp = Integer(segment.start_time.to_f * 1000.0)
@@ -88,7 +88,7 @@ module NewRelic
               )
 
               segment.start
-              advance_time 1.0
+              advance_process_time(1.0)
               segment.finish
             end
           end

--- a/infinite_tracing/test/infinite_tracing/agent_integrations/external_request_segment_test.rb
+++ b/infinite_tracing/test/infinite_tracing/agent_integrations/external_request_segment_test.rb
@@ -30,7 +30,7 @@ module NewRelic
 
               txn.add_segment segment
               segment.start
-              advance_time 1.0
+              advance_process_time(1.0)
               segment.finish
 
               timestamp = Integer(segment.start_time.to_f * 1000.0)
@@ -78,7 +78,7 @@ module NewRelic
 
               txn.add_segment segment
               segment.start
-              advance_time 1.0
+              advance_process_time(1.0)
               segment.finish
             end
           end

--- a/infinite_tracing/test/infinite_tracing/agent_integrations/segment_test.rb
+++ b/infinite_tracing/test/infinite_tracing/agent_integrations/segment_test.rb
@@ -25,7 +25,7 @@ module NewRelic
               segment = Transaction::Segment.new 'Ummm'
               txn.add_segment segment
               segment.start
-              advance_time 1.0
+              advance_process_time(1.0)
               segment.finish
 
               timestamp = Integer(segment.start_time.to_f * 1000.0)
@@ -64,7 +64,7 @@ module NewRelic
               segment = Transaction::Segment.new 'Ummm'
               txn.add_segment segment
               segment.start
-              advance_time 1.0
+              advance_process_time(1.0)
               segment.finish
             end
           end
@@ -75,7 +75,7 @@ module NewRelic
         def test_streams_multiple_segments
           total_spans = 5
           segments = []
-        
+
           span_events = generate_and_stream_segments do
             total_spans.times do |index|
               with_segment do |segment|
@@ -83,7 +83,7 @@ module NewRelic
               end
             end
           end
-      
+
           assert_equal total_spans, span_events.size
           assert_equal total_spans, segments.size
         end

--- a/infinite_tracing/test/support/fake_trace_observer_helpers.rb
+++ b/infinite_tracing/test/support/fake_trace_observer_helpers.rb
@@ -70,8 +70,8 @@ if NewRelic::Agent::InfiniteTracing::Config.should_load?
           RUNNING_SERVER_CONTEXTS = {}
 
           # ServerContext lets us centralize starting/stopping the Fake Trace Observer Server
-          # and track spans the server receives across multiple Tracers and Server restarts.  
-          # One ServerContext instance per unit test is expected and is in play for 
+          # and track spans the server receives across multiple Tracers and Server restarts.
+          # One ServerContext instance per unit test is expected and is in play for
           # the duration of the unit test.
           class ServerContext
             attr_reader :port
@@ -98,7 +98,7 @@ if NewRelic::Agent::InfiniteTracing::Config.should_load?
             end
 
             def stop
-              @lock.synchronize do 
+              @lock.synchronize do
                 @server.stop
                 RUNNING_SERVER_CONTEXTS[self] = :stopped
               end
@@ -109,7 +109,7 @@ if NewRelic::Agent::InfiniteTracing::Config.should_load?
             end
 
             # We really shouldn't have to sleep, but this workaround gets us past
-            # various intermittent failing tests.  At the core of this issue is that 
+            # various intermittent failing tests.  At the core of this issue is that
             # in the agent_integrations/agent, we call Client.start_streaming in a thread
             # This is the thread that lingers in "run" state alongside our active test runner.
             # Various attempts to join or explicitly kill this thread led to more errors
@@ -138,7 +138,7 @@ if NewRelic::Agent::InfiniteTracing::Config.should_load?
               start
             end
           end
-          
+
           def restart_fake_trace_observer_server context, tracer_class=nil
             context.restart tracer_class
           end
@@ -262,7 +262,7 @@ if NewRelic::Agent::InfiniteTracing::Config.should_load?
           # A block that generates segments is expected and yielded to by this methd
           # The spans collected by the server are returned for further inspection
           def generate_and_stream_segments
-            NewRelic::Agent::InfiniteTracing::Client.any_instance.stubs(:handle_close).returns(nil) 
+            NewRelic::Agent::InfiniteTracing::Client.any_instance.stubs(:handle_close).returns(nil)
             unstub_reconnection
             server_context = nil
             with_config fake_server_config do
@@ -270,6 +270,7 @@ if NewRelic::Agent::InfiniteTracing::Config.should_load?
               # (the retry loop goes _much_ faster)
               Connection.instance.stubs(:retry_connection_period).returns(0.01)
               nr_freeze_time
+              nr_freeze_process_time
 
               simulate_connect_to_collector fake_server_config do |simulator|
                 # starts server and simulated agent connection
@@ -290,6 +291,7 @@ if NewRelic::Agent::InfiniteTracing::Config.should_load?
                 server_context.stop unless server_context.nil?
                 reset_infinite_tracer
                 nr_unfreeze_time
+                nr_unfreeze_process_time
               end
             end
           end

--- a/lib/new_relic/agent/adaptive_sampler.rb
+++ b/lib/new_relic/agent/adaptive_sampler.rb
@@ -13,7 +13,7 @@ module NewRelic
         @sampled_count = 0
         @period_duration = period_duration
         @first_period = true
-        @period_start = Time.now.to_f
+        @period_start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
         @lock = Mutex.new
         register_config_callbacks
       end
@@ -53,7 +53,7 @@ module NewRelic
       private
 
       def reset_if_period_expired!
-        now = Time.now.to_f
+        now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
         return unless @period_start + @period_duration <= now
 
         elapsed_periods = Integer((now - @period_start) / @period_duration)

--- a/lib/new_relic/agent/agent.rb
+++ b/lib/new_relic/agent/agent.rb
@@ -215,6 +215,7 @@ module NewRelic
             @connected_pid = Process.pid
           else
             ::NewRelic::Agent.logger.debug("Child process #{Process.pid} not reporting to non-connected parent (process #{Process.ppid}).")
+            # TODO: IS THE TIME ARGUMENT NECESSARY?
             @service.shutdown(Time.now)
             disconnect
           end
@@ -1123,7 +1124,7 @@ module NewRelic
         end
 
         def transmit_single_data_type(harvest_method, supportability_name)
-          now = Time.now
+          now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
           msg = "Sending #{supportability_name} data to New Relic Service"
           ::NewRelic::Agent.logger.debug msg
@@ -1132,12 +1133,12 @@ module NewRelic
             self.send(harvest_method)
           end
         ensure
-          duration = (Time.now - now).to_f
+          duration = Process.clock_gettime(Process::CLOCK_MONOTONIC) - now
           NewRelic::Agent.record_metric("Supportability/#{supportability_name}Harvest", duration)
         end
 
         def transmit_data
-          now = Time.now
+          now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
           ::NewRelic::Agent.logger.debug "Sending data to New Relic Service"
 
           @events.notify(:before_harvest)
@@ -1154,7 +1155,7 @@ module NewRelic
           end
         ensure
           NewRelic::Agent::Database.close_connections
-          duration = (Time.now - now).to_f
+          duration = Process.clock_gettime(Process::CLOCK_MONOTONIC) - now
           NewRelic::Agent.record_metric('Supportability/Harvest', duration)
         end
 

--- a/lib/new_relic/agent/agent.rb
+++ b/lib/new_relic/agent/agent.rb
@@ -215,8 +215,7 @@ module NewRelic
             @connected_pid = Process.pid
           else
             ::NewRelic::Agent.logger.debug("Child process #{Process.pid} not reporting to non-connected parent (process #{Process.ppid}).")
-            # TODO: IS THE TIME ARGUMENT NECESSARY?
-            @service.shutdown(Time.now)
+            @service.shutdown
             disconnect
           end
         end
@@ -1180,7 +1179,7 @@ module NewRelic
 
               if @connected_pid == $$ && !@service.kind_of?(NewRelic::Agent::NewRelicService)
                 ::NewRelic::Agent.logger.debug "Sending New Relic service agent run shutdown message"
-                @service.shutdown(Time.now.to_f)
+                @service.shutdown
               else
                 ::NewRelic::Agent.logger.debug "This agent connected from parent process #{@connected_pid}--not sending shutdown"
               end

--- a/lib/new_relic/agent/commands/thread_profiler_session.rb
+++ b/lib/new_relic/agent/commands/thread_profiler_session.rb
@@ -38,7 +38,7 @@ module NewRelic
             agent_command.arguments
           )
 
-          @started_at = Time.now
+          @started_at = Process.clock_gettime(Process::CLOCK_REALTIME)
           @duration = profile.duration if profile
         end
 
@@ -51,7 +51,9 @@ module NewRelic
         end
 
         def harvest
-          NewRelic::Agent.logger.debug("Harvesting from Thread Profiler #{@finished_profile.to_log_description unless @finished_profile.nil?}")
+          NewRelic::Agent.logger.debug(
+            "Harvesting from Thread Profiler #{@finished_profile.to_log_description unless @finished_profile.nil?}"
+          )
           profile = @finished_profile
           @backtrace_service.profile_agent_code = false
           @finished_profile = nil
@@ -72,7 +74,9 @@ module NewRelic
         end
 
         def past_time?
-          @started_at && (Time.now > @started_at + @duration)
+          @started_at && (
+            Process.clock_gettime(Process::CLOCK_REALTIME) > @started_at + @duration
+          )
         end
 
         def stopped?

--- a/lib/new_relic/agent/custom_event_aggregator.rb
+++ b/lib/new_relic/agent/custom_event_aggregator.rb
@@ -46,7 +46,8 @@ module NewRelic
 
       def create_event(type, priority, attributes)
         [
-          { TYPE => type, TIMESTAMP => Time.now.to_i,
+          { TYPE => type,
+            TIMESTAMP => Process.clock_gettime(Process::CLOCK_REALTIME).to_i,
             PRIORITY => priority
           },
           AttributeProcessing.flatten_and_coerce(attributes)

--- a/lib/new_relic/agent/database.rb
+++ b/lib/new_relic/agent/database.rb
@@ -228,9 +228,12 @@ module NewRelic
         def explain
           return unless explainable?
           handle_exception_in_explain do
-            start = Time.now
+            start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
             plan = @explainer.call(self)
-            ::NewRelic::Agent.record_metric("Supportability/Database/execute_explain_plan", Time.now - start)
+            ::NewRelic::Agent.record_metric(
+              "Supportability/Database/execute_explain_plan",
+              Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
+            )
             return process_resultset(plan, adapter) if plan
           end
         end

--- a/lib/new_relic/agent/datastores.rb
+++ b/lib/new_relic/agent/datastores.rb
@@ -21,7 +21,7 @@ module NewRelic
       # query content into Transaction Traces. Use wrap if you want to provide
       # that functionality.
       #
-      # @param [Class] clazz the class to instrument
+      # @param [Class] klass the class to instrument
       #
       # @param [String, Symbol] method_name the name of instance method to
       #   instrument
@@ -33,16 +33,16 @@ module NewRelic
       #
       # @api public
       #
-      def self.trace(clazz, method_name, product, operation = method_name)
+      def self.trace(klass, method_name, product, operation = method_name)
         NewRelic::Agent.record_api_supportability_metric(:trace)
 
-        clazz.class_eval do
+        klass.class_eval do
           method_name_without_newrelic = "#{method_name}_without_newrelic"
 
-          if NewRelic::Helper.instance_methods_include?(clazz, method_name) &&
-             !NewRelic::Helper.instance_methods_include?(clazz, method_name_without_newrelic)
+          if NewRelic::Helper.instance_methods_include?(klass, method_name) &&
+             !NewRelic::Helper.instance_methods_include?(klass, method_name_without_newrelic)
 
-            visibility = NewRelic::Helper.instance_method_visibility(clazz, method_name)
+            visibility = NewRelic::Helper.instance_method_visibility(klass, method_name)
 
             alias_method method_name_without_newrelic, method_name
 

--- a/lib/new_relic/agent/datastores.rb
+++ b/lib/new_relic/agent/datastores.rb
@@ -123,7 +123,7 @@ module NewRelic
         ensure
           begin
             if callback
-              elapsed_time = (Time.now - segment.start_time).to_f
+              elapsed_time = Process.clock_gettime(Process::CLOCK_REALTIME) - segment.start_time
               callback.call(result, segment.name, elapsed_time)
             end
           ensure

--- a/lib/new_relic/agent/distributed_tracing/cross_app_payload.rb
+++ b/lib/new_relic/agent/distributed_tracing/cross_app_payload.rb
@@ -19,15 +19,15 @@ module NewRelic
       end
 
       def as_json_array(content_length)
-        queue_time_in_seconds = [transaction.queue_time.to_f, 0.0].max
-        start_time_in_seconds = [transaction.start_time.to_f, 0.0].max
-        app_time_in_seconds   = Time.now.to_f - start_time_in_seconds
+        queue_time_in_seconds = [transaction.queue_time, 0.0].max
+        start_time_in_seconds = [transaction.start_time, 0.0].max
+        app_time_in_seconds   = Process.clock_gettime(Process::CLOCK_REALTIME) - start_time_in_seconds
 
         [
           NewRelic::Agent.config[:cross_process_id],
           transaction.best_name,
-          queue_time_in_seconds.to_f,
-          app_time_in_seconds.to_f,
+          queue_time_in_seconds,
+          app_time_in_seconds,
           content_length,
           transaction.guid,
           false

--- a/lib/new_relic/agent/distributed_tracing/cross_app_tracing.rb
+++ b/lib/new_relic/agent/distributed_tracing/cross_app_tracing.rb
@@ -75,8 +75,11 @@ module NewRelic
 
       def record_cross_app_metrics
         if (id = cross_app_payload && cross_app_payload.id)
-          app_time_in_seconds = [Time.now.to_f - transaction.start_time.to_f, 0.0].max
-          NewRelic::Agent.record_metric "ClientApplication/#{id}/all", app_time_in_seconds
+          app_time_in_seconds = [
+            Process.clock_gettime(Process::CLOCK_REALTIME) - transaction.start_time,
+            0.0
+          ].max
+          NewRelic::Agent.record_metric("ClientApplication/#{id}/all", app_time_in_seconds)
         end
       end
 

--- a/lib/new_relic/agent/distributed_tracing/distributed_trace_attributes.rb
+++ b/lib/new_relic/agent/distributed_tracing/distributed_trace_attributes.rb
@@ -64,7 +64,6 @@ module NewRelic
           destination[PARENT_TYPE_KEY] = trace_payload.parent_type
           destination[PARENT_APP_KEY] = trace_payload.parent_app_id
           destination[PARENT_ACCOUNT_ID_KEY] = trace_payload.parent_account_id
-
           destination[PARENT_TRANSPORT_DURATION_KEY] = transaction.calculate_transport_duration trace_payload
 
           if parent_transaction_id = transaction.distributed_tracer.parent_transaction_id

--- a/lib/new_relic/agent/distributed_tracing/distributed_trace_payload.rb
+++ b/lib/new_relic/agent/distributed_tracing/distributed_trace_payload.rb
@@ -50,7 +50,7 @@ module NewRelic
 
           payload.id = current_segment_id(transaction)
           payload.transaction_id = transaction.guid
-          payload.timestamp = (Time.now.to_f * 1000).round
+          payload.timestamp = (Process.clock_gettime(Process::CLOCK_REALTIME) * 1000).round
           payload.trace_id = transaction.trace_id
           payload.sampled = transaction.sampled?
           payload.priority = transaction.priority

--- a/lib/new_relic/agent/distributed_tracing/distributed_trace_payload.rb
+++ b/lib/new_relic/agent/distributed_tracing/distributed_trace_payload.rb
@@ -50,7 +50,7 @@ module NewRelic
 
           payload.id = current_segment_id(transaction)
           payload.transaction_id = transaction.guid
-          payload.timestamp = (Process.clock_gettime(Process::CLOCK_REALTIME) * 1000).round
+          payload.timestamp = Process.clock_gettime(Process::CLOCK_REALTIME, :millisecond)
           payload.trace_id = transaction.trace_id
           payload.sampled = transaction.sampled?
           payload.priority = transaction.priority

--- a/lib/new_relic/agent/distributed_tracing/trace_context_payload.rb
+++ b/lib/new_relic/agent/distributed_tracing/trace_context_payload.rb
@@ -57,7 +57,7 @@ module NewRelic
         private
 
         def now_ms
-          (Time.now.to_f * 1000).round
+          (Process.clock_gettime(Process::CLOCK_REALTIME) * 1000).round
         end
 
         def handle_invalid_payload error: nil, message: nil

--- a/lib/new_relic/agent/distributed_tracing/trace_context_payload.rb
+++ b/lib/new_relic/agent/distributed_tracing/trace_context_payload.rb
@@ -57,7 +57,7 @@ module NewRelic
         private
 
         def now_ms
-          (Process.clock_gettime(Process::CLOCK_REALTIME) * 1000).round
+          Process.clock_gettime(Process::CLOCK_REALTIME, :millisecond)
         end
 
         def handle_invalid_payload error: nil, message: nil

--- a/lib/new_relic/agent/event_loop.rb
+++ b/lib/new_relic/agent/event_loop.rb
@@ -14,7 +14,7 @@ module NewRelic
           @interval      = interval
           @event         = event
           @repeat        = repeat
-          @started_at    = Time.now
+          @started_at    = Process.clock_gettime(Process::CLOCK_REALTIME)
           @last_fired_at = nil
           reschedule
         end
@@ -32,7 +32,7 @@ module NewRelic
         end
 
         def calculate_next_fire_time
-          now = Time.now
+          now = Process.clock_gettime(Process::CLOCK_REALTIME)
           return now if @interval == 0
           fire_time = @last_fired_at || now
           while fire_time <= now
@@ -42,10 +42,10 @@ module NewRelic
         end
 
         def set_fired_time
-          @last_fired_at = Time.now
+          @last_fired_at = Process.clock_gettime(Process::CLOCK_REALTIME)
         end
 
-        def due?(now=Time.now)
+        def due?(now=Process.clock_gettime(Process::CLOCK_REALTIME))
           now >= @next_fire_time
         end
 
@@ -69,7 +69,7 @@ module NewRelic
         existing_timer = @timers[timer.event]
 
         if existing_timer
-          elapsed_interval = Time.now - existing_timer.last_interval_start
+          elapsed_interval = Process.clock_gettime(Process::CLOCK_REALTIME) - existing_timer.last_interval_start
           timer.advance(elapsed_interval)
         end
 
@@ -80,7 +80,7 @@ module NewRelic
 
       def next_timeout
         return nil if @timers.empty?
-        timeout = @timers.values.map(&:next_fire_time).min - Time.now
+        timeout = @timers.values.map(&:next_fire_time).min - Process.clock_gettime(Process::CLOCK_REALTIME)
         timeout < 0 ? 0 : timeout
       end
 

--- a/lib/new_relic/agent/instrumentation/action_controller_subscriber.rb
+++ b/lib/new_relic/agent/instrumentation/action_controller_subscriber.rb
@@ -91,7 +91,7 @@ module NewRelic
 
         def queue_start(request)
           if request && request.respond_to?(:env)
-            QueueTime.parse_frontend_timestamp(request.env, Time.now)
+            QueueTime.parse_frontend_timestamp(request.env, Process.clock_gettime(Process::CLOCK_REALTIME))
           end
         end
       end

--- a/lib/new_relic/agent/instrumentation/bunny/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/bunny/instrumentation.rb
@@ -65,7 +65,7 @@ module NewRelic
           def pop_with_tracing
             bunny_error, delivery_info, message_properties, _payload = nil, nil, nil, nil
             begin
-              t0 = Time.now
+              t0 = Process.clock_gettime(Process::CLOCK_REALTIME)
               msg = yield
               delivery_info, message_properties, _payload = msg
             rescue StandardError => error

--- a/lib/new_relic/agent/instrumentation/queue_time.rb
+++ b/lib/new_relic/agent/instrumentation/queue_time.rb
@@ -15,7 +15,7 @@ module NewRelic
         ALL_QUEUE_METRIC        = 'WebFrontend/QueueTime'.freeze
         # any timestamps before this are thrown out and the parser
         # will try again with a larger unit (2000/1/1 UTC)
-        EARLIEST_ACCEPTABLE_TIME = Time.at(946684800)
+        EARLIEST_ACCEPTABLE_TIME = Time.at(946684800).to_f
 
         CANDIDATE_HEADERS = [
           REQUEST_START_HEADER,
@@ -27,7 +27,7 @@ module NewRelic
 
         module_function
 
-        def parse_frontend_timestamp(headers, now=Time.now)
+        def parse_frontend_timestamp(headers, now=Process.clock_gettime(Process::CLOCK_REALTIME))
           earliest = nil
 
           CANDIDATE_HEADERS.each do |header|
@@ -40,7 +40,7 @@ module NewRelic
           end
 
           if earliest && earliest > now
-            NewRelic::Agent.logger.debug("Negative queue time detected, treating as zero: start=#{earliest.to_f} > now=#{now.to_f}")
+            NewRelic::Agent.logger.debug("Negative queue time detected, treating as zero: start=#{earliest.to_f} > now=#{now}")
             earliest = now
           end
 
@@ -59,7 +59,7 @@ module NewRelic
         def parse_timestamp(string)
           DIVISORS.each do |divisor|
             begin
-              t = Time.at(string.to_f / divisor)
+              t = (string.to_f / divisor)
               return t if t > EARLIEST_ACCEPTABLE_TIME
             rescue RangeError
               # On Ruby versions built with a 32-bit time_t, attempting to

--- a/lib/new_relic/agent/javascript_instrumentor.rb
+++ b/lib/new_relic/agent/javascript_instrumentor.rb
@@ -136,9 +136,9 @@ module NewRelic
 
       # NOTE: Internal prototyping may override this, so leave name stable!
       def data_for_js_agent(transaction)
-        queue_time_in_seconds = [transaction.queue_time.to_f, 0.0].max
-        start_time_in_seconds = [transaction.start_time.to_f, 0.0].max
-        app_time_in_seconds   = Time.now.to_f - start_time_in_seconds
+        queue_time_in_seconds = [transaction.queue_time, 0.0].max
+        start_time_in_seconds = [transaction.start_time, 0.0].max
+        app_time_in_seconds   = Process.clock_gettime(Process::CLOCK_REALTIME) - start_time_in_seconds
 
         queue_time_in_millis = (1000.0 * queue_time_in_seconds).round
         app_time_in_millis   = (1000.0 * app_time_in_seconds).round

--- a/lib/new_relic/agent/pipe_service.rb
+++ b/lib/new_relic/agent/pipe_service.rb
@@ -61,10 +61,7 @@ module NewRelic
         write_to_pipe(:sql_trace_data, sql) if sql
       end
 
-      # TODO: IS THE TIME ARGUMENT NECESSARY?
-      # IF NOT, REMOVE THE ARGUMENT FROM THE CALLS TO THIS METHOD
-      # OFTEN @service.shutdown()
-      def shutdown(time)
+      def shutdown
         @pipe.close if @pipe
       end
 

--- a/lib/new_relic/agent/pipe_service.rb
+++ b/lib/new_relic/agent/pipe_service.rb
@@ -61,6 +61,9 @@ module NewRelic
         write_to_pipe(:sql_trace_data, sql) if sql
       end
 
+      # TODO: IS THE TIME ARGUMENT NECESSARY?
+      # IF NOT, REMOVE THE ARGUMENT FROM THE CALLS TO THIS METHOD
+      # OFTEN @service.shutdown()
       def shutdown(time)
         @pipe.close if @pipe
       end

--- a/lib/new_relic/agent/samplers/cpu_sampler.rb
+++ b/lib/new_relic/agent/samplers/cpu_sampler.rb
@@ -48,7 +48,7 @@ module NewRelic
         end
 
         def poll
-          now = Time.now
+          now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
           t = Process.times
 
           if @last_time && t.utime != 0.0 && t.stime != 0.0

--- a/lib/new_relic/agent/sql_sampler.rb
+++ b/lib/new_relic/agent/sql_sampler.rb
@@ -46,6 +46,7 @@ module NewRelic
           NewRelic::Agent::Database.should_record_sql?(:slow_sql)
       end
 
+      # TODO: IS THE START TIME ARGUMENT USED? COULD IT BE REMOVED?
       def on_start_transaction(state, start_time, uri=nil)
         return unless enabled?
 

--- a/lib/new_relic/agent/sql_sampler.rb
+++ b/lib/new_relic/agent/sql_sampler.rb
@@ -46,8 +46,7 @@ module NewRelic
           NewRelic::Agent::Database.should_record_sql?(:slow_sql)
       end
 
-      # TODO: IS THE START TIME ARGUMENT USED? COULD IT BE REMOVED?
-      def on_start_transaction(state, start_time, uri=nil)
+      def on_start_transaction(state, uri=nil)
         return unless enabled?
 
         state.sql_sampler_transaction_data = TransactionSqlData.new

--- a/lib/new_relic/agent/stats_engine.rb
+++ b/lib/new_relic/agent/stats_engine.rb
@@ -150,7 +150,7 @@ module NewRelic
       end
 
       def harvest!
-        now = Time.now
+        now = Process.clock_gettime(Process::CLOCK_REALTIME)
         snapshot = reset!
         snapshot = apply_rules_to_metric_data(@metric_rules, snapshot)
         snapshot.harvested_at = now

--- a/lib/new_relic/agent/stats_engine/stats_hash.rb
+++ b/lib/new_relic/agent/stats_engine/stats_hash.rb
@@ -33,7 +33,7 @@ module NewRelic
 
       attr_accessor :started_at, :harvested_at
 
-      def initialize(started_at=Time.now)
+      def initialize(started_at=Process.clock_gettime(Process::CLOCK_REALTIME))
         @started_at = started_at.to_f
         @scoped     = Hash.new { |h, k| h[k] = NewRelic::Agent::Stats.new }
         @unscoped   = Hash.new { |h, k| h[k] = NewRelic::Agent::Stats.new }

--- a/lib/new_relic/agent/threading/backtrace_service.rb
+++ b/lib/new_relic/agent/threading/backtrace_service.rb
@@ -105,7 +105,7 @@ module NewRelic
           @lock.synchronize do
             if @profiles[transaction_name]
               profile = @profiles.delete(transaction_name)
-              profile.finished_at = Time.now
+              profile.finished_at = Process.clock_gettime(Process::CLOCK_REALTIME)
               @profiles[transaction_name] = ThreadProfile.new(profile.command_arguments)
               profile
             end
@@ -163,7 +163,7 @@ module NewRelic
         end
 
         def poll
-          poll_start = Time.now
+          poll_start = Process.clock_gettime(Process::CLOCK_REALTIME)
 
           @lock.synchronize do
             AgentThread.list.each do |thread|
@@ -173,7 +173,7 @@ module NewRelic
             @buffer.delete_if { |thread, _| !thread.alive? }
           end
 
-          end_time = Time.now
+          end_time = Process.clock_gettime(Process::CLOCK_REALTIME)
           adjust_polling_time(end_time, poll_start)
           record_supportability_metrics(end_time, poll_start)
         end
@@ -230,7 +230,7 @@ module NewRelic
           bucket = AgentThread.bucket_thread(thread, @profile_agent_code)
 
           if need_backtrace?(bucket)
-            timestamp = Time.now.to_f
+            timestamp = Process.clock_gettime(Process::CLOCK_REALTIME)
             backtrace = AgentThread.scrub_backtrace(thread, @profile_agent_code)
             aggregate_global_backtrace(backtrace, bucket, thread)
             buffer_backtrace_for_thread(thread, timestamp, backtrace, bucket)
@@ -277,7 +277,6 @@ module NewRelic
           end
           @last_poll = poll_start
         end
-
       end
     end
   end

--- a/lib/new_relic/agent/threading/thread_profile.rb
+++ b/lib/new_relic/agent/threading/thread_profile.rb
@@ -39,7 +39,7 @@ module NewRelic
           @failure_count = 0
           @unique_threads = []
 
-          @created_at = Time.now
+          @created_at = Process.clock_gettime(Process::CLOCK_REALTIME)
         end
 
         def requested_period

--- a/lib/new_relic/agent/transaction.rb
+++ b/lib/new_relic/agent/transaction.rb
@@ -602,7 +602,7 @@ module NewRelic
       def calculate_transport_duration distributed_trace_payload
         return unless distributed_trace_payload
 
-        duration = start_time - distributed_trace_payload.timestamp
+        duration = start_time - (distributed_trace_payload.timestamp / 1000.0)
         duration < 0 ? 0 : duration
       end
 

--- a/lib/new_relic/agent/transaction.rb
+++ b/lib/new_relic/agent/transaction.rb
@@ -395,7 +395,7 @@ module NewRelic
       def start
         return if !state.is_execution_traced?
 
-        sql_sampler.on_start_transaction(state, start_time, request_path)
+        sql_sampler.on_start_transaction(state, request_path)
         NewRelic::Agent.instance.events.notify(:start_transaction)
         NewRelic::Agent::TransactionTimeAggregator.transaction_start(start_time)
 

--- a/lib/new_relic/agent/transaction.rb
+++ b/lib/new_relic/agent/transaction.rb
@@ -227,7 +227,7 @@ module NewRelic
         @start_time = Process.clock_gettime(Process::CLOCK_REALTIME)
         @end_time = nil
         @duration = nil
-        # TODO: MAKE SURE THAT THIS IS NOT GETTING PASSED AS A TIME OBJECT
+
         @apdex_start = options[:apdex_start_time] || @start_time
         @jruby_cpu_start = jruby_cpu_time
         @process_cpu_start = process_cpu

--- a/lib/new_relic/agent/transaction.rb
+++ b/lib/new_relic/agent/transaction.rb
@@ -624,7 +624,7 @@ module NewRelic
         @payload = {
           :name                 => @frozen_name,
           :bucket               => recording_web_transaction? ? :request : :background,
-          :start_timestamp      => start_time.to_f,
+          :start_timestamp      => start_time,
           :duration             => duration,
           :metrics              => @metrics,
           :attributes           => @attributes,

--- a/lib/new_relic/agent/transaction.rb
+++ b/lib/new_relic/agent/transaction.rb
@@ -602,7 +602,7 @@ module NewRelic
       def calculate_transport_duration distributed_trace_payload
         return unless distributed_trace_payload
 
-        duration = (start_time * 1000 - distributed_trace_payload.timestamp) / 1000
+        duration = start_time - distributed_trace_payload.timestamp
         duration < 0 ? 0 : duration
       end
 

--- a/lib/new_relic/agent/transaction.rb
+++ b/lib/new_relic/agent/transaction.rb
@@ -119,28 +119,6 @@ module NewRelic
         "#{namer.prefix_for_category(self, category)}#{partial_name}"
       end
 
-      def self.wrap(state, name, category, options = {})
-        Deprecator.deprecate 'Transaction.wrap',
-                             'Tracer#in_transaction'
-
-        finishable = Tracer.start_transaction_or_segment(
-              name: name,
-              category: category,
-              options: options
-            )
-
-        begin
-          # We shouldn't raise from Transaction.start, but only wrap the yield
-          # to be absolutely sure we don't report agent problems as app errors
-          yield
-        rescue => e
-          Transaction.notice_error(e)
-          raise e
-        ensure
-          finishable.finish if finishable
-        end
-      end
-
       def self.start_new_transaction(state, category, options)
         txn = Transaction.new(category, options)
         state.reset(txn)

--- a/lib/new_relic/agent/transaction.rb
+++ b/lib/new_relic/agent/transaction.rb
@@ -227,6 +227,7 @@ module NewRelic
         @start_time = Process.clock_gettime(Process::CLOCK_REALTIME)
         @end_time = nil
         @duration = nil
+        # TODO: MAKE SURE THAT THIS IS NOT GETTING PASSED AS A TIME OBJECT
         @apdex_start = options[:apdex_start_time] || @start_time
         @jruby_cpu_start = jruby_cpu_time
         @process_cpu_start = process_cpu
@@ -601,7 +602,7 @@ module NewRelic
       def calculate_transport_duration distributed_trace_payload
         return unless distributed_trace_payload
 
-        duration = (start_time.to_f * 1000 - distributed_trace_payload.timestamp) / 1000
+        duration = (start_time * 1000 - distributed_trace_payload.timestamp) / 1000
         duration < 0 ? 0 : duration
       end
 

--- a/lib/new_relic/agent/transaction.rb
+++ b/lib/new_relic/agent/transaction.rb
@@ -224,7 +224,7 @@ module NewRelic
         @frozen_name      = nil
 
         @category = category
-        @start_time = Time.now
+        @start_time = Process.clock_gettime(Process::CLOCK_REALTIME)
         @end_time = nil
         @duration = nil
         @apdex_start = options[:apdex_start_time] || @start_time
@@ -483,8 +483,8 @@ module NewRelic
 
       def finish
         return unless state.is_execution_traced?
-        @end_time = Time.now
-        @duration = @end_time.to_f - @start_time.to_f
+        @end_time = Process.clock_gettime(Process::CLOCK_REALTIME)
+        @duration = @end_time - @start_time
         freeze_name_and_execute_if_not_ignored
 
         if nesting_max_depth == 1

--- a/lib/new_relic/agent/transaction/abstract_segment.rb
+++ b/lib/new_relic/agent/transaction/abstract_segment.rb
@@ -48,14 +48,14 @@ module NewRelic
         end
 
         def start
-          @start_time ||= Time.now
+          @start_time ||= Process.clock_gettime(Process::CLOCK_REALTIME)
           return unless transaction
           parent.child_start self if parent
         end
 
         def finish
-          @end_time = Time.now
-          @duration = end_time.to_f - start_time.to_f
+          @end_time = Process.clock_gettime(Process::CLOCK_REALTIME)
+          @duration = end_time - start_time
           return unless transaction
           run_complete_callbacks
           finalize if record_on_finish?

--- a/lib/new_relic/agent/vm/snapshot.rb
+++ b/lib/new_relic/agent/vm/snapshot.rb
@@ -12,7 +12,7 @@ module NewRelic
                       :thread_count, :taken_at
 
         def initialize
-          @taken_at = Time.now.to_f
+          @taken_at = Process.clock_gettime(Process::CLOCK_REALTIME)
         end
       end
     end

--- a/lib/new_relic/agent/worker_loop.rb
+++ b/lib/new_relic/agent/worker_loop.rb
@@ -18,7 +18,7 @@ module NewRelic
       # or :limit (integer) for max number of iterations
       def initialize(opts={})
         @should_run = true
-        @next_invocation_time = Time.now
+        @next_invocation_time = Process.clock_gettime(Process::CLOCK_REALTIME)
         @period = 60.0
         @duration = opts[:duration]
         @limit = opts[:limit]
@@ -34,7 +34,7 @@ module NewRelic
         @should_run = true
         @iterations = 0
 
-        now = Time.now
+        now = Process.clock_gettime(Process::CLOCK_REALTIME)
         @deadline = now + @duration if @duration
         @next_invocation_time = (now + @period)
       end
@@ -53,11 +53,11 @@ module NewRelic
       end
 
       def schedule_next_invocation
-        now = Time.now
+        now = Process.clock_gettime(Process::CLOCK_REALTIME)
         while @next_invocation_time <= now && @period > 0
           @next_invocation_time += @period
         end
-        @next_invocation_time - Time.now
+        @next_invocation_time - Process.clock_gettime(Process::CLOCK_REALTIME)
       end
 
       # a simple accessor for @should_run
@@ -66,7 +66,7 @@ module NewRelic
       end
 
       def under_duration?
-        !@deadline || Time.now < @deadline
+        !@deadline || Process.clock_gettime(Process::CLOCK_REALTIME) < @deadline
       end
 
       def under_limit?

--- a/lib/new_relic/noticed_error.rb
+++ b/lib/new_relic/noticed_error.rb
@@ -33,7 +33,7 @@ class NewRelic::NoticedError
   ERROR_CLASS_KEY    = "#{ERROR_PREFIX_KEY}.class"
   ERROR_EXPECTED_KEY = "#{ERROR_PREFIX_KEY}.expected"
 
-  def initialize(path, exception, timestamp = Time.now, expected = false)
+  def initialize(path, exception, timestamp = Process.clock_gettime(Process::CLOCK_REALTIME), expected = false)
     @exception_id = exception.object_id
     @path = path
 
@@ -139,7 +139,7 @@ class NewRelic::NoticedError
       ERROR_MESSAGE_KEY => string(message),
       ERROR_CLASS_KEY => string(exception_class_name)
     })
-    
+
     @attributes_from_notice_error[ERROR_EXPECTED_KEY] = true if expected
   end
 

--- a/test/agent_helper.rb
+++ b/test/agent_helper.rb
@@ -608,12 +608,12 @@ unless Process.respond_to?(:__original_clock_gettime)
 end
 
 # TODO: TRY TO ALLOW THE CLOCK ID TO BE PASSED
-def advance_process_time(seconds, clock_id=Process::CLOCK_MONOTONIC)
+def advance_process_time(seconds, clock_id=Process::CLOCK_REALTIME)
   Process.__frozen_clock_gettime = Process.clock_gettime(clock_id) + seconds
 end
 
 # TODO: TRY TO ALLOW THE CLOCK ID TO BE PASSED
-def nr_freeze_process_time(now=Process.clock_gettime(Process::CLOCK_MONOTONIC))
+def nr_freeze_process_time(now=Process.clock_gettime(Process::CLOCK_REALTIME))
   Process.__frozen_clock_gettime = now
 end
 

--- a/test/agent_helper.rb
+++ b/test/agent_helper.rb
@@ -695,7 +695,7 @@ def wait_for_backtrace_service_poll opts={}
     :iterations => 1
   }
   opts = defaults.merge(opts)
-  deadline = Time.now + opts[:timeout]
+  deadline = Process.clock_gettime(Process::CLOCK_REALTIME) + opts[:timeout]
 
   service = opts[:service]
   worker_loop = service.worker_loop
@@ -703,7 +703,7 @@ def wait_for_backtrace_service_poll opts={}
 
   until worker_loop.iterations > opts[:iterations]
     sleep(0.01)
-    if Time.now > deadline
+    if Process.clock_gettime(Process::CLOCK_REALTIME) > deadline
       raise "Timed out waiting #{opts[:timeout]} s for backtrace service poll\n" +
             "Worker loop ran for #{opts[:service].worker_loop.iterations} iterations\n\n" +
             Thread.list.map { |t|

--- a/test/agent_helper.rb
+++ b/test/agent_helper.rb
@@ -600,8 +600,8 @@ unless Process.respond_to?(:__original_clock_gettime)
       attr_accessor :__frozen_clock_gettime
       alias_method :__original_clock_gettime, :clock_gettime
 
-      def clock_gettime(clock_id)
-        __frozen_clock_gettime || __original_clock_gettime(clock_id)
+      def clock_gettime(clock_id, unit = :float_second)
+        __frozen_clock_gettime || __original_clock_gettime(clock_id, unit)
       end
     end
   end

--- a/test/agent_helper.rb
+++ b/test/agent_helper.rb
@@ -607,12 +607,10 @@ unless Process.respond_to?(:__original_clock_gettime)
   end
 end
 
-# TODO: TRY TO ALLOW THE CLOCK ID TO BE PASSED
 def advance_process_time(seconds, clock_id=Process::CLOCK_REALTIME)
   Process.__frozen_clock_gettime = Process.clock_gettime(clock_id) + seconds
 end
 
-# TODO: TRY TO ALLOW THE CLOCK ID TO BE PASSED
 def nr_freeze_process_time(now=Process.clock_gettime(Process::CLOCK_REALTIME))
   Process.__frozen_clock_gettime = now
 end

--- a/test/environments/lib/environments/runner.rb
+++ b/test/environments/lib/environments/runner.rb
@@ -18,7 +18,7 @@ module Environments
       "2.1"         => ["rails50", "rails60"],
       "2.0"         => ["rails50", "rails60"],
       "jruby-9.2.6.0" => ["rails60"],
-      "jruby-9.0"   => ["rails30", "rails31", "rails32"]
+      "jruby-9.0"   => ["rails32"]
     }
 
     attr_reader :envs

--- a/test/helpers/minitest.rb
+++ b/test/helpers/minitest.rb
@@ -27,6 +27,7 @@ class Minitest::Test
 
   def after_teardown
     nr_unfreeze_time
+    nr_unfreeze_process_time
 
     threads = ruby_threads
     if @__thread_count != threads.count

--- a/test/multiverse/suites/agent_only/adaptive_sampler_test.rb
+++ b/test/multiverse/suites/agent_only/adaptive_sampler_test.rb
@@ -16,7 +16,7 @@ module NewRelic
       end
 
       def test_adaptive_sampler_valid_stats_and_reset_after_harvest
-        nr_freeze_time
+        nr_freeze_process_time
 
         sampled_count = 0
         20.times do |i|
@@ -30,7 +30,7 @@ module NewRelic
         assert_equal 20, stats[:seen]
         assert_equal sampled_count, stats[:sampled_count]
 
-        advance_time(60)
+        advance_process_time(60)
 
         in_transaction("test_txn_20") {}
 

--- a/test/multiverse/suites/agent_only/audit_log_test.rb
+++ b/test/multiverse/suites/agent_only/audit_log_test.rb
@@ -47,7 +47,7 @@ class AuditLogTest < Minitest::Test
 
   def perform_actions
     state = NewRelic::Agent::Tracer.state
-    NewRelic::Agent.instance.sql_sampler.on_start_transaction(state, nil)
+    NewRelic::Agent.instance.sql_sampler.on_start_transaction(state)
     NewRelic::Agent.instance.sql_sampler.notice_sql("select * from test",
                                  "Database/test/select",
                                  nil, 1.5, state)

--- a/test/multiverse/suites/agent_only/custom_analytics_events_test.rb
+++ b/test/multiverse/suites/agent_only/custom_analytics_events_test.rb
@@ -12,7 +12,7 @@ class CustomAnalyticsEventsTest < Minitest::Test
   end
 
   def test_custom_analytics_events_are_submitted
-    t0 = nr_freeze_time
+    t0 = nr_freeze_process_time
     NewRelic::Agent.record_custom_event(:DummyType, :foo => :bar, :baz => :qux)
 
     NewRelic::Agent.agent.send(:harvest_and_send_custom_event_data)

--- a/test/multiverse/suites/agent_only/custom_queue_time_test.rb
+++ b/test/multiverse/suites/agent_only/custom_queue_time_test.rb
@@ -21,7 +21,7 @@ class CustomQueueTimeTest < Minitest::Test
     def run_transaction(request, simulated_queue_time)
       opts = { :name => 'run_transaction', :class_name => 'DummyApp', :request => request }
 
-      advance_time(simulated_queue_time)
+      advance_process_time(simulated_queue_time)
 
       perform_action_with_newrelic_trace(opts) do
         # nothing
@@ -30,8 +30,8 @@ class CustomQueueTimeTest < Minitest::Test
   end
 
   def setup
-    nr_freeze_time
-    @headers = { 'HTTP_X_REQUEST_START' => "t=#{Time.now.to_f}" }
+    nr_freeze_process_time
+    @headers = { 'HTTP_X_REQUEST_START' => "t=#{Process.clock_gettime(Process::CLOCK_REALTIME)}" }
   end
 
   def test_pulls_request_headers_from_passed_in_rack_request

--- a/test/multiverse/suites/agent_only/error_events_test.rb
+++ b/test/multiverse/suites/agent_only/error_events_test.rb
@@ -6,7 +6,7 @@ class ErrorEventsTest < Minitest::Test
   include MultiverseHelpers
 
   setup_and_teardown_agent do
-    nr_freeze_time
+    nr_freeze_process_time
   end
 
   def test_error_events_are_submitted
@@ -99,7 +99,7 @@ class ErrorEventsTest < Minitest::Test
     intrinsics, _, _ = last_error_event
 
     assert_equal "TransactionError", intrinsics["type"]
-    assert_in_delta Time.now.to_f, intrinsics["timestamp"], 0.001
+    assert_in_delta Process.clock_gettime(Process::CLOCK_REALTIME), intrinsics["timestamp"], 0.001
     assert_equal "RuntimeError", intrinsics["error.class"]
     assert_equal "No Txn", intrinsics["error.message"]
   end

--- a/test/multiverse/suites/agent_only/exclusive_time_test.rb
+++ b/test/multiverse/suites/agent_only/exclusive_time_test.rb
@@ -13,24 +13,24 @@ class ExclusiveTimeTest < Minitest::Test
       include NewRelic::Agent::MethodTracer
 
       def outer_a
-        advance_time 2
+        advance_process_time 2
         outer_b
       end
       add_transaction_tracer :outer_a, :class_name => 'traced'
 
       def outer_b
-        advance_time 5
+        advance_process_time 5
         inner
       end
       add_transaction_tracer :outer_b, :class_name => 'traced'
 
       def inner
-        advance_time 10
+        advance_process_time 10
       end
       add_method_tracer :inner, 'inner'
     end
 
-    nr_freeze_time
+    nr_freeze_process_time
     traced_class.new.outer_a
 
     txn_name = 'Controller/traced/outer_b'
@@ -64,18 +64,18 @@ class ExclusiveTimeTest < Minitest::Test
       include NewRelic::Agent::MethodTracer
 
       def outer
-        advance_time 2
+        advance_process_time 2
         inner
       end
       add_transaction_tracer :outer, :class_name => 'traced'
 
       def inner
-        advance_time 10
+        advance_process_time 10
       end
       add_method_tracer :inner, 'inner'
     end
 
-    nr_freeze_time
+    nr_freeze_process_time
     traced_class.new.outer
 
     txn_name = 'Controller/traced/outer'

--- a/test/multiverse/suites/agent_only/harvest_timestamps_test.rb
+++ b/test/multiverse/suites/agent_only/harvest_timestamps_test.rb
@@ -10,36 +10,36 @@ class HarvestTimestampsTest < Minitest::Test
   setup_and_teardown_agent
 
   def test_resets_metric_data_timestamps_after_forking
-    nr_freeze_time
+    nr_freeze_process_time
 
-    t1 = advance_time 10
+    t1 = advance_process_time 10
 
     simulate_fork
     NewRelic::Agent.after_fork
 
-    t2 = advance_time 10
+    t2 = advance_process_time 10
     trigger_metric_data_post
 
     metric_data_post = $collector.calls_for('metric_data').first
     start_ts, end_ts = metric_data_post[1..2]
 
-    assert_equal(t1.to_f, start_ts)
-    assert_equal(t2.to_f, end_ts)
+    assert_equal(t1, start_ts)
+    assert_equal(t2, end_ts)
   end
 
   def test_start_timestamp_maintained_on_harvest_failure
-    t0 = nr_freeze_time.to_f
+    t0 = nr_freeze_process_time
 
     simulate_fork
     NewRelic::Agent.after_fork
 
     $collector.stub('metric_data', {}, 503)
-    t1 = advance_time(10).to_f
+    t1 = advance_process_time(10)
     trigger_metric_data_post
     first_post = last_metric_data_post
 
     $collector.reset
-    t2 = advance_time(10).to_f
+    t2 = advance_process_time(10)
     trigger_metric_data_post
     second_post = last_metric_data_post
 

--- a/test/multiverse/suites/agent_only/key_transactions_test.rb
+++ b/test/multiverse/suites/agent_only/key_transactions_test.rb
@@ -21,19 +21,19 @@ class KeyTransactionsTest < Minitest::Test
   end
 
   def after_setup
-    nr_freeze_time
+    nr_freeze_process_time
   end
 
   class TestWidget
     include ::NewRelic::Agent::Instrumentation::ControllerInstrumentation
 
     def key_txn
-      advance_time(5)
+      advance_process_time(5)
     end
     add_transaction_tracer :key_txn
 
     def other_txn
-      advance_time(5)
+      advance_process_time(5)
     end
     add_transaction_tracer :other_txn
   end
@@ -49,7 +49,7 @@ class KeyTransactionsTest < Minitest::Test
 
     def job(name)
       ::NewRelic::Agent::Tracer.in_transaction(name: name, category: :other) do
-        advance_time(5)
+        advance_process_time(5)
       end
     end
   end

--- a/test/multiverse/suites/agent_only/span_events_test.rb
+++ b/test/multiverse/suites/agent_only/span_events_test.rb
@@ -59,7 +59,7 @@ class SpanEventsTest < Minitest::Test
       'sampled' => false,
       'guid'    => guid,
       'traceId' => guid,
-      'timestamp' => (Time.now.to_f * 1000).round,
+      'timestamp' => (Process.clock_gettime(Process::CLOCK_REALTIME) * 1000).round,
       'duration' => rand,
       'category' => 'custom'
       },

--- a/test/multiverse/suites/agent_only/span_events_test.rb
+++ b/test/multiverse/suites/agent_only/span_events_test.rb
@@ -59,7 +59,7 @@ class SpanEventsTest < Minitest::Test
       'sampled' => false,
       'guid'    => guid,
       'traceId' => guid,
-      'timestamp' => (Process.clock_gettime(Process::CLOCK_REALTIME) * 1000).round,
+      'timestamp' => Process.clock_gettime(Process::CLOCK_REALTIME, :millisecond),
       'duration' => rand,
       'category' => 'custom'
       },

--- a/test/multiverse/suites/rack/example_app.rb
+++ b/test/multiverse/suites/rack/example_app.rb
@@ -44,11 +44,11 @@ class MiddlewareOne
   end
 
   def call(env)
-    advance_time(1)
+    advance_process_time(1)
     status, headers, body = @app.call(env)
     headers['MiddlewareOne'] = '1'
 
-    advance_time(1)
+    advance_process_time(1)
     [status, headers, body]
   end
 end
@@ -61,7 +61,7 @@ class MiddlewareTwo
   end
 
   def call(env)
-    advance_time(1)
+    advance_process_time(1)
     request = Rack::Request.new(env)
 
     if request.params['return-early']
@@ -86,12 +86,12 @@ class MiddlewareThree
   end
 
   def call(env)
-    advance_time(1)
+    advance_process_time(1)
     status, headers, body = @app.call(env)
     headers['MiddlewareThree'] = '3'
     headers['MiddlewareThreeTag'] = @tag
 
-    advance_time(1)
+    advance_process_time(1)
     [status, headers, body]
   end
 end

--- a/test/multiverse/suites/rack/rack_auto_instrumentation_test.rb
+++ b/test/multiverse/suites/rack/rack_auto_instrumentation_test.rb
@@ -114,8 +114,8 @@ class RackAutoInstrumentationTest < Minitest::Test
   end
 
   def test_middlewares_record_queue_time
-    t0 = nr_freeze_time
-    advance_time(5.0)
+    t0 = nr_freeze_process_time
+    advance_process_time(5.0)
     get '/', {}, { 'HTTP_X_REQUEST_START' => "t=#{t0.to_f}" }
 
     assert_metrics_recorded(
@@ -146,7 +146,7 @@ class RackAutoInstrumentationTest < Minitest::Test
   end
 
   def test_middleware_that_returns_early_middleware_all_has_correct_call_times
-    nr_freeze_time
+    nr_freeze_process_time
     get '/?return-early=true'
     assert_metrics_recorded('Middleware/all' => { :total_exclusive_time => 3.0, :call_count => 2 })
   end

--- a/test/multiverse/suites/rails/app/views/views/_a_partial.html.erb
+++ b/test/multiverse/suites/rails/app/views/views/_a_partial.html.erb
@@ -1,2 +1,2 @@
-<%- advance_time(@delay) if @delay %>
+<%- advance_process_time(@delay) if @delay %>
 This is a partial

--- a/test/multiverse/suites/rails/app/views/views/index.html.erb
+++ b/test/multiverse/suites/rails/app/views/views/index.html.erb
@@ -1,4 +1,4 @@
-<%- advance_time(@delay) if @delay %>
+<%- advance_process_time(@delay) if @delay %>
 <%- 3.times do |i| %>
 <%= render "a_partial" %>
 <%- end%>

--- a/test/multiverse/suites/rails/gc_instrumentation_test.rb
+++ b/test/multiverse/suites/rails/gc_instrumentation_test.rb
@@ -42,9 +42,9 @@ class GCRailsInstrumentationTest < ActionController::TestCase
   end
 
   def test_records_accurate_time_for_gc_activity
-    start = Time.now
+    start = Process.clock_gettime(Process::CLOCK_REALTIME)
     get :gc_action
-    elapsed = Time.now.to_f - start.to_f
+    elapsed = Process.clock_gettime(Process::CLOCK_REALTIME) - start
 
     stats_hash = NewRelic::Agent.instance.stats_engine.reset!
 
@@ -56,9 +56,9 @@ class GCRailsInstrumentationTest < ActionController::TestCase
   end
 
   def test_records_transaction_param_for_gc_activity
-    start = Time.now.to_f
+    start = Process.clock_gettime(Process::CLOCK_REALTIME)
     get :gc_action
-    elapsed = Time.now.to_f - start
+    elapsed = Process.clock_gettime(Process::CLOCK_REALTIME) - start
 
     trace = last_transaction_trace
     assert_in_range(elapsed, attributes_for(trace, :intrinsic)[:gc_time])

--- a/test/multiverse/suites/rails/view_instrumentation_test.rb
+++ b/test/multiverse/suites/rails/view_instrumentation_test.rb
@@ -13,7 +13,7 @@ class ViewsController < ApplicationController
   end
 
   def render_with_delays
-    nr_freeze_time
+    nr_freeze_process_time
     @delay = 1
     render 'index'
   end

--- a/test/new_relic/agent/adaptive_sampler_test.rb
+++ b/test/new_relic/agent/adaptive_sampler_test.rb
@@ -15,7 +15,7 @@ module NewRelic
         stats = sampler.stats
         assert_equal 10, stats[:sampled_count]
         assert_equal 10000, stats[:seen]
-        advance_time(60)
+        advance_process_time(60)
         10001.times { sampler.sampled? }
         stats = sampler.stats
         assert_equal 10000, stats[:seen_last]
@@ -28,7 +28,7 @@ module NewRelic
         stats = sampler.stats
         assert_equal 10, stats[:sampled_count]
         assert_equal 10000, stats[:seen]
-        advance_time(120)
+        advance_process_time(120)
         10001.times { sampler.sampled? }
         stats = sampler.stats
         assert_equal 0, stats[:seen_last]

--- a/test/new_relic/agent/adaptive_sampler_test.rb
+++ b/test/new_relic/agent/adaptive_sampler_test.rb
@@ -9,7 +9,7 @@ module NewRelic
   module Agent
     class AdaptiveSamplerTest < Minitest::Test
       def test_adaptive_sampler
-        nr_freeze_time
+        nr_freeze_process_time
         sampler = AdaptiveSampler.new
         10000.times { sampler.sampled? }
         stats = sampler.stats

--- a/test/new_relic/agent/api_tests/datastore_api_test.rb
+++ b/test/new_relic/agent/api_tests/datastore_api_test.rb
@@ -8,7 +8,7 @@ module NewRelic
   module Agent
     class DatastoreApiTest < Minitest::Test
       def setup
-        nr_freeze_time
+        nr_freeze_process_time
         NewRelic::Agent.drop_buffered_data
       end
 
@@ -31,7 +31,7 @@ module NewRelic
                 database_name: params['database_name']
               )
               segment.notice_sql "select * from foo"
-              advance_time 2.0
+              advance_process_time 2.0
               segment.finish
             end
 

--- a/test/new_relic/agent/commands/agent_command_router_test.rb
+++ b/test/new_relic/agent/commands/agent_command_router_test.rb
@@ -60,7 +60,7 @@ class AgentCommandRouterTest < Minitest::Test
 
   def populate_container(container, n)
     start_profile('duration' => 1.0)
-    advance_time(1.1)
+    advance_process_time(1.1)
     agent_commands.backtrace_service.worker_thread.join if agent_commands.backtrace_service.worker_thread
   end
 
@@ -132,7 +132,7 @@ class AgentCommandRouterTest < Minitest::Test
     def test_harvest_with_profile_completed
       start_profile('duration' => 1.0)
 
-      advance_time(1.1)
+      advance_process_time(1.1)
       result = agent_commands.harvest!
 
       refute_empty result
@@ -141,7 +141,7 @@ class AgentCommandRouterTest < Minitest::Test
     def test_can_stop_multiple_times_safely
       start_profile('duration' => 1.0)
 
-      advance_time(1.1)
+      advance_process_time(1.1)
       agent_commands.thread_profiler_session.stop(true)
 
       result = agent_commands.harvest!
@@ -184,7 +184,7 @@ class AgentCommandRouterTest < Minitest::Test
   end
 
   def start_profile(args={})
-    nr_freeze_time
+    nr_freeze_process_time
     agent_commands.backtrace_service.worker_loop.stubs(:run)
     agent_commands.thread_profiler_session.start(create_agent_command(args))
   end

--- a/test/new_relic/agent/commands/thread_profiler_session_test.rb
+++ b/test/new_relic/agent/commands/thread_profiler_session_test.rb
@@ -110,11 +110,11 @@ else
     end
 
     def test_is_ready_to_harvest_if_duration_has_elapsed
-      nr_freeze_time
+      nr_freeze_process_time
       @profiler.start(start_command)
       assert_false @profiler.ready_to_harvest?
 
-      advance_time(0.026)
+      advance_process_time(0.026)
       assert @profiler.ready_to_harvest?
     end
 
@@ -197,10 +197,10 @@ else
     end
 
     def test_harvested_profile_doesnt_still_report_as_ready_to_harvest
-      nr_freeze_time
+      nr_freeze_process_time
       @profiler.handle_start_command(start_command)
 
-      advance_time(1.0)
+      advance_process_time(1.0)
       @profiler.stop(true)
       assert @profiler.ready_to_harvest?
 

--- a/test/new_relic/agent/custom_event_aggregator_test.rb
+++ b/test/new_relic/agent/custom_event_aggregator_test.rb
@@ -11,7 +11,7 @@ require 'new_relic/agent/custom_event_aggregator'
 module NewRelic::Agent
   class CustomEventAggregatorTest < Minitest::Test
     def setup
-      nr_freeze_time
+      nr_freeze_process_time
       events = NewRelic::Agent.instance.events
       @aggregator = NewRelic::Agent::CustomEventAggregator.new events
     end
@@ -105,7 +105,7 @@ module NewRelic::Agent
     end
 
     def test_record_adds_type_and_timestamp
-      t0 = Time.now
+      t0 = Process.clock_gettime(Process::CLOCK_REALTIME)
       @aggregator.record(:type_a, :foo => :bar, :baz => :qux)
 
       _, events = @aggregator.harvest!

--- a/test/new_relic/agent/datastores_test.rb
+++ b/test/new_relic/agent/datastores_test.rb
@@ -141,19 +141,19 @@ class NewRelic::Agent::DatastoresTest < Minitest::Test
     elapsed = 1.0
 
     in_transaction do |txn|
-      nr_freeze_time
+      nr_freeze_process_time
       segment = NewRelic::Agent::Tracer.start_datastore_segment(
         product: "MyFirstDatabase",
         operation: "find",
         collection: "SomeThing"
       )
       NewRelic::Agent::Datastores.notice_sql(query, metric, elapsed)
-      advance_time elapsed
+      advance_process_time elapsed
       assert_equal segment, txn.current_segment
       segment.finish
-      nr_unfreeze_time
-      assert_equal segment.sql_statement.sql, query
-      assert_equal segment.duration, elapsed
+      nr_unfreeze_process_time
+      assert_equal query, segment.sql_statement.sql
+      assert_equal elapsed, segment.duration
     end
   end
 
@@ -162,19 +162,19 @@ class NewRelic::Agent::DatastoresTest < Minitest::Test
     elapsed = 1.0
 
     in_transaction do |txn|
-      nr_freeze_time
+      nr_freeze_process_time
       segment = NewRelic::Agent::Tracer.start_datastore_segment(
         product: "MyFirstDatastore",
         operation: "get",
         collection: "key"
       )
       NewRelic::Agent::Datastores.notice_statement(query, elapsed)
-      advance_time elapsed
+      advance_process_time elapsed
       assert_equal segment, txn.current_segment
       segment.finish
-      nr_unfreeze_time
-      assert_equal segment.nosql_statement, query
-      assert_equal segment.duration, elapsed
+      nr_unfreeze_process_time
+      assert_equal query, segment.nosql_statement
+      assert_equal elapsed, segment.duration
     end
   end
 

--- a/test/new_relic/agent/distributed_tracing/distributed_trace_metrics_test.rb
+++ b/test/new_relic/agent/distributed_tracing/distributed_trace_metrics_test.rb
@@ -8,7 +8,7 @@ module NewRelic::Agent
   class DistributedTraceMetricsTest < Minitest::Test
 
     def setup
-      nr_freeze_time
+      nr_freeze_process_time
       @config = {
         :account_id => "190",
         :primary_application_id => "46954",
@@ -26,8 +26,8 @@ module NewRelic::Agent
 
     def in_controller_transaction &blk
       in_transaction "controller_txn", :category => :controller do |txn|
-        advance_time 1.0
-        yield txn        
+        advance_process_time(1.0)
+        yield txn
       end
     end
 
@@ -61,7 +61,7 @@ module NewRelic::Agent
 
     def test_record_metrics_for_transaction
       in_transaction "test_txn", :category => :controller do |txn|
-        advance_time 1.0
+        advance_process_time(1.0)
         payload = txn.distributed_tracer.create_trace_state_payload
         assert payload, "payload should not be nil"
 
@@ -76,7 +76,7 @@ module NewRelic::Agent
 
     def test_record_metrics_for_transaction_with_payload
       in_transaction "controller_txn", :category => :controller do |txn|
-        advance_time 1.0
+        advance_process_time(1.0)
         DistributedTracing.accept_distributed_trace_headers valid_trace_context_headers, NewRelic::HTTP
         DistributedTraceMetrics.record_metrics_for_transaction txn
       end
@@ -97,7 +97,7 @@ module NewRelic::Agent
 
     def test_record_metrics_for_transaction_with_garbage_transport_type
       in_transaction "controller_txn", :category => :controller do |txn|
-        advance_time 1.0
+        advance_process_time(1.0)
         DistributedTracing.accept_distributed_trace_headers valid_trace_context_headers, "garbage"
         DistributedTraceMetrics.record_metrics_for_transaction txn
       end
@@ -119,7 +119,7 @@ module NewRelic::Agent
     def test_record_metrics_for_transaction_with_exception_handling
       in_transaction "controller_txn", :category => :controller do |txn|
         begin
-          advance_time 1.0
+          advance_process_time(1.0)
           DistributedTracing.accept_distributed_trace_headers valid_trace_context_headers, NewRelic::HTTP
           raise "oops"
         rescue Exception => e

--- a/test/new_relic/agent/distributed_tracing/distributed_trace_payload_test.rb
+++ b/test/new_relic/agent/distributed_tracing/distributed_trace_payload_test.rb
@@ -8,7 +8,7 @@ module NewRelic::Agent
   class DistributedTracePayloadTest < Minitest::Test
 
     def setup
-      nr_freeze_time
+      nr_freeze_process_time
       NewRelic::Agent::Harvester.any_instance.stubs(:harvest_thread_enabled?).returns(false)
 
 
@@ -23,6 +23,7 @@ module NewRelic::Agent
     end
 
     def teardown
+      nr_unfreeze_process_time
       NewRelic::Agent.config.remove_config(@config)
       NewRelic::Agent.config.reset_to_defaults
       NewRelic::Agent.drop_buffered_data
@@ -32,7 +33,7 @@ module NewRelic::Agent
       created_at, payload = nil, nil
 
       in_transaction "test_txn" do |txn|
-        created_at = (Time.now.to_f * 1000).round
+        created_at = (Process.clock_gettime(Process::CLOCK_REALTIME) * 1000).round
         payload = DistributedTracePayload.for_transaction txn
       end
 
@@ -99,7 +100,7 @@ module NewRelic::Agent
     end
 
     def test_payload_attributes_populated_from_serialized_version
-      created_at = (Time.now.to_f * 1000).round
+      created_at = (Process.clock_gettime(Process::CLOCK_REALTIME) * 1000).round
 
       NewRelic::Agent.instance.adaptive_sampler.stubs(:sampled?).returns(true)
 
@@ -125,7 +126,7 @@ module NewRelic::Agent
     end
 
     def test_payload_attributes_populated_from_html_safe_version
-      created_at = (Time.now.to_f * 1000).round
+      created_at = (Process.clock_gettime(Process::CLOCK_REALTIME) * 1000).round
 
       NewRelic::Agent.instance.adaptive_sampler.stubs(:sampled?).returns(true)
 

--- a/test/new_relic/agent/distributed_tracing/distributed_trace_payload_test.rb
+++ b/test/new_relic/agent/distributed_tracing/distributed_trace_payload_test.rb
@@ -8,7 +8,7 @@ module NewRelic::Agent
   class DistributedTracePayloadTest < Minitest::Test
 
     def setup
-      nr_freeze_process_time
+      nr_freeze_process_time(Process.clock_gettime(Process::CLOCK_REALTIME, :millisecond))
       NewRelic::Agent::Harvester.any_instance.stubs(:harvest_thread_enabled?).returns(false)
 
 
@@ -33,7 +33,7 @@ module NewRelic::Agent
       created_at, payload = nil, nil
 
       in_transaction "test_txn" do |txn|
-        created_at = (Process.clock_gettime(Process::CLOCK_REALTIME, :millisecond)
+        created_at = Process.clock_gettime(Process::CLOCK_REALTIME, :millisecond)
         payload = DistributedTracePayload.for_transaction txn
       end
 
@@ -100,7 +100,7 @@ module NewRelic::Agent
     end
 
     def test_payload_attributes_populated_from_serialized_version
-      created_at = (Process.clock_gettime(Process::CLOCK_REALTIME, :millisecond)
+      created_at = Process.clock_gettime(Process::CLOCK_REALTIME, :millisecond)
 
       NewRelic::Agent.instance.adaptive_sampler.stubs(:sampled?).returns(true)
 

--- a/test/new_relic/agent/distributed_tracing/distributed_trace_payload_test.rb
+++ b/test/new_relic/agent/distributed_tracing/distributed_trace_payload_test.rb
@@ -33,7 +33,7 @@ module NewRelic::Agent
       created_at, payload = nil, nil
 
       in_transaction "test_txn" do |txn|
-        created_at = (Process.clock_gettime(Process::CLOCK_REALTIME) * 1000).round
+        created_at = (Process.clock_gettime(Process::CLOCK_REALTIME, :millisecond)
         payload = DistributedTracePayload.for_transaction txn
       end
 
@@ -100,7 +100,7 @@ module NewRelic::Agent
     end
 
     def test_payload_attributes_populated_from_serialized_version
-      created_at = (Process.clock_gettime(Process::CLOCK_REALTIME) * 1000).round
+      created_at = (Process.clock_gettime(Process::CLOCK_REALTIME, :millisecond)
 
       NewRelic::Agent.instance.adaptive_sampler.stubs(:sampled?).returns(true)
 
@@ -126,7 +126,7 @@ module NewRelic::Agent
     end
 
     def test_payload_attributes_populated_from_html_safe_version
-      created_at = (Process.clock_gettime(Process::CLOCK_REALTIME) * 1000).round
+      created_at = Process.clock_gettime(Process::CLOCK_REALTIME, :millisecond)
 
       NewRelic::Agent.instance.adaptive_sampler.stubs(:sampled?).returns(true)
 

--- a/test/new_relic/agent/distributed_tracing/trace_context_payload_test.rb
+++ b/test/new_relic/agent/distributed_tracing/trace_context_payload_test.rb
@@ -127,7 +127,7 @@ module NewRelic
       private
 
       def now_ms
-        (Process.clock_gettime(Process::CLOCK_REALTIME) * 1000).round
+        Process.clock_gettime(Process::CLOCK_REALTIME, :millisecond)
       end
     end
   end

--- a/test/new_relic/agent/distributed_tracing/trace_context_payload_test.rb
+++ b/test/new_relic/agent/distributed_tracing/trace_context_payload_test.rb
@@ -47,7 +47,7 @@ module NewRelic
       end
 
       def test_from_s
-        nr_freeze_time
+        nr_freeze_process_time
 
         payload_str = "0-0-12345-6789-f85f42fd82a4cf1d-164d3b4b0d09cb05-1-0.123-#{now_ms}"
         payload = TraceContextPayload.from_s payload_str
@@ -80,7 +80,7 @@ module NewRelic
       end
 
       def test_additional_attributes
-        nr_freeze_time
+        nr_freeze_process_time
 
         payload_str = "1-0-12345-6789-f85f42fd82a4cf1d-164d3b4b0d09cb05-1-0.123-#{now_ms}-futureattr1"
         payload = TraceContextPayload.from_s payload_str

--- a/test/new_relic/agent/distributed_tracing/trace_context_payload_test.rb
+++ b/test/new_relic/agent/distributed_tracing/trace_context_payload_test.rb
@@ -47,7 +47,7 @@ module NewRelic
       end
 
       def test_from_s
-        nr_freeze_process_time
+        nr_freeze_process_time(Process.clock_gettime(Process::CLOCK_REALTIME, :millisecond))
 
         payload_str = "0-0-12345-6789-f85f42fd82a4cf1d-164d3b4b0d09cb05-1-0.123-#{now_ms}"
         payload = TraceContextPayload.from_s payload_str
@@ -80,7 +80,7 @@ module NewRelic
       end
 
       def test_additional_attributes
-        nr_freeze_process_time
+        nr_freeze_process_time(Process.clock_gettime(Process::CLOCK_REALTIME, :millisecond))
 
         payload_str = "1-0-12345-6789-f85f42fd82a4cf1d-164d3b4b0d09cb05-1-0.123-#{now_ms}-futureattr1"
         payload = TraceContextPayload.from_s payload_str

--- a/test/new_relic/agent/distributed_tracing/trace_context_payload_test.rb
+++ b/test/new_relic/agent/distributed_tracing/trace_context_payload_test.rb
@@ -127,7 +127,7 @@ module NewRelic
       private
 
       def now_ms
-        (Time.now.to_f * 1000).round
+        (Process.clock_gettime(Process::CLOCK_REALTIME) * 1000).round
       end
     end
   end

--- a/test/new_relic/agent/error_event_aggregator_test.rb
+++ b/test/new_relic/agent/error_event_aggregator_test.rb
@@ -70,7 +70,7 @@ module NewRelic
         intrinsics, *_ = last_error_event
 
         assert_equal 'TransactionError', intrinsics['type']
-        assert_in_delta Time.now.to_f, intrinsics['timestamp'], 0.001
+        assert_in_delta Process.clock_gettime(Process::CLOCK_REALTIME), intrinsics['timestamp'], 0.001
         assert_equal "RuntimeError", intrinsics['error.class']
         assert_equal "Big Controller!", intrinsics['error.message']
       end
@@ -81,7 +81,7 @@ module NewRelic
         intrinsics, *_ = last_error_event
 
         assert_equal 'TransactionError', intrinsics['type']
-        assert_in_delta Time.now.to_f, intrinsics['timestamp'], 0.001
+        assert_in_delta Process.clock_gettime(Process::CLOCK_REALTIME), intrinsics['timestamp'], 0.001
         assert_equal "RuntimeError", intrinsics['error.class']
         assert_equal "Big Controller!", intrinsics['error.message']
         assert_equal "Controller/blogs/index", intrinsics['transactionName']
@@ -159,7 +159,7 @@ module NewRelic
         {
           :name => name,
           :type => :controller,
-          :start_timestamp => Time.now.to_f,
+          :start_timestamp => Process.clock_gettime(Process::CLOCK_REALTIME),
           :duration => 0.1,
           :priority => options[:priority] || rand
         }.update(options)

--- a/test/new_relic/agent/error_event_aggregator_test.rb
+++ b/test/new_relic/agent/error_event_aggregator_test.rb
@@ -12,7 +12,7 @@ module NewRelic
   module Agent
     class ErrorEventAggregatorTest < Minitest::Test
       def setup
-        nr_freeze_time
+        nr_freeze_process_time
         NewRelic::Agent::Harvester.any_instance.stubs(:harvest_thread_enabled?).returns(false)
 
         events = NewRelic::Agent.instance.events

--- a/test/new_relic/agent/event_loop_test.rb
+++ b/test/new_relic/agent/event_loop_test.rb
@@ -6,7 +6,7 @@ require File.expand_path(File.join(File.dirname(__FILE__),'..','..','test_helper
 
 class NewRelic::Agent::EventLoopTest < Minitest::Test
   def setup
-    nr_freeze_time
+    nr_freeze_process_time
     @loop = NewRelic::Agent::EventLoop.new
   end
 
@@ -195,7 +195,7 @@ class NewRelic::Agent::EventLoopTest < Minitest::Test
 
   def advance_loop(n)
     n.times do
-      advance_time(1)
+      advance_process_time(1)
       @loop.run_once(true)
     end
   end

--- a/test/new_relic/agent/instrumentation/mongodb_command_subscriber_test.rb
+++ b/test/new_relic/agent/instrumentation/mongodb_command_subscriber_test.rb
@@ -8,7 +8,7 @@ require 'new_relic/agent/instrumentation/mongodb_command_subscriber'
 class NewRelic::Agent::Instrumentation::MongodbCommandSubscriberTest < Minitest::Test
 
   def setup
-    nr_freeze_time
+    nr_freeze_process_time
     @started_event = mock('started event')
     @started_event.stubs(:operation_id).returns(1)
     @started_event.stubs(:command_name).returns('find')
@@ -106,7 +106,7 @@ class NewRelic::Agent::Instrumentation::MongodbCommandSubscriberTest < Minitest:
 
   def simulate_query
     @subscriber.started(@started_event)
-    advance_time @succeeded_event.duration
+    advance_process_time @succeeded_event.duration
     @subscriber.succeeded(@succeeded_event)
   end
 end

--- a/test/new_relic/agent/instrumentation/rails/action_cable_subscriber.rb
+++ b/test/new_relic/agent/instrumentation/rails/action_cable_subscriber.rb
@@ -8,7 +8,7 @@ module NewRelic
       class ActionCableSubscriberTest < Minitest::Test
 
         def setup
-          nr_freeze_time
+          nr_freeze_process_time
           @subscriber = ActionCableSubscriber.new
 
           NewRelic::Agent.drop_buffered_data
@@ -26,7 +26,7 @@ module NewRelic
         def test_creates_web_transaction
           @subscriber.start('perform_action.action_cable', :id, payload_for_perform_action)
           assert NewRelic::Agent::Tracer.current_transaction.recording_web_transaction?
-          advance_time(1.0)
+          advance_process_time(1.0)
           @subscriber.finish('perform_action.action_cable', :id, payload_for_perform_action)
 
           assert_equal('Controller/ActionCable/TestChannel/test_action',
@@ -37,7 +37,7 @@ module NewRelic
 
         def test_records_apdex_metrics
           @subscriber.start('perform_action.action_cable', :id, payload_for_perform_action)
-          advance_time(1.5)
+          advance_process_time(1.5)
           @subscriber.finish('perform_action.action_cable', :id, payload_for_perform_action)
 
           expected_values = { :apdex_f => 0, :apdex_t => 1, :apdex_s => 0 }
@@ -81,7 +81,7 @@ module NewRelic
           @subscriber.start('perform_action.action_cable', :id, payload_for_perform_action)
           assert NewRelic::Agent::Tracer.current_transaction.recording_web_transaction?
           @subscriber.start('transmit.action_cable', :id, payload_for_transmit)
-          advance_time(1.0)
+          advance_process_time(1.0)
           @subscriber.finish('transmit.action_cable', :id, payload_for_transmit)
           @subscriber.finish('perform_action.action_cable', :id, payload_for_perform_action)
 
@@ -94,7 +94,7 @@ module NewRelic
 
         def test_does_not_record_unscoped_metrics_nor_create_trace_for_transmit_outside_of_active_txn
           @subscriber.start('transmit.action_cable', :id, payload_for_transmit)
-          advance_time(1.0)
+          advance_process_time(1.0)
           @subscriber.finish('transmit.action_cable', :id, payload_for_transmit)
 
           sample = last_transaction_trace

--- a/test/new_relic/agent/instrumentation/rails/action_view_subscriber.rb
+++ b/test/new_relic/agent/instrumentation/rails/action_view_subscriber.rb
@@ -14,12 +14,12 @@ class NewRelic::Agent::Instrumentation::ActionViewSubscriberTest < Minitest::Tes
 
   def test_records_metrics_for_simple_template
     params = { :identifier => '/root/app/views/model/index.html.erb' }
-    nr_freeze_time
+    nr_freeze_process_time
     in_transaction do
       @subscriber.start('render_template.action_view', :id, params)
       @subscriber.start('!render_template.action_view', :id,
                         :virtual_path => 'model/index')
-      advance_time 2.0
+      advance_process_time 2.0
       @subscriber.finish('!render_template.action_view', :id,
                          :virtual_path => 'model/index')
       @subscriber.finish('render_template.action_view', :id, params)
@@ -30,12 +30,12 @@ class NewRelic::Agent::Instrumentation::ActionViewSubscriberTest < Minitest::Tes
 
   def test_records_metrics_for_simple_file
     params = { :identifier => '/root/something.txt' }
-    nr_freeze_time
+    nr_freeze_process_time
     in_transaction do
       @subscriber.start('render_template.action_view', :id, params)
       @subscriber.start('!render_template.action_view', :id,
                         :virtual_path => nil)
-      advance_time 2.0
+      advance_process_time 2.0
       @subscriber.finish('!render_template.action_view', :id,
                          :virtual_path => nil)
       @subscriber.finish('render_template.action_view', :id, params)
@@ -46,12 +46,12 @@ class NewRelic::Agent::Instrumentation::ActionViewSubscriberTest < Minitest::Tes
 
   def test_records_metrics_for_simple_inline
     params = { :identifier => 'inline template' }
-    nr_freeze_time
+    nr_freeze_process_time
     in_transaction do
       @subscriber.start('render_template.action_view', :id, params)
       @subscriber.start('!render_template.action_view', :id,
                         :virtual_path => nil)
-      advance_time 2.0
+      advance_process_time 2.0
       @subscriber.finish('!render_template.action_view', :id,
                          :virtual_path => nil)
       @subscriber.finish('render_template.action_view', :id, params)
@@ -62,10 +62,10 @@ class NewRelic::Agent::Instrumentation::ActionViewSubscriberTest < Minitest::Tes
 
   def test_records_metrics_for_simple_text
     params = { :identifier => 'text template' }
-    nr_freeze_time
+    nr_freeze_process_time
     in_transaction do
       @subscriber.start('render_template.action_view', :id, params)
-      advance_time 2.0
+      advance_process_time 2.0
       @subscriber.finish('render_template.action_view', :id, params)
     end
     expected = { :call_count => 1, :total_call_time => 2.0 }
@@ -74,12 +74,12 @@ class NewRelic::Agent::Instrumentation::ActionViewSubscriberTest < Minitest::Tes
 
   def test_records_metrics_for_simple_partial
     params = { :identifier => '/root/app/views/model/_form.html.erb' }
-    nr_freeze_time
+    nr_freeze_process_time
     in_transaction do
       @subscriber.start('render_partial.action_view', :id, params)
       @subscriber.start('!render_template.action_view', :id,
                         :virtual_path => 'model/_form')
-      advance_time 2.0
+      advance_process_time 2.0
       @subscriber.finish('!render_template.action_view', :id,
                          :virtual_path => 'model/_form')
       @subscriber.finish('render_partial.action_view', :id, params)
@@ -90,12 +90,12 @@ class NewRelic::Agent::Instrumentation::ActionViewSubscriberTest < Minitest::Tes
 
   def test_records_metrics_for_simple_collection
     params = { :identifier => '/root/app/views/model/_user.html.erb' }
-    nr_freeze_time
+    nr_freeze_process_time
     in_transaction do
       @subscriber.start('render_collection.action_view', :id, params)
       @subscriber.start('!render_template.action_view', :id,
                         :virtual_path => 'model/_user')
-      advance_time 2.0
+      advance_process_time 2.0
       @subscriber.finish('!render_template.action_view', :id,
                          :virtual_path => 'model/_user')
       @subscriber.finish('render_collection.action_view', :id, params)
@@ -105,11 +105,11 @@ class NewRelic::Agent::Instrumentation::ActionViewSubscriberTest < Minitest::Tes
   end
 
   def test_records_metrics_for_layout
-    nr_freeze_time
+    nr_freeze_process_time
     in_transaction do
       @subscriber.start('!render_template.action_view', :id,
                         :virtual_path => 'layouts/application')
-      advance_time 2.0
+      advance_process_time 2.0
       @subscriber.finish('!render_template.action_view', :id,
                          :virtual_path => 'layouts/application')
     end

--- a/test/new_relic/agent/instrumentation/rails/active_record_subscriber.rb
+++ b/test/new_relic/agent/instrumentation/rails/active_record_subscriber.rb
@@ -23,7 +23,7 @@ class NewRelic::Agent::Instrumentation::ActiveRecordSubscriberTest < Minitest::T
   end
 
   def test_records_metrics_for_simple_find
-    nr_freeze_time
+    nr_freeze_process_time
 
     in_transaction('test_txn') { simulate_query(2) }
 
@@ -34,7 +34,7 @@ class NewRelic::Agent::Instrumentation::ActiveRecordSubscriberTest < Minitest::T
   end
 
   def test_records_scoped_metrics
-    nr_freeze_time
+    nr_freeze_process_time
 
     in_transaction('test_txn') { simulate_query(2) }
 
@@ -122,7 +122,7 @@ class NewRelic::Agent::Instrumentation::ActiveRecordSubscriberTest < Minitest::T
   end
 
   def test_records_nothing_if_tracing_disabled
-    nr_freeze_time
+    nr_freeze_process_time
 
     in_transaction('test_txn') do
       NewRelic::Agent.disable_all_tracing { simulate_query(2) }
@@ -133,7 +133,7 @@ class NewRelic::Agent::Instrumentation::ActiveRecordSubscriberTest < Minitest::T
   end
 
   def test_records_rollup_metrics
-    nr_freeze_time
+    nr_freeze_process_time
 
     in_web_transaction { simulate_query(2) }
 
@@ -145,7 +145,7 @@ class NewRelic::Agent::Instrumentation::ActiveRecordSubscriberTest < Minitest::T
   end
 
   def test_creates_txn_node
-    nr_freeze_time
+    nr_freeze_process_time
 
     in_transaction do
       simulate_query(2)
@@ -161,7 +161,7 @@ class NewRelic::Agent::Instrumentation::ActiveRecordSubscriberTest < Minitest::T
   end
 
   def test_creates_slow_sql_node
-    nr_freeze_time
+    nr_freeze_process_time
 
     sampler = NewRelic::Agent.instance.sql_sampler
     sql = nil
@@ -220,7 +220,7 @@ class NewRelic::Agent::Instrumentation::ActiveRecordSubscriberTest < Minitest::T
 
   def simulate_query(duration=nil)
     @subscriber.start('sql.active_record', :id, @params)
-    advance_time(duration) if duration
+    advance_process_time(duration) if duration
     @subscriber.finish('sql.active_record', :id, @params)
   end
 end

--- a/test/new_relic/agent/instrumentation/rails/active_storage_subscriber.rb
+++ b/test/new_relic/agent/instrumentation/rails/active_storage_subscriber.rb
@@ -7,7 +7,7 @@ module NewRelic
     module Instrumentation
       class ActiveStorageSubscriberTest < Minitest::Test
         def setup
-          nr_freeze_time
+          nr_freeze_process_time
           @subscriber = ActiveStorageSubscriber.new
           @id = fake_guid(32)
 

--- a/test/new_relic/agent/javascript_instrumentor_test.rb
+++ b/test/new_relic/agent/javascript_instrumentor_test.rb
@@ -151,12 +151,12 @@ class NewRelic::Agent::JavascriptInstrumentorTest < Minitest::Test
   end
 
   def test_config_data_for_js_agent
-    nr_freeze_time
+    nr_freeze_process_time
     with_config(CAPTURE_ATTRIBUTES => true) do
       in_transaction('most recent transaction') do
         txn = NewRelic::Agent::Transaction.tl_current
         txn.stubs(:queue_time).returns(0)
-        txn.stubs(:start_time).returns(Time.now - 10)
+        txn.stubs(:start_time).returns(Process.clock_gettime(Process::CLOCK_REALTIME) - 10)
         txn.stubs(:guid).returns('ABC')
 
         state = NewRelic::Agent::Tracer.state
@@ -183,7 +183,7 @@ class NewRelic::Agent::JavascriptInstrumentorTest < Minitest::Test
   end
 
   def test_config_data_for_js_agent_attributes
-    nr_freeze_time
+    nr_freeze_process_time
     with_config(CAPTURE_ATTRIBUTES => true) do
       in_transaction('most recent transaction') do |txn|
         NewRelic::Agent.add_custom_attributes(:user => "user")

--- a/test/new_relic/agent/method_tracer/instance_methods/trace_execution_scoped_test.rb
+++ b/test/new_relic/agent/method_tracer/instance_methods/trace_execution_scoped_test.rb
@@ -113,12 +113,12 @@ class NewRelic::Agent::MethodTracer::TraceExecutionScopedTest < Minitest::Test
   end
 
   def test_trace_execution_scoped_calculates_exclusive_time
-    nr_freeze_time
+    nr_freeze_process_time
     in_transaction('txn') do
       trace_execution_scoped(['parent']) do
-        advance_time(10)
+        advance_process_time(10)
         trace_execution_scoped(['child']) do
-          advance_time(10)
+          advance_process_time(10)
         end
       end
     end

--- a/test/new_relic/agent/method_tracer_params_test.rb
+++ b/test/new_relic/agent/method_tracer_params_test.rb
@@ -16,7 +16,7 @@ class NewRelic::Agent::MethodTracerParamsTest < Minitest::Test
     @stats_engine.clear_stats
     @metric_name ||= nil
 
-    nr_freeze_time
+    nr_freeze_process_time
 
     super
   end
@@ -56,7 +56,7 @@ class NewRelic::Agent::MethodTracerParamsTest < Minitest::Test
         process(i, hash)
       end
     end
-  
+
     def process(i, hash)
       hash[i] = i * 3
     end
@@ -64,7 +64,7 @@ class NewRelic::Agent::MethodTracerParamsTest < Minitest::Test
 
   class TracedMethods < UntracedMethods
     include NewRelic::Agent::MethodTracer
-  
+
     add_method_tracer :no_args
     add_method_tracer :last_arg_expects_a_hash
     add_method_tracer :last_arg_is_a_keyword
@@ -73,7 +73,7 @@ class NewRelic::Agent::MethodTracerParamsTest < Minitest::Test
     add_method_tracer :args_and_kwargs
     add_method_tracer :process
   end
-  
+
   class TracedMetricMethods < UntracedMethods
     add_method_tracer :no_args, METRIC
     add_method_tracer :last_arg_expects_a_hash, METRIC
@@ -83,7 +83,7 @@ class NewRelic::Agent::MethodTracerParamsTest < Minitest::Test
     add_method_tracer :args_and_kwargs, METRIC
     add_method_tracer :process, METRIC
   end
-   
+
   class TracedMetricMethodsUnscoped < UntracedMethods
     add_method_tracer :no_args, METRIC, push_scope: false
     add_method_tracer :last_arg_expects_a_hash, METRIC, push_scope: false
@@ -93,7 +93,7 @@ class NewRelic::Agent::MethodTracerParamsTest < Minitest::Test
     add_method_tracer :args_and_kwargs, METRIC, push_scope: false
     add_method_tracer :process, METRIC, push_scope: false
   end
-  
+
   def refute_deprecation_warning
     in_transaction do
       _out, err = capture_io { yield }
@@ -145,7 +145,7 @@ class NewRelic::Agent::MethodTracerParamsTest < Minitest::Test
 
       refute_deprecation_warning { instance.wildcard_args(:foo, bar: "foobar") }
       refute_deprecation_warning { instance.wildcard_args(:foo, {bar: "foobar"}) }
- 
+
       refute_deprecation_warning { instance.last_arg_is_a_keyword(:foo, bar: "foobar") }
       refute_deprecation_warning { instance.all_args_are_keywords(foo: :foo, bar: {bar: "foobar"}) }
       refute_deprecation_warning { instance.args_and_kwargs(:foo, bar: "foobar") }
@@ -168,5 +168,5 @@ class NewRelic::Agent::MethodTracerParamsTest < Minitest::Test
       silence_expected_warnings { assert_equal version_specific_expected, instance.args_and_kwargs(:foo, {bar: "foobar"}) }
     end
   end
- 
+
 end

--- a/test/new_relic/agent/method_tracer_test.rb
+++ b/test/new_relic/agent/method_tracer_test.rb
@@ -3,7 +3,7 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 
 require File.expand_path(File.join(File.dirname(__FILE__),'..','..','test_helper'))
-require 'pry'
+
 class Insider
   def initialize(stats_engine)
     @stats_engine = stats_engine

--- a/test/new_relic/agent/method_tracer_test.rb
+++ b/test/new_relic/agent/method_tracer_test.rb
@@ -81,7 +81,7 @@ class NewRelic::Agent::MethodTracerTest < Minitest::Test
     @stats_engine.clear_stats
     @metric_name ||= nil
 
-    nr_freeze_time
+    nr_freeze_process_time
 
     super
   end
@@ -105,7 +105,7 @@ class NewRelic::Agent::MethodTracerTest < Minitest::Test
 
     in_transaction do
       self.class.trace_execution_scoped(metric) do
-        advance_time 0.05
+        advance_process_time 0.05
       end
     end
 
@@ -114,7 +114,7 @@ class NewRelic::Agent::MethodTracerTest < Minitest::Test
 
   def test_trace_execution_scoped_with_no_metrics_skips_out
     self.class.trace_execution_scoped([]) do
-      advance_time 0.05
+      advance_process_time 0.05
     end
 
     assert_metrics_recorded_exclusive(['Supportability/API/trace_execution_scoped'])
@@ -302,7 +302,7 @@ class NewRelic::Agent::MethodTracerTest < Minitest::Test
     self.class.add_method_tracer :method_with_block, METRIC
     in_transaction do
       method_with_block(1,2,3,true,METRIC) do
-        advance_time 0.1
+        advance_process_time 0.1
       end
     end
 
@@ -322,7 +322,7 @@ class NewRelic::Agent::MethodTracerTest < Minitest::Test
     metrics = %w[first second third]
     in_transaction do
       self.class.trace_execution_scoped metrics do
-        advance_time 0.05
+        advance_process_time 0.05
       end
     end
 
@@ -336,7 +336,7 @@ class NewRelic::Agent::MethodTracerTest < Minitest::Test
   def test_multiple_metrics__unscoped
     metrics = %w[first second third]
     self.class.trace_execution_unscoped metrics do
-      advance_time 0.05
+      advance_process_time 0.05
     end
 
     assert_metrics_recorded({
@@ -428,14 +428,14 @@ class NewRelic::Agent::MethodTracerTest < Minitest::Test
   # =======================================================
   # test methods to be traced
   def method_to_be_traced(x, y, z, is_traced, expected_metric)
-    advance_time 0.05
+    advance_process_time 0.05
     assert x == 1
     assert y == 2
     assert z == 3
   end
 
   def method_with_block(x, y, z, is_traced, expected_metric, &block)
-    advance_time 0.05
+    advance_process_time 0.05
     assert x == 1
     assert y == 2
     assert z == 3
@@ -443,7 +443,7 @@ class NewRelic::Agent::MethodTracerTest < Minitest::Test
   end
 
   def method_with_kwargs(arg1, arg2: true)
-    advance_time 0.05
+    advance_process_time 0.05
     arg1 == arg2
   end
 

--- a/test/new_relic/agent/monitors/cross_app_monitor_test.rb
+++ b/test/new_relic/agent/monitors/cross_app_monitor_test.rb
@@ -216,13 +216,13 @@ module NewRelic::Agent
     #
 
     def when_request_runs(request=for_id(REQUEST_CROSS_APP_ID), name = 'transaction', duration = nil)
-      nr_freeze_time if duration
+      nr_freeze_process_time if duration
 
       in_transaction(name) do |txn|
         @events.notify(:before_call, request)
         # Fake out our GUID for easier comparison in tests
         Transaction.tl_current.stubs(:guid).returns(TRANSACTION_GUID)
-        advance_time duration if duration
+        advance_process_time(duration) if duration
         @events.notify(:after_call, request, [200, @response, ''])
         txn
       end

--- a/test/new_relic/agent/new_relic_service_test.rb
+++ b/test/new_relic/agent/new_relic_service_test.rb
@@ -399,28 +399,27 @@ class NewRelicServiceTest < Minitest::Test
     assert_equal dummy_rsp, response
   end
 
-  # TODO: FAILS INTERMITTENTLY
-  # def test_metric_data_sends_harvest_timestamps
-  #   @http_handle.respond_to(:metric_data, 'foo')
+  def test_metric_data_sends_harvest_timestamps
+    @http_handle.respond_to(:metric_data, 'foo')
 
-  #   t0 = nr_freeze_process_time
-  #   stats_hash = NewRelic::Agent::StatsHash.new
-  #   stats_hash.harvested_at = Process.clock_gettime(Process::CLOCK_REALTIME)
+    t0 = nr_freeze_process_time
+    stats_hash = NewRelic::Agent::StatsHash.new
+    stats_hash.harvested_at = Process.clock_gettime(Process::CLOCK_REALTIME)
 
-  #   @service.metric_data(stats_hash)
-  #   payload = @http_handle.last_request_payload
-  #   _, last_harvest_timestamp, harvest_timestamp, _ = payload
-  #   assert_in_delta(t0, harvest_timestamp, 0.0001)
+    @service.metric_data(stats_hash)
+    payload = @http_handle.last_request_payload
+    _, last_harvest_timestamp, harvest_timestamp, _ = payload
+    assert_in_delta(t0, harvest_timestamp, 0.0001)
 
-  #   t1 = advance_process_time(10)
-  #   stats_hash.harvested_at = t1
+    t1 = advance_process_time(10)
+    stats_hash.harvested_at = t1
 
-  #   @service.metric_data(stats_hash)
-  #   payload = @http_handle.last_request_payload
-  #   _, last_harvest_timestamp, harvest_timestamp, _ = payload
-  #   assert_in_delta(t1, harvest_timestamp, 0.0001)
-  #   assert_in_delta(t0, last_harvest_timestamp, 0.0001)
-  # end
+    @service.metric_data(stats_hash)
+    payload = @http_handle.last_request_payload
+    _, last_harvest_timestamp, harvest_timestamp, _ = payload
+    assert_in_delta(t1, harvest_timestamp, 0.0001)
+    assert_in_delta(t0, last_harvest_timestamp, 0.0001)
+  end
 
   def test_metric_data_harvest_time_based_on_stats_hash_creation
     t0 = nr_freeze_process_time

--- a/test/new_relic/agent/new_relic_service_test.rb
+++ b/test/new_relic/agent/new_relic_service_test.rb
@@ -399,27 +399,28 @@ class NewRelicServiceTest < Minitest::Test
     assert_equal dummy_rsp, response
   end
 
-  def test_metric_data_sends_harvest_timestamps
-    @http_handle.respond_to(:metric_data, 'foo')
+  # TODO: FAILS INTERMITTENTLY
+  # def test_metric_data_sends_harvest_timestamps
+  #   @http_handle.respond_to(:metric_data, 'foo')
 
-    t0 = nr_freeze_process_time
-    stats_hash = NewRelic::Agent::StatsHash.new
-    stats_hash.harvested_at = Process.clock_gettime(Process::CLOCK_REALTIME)
+  #   t0 = nr_freeze_process_time
+  #   stats_hash = NewRelic::Agent::StatsHash.new
+  #   stats_hash.harvested_at = Process.clock_gettime(Process::CLOCK_REALTIME)
 
-    @service.metric_data(stats_hash)
-    payload = @http_handle.last_request_payload
-    _, last_harvest_timestamp, harvest_timestamp, _ = payload
-    assert_in_delta(t0.to_f, harvest_timestamp, 0.0001)
+  #   @service.metric_data(stats_hash)
+  #   payload = @http_handle.last_request_payload
+  #   _, last_harvest_timestamp, harvest_timestamp, _ = payload
+  #   assert_in_delta(t0, harvest_timestamp, 0.0001)
 
-    t1 = advance_process_time(10)
-    stats_hash.harvested_at = t1
+  #   t1 = advance_process_time(10)
+  #   stats_hash.harvested_at = t1
 
-    @service.metric_data(stats_hash)
-    payload = @http_handle.last_request_payload
-    _, last_harvest_timestamp, harvest_timestamp, _ = payload
-    assert_in_delta(t1.to_f, harvest_timestamp, 0.0001)
-    assert_in_delta(t0.to_f, last_harvest_timestamp, 0.0001)
-  end
+  #   @service.metric_data(stats_hash)
+  #   payload = @http_handle.last_request_payload
+  #   _, last_harvest_timestamp, harvest_timestamp, _ = payload
+  #   assert_in_delta(t1, harvest_timestamp, 0.0001)
+  #   assert_in_delta(t0, last_harvest_timestamp, 0.0001)
+  # end
 
   def test_metric_data_harvest_time_based_on_stats_hash_creation
     t0 = nr_freeze_process_time

--- a/test/new_relic/agent/new_relic_service_test.rb
+++ b/test/new_relic/agent/new_relic_service_test.rb
@@ -378,13 +378,13 @@ class NewRelicServiceTest < Minitest::Test
   def test_shutdown
     @service.agent_id = 666
     @http_handle.respond_to(:shutdown, 'shut this bird down')
-    response = @service.shutdown(Time.now)
+    response = @service.shutdown(Process.clock_gettime(Process::CLOCK_REALTIME))
     assert_equal 'shut this bird down', response
   end
 
   def test_should_not_shutdown_if_never_connected
     @http_handle.respond_to(:shutdown, 'shut this bird down')
-    response = @service.shutdown(Time.now)
+    response = @service.shutdown(Process.clock_gettime(Process::CLOCK_REALTIME))
     assert_nil response
   end
 
@@ -392,7 +392,7 @@ class NewRelicServiceTest < Minitest::Test
     dummy_rsp = 'met rick date uhh'
     @http_handle.respond_to(:metric_data, dummy_rsp)
     stats_hash = NewRelic::Agent::StatsHash.new
-    stats_hash.harvested_at = Time.now
+    stats_hash.harvested_at = Process.clock_gettime(Process::CLOCK_REALTIME)
     response = @service.metric_data(stats_hash)
 
     assert_equal 4, @http_handle.last_request_payload.size
@@ -402,16 +402,16 @@ class NewRelicServiceTest < Minitest::Test
   def test_metric_data_sends_harvest_timestamps
     @http_handle.respond_to(:metric_data, 'foo')
 
-    t0 = nr_freeze_time
+    t0 = nr_freeze_process_time
     stats_hash = NewRelic::Agent::StatsHash.new
-    stats_hash.harvested_at = Time.now
+    stats_hash.harvested_at = Process.clock_gettime(Process::CLOCK_REALTIME)
 
     @service.metric_data(stats_hash)
     payload = @http_handle.last_request_payload
     _, last_harvest_timestamp, harvest_timestamp, _ = payload
     assert_in_delta(t0.to_f, harvest_timestamp, 0.0001)
 
-    t1 = advance_time(10)
+    t1 = advance_process_time(10)
     stats_hash.harvested_at = t1
 
     @service.metric_data(stats_hash)
@@ -422,14 +422,14 @@ class NewRelicServiceTest < Minitest::Test
   end
 
   def test_metric_data_harvest_time_based_on_stats_hash_creation
-    t0 = nr_freeze_time
+    t0 = nr_freeze_process_time
     dummy_rsp = 'met rick date uhh'
     @http_handle.respond_to(:metric_data, dummy_rsp)
 
-    advance_time 10
+    advance_process_time 10
     stats_hash = NewRelic::Agent::StatsHash.new
-    advance_time 1
-    stats_hash.harvested_at = Time.now
+    advance_process_time 1
+    stats_hash.harvested_at = Process.clock_gettime(Process::CLOCK_REALTIME)
 
     @service.metric_data(stats_hash)
 
@@ -522,7 +522,7 @@ class NewRelicServiceTest < Minitest::Test
     @service.connect
     @http_handle.respond_to(:metric_data, 0)
     stats_hash = NewRelic::Agent::StatsHash.new
-    stats_hash.harvested_at = Time.now
+    stats_hash.harvested_at = Process.clock_gettime(Process::CLOCK_REALTIME)
     @service.metric_data(stats_hash)
 
     @http_handle.respond_to(:transaction_sample_data, 1)
@@ -944,7 +944,7 @@ class NewRelicServiceTest < Minitest::Test
     items.each do |key, value|
       hash.record(NewRelic::MetricSpec.new(key), value)
     end
-    hash.harvested_at = Time.now
+    hash.harvested_at = Process.clock_gettime(Process::CLOCK_REALTIME)
     hash
   end
 

--- a/test/new_relic/agent/pipe_channel_manager_test.rb
+++ b/test/new_relic/agent/pipe_channel_manager_test.rb
@@ -111,7 +111,7 @@ class NewRelic::Agent::PipeChannelManagerTest < Minitest::Test
       run_child(699) do
         NewRelic::Agent.after_fork(:report_to_channel => 699)
         transaction_event_aggregator.record event: NewRelic::Agent::TransactionEventPrimitive.create({
-          :start_timestamp => Time.now,
+          :start_timestamp => Process.clock_gettime(Process::CLOCK_REALTIME),
           :name => 'whatever',
           :duration => 10,
           :type => :controller,
@@ -219,7 +219,7 @@ class NewRelic::Agent::PipeChannelManagerTest < Minitest::Test
 
     def create_sql_sample(sampler)
       state = NewRelic::Agent::Tracer.state
-      sampler.on_start_transaction(state, Time.now)
+      sampler.on_start_transaction(state, Process.clock_gettime(Process::CLOCK_REALTIME))
       sampler.notice_sql("SELECT * FROM table", "ActiveRecord/Widgets/find", nil, 100, state)
       sampler.on_finishing_transaction(state, 'noodles')
     end

--- a/test/new_relic/agent/pipe_channel_manager_test.rb
+++ b/test/new_relic/agent/pipe_channel_manager_test.rb
@@ -219,7 +219,7 @@ class NewRelic::Agent::PipeChannelManagerTest < Minitest::Test
 
     def create_sql_sample(sampler)
       state = NewRelic::Agent::Tracer.state
-      sampler.on_start_transaction(state, Process.clock_gettime(Process::CLOCK_REALTIME))
+      sampler.on_start_transaction(state)
       sampler.notice_sql("SELECT * FROM table", "ActiveRecord/Widgets/find", nil, 100, state)
       sampler.on_finishing_transaction(state, 'noodles')
     end

--- a/test/new_relic/agent/pipe_service_test.rb
+++ b/test/new_relic/agent/pipe_service_test.rb
@@ -112,7 +112,7 @@ class PipeServiceTest < Minitest::Test
         @service.transaction_sample_data(['txn0'])
         @service.error_data(['err0'])
         @service.sql_trace_data(['sql0'])
-        @service.shutdown(Time.now)
+        @service.shutdown
       end
       Process.wait(pid)
 
@@ -125,7 +125,7 @@ class PipeServiceTest < Minitest::Test
 
     def test_shutdown_closes_pipe
       data_from_forked_process do
-        @service.shutdown(Time.now)
+        @service.shutdown
         assert NewRelic::Agent::PipeChannelManager \
           .channels[:pipe_service_test].closed?
       end

--- a/test/new_relic/agent/samplers/cpu_sampler_test.rb
+++ b/test/new_relic/agent/samplers/cpu_sampler_test.rb
@@ -48,7 +48,7 @@ class NewRelic::Agent::Samplers::CpuSamplerTest < Minitest::Test
     Object.send(:remove_const, 'JRUBY_VERSION') if defined?(JRUBY_VERSION)
     Object.const_set('JRUBY_VERSION', string)
   end
-  
+
   def test_cpu_sampler_records_user_and_system_time
     timeinfo0 = mock
     timeinfo0.stubs(:utime).returns(10.0)
@@ -60,12 +60,12 @@ class NewRelic::Agent::Samplers::CpuSamplerTest < Minitest::Test
 
     elapsed = 10
 
-    nr_freeze_time
+    nr_freeze_process_time
     Process.stubs(:times).returns(timeinfo0, timeinfo1)
     NewRelic::Agent::SystemInfo.stubs(:num_logical_processors).returns(4)
 
     s = NewRelic::Agent::Samplers::CpuSampler.new # this calls poll
-    advance_time(elapsed)
+    advance_process_time(elapsed)
     s.poll
 
     assert_metrics_recorded({
@@ -87,7 +87,7 @@ class NewRelic::Agent::Samplers::CpuSamplerTest < Minitest::Test
     timeinfo1.stubs(:utime).returns(0.0)
     timeinfo1.stubs(:stime).returns(0.0)
 
-    nr_freeze_time
+    nr_freeze_process_time
     Process.stubs(:times).returns(timeinfo0, timeinfo1)
 
     s = NewRelic::Agent::Samplers::CpuSampler.new # this calls poll

--- a/test/new_relic/agent/span_event_aggregator_test.rb
+++ b/test/new_relic/agent/span_event_aggregator_test.rb
@@ -15,7 +15,7 @@ module NewRelic
         @additional_config = { :'distributed_tracing.enabled' => true }
         NewRelic::Agent.config.add_config_for_testing(@additional_config)
 
-        nr_freeze_time
+        nr_freeze_process_time
         events = NewRelic::Agent.instance.events
         @event_aggregator = SpanEventAggregator.new events
       end

--- a/test/new_relic/agent/span_event_aggregator_test.rb
+++ b/test/new_relic/agent/span_event_aggregator_test.rb
@@ -51,7 +51,7 @@ module NewRelic
           'sampled' => false,
           'guid'    => guid,
           'traceId' => guid,
-          'timestamp' => (Process.clock_gettime(Process::CLOCK_REALTIME) * 1000).round,
+          'timestamp' => Process.clock_gettime(Process::CLOCK_REALTIME, :millisecond),
           'duration' => rand,
           'category' => 'custom'
           },

--- a/test/new_relic/agent/span_event_aggregator_test.rb
+++ b/test/new_relic/agent/span_event_aggregator_test.rb
@@ -51,7 +51,7 @@ module NewRelic
           'sampled' => false,
           'guid'    => guid,
           'traceId' => guid,
-          'timestamp' => (Time.now.to_f * 1000).round,
+          'timestamp' => (Process.clock_gettime(Process::CLOCK_REALTIME) * 1000).round,
           'duration' => rand,
           'category' => 'custom'
           },

--- a/test/new_relic/agent/span_event_primitive_test.rb
+++ b/test/new_relic/agent/span_event_primitive_test.rb
@@ -13,7 +13,7 @@ module NewRelic
           @additional_config = { :'distributed_tracing.enabled' => true }
           NewRelic::Agent.config.add_config_for_testing(@additional_config)
           NewRelic::Agent.config.notify_server_source_added
-          nr_freeze_time
+          nr_freeze_process_time
         end
 
         def teardown

--- a/test/new_relic/agent/span_event_primitive_test.rb
+++ b/test/new_relic/agent/span_event_primitive_test.rb
@@ -180,7 +180,7 @@ module NewRelic
             payload = {
               :name => "Controller/whatever",
               :type => :controller,
-              :start_timestamp =>  Time.now.to_f,
+              :start_timestamp =>  Process.clock_gettime(Process::CLOCK_REALTIME),
               :duration => 0.1,
               :attributes => attributes,
               :error => false,

--- a/test/new_relic/agent/sql_sampler_test.rb
+++ b/test/new_relic/agent/sql_sampler_test.rb
@@ -468,7 +468,7 @@ class NewRelic::Agent::SqlSamplerTest < Minitest::Test
                  :account_id => 190,
                  :'slow_sql.explain_threshold' => -1 }) do
 
-      nr_freeze_process_time
+      nr_freeze_process_time(Process.clock_gettime(Process::CLOCK_REALTIME, :millisecond))
 
       in_transaction do |txn|
         payload = txn.distributed_tracer.create_distributed_trace_payload

--- a/test/new_relic/agent/sql_sampler_test.rb
+++ b/test/new_relic/agent/sql_sampler_test.rb
@@ -30,7 +30,7 @@ class NewRelic::Agent::SqlSamplerTest < Minitest::Test
 
   def populate_container(sampler, n)
     n.times do |i|
-      sampler.on_start_transaction(@state, nil)
+      sampler.on_start_transaction(@state)
       sampler.notice_sql("SELECT * FROM test#{i}", "Database/test/select", {}, 1, @state)
       sampler.on_finishing_transaction(@state, 'txn')
     end
@@ -42,7 +42,7 @@ class NewRelic::Agent::SqlSamplerTest < Minitest::Test
 
   def test_on_start_transaction
     assert_nil @sampler.tl_transaction_data
-    @sampler.on_start_transaction(@state, nil)
+    @sampler.on_start_transaction(@state)
     refute_nil @sampler.tl_transaction_data
     @sampler.on_finishing_transaction(@state, 'txn')
 
@@ -56,7 +56,7 @@ class NewRelic::Agent::SqlSamplerTest < Minitest::Test
   end
 
   def test_notice_sql
-    @sampler.on_start_transaction(@state, nil)
+    @sampler.on_start_transaction(@state)
     @sampler.notice_sql("select * from test", "Database/test/select", nil, 1.5, @state)
     @sampler.notice_sql("select * from test2", "Database/test2/select", nil, 1.3, @state)
     # this sql will not be captured
@@ -66,7 +66,7 @@ class NewRelic::Agent::SqlSamplerTest < Minitest::Test
   end
 
   def test_notice_sql_statement
-    @sampler.on_start_transaction(@state, nil)
+    @sampler.on_start_transaction(@state)
 
     sql = "select * from test"
     metric_name = "Database/test/select"
@@ -81,7 +81,7 @@ class NewRelic::Agent::SqlSamplerTest < Minitest::Test
   end
 
   def test_notice_sql_truncates_query
-    @sampler.on_start_transaction(@state, nil)
+    @sampler.on_start_transaction(@state)
     message = 'a' * 17_000
     @sampler.notice_sql(message, "Database/test/select", nil, 1.5, @state)
     assert_equal('a' * 16_381 + '...', @sampler.tl_transaction_data.sql_data[0].sql)

--- a/test/new_relic/agent/sql_sampler_test.rb
+++ b/test/new_relic/agent/sql_sampler_test.rb
@@ -468,13 +468,13 @@ class NewRelic::Agent::SqlSamplerTest < Minitest::Test
                  :account_id => 190,
                  :'slow_sql.explain_threshold' => -1 }) do
 
-      nr_freeze_time
+      nr_freeze_process_time
 
       in_transaction do |txn|
         payload = txn.distributed_tracer.create_distributed_trace_payload
       end
 
-      advance_time 2.0
+      advance_process_time 2.0
 
       segment = nil
       txn = nil

--- a/test/new_relic/agent/stats_engine_test.rb
+++ b/test/new_relic/agent/stats_engine_test.rb
@@ -323,7 +323,7 @@ class NewRelic::Agent::StatsEngineTest < Minitest::Test
   end
 
   def test_harvest_adds_harvested_at_time
-    t0 = nr_freeze_time
+    t0 = nr_freeze_process_time
     result = @engine.harvest!
     assert_equal(t0, result.harvested_at)
   end

--- a/test/new_relic/agent/synthetics_event_aggregator_test.rb
+++ b/test/new_relic/agent/synthetics_event_aggregator_test.rb
@@ -12,7 +12,7 @@ module NewRelic
   module Agent
     class SyntheticsEventAggregatorTest < Minitest::Test
       def setup
-        nr_freeze_time
+        nr_freeze_process_time
         @attributes = nil
         events = NewRelic::Agent.instance.events
         @synthetics_event_aggregator = SyntheticsEventAggregator.new events

--- a/test/new_relic/agent/synthetics_event_aggregator_test.rb
+++ b/test/new_relic/agent/synthetics_event_aggregator_test.rb
@@ -95,7 +95,7 @@ module NewRelic
       def test_lower_priority_events_discarded_in_favor_higher_priority_events
         with_config aggregator.class.capacity_key => 5 do
           10.times { |i| generate_event "event_#{i}" }
-          # Each event gets a timestamp of Time.now, which is used to determine priority
+          # Each event gets a timestamp, which is used to determine priority
           # (older events are higher priority)
 
           _, events = aggregator.harvest!
@@ -145,7 +145,7 @@ module NewRelic
         payload = {
           :name => name,
           :type => :controller,
-          :start_timestamp => options[:timestamp] || Time.now.to_f,
+          :start_timestamp => options[:timestamp] || Process.clock_gettime(Process::CLOCK_REALTIME),
           :duration => 0.1,
           :synthetics_resource_id => 100,
           :attributes => attributes,

--- a/test/new_relic/agent/threading/thread_profile_test.rb
+++ b/test/new_relic/agent/threading/thread_profile_test.rb
@@ -166,13 +166,13 @@ if NewRelic::Agent::Threading::BacktraceService.is_supported?
       end
 
       def test_aggregate_updates_created_at_timestamp
-        expected = nr_freeze_time
+        expected = nr_freeze_process_time
         @profile = ThreadProfile.new
 
         @profile.aggregate(@single_trace, :request, Thread.current)
         t0 = @profile.created_at
 
-        advance_time(5.0)
+        advance_process_time(5.0)
         @profile.aggregate(@single_trace, :request, Thread.current)
 
         assert_equal expected, t0

--- a/test/new_relic/agent/tracer_test.rb
+++ b/test/new_relic/agent/tracer_test.rb
@@ -289,7 +289,7 @@ module NewRelic
           "Custom/Segment/something/allWeb"
         ]
         parent = Transaction::Segment.new("parent")
-        start_time = Time.now
+        start_time = Process.clock_gettime(Process::CLOCK_REALTIME)
 
         in_transaction 'test' do
           segment = Tracer.start_segment(
@@ -312,7 +312,7 @@ module NewRelic
         host            = "localhost"
         port_path_or_id = "3306"
         database_name   = "blog_app"
-        start_time      = Time.now
+        start_time      = Process.clock_gettime(Process::CLOCK_REALTIME)
         parent          = Transaction::Segment.new("parent")
 
         in_transaction 'test' do
@@ -337,7 +337,7 @@ module NewRelic
         library    = "Net::HTTP"
         uri        = "https://docs.newrelic.com"
         procedure  = "GET"
-        start_time = Time.now
+        start_time = Process.clock_gettime(Process::CLOCK_REALTIME)
         parent     = Transaction::Segment.new("parent")
 
         in_transaction 'test' do

--- a/test/new_relic/agent/transaction/abstract_segment_test.rb
+++ b/test/new_relic/agent/transaction/abstract_segment_test.rb
@@ -125,7 +125,7 @@ module NewRelic
             segment.expects(:transaction_assigned)
             txn.add_segment segment
             segment.start
-            advance_time 1.0
+            advance_process_time(1.0)
             segment.finish
           end
         end
@@ -135,7 +135,7 @@ module NewRelic
             segment = BasicSegment.new "Custom/basic/segment"
             txn.add_segment segment
             segment.start
-            advance_time 1.0
+            advance_process_time(1.0)
             segment.record_on_finish = true
             segment.finish
             assert_includes txn.metrics.instance_variable_get(:@scoped).keys, 'Custom/basic/segment'

--- a/test/new_relic/agent/transaction/abstract_segment_test.rb
+++ b/test/new_relic/agent/transaction/abstract_segment_test.rb
@@ -19,7 +19,7 @@ module NewRelic
         end
 
         def setup
-          nr_freeze_time
+          nr_freeze_process_time
         end
 
         def teardown
@@ -54,13 +54,13 @@ module NewRelic
             segment = BasicSegment.new "Custom/basic/segment"
             txn.add_segment segment
             segment.start
-            assert_equal Time.now, segment.start_time
+            assert_equal Process.clock_gettime(Process::CLOCK_REALTIME), segment.start_time
 
-            advance_time 1.0
+            advance_process_time 1.0
             segment.finish
           end
 
-          assert_equal Time.now, segment.end_time
+          assert_equal Process.clock_gettime(Process::CLOCK_REALTIME), segment.end_time
           assert_equal 1.0, segment.duration
           assert_equal 1.0, segment.exclusive_duration
         end
@@ -70,7 +70,7 @@ module NewRelic
             segment = BasicSegment.new "Custom/basic/segment"
             txn.add_segment segment
             segment.start
-            advance_time 1.0
+            advance_process_time 1.0
             segment.finish
           end
 
@@ -82,7 +82,7 @@ module NewRelic
           in_transaction "test_transaction" do |txn|
             txn.add_segment segment
             segment.start
-            advance_time 1.0
+            advance_process_time 1.0
             segment.finish
 
             refute_metrics_recorded ["Custom/basic/segment", "Basic/all"]
@@ -101,7 +101,7 @@ module NewRelic
             txn.add_segment segment
             segment.record_metrics = false
             segment.start
-            advance_time 1.0
+            advance_process_time 1.0
             segment.finish
           end
 
@@ -114,7 +114,7 @@ module NewRelic
             txn.add_segment segment
             segment.expects(:segment_complete)
             segment.start
-            advance_time 1.0
+            advance_process_time 1.0
             segment.finish
           end
         end
@@ -154,23 +154,23 @@ module NewRelic
         end
 
         def test_sets_start_time_from_constructor
-          t = Time.now
+          t = Process.clock_gettime(Process::CLOCK_REALTIME)
           segment = BasicSegment.new nil, t
           assert_equal t, segment.start_time
         end
 
         def test_sets_start_time_if_not_given_when_started
-          t = Time.now
+          t = Process.clock_gettime(Process::CLOCK_REALTIME)
           segment = BasicSegment.new
           segment.start
           assert_equal t, segment.start_time
         end
 
         def test_does_not_override_construction_start_time_when_started
-          t = Time.now
+          t = Process.clock_gettime(Process::CLOCK_REALTIME)
           segment = BasicSegment.new nil, t
           assert_equal t, segment.start_time
-          advance_time 1
+          advance_process_time 1
           segment.start
           assert_equal t, segment.start_time
         end

--- a/test/new_relic/agent/transaction/datastore_segment_test.rb
+++ b/test/new_relic/agent/transaction/datastore_segment_test.rb
@@ -15,7 +15,7 @@ module NewRelic
           NewRelic::Agent.config.add_config_for_testing(@additional_config)
           NewRelic::Agent.config.notify_server_source_added
 
-          nr_freeze_time
+          nr_freeze_process_time
         end
 
         def teardown
@@ -37,7 +37,7 @@ module NewRelic
         def test_segment_does_not_record_metrics_outside_of_txn
           segment = DatastoreSegment.new "SQLite", "insert", "Blog"
           segment.start
-          advance_time 1
+          advance_process_time 1
           segment.finish
 
           refute_metrics_recorded [
@@ -58,7 +58,7 @@ module NewRelic
               collection: "Blog"
             )
             segment.start
-            advance_time 1
+            advance_process_time 1
             segment.finish
           end
 
@@ -79,7 +79,7 @@ module NewRelic
               operation: "select"
             )
             segment.start
-            advance_time 1
+            advance_process_time 1
             segment.finish
           end
 
@@ -101,7 +101,7 @@ module NewRelic
               port_path_or_id: "1337807"
             )
             segment.start
-            advance_time 1
+            advance_process_time 1
             segment.finish
           end
 
@@ -123,7 +123,7 @@ module NewRelic
               host: "jonan-01"
             )
             segment.start
-            advance_time 1
+            advance_process_time 1
             segment.finish
           end
 
@@ -145,7 +145,7 @@ module NewRelic
               port_path_or_id: 1337807
             )
             segment.start
-            advance_time 1
+            advance_process_time 1
             segment.finish
           end
 
@@ -166,7 +166,7 @@ module NewRelic
               operation: "select"
             )
             segment.start
-            advance_time 1
+            advance_process_time 1
             segment.finish
           end
 
@@ -183,7 +183,7 @@ module NewRelic
                 port_path_or_id: "1337807"
               )
               segment.start
-              advance_time 1
+              advance_process_time 1
               segment.finish
             end
 
@@ -202,7 +202,7 @@ module NewRelic
             )
 
             segment.start
-            advance_time 1.0
+            advance_process_time 1.0
             segment.finish
           end
 
@@ -231,7 +231,7 @@ module NewRelic
             )
 
             segment.notice_sql sql_statement
-            advance_time 1
+            advance_process_time 1
             segment.finish
 
             timestamp = Integer(segment.start_time.to_f * 1000.0)
@@ -286,7 +286,7 @@ module NewRelic
               )
 
               segment.notice_sql sql
-              advance_time 1
+              advance_process_time 1
               segment.finish
             end
 
@@ -315,7 +315,7 @@ module NewRelic
               )
 
               segment.notice_sql sql
-              advance_time 1
+              advance_process_time 1
               segment.finish
             end
 
@@ -343,7 +343,7 @@ module NewRelic
             )
 
             segment.notice_nosql_statement nosql_statement
-            advance_time 1
+            advance_process_time 1
             segment.finish
           end
 
@@ -458,7 +458,7 @@ module NewRelic
               host: "jonan-01",
               port_path_or_id: "1337807"
             )
-            advance_time 1
+            advance_process_time 1
             segment.finish
           end
 
@@ -495,7 +495,7 @@ module NewRelic
               operation: "select",
               database_name: "pizza_cube"
             )
-            advance_time 1
+            advance_process_time 1
             segment.finish
           end
 
@@ -515,7 +515,7 @@ module NewRelic
                 operation: "select",
                 database_name: "pizza_cube"
               )
-              advance_time 1
+              advance_process_time 1
               segment.finish
             end
 
@@ -533,7 +533,7 @@ module NewRelic
               operation: "select"
             )
             segment.notice_sql "select * from blogs"
-            advance_time 2.0
+            advance_process_time 2.0
             Agent.instance.sql_sampler.expects(:notice_sql_statement) do |statement, name, duration|
               assert_equal segment.sql_statement.sql, statement.sql_statement
               assert_equal segment.name, name
@@ -622,7 +622,7 @@ module NewRelic
               operation: "select"
             )
             segment._notice_sql "select * from blogs", {:adapter => :sqlite}, explainer
-            advance_time 2.0
+            advance_process_time 2.0
             Agent.instance.sql_sampler.expects(:notice_sql_statement) do |statement, name, duration|
               assert_equal segment.sql_statement.sql, statement.sql_statement
               assert_equal segment.name, name
@@ -641,7 +641,7 @@ module NewRelic
               operation: "set"
             )
             segment.notice_nosql_statement statement
-            advance_time 2.0
+            advance_process_time 2.0
 
             segment.finish
             assert_equal segment.params[:statement], statement
@@ -705,7 +705,7 @@ module NewRelic
                 collection: "Blog"
               )
               segment.start
-              advance_time 1.0
+              advance_process_time 1.0
               segment.finish
             end
           end
@@ -727,7 +727,7 @@ module NewRelic
                 collection: "Blog"
               )
               segment.start
-              advance_time 2.0
+              advance_process_time 2.0
               segment.finish
             end
           end
@@ -753,7 +753,7 @@ module NewRelic
         end
 
         def test_sets_start_time_from_api
-          t = Time.now
+          t = Process.clock_gettime(Process::CLOCK_REALTIME)
 
           in_transaction do |txn|
 

--- a/test/new_relic/agent/transaction/distributed_tracing_test.rb
+++ b/test/new_relic/agent/transaction/distributed_tracing_test.rb
@@ -32,8 +32,8 @@ module NewRelic
 
         def test_create_distributed_trace_payload_returns_payload
           NewRelic::Agent.instance.adaptive_sampler.stubs(:sampled?).returns(true)
-          nr_freeze_time
-          created_at = (Time.now.to_f * 1000).round
+          nr_freeze_process_time
+          created_at = (Process.clock_gettime(Process::CLOCK_REALTIME) * 1000).round
           payload = nil
 
           transaction = in_transaction "test_txn" do |t|
@@ -52,7 +52,7 @@ module NewRelic
         end
 
         def test_create_distributed_trace_payload_while_disconnected_returns_nil
-          nr_freeze_time
+          nr_freeze_process_time
 
           payload = 'definitely not nil'
 

--- a/test/new_relic/agent/transaction/distributed_tracing_test.rb
+++ b/test/new_relic/agent/transaction/distributed_tracing_test.rb
@@ -574,8 +574,8 @@ module NewRelic
           # sampler into a new interval and resets the counts
           adaptive_sampler = NewRelic::Agent.instance.adaptive_sampler
           interval_duration = adaptive_sampler.instance_variable_get :@period_duration
-          nr_freeze_time
-          advance_time(interval_duration)
+          nr_freeze_process_time
+          advance_process_time(interval_duration)
           adaptive_sampler.send(:reset_if_period_expired!)
 
           20.times do

--- a/test/new_relic/agent/transaction/distributed_tracing_test.rb
+++ b/test/new_relic/agent/transaction/distributed_tracing_test.rb
@@ -574,7 +574,7 @@ module NewRelic
           # sampler into a new interval and resets the counts
           adaptive_sampler = NewRelic::Agent.instance.adaptive_sampler
           interval_duration = adaptive_sampler.instance_variable_get :@period_duration
-          nr_freeze_process_time
+          nr_freeze_process_time(Process.clock_gettime(Process::CLOCK_REALTIME, :millisecond))
           advance_process_time(interval_duration)
           adaptive_sampler.send(:reset_if_period_expired!)
 

--- a/test/new_relic/agent/transaction/distributed_tracing_test.rb
+++ b/test/new_relic/agent/transaction/distributed_tracing_test.rb
@@ -33,7 +33,7 @@ module NewRelic
         def test_create_distributed_trace_payload_returns_payload
           NewRelic::Agent.instance.adaptive_sampler.stubs(:sampled?).returns(true)
           nr_freeze_process_time
-          created_at = (Process.clock_gettime(Process::CLOCK_REALTIME) * 1000).round
+          created_at = Process.clock_gettime(Process::CLOCK_REALTIME, :millisecond)
           payload = nil
 
           transaction = in_transaction "test_txn" do |t|

--- a/test/new_relic/agent/transaction/external_request_segment_test.rb
+++ b/test/new_relic/agent/transaction/external_request_segment_test.rb
@@ -43,7 +43,7 @@ module NewRelic::Agent
         NewRelic::Agent::CrossAppTracing.stubs(:obfuscator).returns(@obfuscator)
         NewRelic::Agent::CrossAppTracing.stubs(:valid_encoding_key?).returns(true)
         NewRelic::Agent.instance.span_event_aggregator.stubs(:enabled?).returns(true)
-        nr_freeze_time
+        nr_freeze_process_time
       end
 
       def teardown
@@ -253,7 +253,7 @@ module NewRelic::Agent
 
           NewRelic::Agent.drop_buffered_data
           transport_type = nil
-          
+
           in_transaction "test_txn2", :category => :controller do |txn|
             txn.distributed_tracer.accept_distributed_trace_payload payload.text
             segment = Tracer.start_external_request_segment(
@@ -420,7 +420,7 @@ module NewRelic::Agent
         end
       end
 
-      # Can pass :status_code and any HTTP code in headers to alter 
+      # Can pass :status_code and any HTTP code in headers to alter
       # default 200 (OK) HTTP status code
       def with_external_segment headers, config, segment_params
         segment = nil
@@ -762,7 +762,7 @@ module NewRelic::Agent
       end
 
       def test_sets_start_time_from_api
-        t = Time.now
+        t = Process.clock_gettime(Process::CLOCK_REALTIME)
 
         in_transaction do |txn|
 
@@ -795,10 +795,10 @@ module NewRelic::Agent
                                                  "GET"
             txn.add_segment segment
             segment.start
-            advance_time 1.0
+            advance_process_time 1.0
             segment.finish
 
-            timestamp = Integer(segment.start_time.to_f * 1000.0)
+            timestamp = Integer(segment.start_time * 1000.0)
 
             trace_id = txn.trace_id
             txn_guid = txn.guid
@@ -834,7 +834,7 @@ module NewRelic::Agent
       def test_urls_are_filtered
         with_config(distributed_tracing_config) do
           segment   = nil
-          filtered_url = "https://remotehost.com/bar/baz"                                      
+          filtered_url = "https://remotehost.com/bar/baz"
 
           in_transaction('wat') do |txn|
             txn.stubs(:sampled?).returns(true)
@@ -844,7 +844,7 @@ module NewRelic::Agent
                                                  "GET"
             txn.add_segment segment
             segment.start
-            advance_time 1.0
+            advance_process_time 1.0
             segment.finish
           end
 
@@ -866,7 +866,7 @@ module NewRelic::Agent
                                                "GET"
           txn.add_segment segment
           segment.start
-          advance_time 1.0
+          advance_process_time 1.0
           segment.finish
         end
 

--- a/test/new_relic/agent/transaction/message_broker_segment_test.rb
+++ b/test/new_relic/agent/transaction/message_broker_segment_test.rb
@@ -138,7 +138,7 @@ module NewRelic
         end
 
         def test_sets_start_time_from_constructor
-          t = Time.now
+          t = Process.clock_gettime(Process::CLOCK_REALTIME)
 
           segment = MessageBrokerSegment.new action: :produce,
                                              library: "RabbitMQ",

--- a/test/new_relic/agent/transaction/segment_test.rb
+++ b/test/new_relic/agent/transaction/segment_test.rb
@@ -14,7 +14,7 @@ module NewRelic
           @additional_config = { :'distributed_tracing.enabled' => true }
           NewRelic::Agent.config.add_config_for_testing(@additional_config)
           NewRelic::Agent.config.notify_server_source_added
-          nr_freeze_time
+          nr_freeze_process_time
         end
 
         def teardown
@@ -106,7 +106,7 @@ module NewRelic
         def test_segment_does_not_record_metrics_outside_of_txn
           segment = Segment.new  "Custom/simple/segment", "Segment/all"
           segment.start
-          advance_time 1.0
+          advance_process_time 1.0
           segment.finish
 
           refute_metrics_recorded ["Custom/simple/segment", "Segment/all"]
@@ -117,7 +117,7 @@ module NewRelic
             segment = Segment.new  "Custom/simple/segment", "Segment/all"
             txn.add_segment segment
             segment.start
-            advance_time 1.0
+            advance_process_time 1.0
             segment.finish
           end
 
@@ -139,7 +139,7 @@ module NewRelic
             segment = Segment.new  "Custom/simple/segment", ["Segment/all", "Other/all"]
             txn.add_segment segment
             segment.start
-            advance_time 1.0
+            advance_process_time 1.0
             segment.finish
           end
 
@@ -152,7 +152,7 @@ module NewRelic
             segment.record_scoped_metric = false
             txn.add_segment segment
             segment.start
-            advance_time 1.0
+            advance_process_time 1.0
             segment.finish
           end
 
@@ -175,7 +175,7 @@ module NewRelic
             segment.record_scoped_metric = false
             txn.add_segment segment
             segment.start
-            advance_time 1.0
+            advance_process_time 1.0
             segment.finish
           end
 
@@ -199,7 +199,7 @@ module NewRelic
             segment = Segment.new 'Ummm'
             txn.add_segment segment
             segment.start
-            advance_time 1.0
+            advance_process_time 1.0
             segment.finish
           end
 
@@ -220,10 +220,10 @@ module NewRelic
             segment = Segment.new 'Ummm'
             txn.add_segment segment
             segment.start
-            advance_time 1.0
+            advance_process_time 1.0
             segment.finish
 
-            timestamp = Integer(segment.start_time.to_f * 1000.0)
+            timestamp = Integer(segment.start_time * 1000.0)
 
             trace_id = txn.trace_id
             txn_guid = txn.guid
@@ -251,7 +251,7 @@ module NewRelic
         end
 
         def test_sets_start_time_from_constructor
-          t = Time.now
+          t = Process.clock_gettime(Process::CLOCK_REALTIME)
           segment = Segment.new nil, nil, t
           assert_equal t, segment.start_time
         end

--- a/test/new_relic/agent/transaction/trace_builder_test.rb
+++ b/test/new_relic/agent/transaction/trace_builder_test.rb
@@ -10,7 +10,7 @@ module NewRelic
     class Transaction
       class TraceBuilderTest < Minitest::Test
         def setup
-          nr_freeze_time
+          nr_freeze_process_time
         end
 
         def test_builds_trace_for_transaction
@@ -18,15 +18,15 @@ module NewRelic
           state = Tracer.state
           Tracer.in_transaction name: "test_txn", category: :controller do
             txn = state.current_transaction
-            advance_time 1
+            advance_process_time 1
             segment_a = Tracer.start_segment name: "segment_a"
             segment_a.params[:foo] = "bar"
-            advance_time 1
+            advance_process_time 1
             segment_b = Tracer.start_segment name: "segment_b"
-            advance_time 2
+            advance_process_time 2
             segment_b.finish
             segment_c = Tracer.start_segment name:  "segment_c"
-            advance_time 3
+            advance_process_time 3
             segment_c.finish
             segment_a.finish
           end
@@ -65,9 +65,9 @@ module NewRelic
           state = Tracer.state
           Tracer.in_transaction name: "test_txn", category: :controller do
             txn = state.current_transaction
-            advance_time 1
+            advance_process_time 1
             Tracer.start_segment name: "segment_a"
-            advance_time 1
+            advance_process_time 1
           end
 
           trace = TraceBuilder.build_trace txn

--- a/test/new_relic/agent/transaction/trace_context_test.rb
+++ b/test/new_relic/agent/transaction/trace_context_test.rb
@@ -9,7 +9,7 @@ module NewRelic::Agent
     module TraceContext
       class TraceContextTest < Minitest::Test
         def setup
-          nr_freeze_time
+          nr_freeze_process_time
 
           @config = {
             :'distributed_tracing.enabled' => true,
@@ -30,7 +30,7 @@ module NewRelic::Agent
         end
 
         def test_insert_trace_context_header
-          nr_freeze_time
+          nr_freeze_process_time
 
           carrier = {}
           trace_state = nil
@@ -325,11 +325,11 @@ module NewRelic::Agent
         end
 
         def test_creates_trace_context_payload
-          nr_freeze_time
+          nr_freeze_process_time
 
           payload = nil
           parent_id = nil
-          now_ms = (Time.now.to_f * 1000).round
+          now_ms = (Process.clock_gettime(Process::CLOCK_REALTIME) * 1000).round
 
           txn = in_transaction do |t|
             t.sampled = true
@@ -347,11 +347,11 @@ module NewRelic::Agent
         end
 
         def test_omits_transaction_guid_from_payload_when_analytics_events_disabled
-          nr_freeze_time
+          nr_freeze_process_time
 
           payload = nil
           parent_id = nil
-          now_ms = (Time.now.to_f * 1000).round
+          now_ms = (Process.clock_gettime(Process::CLOCK_REALTIME) * 1000).round
 
           disabled_analytics_events = @config.merge({
              :'analytics_events.enabled' => false
@@ -376,10 +376,10 @@ module NewRelic::Agent
         end
 
         def test_omits_span_guid_from_payload_when_span_events_disabled
-          nr_freeze_time
+          nr_freeze_process_time
 
           payload = nil
-          now_ms = (Time.now.to_f * 1000).round
+          now_ms = (Process.clock_gettime(Process::CLOCK_REALTIME) * 1000).round
 
           disabled_span_events = @config.merge({
              :'span_events.enabled' => false

--- a/test/new_relic/agent/transaction/trace_context_test.rb
+++ b/test/new_relic/agent/transaction/trace_context_test.rb
@@ -9,7 +9,7 @@ module NewRelic::Agent
     module TraceContext
       class TraceContextTest < Minitest::Test
         def setup
-          nr_freeze_process_time
+          nr_freeze_process_time(Process.clock_gettime(Process::CLOCK_REALTIME, :millisecond))
 
           @config = {
             :'distributed_tracing.enabled' => true,

--- a/test/new_relic/agent/transaction/trace_context_test.rb
+++ b/test/new_relic/agent/transaction/trace_context_test.rb
@@ -329,7 +329,7 @@ module NewRelic::Agent
 
           payload = nil
           parent_id = nil
-          now_ms = (Process.clock_gettime(Process::CLOCK_REALTIME) * 1000).round
+          now_ms = Process.clock_gettime(Process::CLOCK_REALTIME, :millisecond)
 
           txn = in_transaction do |t|
             t.sampled = true
@@ -351,7 +351,7 @@ module NewRelic::Agent
 
           payload = nil
           parent_id = nil
-          now_ms = (Process.clock_gettime(Process::CLOCK_REALTIME) * 1000).round
+          now_ms = Process.clock_gettime(Process::CLOCK_REALTIME, :millisecond)
 
           disabled_analytics_events = @config.merge({
              :'analytics_events.enabled' => false
@@ -379,7 +379,7 @@ module NewRelic::Agent
           nr_freeze_process_time
 
           payload = nil
-          now_ms = (Process.clock_gettime(Process::CLOCK_REALTIME) * 1000).round
+          now_ms = Process.clock_gettime(Process::CLOCK_REALTIME, :millisecond)
 
           disabled_span_events = @config.merge({
              :'span_events.enabled' => false

--- a/test/new_relic/agent/transaction/trace_node_test.rb
+++ b/test/new_relic/agent/transaction/trace_node_test.rb
@@ -8,12 +8,12 @@ require 'new_relic/agent/transaction/trace_node'
 class NewRelic::Agent::Transaction::TraceNodeTest < Minitest::Test
   def test_node_creation
     # basic smoke test
-    s = NewRelic::Agent::Transaction::TraceNode.new('Custom/test/metric', Time.now)
+    s = NewRelic::Agent::Transaction::TraceNode.new('Custom/test/metric', Process.clock_gettime(Process::CLOCK_REALTIME))
     assert_equal NewRelic::Agent::Transaction::TraceNode, s.class
   end
 
   def test_readers
-    t = Time.now
+    t = Process.clock_gettime(Process::CLOCK_REALTIME)
     s = NewRelic::Agent::Transaction::TraceNode.new('Custom/test/metric', t)
     assert_equal(t, s.entry_timestamp)
     assert_nil(s.exit_timestamp)
@@ -22,14 +22,14 @@ class NewRelic::Agent::Transaction::TraceNodeTest < Minitest::Test
   end
 
   def test_end_trace
-    s = NewRelic::Agent::Transaction::TraceNode.new('Custom/test/metric', Time.now)
-    t = Time.now
+    s = NewRelic::Agent::Transaction::TraceNode.new('Custom/test/metric', Process.clock_gettime(Process::CLOCK_REALTIME))
+    t = Process.clock_gettime(Process::CLOCK_REALTIME)
     s.end_trace(t)
     assert_equal(t, s.exit_timestamp)
   end
 
   def test_to_s
-    s = NewRelic::Agent::Transaction::TraceNode.new('Custom/test/metric', Time.now)
+    s = NewRelic::Agent::Transaction::TraceNode.new('Custom/test/metric', Process.clock_gettime(Process::CLOCK_REALTIME))
     s.expects(:to_debug_str).with(0)
     s.to_s
   end
@@ -54,7 +54,7 @@ class NewRelic::Agent::Transaction::TraceNodeTest < Minitest::Test
   end
 
   def test_path_string
-    s = NewRelic::Agent::Transaction::TraceNode.new('Custom/test/metric', Time.now)
+    s = NewRelic::Agent::Transaction::TraceNode.new('Custom/test/metric', Process.clock_gettime(Process::CLOCK_REALTIME))
     assert_equal("Custom/test/metric[]", s.path_string)
 
     fake_node = mock('node')
@@ -66,7 +66,7 @@ class NewRelic::Agent::Transaction::TraceNodeTest < Minitest::Test
   end
 
   def test_to_s_compact
-    s = NewRelic::Agent::Transaction::TraceNode.new('Custom/test/metric', Time.now)
+    s = NewRelic::Agent::Transaction::TraceNode.new('Custom/test/metric', Process.clock_gettime(Process::CLOCK_REALTIME))
     assert_equal("Custom/test/metric", s.to_s_compact)
 
     fake_node = mock('node')
@@ -136,12 +136,12 @@ class NewRelic::Agent::Transaction::TraceNodeTest < Minitest::Test
   end
 
   def test_children_default
-    s = NewRelic::Agent::Transaction::TraceNode.new('Custom/test/metric', Time.now)
+    s = NewRelic::Agent::Transaction::TraceNode.new('Custom/test/metric', Process.clock_gettime(Process::CLOCK_REALTIME))
     assert_equal([], s.children)
   end
 
   def test_children_with_nodes
-    s = NewRelic::Agent::Transaction::TraceNode.new('Custom/test/metric', Time.now)
+    s = NewRelic::Agent::Transaction::TraceNode.new('Custom/test/metric', Process.clock_gettime(Process::CLOCK_REALTIME))
     fake_node = mock('node')
     s.children << fake_node
 
@@ -161,13 +161,13 @@ class NewRelic::Agent::Transaction::TraceNodeTest < Minitest::Test
   end
 
   def test_exclusive_duration_no_children
-    s = NewRelic::Agent::Transaction::TraceNode.new('Custom/test/metric', Time.now)
+    s = NewRelic::Agent::Transaction::TraceNode.new('Custom/test/metric', Process.clock_gettime(Process::CLOCK_REALTIME))
     s.expects(:duration).returns(0.5)
     assert_equal(0.5, s.exclusive_duration)
   end
 
   def test_exclusive_duration_with_children
-    s = NewRelic::Agent::Transaction::TraceNode.new('Custom/test/metric', Time.now)
+    s = NewRelic::Agent::Transaction::TraceNode.new('Custom/test/metric', Process.clock_gettime(Process::CLOCK_REALTIME))
 
     s.expects(:duration).returns(0.5)
 
@@ -180,12 +180,12 @@ class NewRelic::Agent::Transaction::TraceNodeTest < Minitest::Test
   end
 
   def test_count_nodes_default
-    s = NewRelic::Agent::Transaction::TraceNode.new('Custom/test/metric', Time.now)
+    s = NewRelic::Agent::Transaction::TraceNode.new('Custom/test/metric', Process.clock_gettime(Process::CLOCK_REALTIME))
     assert_equal(1, s.count_nodes)
   end
 
   def test_count_nodes_with_children
-    s = NewRelic::Agent::Transaction::TraceNode.new('Custom/test/metric', Time.now)
+    s = NewRelic::Agent::Transaction::TraceNode.new('Custom/test/metric', Process.clock_gettime(Process::CLOCK_REALTIME))
 
     fake_node = mock('node')
     fake_node.expects(:count_nodes).returns(1)
@@ -196,7 +196,7 @@ class NewRelic::Agent::Transaction::TraceNodeTest < Minitest::Test
   end
 
   def test_key_equals
-    s = NewRelic::Agent::Transaction::TraceNode.new('Custom/test/metric', Time.now)
+    s = NewRelic::Agent::Transaction::TraceNode.new('Custom/test/metric', Process.clock_gettime(Process::CLOCK_REALTIME))
     # doing this to hold the reference to the hash
     params = {}
     s.params = params
@@ -209,13 +209,13 @@ class NewRelic::Agent::Transaction::TraceNodeTest < Minitest::Test
   end
 
   def test_key
-    s = NewRelic::Agent::Transaction::TraceNode.new('Custom/test/metric', Time.now)
+    s = NewRelic::Agent::Transaction::TraceNode.new('Custom/test/metric', Process.clock_gettime(Process::CLOCK_REALTIME))
     s.params = {:foo => 'correct'}
     assert_equal('correct', s[:foo])
   end
 
   def test_params
-    s = NewRelic::Agent::Transaction::TraceNode.new('Custom/test/metric', Time.now)
+    s = NewRelic::Agent::Transaction::TraceNode.new('Custom/test/metric', Process.clock_gettime(Process::CLOCK_REALTIME))
 
     assert_equal({}, s.params)
 
@@ -225,7 +225,7 @@ class NewRelic::Agent::Transaction::TraceNodeTest < Minitest::Test
   end
 
   def test_each_node_default
-    s = NewRelic::Agent::Transaction::TraceNode.new('Custom/test/metric', Time.now)
+    s = NewRelic::Agent::Transaction::TraceNode.new('Custom/test/metric', Process.clock_gettime(Process::CLOCK_REALTIME))
     # in the base case it just yields the block to itself
     count = 0
     s.each_node do |x|
@@ -237,7 +237,7 @@ class NewRelic::Agent::Transaction::TraceNodeTest < Minitest::Test
   end
 
   def test_each_node_with_children
-    s = NewRelic::Agent::Transaction::TraceNode.new('Custom/test/metric', Time.now)
+    s = NewRelic::Agent::Transaction::TraceNode.new('Custom/test/metric', Process.clock_gettime(Process::CLOCK_REALTIME))
 
     fake_node = mock('node')
     fake_node.expects(:each_node).yields(fake_node)
@@ -253,7 +253,7 @@ class NewRelic::Agent::Transaction::TraceNodeTest < Minitest::Test
   end
 
   def test_each_node_with_nest_tracking
-    s = NewRelic::Agent::Transaction::TraceNode.new('Custom/test/metric', Time.now)
+    s = NewRelic::Agent::Transaction::TraceNode.new('Custom/test/metric', Process.clock_gettime(Process::CLOCK_REALTIME))
 
     summary = mock('summary')
     summary.expects(:current_nest_count).twice.returns(0).then.returns(1)
@@ -264,7 +264,7 @@ class NewRelic::Agent::Transaction::TraceNodeTest < Minitest::Test
   end
 
   def test_explain_sql_raising_an_error
-    s = NewRelic::Agent::Transaction::TraceNode.new('Custom/test/metric', Time.now)
+    s = NewRelic::Agent::Transaction::TraceNode.new('Custom/test/metric', Process.clock_gettime(Process::CLOCK_REALTIME))
     config = { :adapter => 'mysql' }
     statement = NewRelic::Agent::Database::Statement.new('SELECT')
     statement.config = config
@@ -276,13 +276,13 @@ class NewRelic::Agent::Transaction::TraceNodeTest < Minitest::Test
 
   def test_explain_sql_can_handle_missing_config
     # If TT node came over from Resque child, might not be a Statement
-    s = NewRelic::Agent::Transaction::TraceNode.new('Custom/test/metric', Time.now)
+    s = NewRelic::Agent::Transaction::TraceNode.new('Custom/test/metric', Process.clock_gettime(Process::CLOCK_REALTIME))
     s.params = { :sql => "SELECT * FROM galaxy" }
     s.explain_sql
   end
 
   def test_explain_sql_can_use_already_existing_plan
-    s = NewRelic::Agent::Transaction::TraceNode.new('Custom/test/metric', Time.now)
+    s = NewRelic::Agent::Transaction::TraceNode.new('Custom/test/metric', Process.clock_gettime(Process::CLOCK_REALTIME))
     s.params = {
       :sql => "SELECT * FROM galaxy",
       :explain_plan => "EXPLAIN IT!"
@@ -292,7 +292,7 @@ class NewRelic::Agent::Transaction::TraceNodeTest < Minitest::Test
   end
 
   def test_params_equal
-    s = NewRelic::Agent::Transaction::TraceNode.new('Custom/test/metric', Time.now)
+    s = NewRelic::Agent::Transaction::TraceNode.new('Custom/test/metric', Process.clock_gettime(Process::CLOCK_REALTIME))
 
     params = {:foo => 'correct'}
 
@@ -302,20 +302,20 @@ class NewRelic::Agent::Transaction::TraceNodeTest < Minitest::Test
 
   def test_obfuscated_sql
     sql = 'select * from table where id = 1'
-    s = NewRelic::Agent::Transaction::TraceNode.new('Custom/test/metric', Time.now)
+    s = NewRelic::Agent::Transaction::TraceNode.new('Custom/test/metric', Process.clock_gettime(Process::CLOCK_REALTIME))
     s[:sql] = NewRelic::Agent::Database::Statement.new(sql)
     assert_equal('select * from table where id = ?', s.obfuscated_sql)
   end
 
   def test_children_equals
-    s = NewRelic::Agent::Transaction::TraceNode.new('Custom/test/metric', Time.now)
+    s = NewRelic::Agent::Transaction::TraceNode.new('Custom/test/metric', Process.clock_gettime(Process::CLOCK_REALTIME))
     assert_nil(s.instance_eval { @children })
     s.children = [1, 2, 3]
     assert_equal([1, 2, 3], s.instance_eval { @children })
   end
 
   def test_parent_node_equals
-    s = NewRelic::Agent::Transaction::TraceNode.new('Custom/test/metric', Time.now)
+    s = NewRelic::Agent::Transaction::TraceNode.new('Custom/test/metric', Process.clock_gettime(Process::CLOCK_REALTIME))
     assert_nil(s.parent_node)
     fake_node = mock('node')
     s.send(:parent_node=, fake_node)

--- a/test/new_relic/agent/transaction/trace_test.rb
+++ b/test/new_relic/agent/transaction/trace_test.rb
@@ -8,8 +8,8 @@ require 'new_relic/agent/database'
 
 class NewRelic::Agent::Transaction::TraceTest < Minitest::Test
   def setup
-    nr_freeze_time
-    @start_time = Time.now
+    nr_freeze_process_time
+    @start_time = Process.clock_gettime(Process::CLOCK_REALTIME)
     @trace = NewRelic::Agent::Transaction::Trace.new(@start_time)
     @trace.root_node.end_trace(@start_time)
 
@@ -314,7 +314,7 @@ class NewRelic::Agent::Transaction::TraceTest < Minitest::Test
   end
 
   def test_trace_tree_includes_start_time
-    assert_trace_tree_contains(:start_time, @start_time.to_f)
+    assert_trace_tree_contains(:start_time, @start_time)
   end
 
   def test_trace_tree_includes_unused_legacy_request_params

--- a/test/new_relic/agent/transaction_error_primitive_test.rb
+++ b/test/new_relic/agent/transaction_error_primitive_test.rb
@@ -107,7 +107,7 @@ module NewRelic
         {
           :name => "Controller/blogs/index",
           :type => :controller,
-          :start_timestamp => Time.now.to_f,
+          :start_timestamp => Process.clock_gettime(Process::CLOCK_REALTIME),
           :duration => 0.1
         }.update(options)
       end

--- a/test/new_relic/agent/transaction_error_primitive_test.rb
+++ b/test/new_relic/agent/transaction_error_primitive_test.rb
@@ -12,7 +12,7 @@ module NewRelic
   module Agent
     class TransactionErrorPrimitiveTest < Minitest::Test
       def setup
-        nr_freeze_time
+        nr_freeze_process_time
         @span_id = NewRelic::Agent::GuidGenerator.generate_guid
       end
 
@@ -21,7 +21,7 @@ module NewRelic
         intrinsics, *_ = create_event
 
         assert_equal 'TransactionError', intrinsics['type']
-        assert_in_delta Time.now.to_f, intrinsics['timestamp'], 0.001
+        assert_in_delta Process.clock_gettime(Process::CLOCK_REALTIME), intrinsics['timestamp'], 0.001
         assert_equal "RuntimeError", intrinsics['error.class']
         assert_equal "Big Controller!", intrinsics['error.message']
         refute intrinsics['error.expected']

--- a/test/new_relic/agent/transaction_event_aggregator_test.rb
+++ b/test/new_relic/agent/transaction_event_aggregator_test.rb
@@ -93,7 +93,7 @@ module NewRelic
         {
           :name => name,
           :type => :controller,
-          :start_timestamp => options[:timestamp] || Time.now.to_f,
+          :start_timestamp => options[:timestamp] || Process.clock_gettime(Process::CLOCK_REALTIME),
           :duration => 0.1,
           :attributes => attributes,
           :error => false,

--- a/test/new_relic/agent/transaction_event_aggregator_test.rb
+++ b/test/new_relic/agent/transaction_event_aggregator_test.rb
@@ -15,7 +15,7 @@ module NewRelic
     class TransactionEventAggregatorTest < Minitest::Test
 
       def setup
-        nr_freeze_time
+        nr_freeze_process_time
         events = NewRelic::Agent.instance.events
         @event_aggregator = TransactionEventAggregator.new events
 

--- a/test/new_relic/agent/transaction_event_primitive_test.rb
+++ b/test/new_relic/agent/transaction_event_primitive_test.rb
@@ -18,7 +18,7 @@ module NewRelic
         intrinsics, *_ = TransactionEventPrimitive.create generate_payload
 
         assert_equal "Transaction", intrinsics['type']
-        assert_in_delta Time.now.to_f, intrinsics['timestamp'], 0.001
+        assert_in_delta Process.clock_gettime(Process::CLOCK_REALTIME), intrinsics['timestamp'], 0.001
         assert_equal "Controller/whatever", intrinsics['name']
         assert_equal false, intrinsics['error']
         assert_equal 0.1, intrinsics['duration']
@@ -177,7 +177,7 @@ module NewRelic
         {
           :name => "Controller/#{name}",
           :type => :controller,
-          :start_timestamp => options[:timestamp] || Time.now.to_f,
+          :start_timestamp => options[:timestamp] || Process.clock_gettime(Process::CLOCK_REALTIME),
           :duration => 0.1,
           :attributes => attributes,
           :error => false,

--- a/test/new_relic/agent/transaction_event_primitive_test.rb
+++ b/test/new_relic/agent/transaction_event_primitive_test.rb
@@ -11,7 +11,7 @@ module NewRelic
   module Agent
     class TransactionEventPrimitiveTest < Minitest::Test
       def setup
-        nr_freeze_time
+        nr_freeze_process_time
       end
 
       def test_creates_intrinsics

--- a/test/new_relic/agent/transaction_event_recorder_test.rb
+++ b/test/new_relic/agent/transaction_event_recorder_test.rb
@@ -76,7 +76,7 @@ module NewRelic
         payload = {
           :name => "Controller/#{name}",
           :type => :controller,
-          :start_timestamp => options[:timestamp] || Time.now.to_f,
+          :start_timestamp => options[:timestamp] || Process.clock_gettime(Process::CLOCK_REALTIME),
           :duration => 0.1,
           :attributes => attributes,
           :error => false,

--- a/test/new_relic/agent/transaction_sampler_test.rb
+++ b/test/new_relic/agent/transaction_sampler_test.rb
@@ -281,7 +281,7 @@ module NewRelic::Agent
         assert((new_slowest != slowest), "Should not harvest the same trace since the new one should be slower")
         assert_equal(new_slowest.duration.round, 10, "Slowest duration must be = 10, but was: #{new_slowest.duration.inspect}")
       end
-      nr_unfreeze_time
+      nr_unfreeze_process_time
     end
 
     def test_harvest_prepare_samples

--- a/test/new_relic/agent/transaction_sampler_test.rb
+++ b/test/new_relic/agent/transaction_sampler_test.rb
@@ -436,7 +436,7 @@ module NewRelic::Agent
     end
 
     def run_long_sample_trace(n)
-      @sampler.on_start_transaction(@state, Process.clock_gettime(Process::CLOCK_REALTIME))
+      @sampler.on_start_transaction(@state)
       n.times do |i|
         @sampler.notice_push_frame(@state)
         yield if block_given?
@@ -445,8 +445,8 @@ module NewRelic::Agent
       @sampler.on_finishing_transaction(@state, @txn)
     end
 
-    def run_sample_trace(start = Process.clock_gettime(Process::CLOCK_REALTIME), stop = nil, state = @state)
-      @sampler.on_start_transaction(state, start)
+    def run_sample_trace(state = @state)
+      @sampler.on_start_transaction(state)
       @sampler.notice_push_frame(state)
       @sampler.notice_sql("SELECT * FROM sandwiches WHERE bread = 'wheat'", {}, 0, state)
       @sampler.notice_push_frame(state)

--- a/test/new_relic/agent/transaction_test.rb
+++ b/test/new_relic/agent/transaction_test.rb
@@ -793,8 +793,8 @@ module NewRelic::Agent
     end
 
     def make_transport_duration_timestamps duration
-      transaction_start = Process.clock_gettime(Process::CLOCK_REALTIME)
-      parent_timestamp = ((transaction_start - duration) * 1000).round
+      transaction_start = Process.clock_gettime(Process::CLOCK_REALTIME, :millisecond)
+      parent_timestamp = transaction_start - duration
 
       return parent_timestamp, transaction_start
     end

--- a/test/new_relic/agent/transaction_test.rb
+++ b/test/new_relic/agent/transaction_test.rb
@@ -3,7 +3,7 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 
 require File.expand_path(File.join(File.dirname(__FILE__),'..','..','test_helper'))
-
+require 'pry'
 module NewRelic::Agent
 
   class TransactionTest < Minitest::Test
@@ -793,8 +793,8 @@ module NewRelic::Agent
     end
 
     def make_transport_duration_timestamps duration
-      transaction_start = Process.clock_gettime(Process::CLOCK_REALTIME, :millisecond)
-      parent_timestamp = transaction_start - duration
+      transaction_start = Process.clock_gettime(Process::CLOCK_REALTIME)
+      parent_timestamp = (transaction_start - duration) * 1000
 
       return parent_timestamp, transaction_start
     end

--- a/test/new_relic/agent/transaction_test.rb
+++ b/test/new_relic/agent/transaction_test.rb
@@ -152,21 +152,21 @@ module NewRelic::Agent
     }
 
     def test_update_apdex_records_correct_apdex_for_key_transaction
-      nr_freeze_time
+      nr_freeze_process_time
       with_config(KEY_TRANSACTION_CONFIG) do
         # apdex_s
         in_web_transaction('Controller/slow/txn') do
-          advance_time(3.5)
+          advance_process_time(3.5)
         end
 
         # apdex_t
         in_web_transaction('Controller/slow/txn') do
-          advance_time(5.5)
+          advance_process_time(5.5)
         end
 
         # adpex_f
         in_web_transaction('Controller/slow/txn') do
-          advance_time(16.5)
+          advance_process_time(16.5)
         end
 
         assert_metrics_recorded(
@@ -178,22 +178,22 @@ module NewRelic::Agent
     end
 
     def test_update_apdex_records_correct_apdex_for_non_key_transaction
-      nr_freeze_time
-      advance_time(1.0)
+      nr_freeze_process_time
+      advance_process_time(1.0)
       with_config(KEY_TRANSACTION_CONFIG) do
         # apdex_s
         in_web_transaction('Controller/other/txn') do
-          advance_time(0.5)
+          advance_process_time(0.5)
         end
 
         # apdex_t
         in_web_transaction('Controller/other/txn') do
-          advance_time(2.0)
+          advance_process_time(2.0)
         end
 
         # apdex_f
         in_web_transaction('Controller/other/txn') do
-          advance_time(5.0)
+          advance_process_time(5.0)
         end
 
         assert_metrics_recorded(
@@ -205,21 +205,21 @@ module NewRelic::Agent
     end
 
     def test_update_apdex_records_for_background_key_transaction
-      nr_freeze_time
+      nr_freeze_process_time
       with_config(KEY_TRANSACTION_CONFIG) do
         # apdex_s
         in_background_transaction('OtherTransaction/back/ground') do
-          advance_time(7.5)
+          advance_process_time(7.5)
         end
 
         # apdex_t
         in_background_transaction('OtherTransaction/back/ground') do
-          advance_time(9.5)
+          advance_process_time(9.5)
         end
 
         # apdex_f
         in_background_transaction('OtherTransaction/back/ground') do
-          advance_time(32.5)
+          advance_process_time(32.5)
         end
 
         assert_metrics_recorded(
@@ -231,18 +231,18 @@ module NewRelic::Agent
     end
 
     def test_skips_apdex_records_for_background_non_key_transaction
-      nr_freeze_time
+      nr_freeze_process_time
       with_config(KEY_TRANSACTION_CONFIG) do
         in_background_transaction('OtherTransaction/other/task') do
-          advance_time(7.5)
+          advance_process_time(7.5)
         end
 
         in_background_transaction('OtherTransaction/other/task') do
-          advance_time(9.5)
+          advance_process_time(9.5)
         end
 
         in_background_transaction('OtherTransaction/other/task') do
-          advance_time(32.5)
+          advance_process_time(32.5)
         end
 
         refute_metrics_recorded(['ApdexOther', 'ApdexOther/Transaction/other/task'])
@@ -264,36 +264,36 @@ module NewRelic::Agent
     end
 
     def test_records_apdex_all_for_both_transaction_types
-      nr_freeze_time
+      nr_freeze_process_time
       with_config(KEY_TRANSACTION_CONFIG) do
         # apdex_s
         in_background_transaction('OtherTransaction/back/ground') do
-          advance_time(7.5)
+          advance_process_time(7.5)
         end
 
         # apdex_t
         in_background_transaction('OtherTransaction/back/ground') do
-          advance_time(9.5)
+          advance_process_time(9.5)
         end
 
         # apdex_f
         in_background_transaction('OtherTransaction/back/ground') do
-          advance_time(32.5)
+          advance_process_time(32.5)
         end
 
         # apdex_s
         in_web_transaction('Controller/slow/txn') do
-          advance_time(3.5)
+          advance_process_time(3.5)
         end
 
         # apdex_t
         in_web_transaction('Controller/slow/txn') do
-          advance_time(5.5)
+          advance_process_time(5.5)
         end
 
         # apdex_f
         in_web_transaction('Controller/slow/txn') do
-          advance_time(16.5)
+          advance_process_time(16.5)
         end
 
         assert_metrics_recorded(
@@ -394,9 +394,9 @@ module NewRelic::Agent
         duration = payload[:duration]
       end
 
-      start_time = nr_freeze_time
+      start_time = nr_freeze_process_time
       in_web_transaction('Controller/foo/1/bar/22') do
-        advance_time(5)
+        advance_process_time(5)
         Transaction.tl_current.freeze_name_and_execute_if_not_ignored
       end
 
@@ -406,7 +406,7 @@ module NewRelic::Agent
     end
 
     def test_end_fires_a_transaction_finished_event_with_overview_metrics
-      nr_freeze_time
+      nr_freeze_process_time
       options = nil
       NewRelic::Agent.subscribe(:transaction_finished) do |payload|
         options = payload[:metrics]
@@ -510,16 +510,16 @@ module NewRelic::Agent
         apdex = payload[:apdex_perf_zone]
       end
 
-      nr_freeze_time
+      nr_freeze_process_time
 
       with_config(:apdex_t => 1.0) do
-        in_web_transaction { advance_time 0.5 }
+        in_web_transaction { advance_process_time 0.5 }
         assert_equal('S', apdex)
 
-        in_web_transaction { advance_time 1.5 }
+        in_web_transaction { advance_process_time 1.5 }
         assert_equal('T', apdex)
 
-        in_web_transaction { advance_time 4.5 }
+        in_web_transaction { advance_process_time 4.5 }
         assert_equal('F', apdex)
       end
     end
@@ -530,10 +530,10 @@ module NewRelic::Agent
         apdex = payload[:apdex_perf_zone]
       end
 
-      nr_freeze_time
+      nr_freeze_process_time
 
       with_config(:apdex_t => 1.0) do
-        in_background_transaction { advance_time 0.5 }
+        in_background_transaction { advance_process_time 0.5 }
         assert_nil apdex
       end
     end
@@ -544,19 +544,19 @@ module NewRelic::Agent
         apdex = payload[:apdex_perf_zone]
       end
 
-      nr_freeze_time
+      nr_freeze_process_time
 
       txn_name = 'OtherTransaction/back/ground'
       key_transactions = { txn_name => 1.0 }
 
       with_config(:apdex_t => 1.0, :web_transactions_apdex => key_transactions) do
-        in_background_transaction(txn_name) { advance_time 0.5 }
+        in_background_transaction(txn_name) { advance_process_time 0.5 }
         assert_equal('S', apdex)
 
-        in_background_transaction(txn_name) { advance_time 1.5 }
+        in_background_transaction(txn_name) { advance_process_time 1.5 }
         assert_equal('T', apdex)
 
-        in_background_transaction(txn_name) { advance_time 4.5 }
+        in_background_transaction(txn_name) { advance_process_time 4.5 }
         assert_equal('F', apdex)
       end
     end
@@ -598,10 +598,10 @@ module NewRelic::Agent
         keys = payload.keys
       end
 
-      nr_freeze_time
+      nr_freeze_process_time
 
       in_transaction do |txn|
-        advance_time(10)
+        advance_process_time(10)
 
         txn.distributed_tracer.is_cross_app_caller = false
       end
@@ -774,7 +774,7 @@ module NewRelic::Agent
 
     def test_transport_duration_returned_in_seconds_when_positive
       duration = 2.0
-      parent_timestamp, txn_start = make_transport_duration_timestamps duration
+      parent_timestamp, txn_start = make_transport_duration_timestamps(duration)
       txn = in_transaction { |t| t.start_time = txn_start }
       payload = stub(timestamp: parent_timestamp)
 
@@ -785,7 +785,7 @@ module NewRelic::Agent
 
     def test_transport_duration_zero_with_clock_skew
       duration = -1.0
-      parent_timestamp, txn_start = make_transport_duration_timestamps duration
+      parent_timestamp, txn_start = make_transport_duration_timestamps(duration)
       txn = in_transaction { |t| t.start_time = txn_start }
       payload = stub(timestamp: parent_timestamp)
 
@@ -793,8 +793,8 @@ module NewRelic::Agent
     end
 
     def make_transport_duration_timestamps duration
-      transaction_start = Time.now()
-      parent_timestamp = ((transaction_start.to_f - duration) * 1000).round
+      transaction_start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      parent_timestamp = ((transaction_start - duration) * 1000).round
 
       return parent_timestamp, transaction_start
     end
@@ -1185,8 +1185,8 @@ module NewRelic::Agent
     end
 
     def test_doesnt_record_scoped_queue_time_metric
-      t0 = nr_freeze_time
-      advance_time 10.0
+      t0 = nr_freeze_process_time
+      advance_process_time 10.0
       in_transaction('boo', :apdex_start_time => t0) do
         # nothing
       end
@@ -1197,8 +1197,8 @@ module NewRelic::Agent
     end
 
     def test_doesnt_record_crazy_high_queue_times
-      t0 = nr_freeze_time(Time.at(10.0))
-      advance_time(40 * 365 * 24 * 60 * 60) # 40 years
+      t0 = nr_freeze_process_time(Time.at(10.0))
+      advance_process_time(40 * 365 * 24 * 60 * 60) # 40 years
       in_transaction('boo', :apdex_start_time => t0) do
         # nothing
       end

--- a/test/new_relic/agent/transaction_test.rb
+++ b/test/new_relic/agent/transaction_test.rb
@@ -1259,47 +1259,6 @@ module NewRelic::Agent
       assert_equal(value, attributes_for(txn, :custom)[key])
     end
 
-    def test_wrap_transaction
-      state = Tracer.state
-      Transaction.wrap(state, 'test', :other) do
-        # No-op
-      end
-
-      assert_metrics_recorded(['test'])
-    end
-
-    def test_wrap_transaction_with_early_failure
-      yielded = false
-      state = Tracer.state
-      Transaction.any_instance.stubs(:start).raises("Boom")
-      Transaction.wrap(state, 'test', :other) do
-        yielded = true
-      end
-
-      assert yielded
-    end
-
-    def test_wrap_transaction_with_late_failure
-      state = Tracer.state
-      Transaction.any_instance.stubs(:commit!).raises("Boom")
-      Transaction.wrap(state, 'test', :other) do
-        # No-op
-      end
-
-      refute_metrics_recorded(['test'])
-    end
-
-    def test_wrap_transaction_notices_errors
-      state = Tracer.state
-      assert_raises RuntimeError do
-        Transaction.wrap(state, 'test', :other) do
-          raise "O_o"
-        end
-      end
-
-      assert_metrics_recorded(["Errors/all"])
-    end
-
     def test_instrumentation_state
       in_transaction do |txn|
         txn.instrumentation_state[:a] = 42

--- a/test/new_relic/agent/transaction_test.rb
+++ b/test/new_relic/agent/transaction_test.rb
@@ -401,7 +401,7 @@ module NewRelic::Agent
       end
 
       assert_equal 'Controller/foo/1/bar/22', name
-      assert_equal start_time.to_f, timestamp
+      assert_equal start_time, timestamp
       assert_equal 5.0, duration
     end
 

--- a/test/new_relic/agent/transaction_test.rb
+++ b/test/new_relic/agent/transaction_test.rb
@@ -394,7 +394,7 @@ module NewRelic::Agent
         duration = payload[:duration]
       end
 
-      start_time = nr_freeze_process_time
+      start_time = nr_freeze_process_time(Process.clock_gettime(Process::CLOCK_REALTIME))
       in_web_transaction('Controller/foo/1/bar/22') do
         advance_process_time(5)
         Transaction.tl_current.freeze_name_and_execute_if_not_ignored
@@ -793,7 +793,7 @@ module NewRelic::Agent
     end
 
     def make_transport_duration_timestamps duration
-      transaction_start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      transaction_start = Process.clock_gettime(Process::CLOCK_REALTIME)
       parent_timestamp = ((transaction_start - duration) * 1000).round
 
       return parent_timestamp, transaction_start

--- a/test/new_relic/agent/vm/snapshot_test.rb
+++ b/test/new_relic/agent/vm/snapshot_test.rb
@@ -6,8 +6,8 @@ require 'new_relic/agent/vm/snapshot'
 
 class NewRelic::Agent::VM::SnapshotTestCase < Minitest::Test
   def test_records_taken_at_on_initialization
-    t = nr_freeze_time
+    t = nr_freeze_process_time
     snap = NewRelic::Agent::VM::Snapshot.new
-    assert_equal(t.to_f, snap.taken_at)
+    assert_equal(t, snap.taken_at)
   end
 end

--- a/test/new_relic/agent/worker_loop_test.rb
+++ b/test/new_relic/agent/worker_loop_test.rb
@@ -42,13 +42,12 @@ class NewRelic::Agent::WorkerLoopTest < Minitest::Test
     assert !worker_loop.instance_variable_get(:@deadline).nil?
   end
 
-  # TODO: INFINITE LOOP
-  # def test_loop_limit
-  #   worker_loop = NewRelic::Agent::WorkerLoop.new(:limit => 2)
-  #   iterations = 0
-  #   worker_loop.run(0) { iterations += 1 }
-  #   assert_equal 2, iterations
-  # end
+  def test_loop_limit
+    worker_loop = NewRelic::Agent::WorkerLoop.new(:limit => 2)
+    iterations = 0
+    worker_loop.run(0) { iterations += 1 }
+    assert_equal 2, iterations
+  end
 
   def test_task_error__standard
     expects_logging(:error, any_parameters)
@@ -83,14 +82,13 @@ class NewRelic::Agent::WorkerLoopTest < Minitest::Test
     end
   end
 
-  # TODO: INTERMITTENT FAILURE
-  # def test_dynamically_adjusts_the_period_once_the_loop_has_been_started
-  #   nr_freeze_process_time
+  def test_dynamically_adjusts_the_period_once_the_loop_has_been_started
+    nr_freeze_process_time
 
-  #   worker_loop = NewRelic::Agent::WorkerLoop.new(:limit => 2)
+    worker_loop = NewRelic::Agent::WorkerLoop.new(:limit => 2)
 
-  #   worker_loop.expects(:sleep).with(5.0)
-  #   worker_loop.expects(:sleep).with(7.0)
-  #   worker_loop.run(5.0) { advance_process_time(5.0); worker_loop.period = 7.0 }
-  # end
+    worker_loop.expects(:sleep).with(5.0)
+    worker_loop.expects(:sleep).with(7.0)
+    worker_loop.run(5.0) { advance_process_time(5.0); worker_loop.period = 7.0 }
+  end
 end

--- a/test/new_relic/agent/worker_loop_test.rb
+++ b/test/new_relic/agent/worker_loop_test.rb
@@ -19,13 +19,13 @@ class NewRelic::Agent::WorkerLoopTest < Minitest::Test
   end
 
   def test_with_duration
-    nr_freeze_time
+    nr_freeze_process_time
 
     period = 5.0
     worker_loop = NewRelic::Agent::WorkerLoop.new(:duration => 16.0)
 
     def worker_loop.sleep(duration)
-      advance_time(duration)
+      advance_process_time(duration)
     end
 
     count = 0
@@ -85,12 +85,12 @@ class NewRelic::Agent::WorkerLoopTest < Minitest::Test
 
   # TODO: INTERMITTENT FAILURE
   # def test_dynamically_adjusts_the_period_once_the_loop_has_been_started
-  #   nr_freeze_time
+  #   nr_freeze_process_time
 
   #   worker_loop = NewRelic::Agent::WorkerLoop.new(:limit => 2)
 
   #   worker_loop.expects(:sleep).with(5.0)
   #   worker_loop.expects(:sleep).with(7.0)
-  #   worker_loop.run(5.0) { advance_time(5.0); worker_loop.period = 7.0 }
+  #   worker_loop.run(5.0) { advance_process_time(5.0); worker_loop.period = 7.0 }
   # end
 end

--- a/test/new_relic/agent/worker_loop_test.rb
+++ b/test/new_relic/agent/worker_loop_test.rb
@@ -42,12 +42,13 @@ class NewRelic::Agent::WorkerLoopTest < Minitest::Test
     assert !worker_loop.instance_variable_get(:@deadline).nil?
   end
 
-  def test_loop_limit
-    worker_loop = NewRelic::Agent::WorkerLoop.new(:limit => 2)
-    iterations = 0
-    worker_loop.run(0) { iterations += 1 }
-    assert_equal 2, iterations
-  end
+  # TODO: INFINITE LOOP
+  # def test_loop_limit
+  #   worker_loop = NewRelic::Agent::WorkerLoop.new(:limit => 2)
+  #   iterations = 0
+  #   worker_loop.run(0) { iterations += 1 }
+  #   assert_equal 2, iterations
+  # end
 
   def test_task_error__standard
     expects_logging(:error, any_parameters)
@@ -82,17 +83,14 @@ class NewRelic::Agent::WorkerLoopTest < Minitest::Test
     end
   end
 
-  def test_dynamically_adjusts_the_period_once_the_loop_has_been_started
-    nr_freeze_time
+  # TODO: INTERMITTENT FAILURE
+  # def test_dynamically_adjusts_the_period_once_the_loop_has_been_started
+  #   nr_freeze_time
 
-    worker_loop = NewRelic::Agent::WorkerLoop.new(:limit => 2)
+  #   worker_loop = NewRelic::Agent::WorkerLoop.new(:limit => 2)
 
-    worker_loop.expects(:sleep).with(5.0)
-    worker_loop.expects(:sleep).with(7.0)
-    worker_loop.run(5.0) { advance_time(5.0); worker_loop.period = 7.0 }
-  end
-
-  def ticks(start, finish, step)
-    (start..finish).step(step).map{|i| Time.at(i)}
-  end
+  #   worker_loop.expects(:sleep).with(5.0)
+  #   worker_loop.expects(:sleep).with(7.0)
+  #   worker_loop.run(5.0) { advance_time(5.0); worker_loop.period = 7.0 }
+  # end
 end

--- a/test/new_relic/marshalling_test_cases.rb
+++ b/test/new_relic/marshalling_test_cases.rb
@@ -46,7 +46,7 @@ module MarshallingTestCases
   end
 
   def test_sends_transaction_events
-    t0 = nr_freeze_time(Time.at(Time.now.to_i))
+    t0 = nr_freeze_process_time
 
     with_around_hook do
       Transactioner.new.do_it
@@ -113,7 +113,7 @@ module MarshallingTestCases
   end
 
   def test_sends_error_events
-    t0 = nr_freeze_time(Time.at(Time.now.to_i))
+    t0 = nr_freeze_process_time
 
     span_id = nil
     with_around_hook do
@@ -146,7 +146,7 @@ module MarshallingTestCases
     assert_equal event[0]["duration"], 0.0
     assert event[0]["spanId"] != nil
     assert_equal event[0].size, 8
-    
+
     assert_equal event[1], {}
     assert_equal event[2], {}
 

--- a/test/new_relic/marshalling_test_cases.rb
+++ b/test/new_relic/marshalling_test_cases.rb
@@ -82,7 +82,7 @@ module MarshallingTestCases
   end
 
   def test_sends_custom_events
-    t0 = nr_freeze_time
+    t0 = nr_freeze_process_time
 
     with_around_hook do
       NewRelic::Agent.record_custom_event("CustomEventType", :foo => 'bar', :baz => 'qux')

--- a/test/new_relic/multiverse_helpers.rb
+++ b/test/new_relic/multiverse_helpers.rb
@@ -7,6 +7,7 @@ require File.expand_path(File.join(File.dirname(__FILE__), "..", "agent_helper")
 class Minitest::Test
   def after_teardown
     nr_unfreeze_time
+    nr_unfreeze_process_time
     super
   end
 end

--- a/test/new_relic/noticed_error_test.rb
+++ b/test/new_relic/noticed_error_test.rb
@@ -13,8 +13,8 @@ class NewRelic::Agent::NoticedErrorTest < Minitest::Test
   def setup
     @path = 'foo/bar/baz'
 
-    nr_freeze_time
-    @time = Time.now
+    nr_freeze_process_time
+    @time = Process.clock_gettime(Process::CLOCK_REALTIME)
 
     @attributes = NewRelic::Agent::Attributes.new(NewRelic::Agent.instance.attribute_filter)
     @attributes_from_notice_error = { :user => 'params' }

--- a/test/new_relic/rack/browser_monitoring_test.rb
+++ b/test/new_relic/rack/browser_monitoring_test.rb
@@ -35,7 +35,7 @@ class BrowserMonitoringTest < Minitest::Test
     end
 
     def call(env)
-      advance_time(0.1)
+      advance_process_time(0.1)
       @@doc ||= <<-EOL
 <html>
   <head>
@@ -61,7 +61,7 @@ EOL
 
   def setup
     super
-    nr_freeze_time
+    nr_freeze_process_time
 
     @config = {
       :application_id => 5,

--- a/test/performance/lib/performance/baseline_compare_reporter.rb
+++ b/test/performance/lib/performance/baseline_compare_reporter.rb
@@ -82,8 +82,8 @@ module Performance
           retained_delta  = retained_after - retained_before
           retained_percent = retained_delta.to_f / retained_before * 100
         end
-        retained_percent = 0.0 if retained_percent.nan?
-        
+        retained_percent = 0.0 if (retained_percent.to_f).nan?
+
         rows << [
           identifier,
           old_result.time_per_iteration,

--- a/test/performance/lib/performance/result.rb
+++ b/test/performance/lib/performance/result.rb
@@ -56,7 +56,7 @@ module Performance
     end
 
     def format_timestamp(t)
-      t.utc.iso8601
+      Time.at(t).utc.iso8601
     end
 
     def ips

--- a/test/performance/lib/performance/runner.rb
+++ b/test/performance/lib/performance/runner.rb
@@ -205,9 +205,9 @@ module Performance
     end
 
     def run_and_report
-      t0 = Time.now
+      t0 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       results = run_all_test_cases
-      report_results(results, Time.now - t0)
+      report_results(results, Process.clock_gettime(Processs::CLOCK_MONOTONIC) - t0)
     end
 
     def list_test_cases

--- a/test/performance/lib/performance/runner.rb
+++ b/test/performance/lib/performance/runner.rb
@@ -205,9 +205,9 @@ module Performance
     end
 
     def run_and_report
-      t0 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      t0 = Time.now
       results = run_all_test_cases
-      report_results(results, Process.clock_gettime(Processs::CLOCK_MONOTONIC) - t0)
+      report_results(results, Time.now - t0)
     end
 
     def list_test_cases

--- a/test/performance/lib/performance/timer.rb
+++ b/test/performance/lib/performance/timer.rb
@@ -13,7 +13,7 @@ module Performance
       @most_recent_start = nil
     end
 
-    def start(t=Time.now)
+    def start(t=Process.clock_gettime(Process::CLOCK_MONOTONIC))
       @start_timestamp ||= t
       @most_recent_start = t
     end
@@ -22,7 +22,7 @@ module Performance
       !!@stop_timestamp
     end
 
-    def stop(t=Time.now)
+    def stop(t=Process.clock_gettime(Process::CLOCK_MONOTONIC))
       @stop_timestamp = t
       @elapsed += t - @most_recent_start
     end

--- a/test/performance/lib/performance/timer.rb
+++ b/test/performance/lib/performance/timer.rb
@@ -13,7 +13,7 @@ module Performance
       @most_recent_start = nil
     end
 
-    def start(t=Process.clock_gettime(Process::CLOCK_MONOTONIC))
+    def start(t=Process.clock_gettime(Process::CLOCK_REALTIME))
       @start_timestamp ||= t
       @most_recent_start = t
     end
@@ -22,7 +22,7 @@ module Performance
       !!@stop_timestamp
     end
 
-    def stop(t=Process.clock_gettime(Process::CLOCK_MONOTONIC))
+    def stop(t=Process.clock_gettime(Process::CLOCK_REALTIME))
       @stop_timestamp = t
       @elapsed += t - @most_recent_start
     end

--- a/test/performance/suites/active_record_subscriber.rb
+++ b/test/performance/suites/active_record_subscriber.rb
@@ -94,7 +94,7 @@ class ActiveRecordSubscriberTest < Performance::TestCase
 
   def simulate_query(duration=nil)
     @subscriber.start(EVENT_NAME, :id, @params)
-    advance_time(duration) if duration
+    advance_process_time(duration) if duration
     @subscriber.finish(EVENT_NAME, :id, @params)
   end
 end

--- a/test/performance/suites/marshalling.rb
+++ b/test/performance/suites/marshalling.rb
@@ -129,7 +129,7 @@ class Marshalling < Performance::TestCase
     events = []
     1000.times do
       event = {
-        'timestamp'        => Time.now.to_f,
+        'timestamp'        => Process.clock_gettime(Process::CLOCK_REALTIME),
         'name'             => "Controller/foo/bar",
         'type'             => "Transaction",
         'duration'         => rand,

--- a/test/performance/suites/thread_profiling.rb
+++ b/test/performance/suites/thread_profiling.rb
@@ -83,13 +83,13 @@ class ThreadProfiling < Performance::TestCase
   def test_gather_backtraces_subscribed
     @service.subscribe('eagle')
     measure do
-      t0 = Time.now.to_f
+      t0 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       @service.poll
       payload = {
         :name => 'eagle',
         :bucket => :request,
         :start_timestamp => t0,
-        :duration => Time.now.to_f-t0,
+        :duration => Process.clock_gettime(Process::CLOCK_MONOTONIC) - t0,
         :thread => @threads.sample
       }
       @service.on_transaction_finished(payload)


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
Replace locations where `Time.now` was coerced into floats or used to perform math operations with [Process.clock_gettime](https://ruby-doc.org/core-3.0.2/Process.html#method-c-clock_gettime) to improve performance and accuracy of time references.

`Process.clock_gettime(Process::CLOCK_REALTIME)`:
- Represents the wall clock time (ex: August 26, 2021 at 4:03 PM) 
- Most performant option in benchmarking tests
- Could still be subject to changes in system time (ex: manually changing a clock's time, leap seconds)
- Can be coerced into a `Time` object using `Time.at(Process.clock_gettime(Process::CLOCK_REALTIME)` 

`Process.clock_gettime(Process::CLOCK_MONOTONIC)`:
- Represents a continuously increasing timer that began with the life of the machine
- Within the margin of error on tests in speed
- Can't be converted into a human-readable timestamp
- Ideal for durations

`Time.now`:
- Creates a time object representing the current wall clock time (ex: August 26, 2021 at 4:03 PM) 
- Ideal strategy for creating timestamps used as strings
- Less performant than `Process.clock_gettime`
- Legacy strategy for duration and float timestamps

Other changes:
* Removed deprecated method, `Transaction.wrap`
* Remove unused time argument on `PipeService#shutdown`

# Related Github Issue
Closes: https://github.com/newrelic/newrelic-ruby-agent/issues/304
Closes: https://github.com/newrelic/newrelic-ruby-agent/issues/758

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
Github Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
