### PR TITLE
added YAML.unsafe_load if the method is available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
   ## v8.0.0
 
+  * **Bugfix: Psych 4.0 causes errors when loading newrelic.yml**
+    Psych 4.0 now uses safe load behavior when using `YAML.load` which by default doesn't allow aliases, causing errors when the agent loads the config file. We have updated how we load the config file to avoid these errors. 
+
   * **Deprecate cross application tracing**
     Cross application tracing is deprecated in favor of [distributed tracing](https://docs.newrelic.com/docs/distributed-tracing/enable-configure/language-agents-enable-distributed-tracing/) and is off by default.
 

--- a/lib/new_relic/agent/configuration/yaml_source.rb
+++ b/lib/new_relic/agent/configuration/yaml_source.rb
@@ -99,7 +99,12 @@ module NewRelic
 
         def process_yaml(file, env, config, path)
           if file
-            confighash = YAML.load(file)
+            confighash = if YAML.respond_to?(:unsafe_load)
+                           YAML.unsafe_load(file)
+                         else 
+                           YAML.load(file)
+                         end
+
             unless confighash.key?(env)
               log_failure("Config file at #{path} doesn't include a '#{env}' section!")
             end

--- a/lib/new_relic/agent/instrumentation/sidekiq.rb
+++ b/lib/new_relic/agent/instrumentation/sidekiq.rb
@@ -60,7 +60,12 @@ DependencyDetection.defer do
 
     class Sidekiq::Extensions::DelayedClass
       def newrelic_trace_args(msg, queue)
-        (target, method_name, _args) = YAML.load(msg['args'][0])
+        (target, method_name, _args) = if YAML.respond_to?(:unsafe_load)
+                                         YAML.unsafe_load(msg['args'][0])
+                                       else 
+                                         YAML.load(msg['args'][0])
+                                       end
+
         {
           :name => method_name,
           :class_name => target.name,

--- a/test/multiverse/suites/active_record/config/database.rb
+++ b/test/multiverse/suites/active_record/config/database.rb
@@ -19,7 +19,11 @@ end
 
 config_raw = File.read(File.join(config_dir, 'database.yml'))
 config_erb = ERB.new(config_raw).result
-config_yml = YAML.load(config_erb)
+config_yml = if YAML.respond_to?(:unsafe_load)
+               YAML.unsafe_load(config_erb)
+             else 
+               YAML.load(config_erb)
+             end
 
 # Rails 2.x didn't keep the Rails out of ActiveRecord much...
 RAILS_ENV  = "test"

--- a/test/multiverse/suites/config_file_loading/Envfile
+++ b/test/multiverse/suites/config_file_loading/Envfile
@@ -8,7 +8,9 @@ gemfile <<-RB
   # Because we delay the agent, order of jruby-openssl matters
   gem 'jruby-openssl', '~> 0.9.10', :platforms => [:jruby]
 
-  gem 'psych', '4.0.0'
+  if RUBY_VERSION >= '2.4.0'
+    gem 'psych', '4.0.0'
+  end
 
   # don't start the agent
   gem 'newrelic_rpm', :require => false, :path => File.expand_path('../../../../')
@@ -22,7 +24,9 @@ gemfile <<-RB
   # Because we delay the agent, order of jruby-openssl matters
   gem 'jruby-openssl', '~> 0.9.10', :platforms => [:jruby]
 
-  gem 'psych', '3.3.0'
+  if RUBY_VERSION >= '2.4.0'
+    gem 'psych', '3.3.0'
+  end
 
   # don't start the agent
   gem 'newrelic_rpm', :require => false, :path => File.expand_path('../../../../')

--- a/test/multiverse/suites/config_file_loading/Envfile
+++ b/test/multiverse/suites/config_file_loading/Envfile
@@ -8,6 +8,22 @@ gemfile <<-RB
   # Because we delay the agent, order of jruby-openssl matters
   gem 'jruby-openssl', '~> 0.9.10', :platforms => [:jruby]
 
+  gem 'psych', '4.0.0'
+
+  # don't start the agent
+  gem 'newrelic_rpm', :require => false, :path => File.expand_path('../../../../')
+RB
+
+gemfile <<-RB
+  # stub file system so we can test that newrelic.yml can be loaded from
+  # various places.
+  gem 'fakefs', '0.5.4', :require => 'fakefs/safe' # 0.5.4 required for 1.8.7 compatibility.
+
+  # Because we delay the agent, order of jruby-openssl matters
+  gem 'jruby-openssl', '~> 0.9.10', :platforms => [:jruby]
+
+  gem 'psych', '3.3.0'
+
   # don't start the agent
   gem 'newrelic_rpm', :require => false, :path => File.expand_path('../../../../')
 RB

--- a/test/multiverse/suites/config_file_loading/config_file_loading_test.rb
+++ b/test/multiverse/suites/config_file_loading/config_file_loading_test.rb
@@ -199,6 +199,34 @@ boom:
     assert_equal 'bazbangbarn', NewRelic::Agent.config[:i_am], "Agent.config did not load bazbangbarn config as requested"
   end
 
+  def test_parses_default_settings_correctly
+    config_contents = <<-YAML
+common: &default_settings
+  license_key: 47ae68e8919929c1d99fa3a1a36a0aa8c06ba690
+  app_name: playground
+  foo: success!!
+
+development:
+  <<: *default_settings
+  app_name: playground (Development)
+
+test:
+  <<: *default_settings
+  monitor_mode: false
+
+bazbangbarn:
+  <<: *default_settings
+  app_name: playground (Bazbangbarn)
+    YAML
+
+    path = File.join(@cwd, 'config', 'newrelic.yml')
+    setup_config(path, {}, config_contents)
+    setup_agent
+
+    log = with_array_logger { NewRelic::Agent.manual_start }
+    assert_equal 'success!!', NewRelic::Agent.config[:foo]
+  end
+
   def refute_log_contains(log, message)
     lines = log.array
     failure_message = "Found unexpected '#{message}' in log. Log contained:\n#{lines.join('')}"


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
Uses the `YAML.unsafe_load` method when it is available, otherwise will still use YAML.load in older psych versions.

# Related Github Issue
closes #759 

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
Github Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
