### PR TITLE
Load hash value for configuration option from yaml file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
   * **Bugfix: Incorrectly loading configuration options from newrelic.yml**
 
-    The agent will now  import the configuration options `error_collector.ignore_messages` and `error_collector.expected_messages` from the `newrelic.yml` file correctly.
+    The agent will now  import the configuration options [`error_collector.ignore_messages`](https://docs.newrelic.com/docs/agents/ruby-agent/configuration/ruby-agent-configuration/#error_collector-ignore_messages) and [`error_collector.expected_messages`](https://docs.newrelic.com/docs/agents/ruby-agent/configuration/ruby-agent-configuration/#error_collector-expected_messages) from the `newrelic.yml` file correctly.
 
 
   * **Deprecate cross application tracing**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
   * **Bugfix: Psych 4.0 causes errors when loading newrelic.yml**
     Psych 4.0 now uses safe load behavior when using `YAML.load` which by default doesn't allow aliases, causing errors when the agent loads the config file. We have updated how we load the config file to avoid these errors. 
 
+  * **Bugfix: Incorrectly loading configuration options from newrelic.yml**
+
+    The agent will now  import the configuration options `error_collector.ignore_messages` and `error_collector.expected_messages` from the `newrelic.yml` file correctly.
+
+
   * **Deprecate cross application tracing**
     Cross application tracing is deprecated in favor of [distributed tracing](https://docs.newrelic.com/docs/distributed-tracing/enable-configure/language-agents-enable-distributed-tracing/) and is off by default.
 

--- a/lib/new_relic/agent/configuration/dotted_hash.rb
+++ b/lib/new_relic/agent/configuration/dotted_hash.rb
@@ -35,7 +35,7 @@ module NewRelic
         def dot_flattened(nested_hash, names=[], result={})
           nested_hash.each do |key, val|
             next if val == nil
-            if val.respond_to?(:has_key?) && !NewRelic::Agent::Configuration::Manager::CONFIG_WITH_HASH_VALUE.include?(key)
+            if val.respond_to?(:has_key?)
               dot_flattened(val, names + [key], result)
             else
               result[(names + [key]).join('.')] = val

--- a/lib/new_relic/agent/configuration/dotted_hash.rb
+++ b/lib/new_relic/agent/configuration/dotted_hash.rb
@@ -35,7 +35,7 @@ module NewRelic
         def dot_flattened(nested_hash, names=[], result={})
           nested_hash.each do |key, val|
             next if val == nil
-            if val.respond_to?(:has_key?)
+            if val.respond_to?(:has_key?) && !NewRelic::Agent::Configuration::Manager::CONFIG_WITH_HASH_VALUE.include?(key)
               dot_flattened(val, names + [key], result)
             else
               result[(names + [key]).join('.')] = val

--- a/lib/new_relic/agent/configuration/manager.rb
+++ b/lib/new_relic/agent/configuration/manager.rb
@@ -15,9 +15,6 @@ module NewRelic
   module Agent
     module Configuration
       class Manager
-
-        CONFIG_WITH_HASH_VALUE = ['expected_messages', 'ignore_messages']
-
         # Defining these explicitly saves object allocations that we incur
         # if we use Forwardable and def_delegators.
         def [](key)

--- a/lib/new_relic/agent/configuration/manager.rb
+++ b/lib/new_relic/agent/configuration/manager.rb
@@ -16,6 +16,8 @@ module NewRelic
     module Configuration
       class Manager
 
+        CONFIG_WITH_HASH_VALUE = ['expected_messages', 'ignore_messages']
+
         # Defining these explicitly saves object allocations that we incur
         # if we use Forwardable and def_delegators.
         def [](key)

--- a/lib/new_relic/agent/configuration/yaml_source.rb
+++ b/lib/new_relic/agent/configuration/yaml_source.rb
@@ -11,6 +11,8 @@ module NewRelic
         attr_accessor :file_path, :failures
         attr_reader :generated_for_user, :license_key
 
+        CONFIG_WITH_HASH_VALUE = ['expected_messages', 'ignore_messages']
+
         def initialize(path, env)
           @path = path
           config    = {}
@@ -145,6 +147,18 @@ module NewRelic
         def log_failure(*messages)
           ::NewRelic::Agent.logger.error(*messages)
           messages.each { |message| @failures << message }
+        end
+
+        def dot_flattened(nested_hash, names=[], result={})
+          nested_hash.each do |key, val|
+            next if val == nil
+            if val.respond_to?(:has_key?) && !CONFIG_WITH_HASH_VALUE.include?(key)
+              dot_flattened(val, names + [key], result)
+            else
+              result[(names + [key]).join('.')] = val
+            end
+          end
+          result
         end
       end
     end

--- a/lib/new_relic/agent/configuration/yaml_source.rb
+++ b/lib/new_relic/agent/configuration/yaml_source.rb
@@ -11,6 +11,8 @@ module NewRelic
         attr_accessor :file_path, :failures
         attr_reader :generated_for_user, :license_key
 
+        # These are configuration options that have a value of a Hash
+        # This is used in YamlSource#dot_flattened prevent flattening these values
         CONFIG_WITH_HASH_VALUE = ['expected_messages', 'ignore_messages']
 
         def initialize(path, env)

--- a/test/config/newrelic.yml
+++ b/test/config/newrelic.yml
@@ -41,6 +41,15 @@ test:
 
   error_collector:
     enabled: true
+    expected_messages:
+      StandardError:
+        - "test error1"
+        - "test error2"
+    ignore_messages:
+      RuntimeError:
+        - "test error3"
+
+
 
 development:
   host: the.wrong.host

--- a/test/new_relic/agent/configuration/yaml_source_test.rb
+++ b/test/new_relic/agent/configuration/yaml_source_test.rb
@@ -14,6 +14,13 @@ module NewRelic::Agent::Configuration
       @source = YamlSource.new(@test_yml_path, 'test')
     end
 
+    def test_should_load_hash_for_specified_configs
+      ignore_messages = {"RuntimeError"=>["test error3"]}
+      expected_messages = {"StandardError"=>["test error1", "test error2"]}
+      assert_equal ignore_messages, @source[:'error_collector.ignore_messages']
+      assert_equal expected_messages, @source[:'error_collector.expected_messages']
+    end
+
     def test_should_load_given_yaml_file
       assert_equal '127.0.0.1', @source[:api_host]
     end


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
The way we load our config file was unable to properly handle hash values, which are now needed for certain configuration values (`error_collector.ignore_messages`, `error_collector.expected_messages`). This fix adds a constant for config values that have a hash type as the value of the configuration option, which we check while we are flattening the config file.

# Related Github Issue
Include a link to the related GitHub issue, if applicable

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
Github Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
