### PR TITLE
Remove deprecated method External#start_segment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,10 @@
 
     This release removes the remaining support for the [Merb](https://weblog.rubyonrails.org/2008/12/23/merb-gets-merged-into-rails-3/) framework. It merged with Rails during the 3.0 release. Now that the Ruby agent supports Rails 3.2 and above, we thought it was time to say goodbye.
 
+  * **Remove deprecated method External.start_segment**
+
+    The method `NewRelic::Agent::External.start_segment` has been deprecated as of Ruby Agent 6.0.0. This method is now removed.
+
   ## v7.2.0
 
   * **Expected Errors and Ignore Errors**

--- a/lib/new_relic/agent/external.rb
+++ b/lib/new_relic/agent/external.rb
@@ -18,34 +18,6 @@ module NewRelic
     module External
       extend self
 
-      # This method creates and starts an external request segment using the
-      # given library, URI, and procedure. This is used to time external calls
-      # made over HTTP.
-      #
-      # @param [String] library a string of the class name of the library used to
-      # make the external call, for example, 'Net::HTTP'.
-      #
-      # @param [String, URI] uri indicates the URI to which the
-      # external request is being made. The URI should begin with the protocol,
-      # for example, 'https://github.com'.
-      #
-      # @param [String] procedure the HTTP method being used for the external
-      # request as a string, for example, 'GET'.
-      #
-      # @api public
-      def start_segment(library:, uri:, procedure:)
-        Deprecator.deprecate 'External.start_segment',
-                             'Tracer#start_external_request_segment'
-
-        ::NewRelic::Agent.record_api_supportability_metric(:start_segment)
-
-        ::NewRelic::Agent::Tracer.start_external_request_segment(
-          library: library,
-          uri: uri,
-          procedure: procedure
-        )
-      end
-
       NON_HTTP_CAT_ID_HEADER  = 'NewRelicID'.freeze
       NON_HTTP_CAT_TXN_HEADER = 'NewRelicTransaction'.freeze
       NON_HTTP_CAT_SYNTHETICS_HEADER = 'NewRelicSynthetics'.freeze

--- a/test/new_relic/agent/external_test.rb
+++ b/test/new_relic/agent/external_test.rb
@@ -23,13 +23,6 @@ module NewRelic
         NewRelic::Agent.drop_buffered_data
       end
 
-      def test_start_segment_starts_an_external_segment
-        s = NewRelic::Agent::External.start_segment library: 'Net::HTTP',
-                                                    uri: 'https://example.com/foobar',
-                                                    procedure: 'GET'
-        assert_instance_of NewRelic::Agent::Transaction::ExternalRequestSegment, s
-      end
-
       # --- process_request_metadata
 
       def test_process_request_metadata

--- a/test/new_relic/agent/supportability_test.rb
+++ b/test/new_relic/agent/supportability_test.rb
@@ -224,11 +224,6 @@ class ExternalAPISupportabilityMetricsTest < Minitest::Test
     assert_metrics_recorded(["Supportability/API/#{method_name}"])
   end
 
-  def test_start_segment_records_supportability_metric
-    NewRelic::Agent::External.start_segment(library: 'Net::HTTP', uri: 'http://example.com/root/index', procedure: 'GET')
-    assert_api_supportability_metric_recorded(:start_segment)
-  end
-
   def test_get_request_metadata_records_supportability_metric
     @segment.get_request_metadata
     assert_api_supportability_metric_recorded(:get_request_metadata)


### PR DESCRIPTION
Per 7.x->8.x migration guide and changelog for 6.0, `NewRelic::Agent::External#start_segment` is deprecated. There were no explicit uses of this method within the code outside of tests.

As @angelatan2 pointed out, this method was not marked deprecated within the actual API documentation here:
https://rubydoc.info/github/newrelic/newrelic-ruby-agent/NewRelic/Agent/External:start_segment

Closes #746 
