### PR TITLE
Accept Integers for ignored status codes in YAML config

### DIFF
--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -1317,10 +1317,10 @@ module NewRelic
           :dynamic_name => true,
           :description => 'A map of error classes to a list of messages. When an error of one of the classes specified here occurs, if its error message contains one of the strings corresponding to it here, that error will be ignored. *Note: this setting cannot be set via environment variable.*'
         },
-        :'error_collector.ignore_status_codes' => {
+        :'error_collector.' => {
           :default => '',
           :public => true,
-          :type => String,
+          :type => String || Integer,
           :allowed_from_server => true,
           :dynamic_name => true,
           :description => 'A comma separated list of status codes, possibly including ranges. Errors associated with these status codes, where applicable, will be ignored.'

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -1317,10 +1317,10 @@ module NewRelic
           :dynamic_name => true,
           :description => 'A map of error classes to a list of messages. When an error of one of the classes specified here occurs, if its error message contains one of the strings corresponding to it here, that error will be ignored. *Note: this setting cannot be set via environment variable.*'
         },
-        :'error_collector.' => {
+        :'error_collector.ignore_status_codes' => {
           :default => '',
           :public => true,
-          :type => String || Integer,
+          :type => String,
           :allowed_from_server => true,
           :dynamic_name => true,
           :description => 'A comma separated list of status codes, possibly including ranges. Errors associated with these status codes, where applicable, will be ignored.'

--- a/lib/new_relic/agent/error_filter.rb
+++ b/lib/new_relic/agent/error_filter.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 # This file is distributed under New Relic's license terms.
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+require 'pry'
 
 module NewRelic
   module Agent
@@ -29,7 +30,9 @@ module NewRelic
       def load_from_config(setting, value = nil)
         errors = nil
         new_value = value || fetch_agent_config(setting.to_sym)
-        return if new_value.nil? || new_value.empty?
+        #edit 33 to account for integer (DONE)
+        
+        return if new_value.nil? || (new_value.instance_of?(String) && new_value.empty?) 
 
         case setting.to_sym
         when :ignore_errors, :ignore_classes
@@ -144,12 +147,15 @@ module NewRelic
         end
       end
 
+      #edit this to account for integers 
       def parse_status_codes(codes)
-        code_list = codes.is_a?(String) ? codes.split(',') : codes
+        # Refactor this to make the integer go into an array so that we can do the .each method (DONE)
+        code_list = codes.is_a?(String) ? codes.split(',') : codes.is_a?(Integer) ? [codes] : codes
         result = []
         code_list.each do |code|
           result << code && next if code.is_a?(Integer)
-          m = code.match(/(\d{3})(-\d{3})?/)
+          #what to do when code is a integer? return just code or something else? 
+          m = code.match(/(\d{3})(-\d{3})?/) 
           if m.nil? || m[1].nil?
             ::NewRelic::Agent.logger.warn("Invalid HTTP status code: '#{code}'; ignoring config")
             next

--- a/lib/new_relic/agent/error_filter.rb
+++ b/lib/new_relic/agent/error_filter.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 # This file is distributed under New Relic's license terms.
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
-require 'pry'
 
 module NewRelic
   module Agent
@@ -30,9 +29,8 @@ module NewRelic
       def load_from_config(setting, value = nil)
         errors = nil
         new_value = value || fetch_agent_config(setting.to_sym)
-        #edit 33 to account for integer (DONE)
-        
-        return if new_value.nil? || (new_value.instance_of?(String) && new_value.empty?) 
+
+        return if new_value.nil? || (new_value.respond_to?(:empty?) && new_value.empty?)
 
         case setting.to_sym
         when :ignore_errors, :ignore_classes
@@ -53,7 +51,7 @@ module NewRelic
       end
 
       def ignore?(ex, status_code = nil)
-        @ignore_classes.include?(ex.class.name) || 
+        @ignore_classes.include?(ex.class.name) ||
           (@ignore_messages.keys.include?(ex.class.name) &&
           @ignore_messages[ex.class.name].any? { |m| ex.message.include?(m) }) ||
           @ignore_status_codes.include?(status_code.to_i)
@@ -147,7 +145,7 @@ module NewRelic
         end
       end
 
-      #edit this to account for integers 
+      #edit this to account for integers
       def parse_status_codes(codes)
         code_list = case codes
           when String
@@ -160,8 +158,8 @@ module NewRelic
         result = []
         code_list.each do |code|
           result << code && next if code.is_a?(Integer)
-          #what to do when code is a integer? return just code or something else? 
-          m = code.match(/(\d{3})(-\d{3})?/) 
+          #what to do when code is a integer? return just code or something else?
+          m = code.match(/(\d{3})(-\d{3})?/)
           if m.nil? || m[1].nil?
             ::NewRelic::Agent.logger.warn("Invalid HTTP status code: '#{code}'; ignoring config")
             next

--- a/lib/new_relic/agent/error_filter.rb
+++ b/lib/new_relic/agent/error_filter.rb
@@ -158,7 +158,6 @@ module NewRelic
         result = []
         code_list.each do |code|
           result << code && next if code.is_a?(Integer)
-          #what to do when code is a integer? return just code or something else?
           m = code.match(/(\d{3})(-\d{3})?/)
           if m.nil? || m[1].nil?
             ::NewRelic::Agent.logger.warn("Invalid HTTP status code: '#{code}'; ignoring config")

--- a/lib/new_relic/agent/error_filter.rb
+++ b/lib/new_relic/agent/error_filter.rb
@@ -149,8 +149,14 @@ module NewRelic
 
       #edit this to account for integers 
       def parse_status_codes(codes)
-        # Refactor this to make the integer go into an array so that we can do the .each method (DONE)
-        code_list = codes.is_a?(String) ? codes.split(',') : codes.is_a?(Integer) ? [codes] : codes
+        code_list = case codes
+          when String
+            codes.split(',')
+          when Integer
+            [codes]
+          else
+            codes
+          end
         result = []
         code_list.each do |code|
           result << code && next if code.is_a?(Integer)

--- a/lib/new_relic/agent/error_filter.rb
+++ b/lib/new_relic/agent/error_filter.rb
@@ -145,7 +145,6 @@ module NewRelic
         end
       end
 
-      #edit this to account for integers
       def parse_status_codes(codes)
         code_list = case codes
           when String

--- a/test/new_relic/agent/error_filter_test.rb
+++ b/test/new_relic/agent/error_filter_test.rb
@@ -88,6 +88,13 @@ module NewRelic::Agent
           assert @error_filter.ignore?(TestExceptionA.new, 401)
           assert @error_filter.ignore?(TestExceptionA.new, 500)
         end
+
+        @error_filter.reset
+
+        with_config :'error_collector.ignore_status_codes' => 418 do
+          @error_filter.load_all
+          assert @error_filter.ignore?(TestExceptionA.new, 418)
+        end
       end
 
       # compatibility for deprecated config setting

--- a/test/new_relic/agent/error_filter_test.rb
+++ b/test/new_relic/agent/error_filter_test.rb
@@ -88,9 +88,9 @@ module NewRelic::Agent
           assert @error_filter.ignore?(TestExceptionA.new, 401)
           assert @error_filter.ignore?(TestExceptionA.new, 500)
         end
+      end
 
-        @error_filter.reset
-
+      def test_ignore_integer_status_codes
         with_config :'error_collector.ignore_status_codes' => 418 do
           @error_filter.load_all
           assert @error_filter.ignore?(TestExceptionA.new, 418)

--- a/test/new_relic/agent/error_filter_test.rb
+++ b/test/new_relic/agent/error_filter_test.rb
@@ -3,7 +3,6 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 
 require File.expand_path(File.join(File.dirname(__FILE__),'..','..','test_helper'))
-require 'pry'
 
 class TestExceptionA < StandardError; end
 class TestExceptionB < StandardError; end

--- a/test/new_relic/agent/error_filter_test.rb
+++ b/test/new_relic/agent/error_filter_test.rb
@@ -3,6 +3,7 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 
 require File.expand_path(File.join(File.dirname(__FILE__),'..','..','test_helper'))
+require 'pry'
 
 class TestExceptionA < StandardError; end
 class TestExceptionB < StandardError; end


### PR DESCRIPTION

# Overview
- Fixes bug where agent errors on ignore_status_codes with Integer values, identified in https://github.com/newrelic/newrelic-ruby-agent/issues/713
- Adds a test to confirm that the fix works

# Related Github Issue
https://github.com/newrelic/newrelic-ruby-agent/issues/713

# Testing
- Additional config added to existing test to verify that Integer status codes can pass

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
