### PR TITLE
Bugfix/net http ipv6 requests

### DIFF
--- a/lib/new_relic/agent/http_clients/net_http_wrappers.rb
+++ b/lib/new_relic/agent/http_clients/net_http_wrappers.rb
@@ -4,6 +4,7 @@
 # frozen_string_literal: true
 
 require_relative 'abstract'
+require 'resolv'
 
 module NewRelic
   module Agent
@@ -61,9 +62,14 @@ module NewRelic
           when /^https?:\/\//
             ::NewRelic::Agent::HTTPClients::URIUtil.parse_and_normalize_url(@request.path)
           else
+            connection_address = @connection.address
+            if (connection_address =~ Resolv::IPv6::Regex)
+              connection_address = "[#{connection_address}]"
+            end
+
             scheme = @connection.use_ssl? ? 'https' : 'http'
             ::NewRelic::Agent::HTTPClients::URIUtil.parse_and_normalize_url(
-              "#{scheme}://#{@connection.address}:#{@connection.port}#{@request.path}"
+              "#{scheme}://#{connection_address}:#{@connection.port}#{@request.path}"
               )
           end
         end

--- a/test/new_relic/net_http_test_cases.rb
+++ b/test/new_relic/net_http_test_cases.rb
@@ -118,33 +118,22 @@ module NetHttpTestCases
 
   # https://newrelic.atlassian.net/browse/RUBY-835
   def test_direct_get_request_doesnt_double_count
-    with_config(:api_host=>"::1") do 
-      http = create_http(default_uri)
-      in_transaction do
-        http.request(Net::HTTP::Get.new(default_uri.request_uri))
-      end
-
-      assert_metrics_recorded(
-        'External/localhost/Net::HTTP/GET' => { :call_count => 1 })
+    http = create_http(default_uri)
+    in_transaction do
+      http.request(Net::HTTP::Get.new(default_uri.request_uri))
     end
+
+    assert_metrics_recorded(
+      'External/localhost/Net::HTTP/GET' => { :call_count => 1 })
   end
   
-  # def create_http(uri)
-  #   http = Net::HTTP.new(uri.host, uri.port)
-  #   if use_ssl?
-  #     http.use_ssl = true
-  #     http.verify_mode = OpenSSL::SSL::VERIFY_NONE
-  #   end
-  #   http
-  # end
-  def test_ipv6_host_get_requests
-    #require "pry"; binding.pry
-    http = Net::HTTP.new('::1', '51744')
+  def test_ipv6_host_get_request_records_metric
+    http = Net::HTTP.new('::1', default_uri.port)
     in_transaction do
       http.request(Net::HTTP::Get.new('/status'))
     end
 
     assert_metrics_recorded(
-      'External/localhost/Net::HTTP/GET' => { :call_count => 1 })
+      'External/[::1]/Net::HTTP/GET' => { :call_count => 1 })
   end
 end


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
- Add conditional in net_http_wrappers to check for IPv6 addresses and add square brackets to hostname if it is.
- Add test case to confirm this is working.

# Related Github Issue
Closes: https://github.com/newrelic/newrelic-ruby-agent/issues/562

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
