### PR TITLE
Remove resolved thor and i18n restrictions for jruby

### DIFF
--- a/test/multiverse/suites/rails/Envfile
+++ b/test/multiverse/suites/rails/Envfile
@@ -4,7 +4,6 @@ if RUBY_VERSION >= '2.5.0'
     gem 'haml', '~>5.0.0'
     gem 'haml-rails', '2.0.0'
     gem 'minitest', '5.2.3'
-    gem 'i18n', '< 1.8.8' if RUBY_PLATFORM == 'java' # NoMethodError: undefined method `deep_merge!' for {}:Concurrent::Hash
     #{ruby3_gem_webrick}
   RB
 end
@@ -16,7 +15,6 @@ if RUBY_VERSION >= '2.5.0' && RUBY_VERSION < '3.0.0'
     gem 'haml', '~>5.0.0'
     gem 'haml-rails', '2.0.0'
     gem 'minitest', '5.2.3'
-    gem 'i18n', '< 1.8.8' if RUBY_PLATFORM == 'java' # NoMethodError: undefined method `deep_merge!' for {}:Concurrent::Hash
   RB
 
 end
@@ -28,7 +26,6 @@ if RUBY_VERSION >= '2.2.2' && RUBY_VERSION < '3.0.0'
     gem 'haml', '~>5.0.0'
     gem 'haml-rails', '~>1.0.0'
     gem 'minitest', '5.2.3'
-    gem 'i18n', '< 1.8.8' if RUBY_PLATFORM == 'java' # NoMethodError: undefined method `deep_merge!' for {}:Concurrent::Hash
   RB
 
   gemfile <<-RB
@@ -36,7 +33,6 @@ if RUBY_VERSION >= '2.2.2' && RUBY_VERSION < '3.0.0'
     gem 'haml', '~>5.0.0'
     gem 'haml-rails', '~>1.0.0'
     gem 'minitest', '5.2.3'
-    gem 'i18n', '< 1.8.8' if RUBY_PLATFORM == 'java' # NoMethodError: undefined method `deep_merge!' for {}:Concurrent::Hash
   RB
 
   gemfile <<-RB
@@ -44,7 +40,6 @@ if RUBY_VERSION >= '2.2.2' && RUBY_VERSION < '3.0.0'
     gem 'haml', '~>5.0.0'
     gem 'haml-rails', '~>1.0.0'
     gem 'minitest', '5.2.3'
-    gem 'i18n', '< 1.8.8' if RUBY_PLATFORM == 'java' # NoMethodError: undefined method `deep_merge!' for {}:Concurrent::Hash
   RB
 end
 
@@ -55,8 +50,6 @@ if RUBY_VERSION < '2.4.0'
     gem 'haml-rails', '~>1.0.0'
     gem 'minitest', '5.2.3'
     gem 'nokogiri', '< 1.7' if RUBY_VERSION < '2.1.0' # nokogiri 1.7.0 only supports >= 2.1.0
-    gem 'thor', '< 0.20.1' if RUBY_PLATFORM == 'java' # unpredictable thor errors
-    gem 'i18n', '< 1.8.8' if RUBY_PLATFORM == 'java' # NoMethodError: undefined method `deep_merge!' for {}:Concurrent::Hash
   RB
 
   gemfile <<-RB
@@ -67,8 +60,6 @@ if RUBY_VERSION < '2.4.0'
     gem 'haml-rails', '~>1.0.0'
     gem 'minitest', '5.2.3'
     gem 'nokogiri', '< 1.7' if RUBY_VERSION < '2.1.0' # nokogiri 1.7.0 only supports >= 2.1.0
-    gem 'thor', '< 0.20.1' if RUBY_PLATFORM == 'java' # unpredictable thor errors
-    gem 'i18n', '< 1.8.8' if RUBY_PLATFORM == 'java' # NoMethodError: undefined method `deep_merge!' for {}:Concurrent::Hash
   RB
 
   gemfile <<-RB
@@ -76,8 +67,6 @@ if RUBY_VERSION < '2.4.0'
     gem 'haml', '~>5.0.0'
     gem 'haml-rails', '~>1.0.0'
     gem 'nokogiri', '< 1.7' if RUBY_VERSION < '2.1.0' # nokogiri 1.7.0 only supports >= 2.1.0
-    gem 'thor', '< 0.20.1' if RUBY_PLATFORM == 'java' # unpredictable thor errors
-    gem 'i18n', '< 1.8.8' if RUBY_PLATFORM == 'java' # NoMethodError: undefined method `deep_merge!' for {}:Concurrent::Hash
   RB
 
   gemfile <<-RB
@@ -85,7 +74,6 @@ if RUBY_VERSION < '2.4.0'
     gem 'i18n', '~>0.6.11'
     gem 'haml', '4.0.2'   # Getting load issues with haml 4.0.3
     gem 'minitest_tu_shim', :require => false
-    gem 'i18n', '< 1.8.8' if RUBY_PLATFORM == 'java' # NoMethodError: undefined method `deep_merge!' for {}:Concurrent::Hash
   RB
 
   gemfile <<-RB
@@ -94,7 +82,5 @@ if RUBY_VERSION < '2.4.0'
     gem 'sinatra', '~> 1.4.5'
     gem 'haml', '4.0.2'   # Getting load issues with haml 4.0.3
     gem 'minitest_tu_shim', :require => false
-    gem 'thor', '< 0.20.1' if RUBY_PLATFORM == 'java' # unpredictable thor errors
-    gem 'i18n', '< 1.8.8' if RUBY_PLATFORM == 'java' # NoMethodError: undefined method `deep_merge!' for {}:Concurrent::Hash
   RB
 end


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
Now that JRuby has pushed a fix for i18n, the version restrictions for JRuby can be removed from the Rails multiverse Envfile. There were also restrictions on Thor version related to another bug. I removed the Thor restrictions and the tests passed locally.

# Related Github Issue
Closes: https://github.com/newrelic/newrelic-ruby-agent/issues/560 

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
Github Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
