### PR TITLE
Logger instrumentation and perf suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 
   ## v8.1.0
 
+  * **Intrumentation for Ruby standard library Logger**
+
+    The agent will now automatically instrument Logger, recording number of lines and size of logging output, with breakdown by severity.
+
   * **Bugfix: Allow Net::HTTP request to IPv6 addresses**
 
-     The agent will no longer raise an `URI::InvalidURIError` error if an IPv6 address is passed to Net::HTTP. Thank you @tristinbarnett and @tabathadelane for crafting a solution!
+    The agent will no longer raise an `URI::InvalidURIError` error if an IPv6 address is passed to Net::HTTP. Thank you @tristinbarnett and @tabathadelane for crafting a solution!
 
   * **Bugfix: Allow integers to be passed to error_collector.ignore_status_codes configuration**
 

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -1000,7 +1000,7 @@ module NewRelic
           :description  => 'Controls auto-instrumentation of dalli gem for Memcache at start up.  May be one of [auto|prepend|chain|disabled].'
         },
         :'instrumentation.logger' => {
-          :default => instrumentation_value_of(:disable_logger_instrumentation),
+          :default => "auto",
           :public => true,
           :type => String,
           :dynamic_name => true,
@@ -1747,15 +1747,6 @@ module NewRelic
           :type         => Boolean,
           :allowed_from_server => false,
           :description  => 'Internal name for controlling Rails 3+ middleware instrumentation'
-        },
-        :disable_logger_instrumentation => {
-          :default      => false,
-          :public       => true,
-          :type         => Boolean,
-          :deprecated   => true,
-          :dynamic_name => true,
-          :allowed_from_server => false,
-          :description  => deprecated_description(:'instrumentation.logger', 'If `true`, disables instrumentation for the Ruby standard library Logger.')
         },
         :'heroku.use_dyno_names' => {
           :default      => true,

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -999,6 +999,14 @@ module NewRelic
           :allowed_from_server => false,
           :description  => 'Controls auto-instrumentation of dalli gem for Memcache at start up.  May be one of [auto|prepend|chain|disabled].'
         },
+        :'instrumentation.logger' => {
+          :default => instrumentation_value_of(:disable_logger_instrumentation),
+          :public => true,
+          :type => String,
+          :dynamic_name => true,
+          :allowed_from_server => false,
+          :description => 'Controls auto-instrumentation of Ruby standard library Logger at start up.  May be one of [auto|prepend|chain|disabled].'
+        },
         :disable_data_mapper => {
           :default => false,
           :public => true,
@@ -1739,6 +1747,15 @@ module NewRelic
           :type         => Boolean,
           :allowed_from_server => false,
           :description  => 'Internal name for controlling Rails 3+ middleware instrumentation'
+        },
+        :disable_logger_instrumentation => {
+          :default      => false,
+          :public       => true,
+          :type         => Boolean,
+          :deprecated   => true,
+          :dynamic_name => true,
+          :allowed_from_server => false,
+          :description  => deprecated_description(:'instrumentation.logger', 'If `true`, disables instrumentation for the Ruby standard library Logger.')
         },
         :'heroku.use_dyno_names' => {
           :default      => true,

--- a/lib/new_relic/agent/instrumentation/logger.rb
+++ b/lib/new_relic/agent/instrumentation/logger.rb
@@ -7,9 +7,7 @@ require_relative 'logger/chain'
 require_relative 'logger/prepend'
 
 DependencyDetection.defer do
-  # Why not just :logger? That ends up with some keys in config that sounds
-  # like controls for logging but are controls for _instrumenting_ logging.
-  named :logger_instrumentation
+  named :logger
 
   depends_on { defined?(::Logger) }
 

--- a/lib/new_relic/agent/instrumentation/logger.rb
+++ b/lib/new_relic/agent/instrumentation/logger.rb
@@ -18,11 +18,10 @@ DependencyDetection.defer do
   end
 
   executes do
-    ::NewRelic::Agent.logger.info  "YOLO"
-    #if use_prepend?
-      #prepend_instrument ::Logger, NewRelic::Agent::Instrumentation::Logger::Prepend
-    #else
-      #chain_instrument NewRelic::Agent::Instrumentation::Logger::Chain
-    #end
+    if use_prepend?
+      prepend_instrument ::Logger, NewRelic::Agent::Instrumentation::Logger::Prepend
+    else
+      chain_instrument NewRelic::Agent::Instrumentation::Logger::Chain
+    end
   end
 end

--- a/lib/new_relic/agent/instrumentation/logger.rb
+++ b/lib/new_relic/agent/instrumentation/logger.rb
@@ -1,0 +1,28 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+
+require_relative 'logger/instrumentation'
+require_relative 'logger/chain'
+require_relative 'logger/prepend'
+
+DependencyDetection.defer do
+  # Why not just :logger? That ends up with some keys in config that sounds
+  # like controls for logging but are controls for _instrumenting_ logging.
+  named :logger_instrumentation
+
+  depends_on { defined?(::Logger) }
+
+  executes do
+    ::NewRelic::Agent.logger.info  "Installing Logger instrumentation"
+  end
+
+  executes do
+    ::NewRelic::Agent.logger.info  "YOLO"
+    #if use_prepend?
+      #prepend_instrument ::Logger, NewRelic::Agent::Instrumentation::Logger::Prepend
+    #else
+      #chain_instrument NewRelic::Agent::Instrumentation::Logger::Chain
+    #end
+  end
+end

--- a/lib/new_relic/agent/instrumentation/logger.rb
+++ b/lib/new_relic/agent/instrumentation/logger.rb
@@ -19,7 +19,7 @@ DependencyDetection.defer do
     if use_prepend?
       prepend_instrument ::Logger, NewRelic::Agent::Instrumentation::Logger::Prepend
     else
-      chain_instrument NewRelic::Agent::Instrumentation::Logger::Chain
+      chain_instrument NewRelic::Agent::Instrumentation::Logger
     end
   end
 end

--- a/lib/new_relic/agent/instrumentation/logger/chain.rb
+++ b/lib/new_relic/agent/instrumentation/logger/chain.rb
@@ -1,3 +1,21 @@
 # encoding: utf-8
 # This file is distributed under New Relic's license terms.
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+
+module NewRelic::Agent::Instrumentation
+  module Logger
+    def self.instrument!
+      ::Logger.class_eval do
+        include NewRelic::Agent::Instrumentation::Logger
+
+        alias_method :format_message_without_new_relic, :format_message
+
+        def format_message(severity, datetime, progname, msg)
+          format_message_with_tracing(severity, datetime, progname, msg) do
+            format_message_without_new_relic(severity, datetime, progname, msg)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/new_relic/agent/instrumentation/logger/chain.rb
+++ b/lib/new_relic/agent/instrumentation/logger/chain.rb
@@ -1,0 +1,3 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.

--- a/lib/new_relic/agent/instrumentation/logger/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/logger/instrumentation.rb
@@ -37,8 +37,8 @@ module NewRelic
           return formatted_message if skip_instrumenting?
 
           begin
-            # It's critical we don't instrumention further logging from our
-            # metric recording in the agent itself or we'll stack overflow!!
+            # It's critical we don't instrument logging from metric recording
+            # methods within NewRelic::Agent, or we'll stack overflow!!
             mark_skip_instrumenting
 
             NewRelic::Agent.increment_metric(LINES)

--- a/lib/new_relic/agent/instrumentation/logger/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/logger/instrumentation.rb
@@ -10,25 +10,34 @@ module NewRelic
           defined?(@skip_instrumenting) && @skip_instrumenting
         end
 
+        def mark_skip_instrumenting
+          @skip_instrumenting = true
+        end
+
+        def clear_skip_instrumenting
+          @skip_instrumenting = false
+        end
+
         def format_message_with_tracing(severity, datetime, progname, msg)
-          return yield if skip_instrumenting?
+          formatted_message = yield
+          return formatted_message if skip_instrumenting?
 
           begin
             # It's critical we don't instrumention further logging from our
             # metric recording or we'll stack overflow!!
-            @skip_instrumenting = true
+            mark_skip_instrumenting
 
             sev = severity || UNKNOWN
             NewRelic::Agent.increment_metric("Logging/lines")
             NewRelic::Agent.increment_metric("Logging/lines/#{sev}")
 
-            size = msg.nil? ? 0 : msg.length
+            size = formatted_message.nil? ? 0 : formatted_message.length
             NewRelic::Agent.record_metric("Logging/size", size)
             NewRelic::Agent.record_metric("Logging/size/#{sev}", size)
 
-            yield
+            return formatted_message
           ensure
-            @skip_instrumenting = false
+            clear_skip_instrumenting
           end
         end
       end

--- a/lib/new_relic/agent/instrumentation/logger/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/logger/instrumentation.rb
@@ -21,14 +21,14 @@ module NewRelic
         LINES = "Logging/lines".freeze
         SIZE = "Logging/size".freeze
 
-        def line_metric_name_by_severity(sev)
+        def line_metric_name_by_severity(severity)
           @line_metrics ||= {}
-          @line_metrics[sev] ||= "Logging/lines/#{sev}".freeze
+          @line_metrics[severity] ||= "Logging/lines/#{severity}".freeze
         end
 
-        def size_metric_name_by_severity(sev)
+        def size_metric_name_by_severity(severity)
           @size_metrics ||= {}
-          @size_metrics[sev] ||= "Logging/size/#{sev}".freeze
+          @size_metrics[severity] ||= "Logging/size/#{severity}".freeze
         end
 
 
@@ -41,13 +41,12 @@ module NewRelic
             # metric recording in the agent itself or we'll stack overflow!!
             mark_skip_instrumenting
 
-            sev = severity || UNKNOWN
             NewRelic::Agent.increment_metric(LINES)
-            NewRelic::Agent.increment_metric(line_metric_name_by_severity(sev))
+            NewRelic::Agent.increment_metric(line_metric_name_by_severity(severity))
 
             size = formatted_message.nil? ? 0 : formatted_message.length
             NewRelic::Agent.record_metric(SIZE, size)
-            NewRelic::Agent.record_metric(size_metric_name_by_severity(sev), size)
+            NewRelic::Agent.record_metric(size_metric_name_by_severity(severity), size)
 
             return formatted_message
           ensure

--- a/lib/new_relic/agent/instrumentation/logger/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/logger/instrumentation.rb
@@ -44,7 +44,7 @@ module NewRelic
             NewRelic::Agent.increment_metric(LINES)
             NewRelic::Agent.increment_metric(line_metric_name_by_severity(severity))
 
-            size = formatted_message.nil? ? 0 : formatted_message.length
+            size = formatted_message.nil? ? 0 : formatted_message.bytesize
             NewRelic::Agent.record_metric(SIZE, size)
             NewRelic::Agent.record_metric(size_metric_name_by_severity(severity), size)
 

--- a/lib/new_relic/agent/instrumentation/logger/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/logger/instrumentation.rb
@@ -1,3 +1,37 @@
 # encoding: utf-8
 # This file is distributed under New Relic's license terms.
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+
+module NewRelic
+  module Agent
+    module Instrumentation
+      module Logger
+        def skip_instrumenting?
+          defined?(@skip_instrumenting) && @skip_instrumenting
+        end
+
+        def format_message_with_tracing(severity, datetime, progname, msg)
+          return yield if skip_instrumenting?
+
+          begin
+            # It's critical we don't instrumention further logging from our
+            # metric recording or we'll stack overflow!!
+            @skip_instrumenting = true
+
+            sev = severity || UNKNOWN
+            NewRelic::Agent.increment_metric("Logging/lines")
+            NewRelic::Agent.increment_metric("Logging/lines/#{sev}")
+
+            size = msg.nil? ? 0 : msg.length
+            NewRelic::Agent.record_metric("Logging/size", size)
+            NewRelic::Agent.record_metric("Logging/size/#{sev}", size)
+
+            yield
+          ensure
+            @skip_instrumenting = false
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/new_relic/agent/instrumentation/logger/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/logger/instrumentation.rb
@@ -1,0 +1,3 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.

--- a/lib/new_relic/agent/instrumentation/logger/prepend.rb
+++ b/lib/new_relic/agent/instrumentation/logger/prepend.rb
@@ -1,3 +1,13 @@
 # encoding: utf-8
 # This file is distributed under New Relic's license terms.
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+
+module NewRelic::Agent::Instrumentation
+  module Logger::Prepend
+    include NewRelic::Agent::Instrumentation::Logger
+
+    def format_message(severity, datetime, progname, msg)
+      format_message_with_tracing(severity, datetime, progname, msg) { super }
+    end
+  end
+end

--- a/lib/new_relic/agent/instrumentation/logger/prepend.rb
+++ b/lib/new_relic/agent/instrumentation/logger/prepend.rb
@@ -1,0 +1,3 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.

--- a/newrelic.yml
+++ b/newrelic.yml
@@ -331,6 +331,10 @@ common: &default_settings
 # May be one of [auto|prepend|chain|disabled].
 # instrumentation.httprb: auto
 
+# Controls auto-instrumentation of the Ruby standard library Logger.rb.
+# May be one of [auto|prepend|chain|disabled].
+# instrumentation.logger: auto
+
 # Controls auto-instrumentation of memcache-client gem for Memcache at start up.
 # May be one of [auto|prepend|chain|disabled].
 # instrumentation.memcache_client: auto

--- a/test/helpers/config_scanning.rb
+++ b/test/helpers/config_scanning.rb
@@ -38,7 +38,7 @@ module NewRelic
         end
       end
 
-      private 
+      private
 
       def disable_name(names)
         names.map { |name| "disable_#{name}" }

--- a/test/multiverse/suites/logger/Envfile
+++ b/test/multiverse/suites/logger/Envfile
@@ -1,0 +1,5 @@
+instrumentation_methods :chain, :prepend
+
+gemfile <<-RB
+  # nothin'
+RB

--- a/test/multiverse/suites/logger/config/newrelic.yml
+++ b/test/multiverse/suites/logger/config/newrelic.yml
@@ -1,0 +1,18 @@
+---
+development:
+  error_collector:
+    enabled: true
+  apdex_t: 0.5
+  monitor_mode: true
+  license_key: bootstrap_newrelic_admin_license_key_000
+  instrumentation:
+      logger: <%= $instrumentation_method %>
+  app_name: test
+  host: 127.0.0.1
+  api_host: 127.0.0.1
+  transaction_trace:
+    record_sql: obfuscated
+    enabled: true
+    stack_trace_threshold: 0.5
+    transaction_threshold: 1.0
+  capture_params: false

--- a/test/multiverse/suites/logger/logger_instrumentation_test.rb
+++ b/test/multiverse/suites/logger/logger_instrumentation_test.rb
@@ -2,10 +2,9 @@
 # This file is distributed under New Relic's license terms.
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 
-require File.expand_path '../../../../../test_helper', __FILE__
-require 'new_relic/agent/instrumentation/logger'
+class LoggerInstrumentationTest < Minitest::Test
+  include MultiverseHelpers
 
-class NewRelic::Agent::Instrumentation::LoggerTest < Minitest::Test
   def setup
     @written = StringIO.new
     @logger = ::Logger.new(@written)
@@ -21,6 +20,7 @@ class NewRelic::Agent::Instrumentation::LoggerTest < Minitest::Test
   def teardown
     NewRelic::Agent.instance.stats_engine.reset!
   end
+
 
   LEVELS = [
     ['debug', Logger::DEBUG],
@@ -151,4 +151,7 @@ class NewRelic::Agent::Instrumentation::LoggerTest < Minitest::Test
       "Supportability/API/record_metric" => {}
     })
   end
+
+
+
 end

--- a/test/multiverse/suites/mongo/mongo2_instrumentation_test.rb
+++ b/test/multiverse/suites/mongo/mongo2_instrumentation_test.rb
@@ -101,6 +101,7 @@ if NewRelic::Agent::Datastores::Mongo.is_supported_version? &&
             metrics = build_test_metrics(:insert, true)
             expected = metrics_with_attributes(metrics)
 
+            assert_metrics_recorded(expected)
           end
 
           def test_records_metrics_for_insert_many

--- a/test/multiverse/suites/mongo/mongo2_instrumentation_test.rb
+++ b/test/multiverse/suites/mongo/mongo2_instrumentation_test.rb
@@ -343,7 +343,7 @@ if NewRelic::Agent::Datastores::Mongo.is_supported_version? &&
               "Logging/size" => {},
               "Logging/size/DEBUG" => {},
               "Supportability/API/increment_metric" => {},
-              "Supportability/API/record_metric" = {},
+              "Supportability/API/record_metric" => {},
             }
             assert_metrics_recorded_exclusive expected
           end

--- a/test/multiverse/suites/mongo/mongo2_instrumentation_test.rb
+++ b/test/multiverse/suites/mongo/mongo2_instrumentation_test.rb
@@ -101,7 +101,6 @@ if NewRelic::Agent::Datastores::Mongo.is_supported_version? &&
             metrics = build_test_metrics(:insert, true)
             expected = metrics_with_attributes(metrics)
 
-            assert_metrics_recorded(expected)
           end
 
           def test_records_metrics_for_insert_many
@@ -338,7 +337,13 @@ if NewRelic::Agent::Datastores::Mongo.is_supported_version? &&
               "Datastore/all" => {:call_count=>3},
               "Supportability/API/drop_buffered_data" => { :call_count => 1 },
               "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all" => { :call_count => 1},
-              "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allWeb" => { :call_count => 1 }
+              "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allWeb" => { :call_count => 1 },
+              "Logging/lines" => {},
+              "Logging/lines/DEBUG" => {},
+              "Logging/size" => {},
+              "Logging/size/DEBUG" => {},
+              "Supportability/API/increment_metric" => {},
+              "Supportability/API/record_metric" = {},
             }
             assert_metrics_recorded_exclusive expected
           end

--- a/test/multiverse/suites/rack/nested_non_rack_app_test.rb
+++ b/test/multiverse/suites/rack/nested_non_rack_app_test.rb
@@ -60,7 +60,13 @@ if NewRelic::Agent::Instrumentation::RackHelpers.rack_version_supported?
           "Nested/Controller/Rack/NestedNonRackAppTest::RailsishApp/call",
           ["Nested/Controller/Rack/NestedNonRackAppTest::RailsishApp/call", "Controller/NestedNonRackAppTest::RailsishApp/inner"],
           'DurationByCaller/Unknown/Unknown/Unknown/HTTP/all',
-          'DurationByCaller/Unknown/Unknown/Unknown/HTTP/allWeb'
+          'DurationByCaller/Unknown/Unknown/Unknown/HTTP/allWeb',
+          'Logging/lines',
+          'Logging/lines/INFO',
+          'Logging/lines/WARN',
+          'Logging/size',
+          'Logging/size/INFO',
+          'Logging/size/WARN',
         ],
         :ignore_filter => /^Supportability/
       )

--- a/test/multiverse/suites/rack/puma_rack_builder_test.rb
+++ b/test/multiverse/suites/rack/puma_rack_builder_test.rb
@@ -81,7 +81,7 @@ if NewRelic::Agent::Instrumentation::RackHelpers.puma_rack_version_supported?
           ["Middleware/Rack/PumaRackBuilderTest::MiddlewareTwo/call", "Controller/Rack/PumaRackBuilderTest::ExampleApp/call"],
           ["Nested/Controller/Rack/PumaRackBuilderTest::ExampleApp/call", "Controller/Rack/PumaRackBuilderTest::ExampleApp/call"]
         ],
-        :ignore_filter => /^(Supportability|RubyVM|Memory|CPU)/
+        :ignore_filter => /^(Supportability|RubyVM|Memory|CPU|Logging)/
       )
     end
   end

--- a/test/multiverse/suites/rack/rack_auto_instrumentation_test.rb
+++ b/test/multiverse/suites/rack/rack_auto_instrumentation_test.rb
@@ -81,7 +81,7 @@ class RackAutoInstrumentationTest < Minitest::Test
         'Supportability/API/recording_web_transaction?',
         'DurationByCaller/Unknown/Unknown/Unknown/HTTP/allWeb'
       ],
-      :ignore_filter => /^Supportability/
+      :ignore_filter => /^(Supportability|Logging)/
     )
   end
 
@@ -115,7 +115,7 @@ class RackAutoInstrumentationTest < Minitest::Test
         'Supportability/API/recording_web_transaction?',
         'DurationByCaller/Unknown/Unknown/Unknown/HTTP/allWeb'
       ],
-      :ignore_filter => /^Supportability\/EnvironmentReport/
+      :ignore_filter => /^(Supportability|Logging)/
     )
   end
 
@@ -147,7 +147,13 @@ class RackAutoInstrumentationTest < Minitest::Test
         ["Middleware/Rack/MiddlewareOne/call", "Controller/Middleware/Rack/MiddlewareTwo/call"],
         ["Middleware/Rack/MiddlewareTwo/call", "Controller/Middleware/Rack/MiddlewareTwo/call"],
         'DurationByCaller/Unknown/Unknown/Unknown/HTTP/all',
-        'DurationByCaller/Unknown/Unknown/Unknown/HTTP/allWeb'
+        'DurationByCaller/Unknown/Unknown/Unknown/HTTP/allWeb',
+        'Logging/lines',
+        'Logging/lines/INFO',
+        'Logging/lines/WARN',
+        'Logging/size',
+        'Logging/size/INFO',
+        'Logging/size/WARN',
       ],
       :ignore_filter => /^Supportability/
     )

--- a/test/multiverse/suites/rack/rack_unsupported_version_test.rb
+++ b/test/multiverse/suites/rack/rack_unsupported_version_test.rb
@@ -36,7 +36,7 @@ if !NewRelic::Agent::Instrumentation::RackHelpers.rack_version_supported? && def
 
     def test_no_instrumentation_when_not_supported
       get '/'
-      assert_metrics_recorded_exclusive([], :ignore_filter => /^Supportability/)
+      assert_metrics_recorded_exclusive([], :ignore_filter => /^(Supportability|Logging)/)
     end
   end
 

--- a/test/multiverse/suites/rack/url_map_test.rb
+++ b/test/multiverse/suites/rack/url_map_test.rb
@@ -86,7 +86,8 @@ class UrlMapTest < Minitest::Test
         ['Middleware/Rack/UrlMapTest::MiddlewareTwo/call', 'Controller/Rack/UrlMapTest::ExampleApp/call'],
         ['Nested/Controller/Rack/UrlMapTest::ExampleApp/call', 'Controller/Rack/UrlMapTest::ExampleApp/call'],
         [nested_controller_metric, 'Controller/Rack/UrlMapTest::ExampleApp/call']
-      ])
+      ], :ignore_filter => /^(Supportability|Logging)/)
+
     end
   end
 
@@ -114,7 +115,7 @@ class UrlMapTest < Minitest::Test
       'DurationByCaller/Unknown/Unknown/Unknown/Unknown/all',
       'Supportability/API/recording_web_transaction?',
       'DurationByCaller/Unknown/Unknown/Unknown/Unknown/allWeb'
-    ])
+    ], :ignore_filter => /^(Supportability|Logging)/)
   end
 
   def test_metrics_for_mapped_prefix_with_extra_middleware
@@ -141,7 +142,7 @@ class UrlMapTest < Minitest::Test
       'DurationByCaller/Unknown/Unknown/Unknown/Unknown/all',
       'Supportability/API/recording_web_transaction?',
       'DurationByCaller/Unknown/Unknown/Unknown/Unknown/allWeb'
-    ])
+    ], :ignore_filter => /^(Supportability|Logging)/)
   end
 
   def nested_controller_metric

--- a/test/multiverse/suites/sinatra/ignoring_test.rb
+++ b/test/multiverse/suites/sinatra/ignoring_test.rb
@@ -192,11 +192,12 @@ class SinatraIgnoreItAllTest < SinatraTestCase
   end
 
   def test_ignores_everything
-    # Avoid Supportability metrics from startup of agent for this check
-    NewRelic::Agent.drop_buffered_data
-
+    # Ignores Supportability and Logging metrics, makes sure we don't see
+    # transaction or other related metrics
     get_and_assert_ok '/'
-    assert_metrics_recorded_exclusive(['Supportability/API/drop_buffered_data'])
+    assert_metrics_recorded_exclusive(
+      [],
+      :ignore_filter => /^(Supportability|Logging)/)
   end
 end
 

--- a/test/multiverse/suites/sinatra/sinatra_metric_explosion_test.rb
+++ b/test/multiverse/suites/sinatra/sinatra_metric_explosion_test.rb
@@ -88,7 +88,7 @@ class SinatraMetricExplosionTest < Minitest::Test
       name_beginnings_to_ignore.any? {|name| metric.start_with?(name)}
     end
 
-    assert_equal 11, metric_names.size, "Explosion detected in: #{metric_names.inspect}"
+    assert_equal 17, metric_names.size, "Explosion detected in: #{metric_names.inspect}"
   end
 
   def test_does_not_break_when_no_verb_matches

--- a/test/new_relic/agent/error_trace_aggregator_test.rb
+++ b/test/new_relic/agent/error_trace_aggregator_test.rb
@@ -183,7 +183,14 @@ module NewRelic
         error_trace_aggregator.notice_agent_error(DifficultToDebugAgentError.new)
         error_trace_aggregator.notice_agent_error(AnotherToughAgentError.new)
 
-        assert_metrics_recorded_exclusive([])
+        assert_metrics_recorded_exclusive([
+          'Logging/lines',
+          'Logging/lines/INFO',
+          'Logging/size',
+          'Logging/size/INFO',
+          'Supportability/API/increment_metric',
+          'Supportability/API/record_metric',
+        ])
       end
 
       def test_notice_agent_error_set_noticed_error_attributes

--- a/test/new_relic/agent/instrumentation/logger/instrumentation_test.rb
+++ b/test/new_relic/agent/instrumentation/logger/instrumentation_test.rb
@@ -16,10 +16,6 @@ class NewRelic::Agent::Instrumentation::LoggerTest < Minitest::Test
     NewRelic::Agent.instance.stats_engine.reset!
   end
 
-  def test_doesnt_touch_construction
-    assert_metrics_recorded_exclusive []
-  end
-
   LEVELS = [
     ['debug', Logger::DEBUG],
     ['error', Logger::ERROR],
@@ -34,6 +30,24 @@ class NewRelic::Agent::Instrumentation::LoggerTest < Minitest::Test
       @logger.send(name, "A message")
       assert_equal(1, @written.string.lines.count)
       assert_match(/#{name.upcase}.*A message/, @written.string)
+      assert_logging_metrics(name.upcase)
+    end
+
+    define_method("test_records_multiple_calls_#{name}") do
+      @logger.send(name, "A message")
+      @logger.send(name, "Another")
+
+      assert_equal(2, @written.string.lines.count)
+      assert_match(/#{name.upcase}.*A message/, @written.string)
+      assert_match(/#{name.upcase}.*Another/, @written.string)
+      assert_logging_metrics(name.upcase, 2)
+    end
+
+    # logger#debug(Object.new)
+    define_method("test_records_not_a_string_#{name}") do
+      @logger.send(name, Object.new)
+      assert_equal(1, @written.string.lines.count)
+      assert_match(/#{name.upcase}.*<Object.*>/, @written.string)
       assert_logging_metrics(name.upcase)
     end
 
@@ -73,6 +87,13 @@ class NewRelic::Agent::Instrumentation::LoggerTest < Minitest::Test
     end
   end
 
+  def test_still_skips_levels
+    @logger.level = ::Logger::INFO
+    @logger.debug("Won't see this")
+    assert_equal(0, @written.string.lines.count)
+    refute_any_logging_metrics()
+  end
+
   def test_unknown
     @logger.unknown("A message")
     assert_equal(1, @written.string.lines.count)
@@ -94,14 +115,27 @@ class NewRelic::Agent::Instrumentation::LoggerTest < Minitest::Test
     assert_logging_metrics("ANY")
   end
 
-  def assert_logging_metrics(label)
-    assert_metrics_recorded_exclusive [
-      "Logging/lines",
-      "Logging/lines/#{label}",
-      "Logging/size",
-      "Logging/size/#{label}",
-      "Supportability/API/increment_metric",
-      "Supportability/API/record_metric",
-    ]
+  def test_skips_when_set
+    @logger.mark_skip_instrumenting
+    @logger.log(1_000_000, "A message", "progname")
+
+    assert_equal(1, @written.string.lines.count)
+    assert_match(/ANY.*progname.*A message/, @written.string)
+    refute_any_logging_metrics()
+  end
+
+  def refute_any_logging_metrics
+    assert_metrics_recorded_exclusive([])
+  end
+
+  def assert_logging_metrics(label, count = 1)
+    assert_metrics_recorded_exclusive({
+      "Logging/lines"          => { :call_count => count },
+      "Logging/lines/#{label}" => { :call_count => count },
+      "Logging/size" => {},
+      "Logging/size/#{label}" => {},
+      "Supportability/API/increment_metric" => {},
+      "Supportability/API/record_metric" => {}
+    })
   end
 end

--- a/test/new_relic/agent/instrumentation/logger/instrumentation_test.rb
+++ b/test/new_relic/agent/instrumentation/logger/instrumentation_test.rb
@@ -1,0 +1,107 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+
+require File.expand_path '../../../../../test_helper', __FILE__
+require 'new_relic/agent/instrumentation/logger'
+
+class NewRelic::Agent::Instrumentation::LoggerTest < Minitest::Test
+  def setup
+    @written = StringIO.new
+    @logger = ::Logger.new(@written)
+    NewRelic::Agent.instance.stats_engine.reset!
+  end
+
+  def teardown
+    NewRelic::Agent.instance.stats_engine.reset!
+  end
+
+  def test_doesnt_touch_construction
+    assert_metrics_recorded_exclusive []
+  end
+
+  LEVELS = [
+    ['debug', Logger::DEBUG],
+    ['error', Logger::ERROR],
+    ['fatal', Logger::FATAL],
+    ['info',  Logger::INFO],
+    ['warn',  Logger::WARN],
+  ]
+
+  LEVELS.each do |(name, level)|
+    # logger#debug("message")
+    define_method("test_records_#{name}") do
+      @logger.send(name, "A message")
+      assert_equal(1, @written.string.lines.count)
+      assert_match(/#{name.upcase}.*A message/, @written.string)
+      assert_logging_metrics(name.upcase)
+    end
+
+    # logger#debug { "message" }
+    define_method("test_records_with_block#{name}") do
+      @logger.send(name) do
+        "A message"
+      end
+
+      assert_equal(1, @written.string.lines.count)
+      assert_match(/#{name.upcase}.*A message/, @written.string)
+      assert_logging_metrics(name.upcase)
+    end
+
+    # logger#log(Logger::DEBUG, "message")
+    define_method("test_records_by_log_method_#{name}") do
+      @logger.log(level, "A message")
+      assert_equal(1, @written.string.lines.count)
+      assert_match(/#{name.upcase}.*A message/, @written.string)
+      assert_logging_metrics(name.upcase)
+    end
+
+    # logger#log(Logger::DEBUG} { "message" }
+    define_method("test_records_by_log_method_with_block_#{name}") do
+      @logger.log(level) { "A message" }
+      assert_equal(1, @written.string.lines.count)
+      assert_match(/#{name.upcase}.*A message/, @written.string)
+      assert_logging_metrics(name.upcase)
+    end
+
+    # logger#log(Logger::DEBUG, "message", "progname")
+    define_method("test_records_by_log_method_plus_progname_#{name}") do
+      @logger.log(level, "A message", "progname")
+      assert_equal(1, @written.string.lines.count)
+      assert_match(/#{name.upcase}.*progname.*A message/, @written.string)
+      assert_logging_metrics(name.upcase)
+    end
+  end
+
+  def test_unknown
+    @logger.unknown("A message")
+    assert_equal(1, @written.string.lines.count)
+    assert_match(/ANY.*A message/, @written.string)
+    assert_logging_metrics("ANY")
+  end
+
+  def test_really_high_level
+    @logger.log(1_000_000, "A message")
+    assert_equal(1, @written.string.lines.count)
+    assert_match(/ANY.*A message/, @written.string)
+    assert_logging_metrics("ANY")
+  end
+
+  def test_really_high_level_with_progname
+    @logger.log(1_000_000, "A message", "progname")
+    assert_equal(1, @written.string.lines.count)
+    assert_match(/ANY.*progname.*A message/, @written.string)
+    assert_logging_metrics("ANY")
+  end
+
+  def assert_logging_metrics(label)
+    assert_metrics_recorded_exclusive [
+      "Logging/lines",
+      "Logging/lines/#{label}",
+      "Logging/size",
+      "Logging/size/#{label}",
+      "Supportability/API/increment_metric",
+      "Supportability/API/record_metric",
+    ]
+  end
+end

--- a/test/new_relic/agent/instrumentation/logger/instrumentation_test.rb
+++ b/test/new_relic/agent/instrumentation/logger/instrumentation_test.rb
@@ -9,6 +9,12 @@ class NewRelic::Agent::Instrumentation::LoggerTest < Minitest::Test
   def setup
     @written = StringIO.new
     @logger = ::Logger.new(@written)
+
+    # Set formatter to avoid different defaults across versions/environments
+    @logger.formatter = proc do |severity, datetime, progname, msg|
+      "#{severity} - #{progname} - #{msg}\n"
+    end
+
     NewRelic::Agent.instance.stats_engine.reset!
   end
 

--- a/test/new_relic/agent/instrumentation/logger/instrumentation_test.rb
+++ b/test/new_relic/agent/instrumentation/logger/instrumentation_test.rb
@@ -121,6 +121,13 @@ class NewRelic::Agent::Instrumentation::LoggerTest < Minitest::Test
     assert_logging_metrics("ANY")
   end
 
+  def test_nil_severity
+    @logger.log(nil, "A message", "progname")
+    assert_equal(1, @written.string.lines.count)
+    assert_match(/ANY.*progname.*A message/, @written.string)
+    assert_logging_metrics("ANY")
+  end
+
   def test_skips_when_set
     @logger.mark_skip_instrumenting
     @logger.log(1_000_000, "A message", "progname")

--- a/test/new_relic/agent/monitors/cross_app_monitor_test.rb
+++ b/test/new_relic/agent/monitors/cross_app_monitor_test.rb
@@ -162,7 +162,12 @@ module NewRelic::Agent
         'Supportability/API/drop_buffered_data',
         'OtherTransactionTotalTime',
         'OtherTransactionTotalTime/transaction',
+        'Logging/lines',
+        'Logging/lines/WARN',
+        'Logging/size',
+        'Logging/size/WARN',
         'Supportability/API/record_metric',
+        'Supportability/API/increment_metric',
         'Supportability/Deprecated/cross_application_tracer'
         ])
     end

--- a/test/new_relic/agent/transaction/segment_test.rb
+++ b/test/new_relic/agent/transaction/segment_test.rb
@@ -166,6 +166,12 @@ module NewRelic
             "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all",
             "Supportability/API/recording_web_transaction?",
             "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther",
+            'Logging/lines',
+            'Logging/lines/INFO',
+            'Logging/size',
+            'Logging/size/INFO',
+            'Supportability/API/increment_metric',
+            'Supportability/API/record_metric',
           ]
         end
 

--- a/test/performance/lib/performance/instrumentation/gc_stats.rb
+++ b/test/performance/lib/performance/instrumentation/gc_stats.rb
@@ -5,7 +5,7 @@
 module Performance
   module Instrumentation
     class MRIGCStats < Instrumentor
-      platforms :mri_20, :mri_21, :mri_22, :mri_23, :mri_24, :mri_25, :mri_26
+      platforms :mri_22, :mri_23, :mri_24, :mri_25, :mri_26, :mri_27, :mri_30
       on_by_default
 
       def before(*)

--- a/test/performance/lib/performance/instrumentation/stackprof.rb
+++ b/test/performance/lib/performance/instrumentation/stackprof.rb
@@ -5,7 +5,7 @@
 module Performance
   module Instrumentation
     class StackProfProfile < Instrumentor
-      platforms :mri_21, :mri_22, :mri_23, :mri_24, :mri_25, :mri_26
+      platforms :mri_22, :mri_23, :mri_24, :mri_25, :mri_26, :mri_27, :mri_30
 
       def self.setup
         require 'tmpdir'

--- a/test/performance/lib/performance/platform.rb
+++ b/test/performance/lib/performance/platform.rb
@@ -23,6 +23,8 @@ module Performance
       when :mri_24  then !jruby? && RUBY_VERSION =~ /^2\.4\./
       when :mri_25  then !jruby? && RUBY_VERSION =~ /^2\.5\./
       when :mri_26  then !jruby? && RUBY_VERSION =~ /^2\.6\./
+      when :mri_27  then !jruby? && RUBY_VERSION =~ /^2\.7\./
+      when :mri_30  then !jruby? && RUBY_VERSION =~ /^3\.0\./
       end
     end
 

--- a/test/performance/suites/logging.rb
+++ b/test/performance/suites/logging.rb
@@ -8,9 +8,17 @@ class LoggingTest < Performance::TestCase
 
   EXAMPLE_MESSAGE = 'This is an example message'.freeze
 
-  def test_logging
+  def test_decorating_logger
     io = StringIO.new
     logger = NewRelic::Agent::Logging::DecoratingLogger.new io
+    measure do
+      logger.info EXAMPLE_MESSAGE
+    end
+  end
+
+  def test_logger_instrumentation
+    io = StringIO.new
+    logger = ::Logger.new io
     measure do
       logger.info EXAMPLE_MESSAGE
     end


### PR DESCRIPTION
# Overview 🪓 
This pull request introduces basic instrumentation for logging line counts and sizes, with faceting by severity. It hooks into the Ruby standard library `Logger` class.

This new instrumentation is controlled by the configuration flags `instrumentation.logger` or the older style `disable_logger_instrumentation`.

I've confirmed that the point that we're instrumenting is available with the same signature all the way back to Ruby 2.2.0, so nothing special needed to support it on all our currently allowed Rubies.

There did end up being one subtle bit here because the agent uses `Logger` ourselves via `AgentLogger`. This meant that if our metric recording caused us to write to the `AgentLogger` again (which does happen in some paths), we could end up in a recursion. This surfaced immediately in one of the unit tests. To address this, we flag when a given instance of `Logger` is already in the midst of a call, so if we end up writing to that logger again it won't instrument the further calls.

# Testing 🔍 
Because the `Logger` is available in the standard library, I could exercise the functionality entirely through unit tests. The tests check that:

* The underlying device still sees messages with the contents we expect (i.e. we don't interfere with normal operation)
* We record the metrics we expect with all the various permutations
* Flagging to skip further instrumentation is obeyed.

~I haven't run the entire Multiverse locally to see whether any of the metric changes show up in unexpected places. Will keep an eye on the PR testing and if anything shows up like that I'll get it fixed.~ Multiverse is running 🟢  now. In some cases I added to the lists of expected metrics, in a few others I took advantage of the `ignore_filter` where it was already in use for `Supportability` metrics to do the same for `Logging/*`. Could arguably just disable that instrumentation on the whole multiverse suite instead if we preferred to take that out of consideration entirely 🤔 

# Performance 💨 
As logging is a common action, we do want to pay attention to the impact of this. I've updated to get the performance suite running on the latest couple of Rubies (was just flagged to not) and added a test case to the Logging performance suite that doesn't use the decorator.

I observed that while there is a relatively sizable relative increase in the call time, we were still in the 10000's of iterations per second with the new path clocking in for me around 20 microseconds (not millis). I will be doing some further testing to confirm these findings in a real app with some significant logging, but all signs point to this being just another method instrumentation like lots of other frequently called things we do in the agent.

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
