### PR TITLE
[BUGFIX] add_method_tracer errors on BasicObject methods

### DIFF
--- a/lib/new_relic/agent/method_tracer.rb
+++ b/lib/new_relic/agent/method_tracer.rb
@@ -320,6 +320,11 @@ module NewRelic
 
               instance_exec(&code_header) if code_header.kind_of?(Proc)
 
+              # NOTE: Calling ::NewRelic::Agent::MethodTracer.trace_execution_scoped and
+              # .trace_execution_unscoped below relies on the fact that MethodTracer is included
+              # in Module on agent startup. If/when this changes, these methods should be
+              # explicitly namespaced and extended in MethodTracer.
+
               # If tracing multiple metrics on this method, nest one unscoped trace inside the scoped trace.
               begin
                 if scoped_metric_eval

--- a/lib/new_relic/agent/method_tracer.rb
+++ b/lib/new_relic/agent/method_tracer.rb
@@ -323,17 +323,17 @@ module NewRelic
               # If tracing multiple metrics on this method, nest one unscoped trace inside the scoped trace.
               begin
                 if scoped_metric_eval
-                  self.class.trace_execution_scoped(scoped_metric_eval, metric: record_metrics, internal: true) do
+                  ::NewRelic::Agent::MethodTracer.trace_execution_scoped(scoped_metric_eval, metric: record_metrics, internal: true) do
                     if unscoped_metrics_eval.empty?
                       super(*args, &block)
                     else
-                      self.class.trace_execution_unscoped(unscoped_metrics_eval, internal: true) do
+                      ::NewRelic::Agent::MethodTracer.trace_execution_unscoped(unscoped_metrics_eval, internal: true) do
                         super(*args, &block)
                       end
                     end
                   end
                 elsif !unscoped_metrics_eval.empty?
-                  self.class.trace_execution_unscoped(unscoped_metrics_eval, internal: true) do
+                  ::NewRelic::Agent::MethodTracer.trace_execution_unscoped(unscoped_metrics_eval, internal: true) do
                     super(*args, &block)
                   end
                 end


### PR DESCRIPTION
Fixes #789 

When using `add_method_tracer`, the created tracer method called `self.class.trace_execution_[un]scoped`; however, `Kernel#class` is not available on BasicObjects. The tracer method is updated here to call `::NewRelic::Agent::MethodTracer.trace_execution_scoped` as these are effectively static methods. A new test case has been added for adding method tracers to BasicObjects.

# Other thoughts
Note that the above method call relies on the fact that `MethodTracer` is included in `Module` at startup. The historic reasons for this are unclear, and it's difficult to trace *how* `trace_execution_scoped` is available as a class method on `MethodTracer`. Making this more explicit in the code would require more refactoring than is in scope here.

If/when we do change `MethodTracer` not to be included in everything via `Module`, this will have to be changed again. Luckily we already have test coverage for this.

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
