### PR TITLE
Fix for staging collector issue on reconnect

### DIFF
--- a/lib/new_relic/agent/new_relic_service.rb
+++ b/lib/new_relic/agent/new_relic_service.rb
@@ -333,7 +333,6 @@ module NewRelic
           conn = proxy.new(@collector.name, @collector.port)
         else
           conn = Net::HTTP.new(@collector.name, @collector.port)
-          # conn = Net::HTTP.new(@configured_collector.name, @configured_collector.port)
         end
 
         setup_connection_for_ssl(conn)


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
This is an _actual_ fix for the issue described in https://github.com/newrelic/newrelic-ruby-agent/issues/657, rather than the temporary workaround I found in https://github.com/newrelic/newrelic-ruby-agent/pull/681. 
Basically the main issue with the original implementation in https://github.com/newrelic/newrelic-ruby-agent/pull/406 was that, while we were using the `@configured_collector` when creating our request (seen as part of the changes in that PR), we were NOT using the `@configured_collector` when creating the new connection (can be seen in the method `create_http_connection` [here](https://github.com/newrelic/newrelic-ruby-agent/blob/8.0.0/lib/new_relic/agent/new_relic_service.rb#L335)), we were still just using `@collector`, which would still be the previous redirect host even when trying to create a new connection when using `:preconnect`.

For this fix, instead of keeping track of 2 different collector attributes (`@collector `and `@configured_collector`) and choosing which one to use in the code when making requests/connections, I changed it so we are going back to only using `@collector` when creating connections/requests, and instead we simply reset `@collector` to `@configured_collector` when we are calling `:preconnect`. Since we no longer need the redirect host stored in `@collector` at that point, it's good to just get rid of it anyways. I think this is better this way since it decreases the chances of other areas of code using the redirect host stored in `@collector` when we are trying to create a fresh connection using `@configured_collector`, and guarantees that everywhere is using the same host at all times to avoid mismatch 

Even though the original problem only showed up on the staging collector, I did test this on both staging and prod collectors to ensure both reacted correctly to this change. 

_note: I did not create a changelog entry for this, as this is an issue that only effected internal new relic users of the agent and may confuse external customers seeing it in the changelog (same thing we did when we released the workaround)_

# Related Github Issue
closes https://github.com/newrelic/newrelic-ruby-agent/issues/682
Also related to https://github.com/newrelic/newrelic-ruby-agent/issues/657 https://github.com/newrelic/newrelic-ruby-agent/pull/681 https://github.com/newrelic/newrelic-ruby-agent/pull/406

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
Github Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
