### PR TITLE
Use Dalli::Protocol::Binary rather than Dalli::Server

### DIFF
--- a/lib/new_relic/agent/instrumentation/memcache/dalli.rb
+++ b/lib/new_relic/agent/instrumentation/memcache/dalli.rb
@@ -51,7 +51,7 @@ module NewRelic
           end
 
           def instrument_send_multiget
-            ::Dalli::Server.class_eval do
+            ::Dalli::Protocol::Binary.class_eval do
               include NewRelic::Agent::Instrumentation::Memcache::Tracer
               alias_method :send_multiget_without_newrelic_trace, :send_multiget
 

--- a/lib/new_relic/agent/instrumentation/memcache/dalli.rb
+++ b/lib/new_relic/agent/instrumentation/memcache/dalli.rb
@@ -51,7 +51,11 @@ module NewRelic
           end
 
           def instrument_send_multiget
-            ::Dalli::Protocol::Binary.class_eval do
+            if supports_binary_protocol?
+              ::Dalli::Protocol::Binary
+            else
+              ::Dalli::Server
+            end.class_eval do
               include NewRelic::Agent::Instrumentation::Memcache::Tracer
               alias_method :send_multiget_without_newrelic_trace, :send_multiget
 

--- a/lib/new_relic/agent/instrumentation/memcache/helper.rb
+++ b/lib/new_relic/agent/instrumentation/memcache/helper.rb
@@ -7,9 +7,14 @@ module NewRelic::Agent::Instrumentation
   module Memcache
     module Helper
       DATASTORE_INSTANCES_SUPPORTED_VERSION = Gem::Version.new '2.6.4'
+      BINARY_PROTOCOL_SUPPORTED_VERSION = Gem::Version.new '3.0.2'
 
       def supports_datastore_instances?
         DATASTORE_INSTANCES_SUPPORTED_VERSION <= Gem::Version.new(::Dalli::VERSION)
+      end
+
+      def supports_binary_protocol?
+        BINARY_PROTOCOL_SUPPORTED_VERSION <= Gem::Version.new(::Dalli::VERSION)
       end
 
       def client_methods

--- a/lib/new_relic/agent/instrumentation/memcache/prepend.rb
+++ b/lib/new_relic/agent/instrumentation/memcache/prepend.rb
@@ -31,7 +31,7 @@ module NewRelic::Agent::Instrumentation
         if supports_datastore_instances?
           yield ::Dalli::Client, dalli_client_prepender(dalli_methods)
           yield ::Dalli::Client, dalli_get_multi_prepender(:get_multi)
-          yield ::Dalli::Server, dalli_server_prepender
+          yield ::Dalli::Protocol::Binary, dalli_server_prepender
           yield ::Dalli::Ring, dalli_ring_prepender
         else
           yield ::Dalli::Client, dalli_client_prepender(client_methods)

--- a/lib/new_relic/agent/instrumentation/memcache/prepend.rb
+++ b/lib/new_relic/agent/instrumentation/memcache/prepend.rb
@@ -31,7 +31,13 @@ module NewRelic::Agent::Instrumentation
         if supports_datastore_instances?
           yield ::Dalli::Client, dalli_client_prepender(dalli_methods)
           yield ::Dalli::Client, dalli_get_multi_prepender(:get_multi)
-          yield ::Dalli::Protocol::Binary, dalli_server_prepender
+
+          if supports_binary_protocol?
+            yield ::Dalli::Protocol::Binary, dalli_server_prepender
+          else
+            yield ::Dalli::Server, dalli_server_prepender
+          end
+
           yield ::Dalli::Ring, dalli_ring_prepender
         else
           yield ::Dalli::Client, dalli_client_prepender(client_methods)

--- a/test/multiverse/suites/memcache/Envfile
+++ b/test/multiverse/suites/memcache/Envfile
@@ -1,4 +1,4 @@
-%w(2.7.6 2.7.8 2.7.11).each do |version|
+%w(2.7.6 2.7.8 2.7.11 3.0.2).each do |version|
   gemfile <<-RB
     gem 'dalli', '~> #{version}'
   RB

--- a/test/multiverse/suites/memcache/Envfile
+++ b/test/multiverse/suites/memcache/Envfile
@@ -1,6 +1,12 @@
-%w(2.7.6 2.7.8 2.7.11 3.0.2).each do |version|
+%w(2.7.6 2.7.8 2.7.11).each do |version|
   gemfile <<-RB
     gem 'dalli', '~> #{version}'
+  RB
+end
+
+if RUBY_VERSION >= '2.5.0'
+  gemfile <<-RB
+    gem 'dalli', '~> 3.0.2'
   RB
 end
 


### PR DESCRIPTION
# Overview
Since Dalli 3.0.2 was released, usage of Dalli::Server has been
deprecated. see: https://github.com/petergoldstein/dalli/pull/760

This commit removes those references and replaces them with the updated
API through Dalli::Protocol::Binary

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
Github Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
