### PR TITLE
Log CAT deprecation warning only when enabled

### DIFF
--- a/lib/new_relic/agent/monitors/cross_app_monitor.rb
+++ b/lib/new_relic/agent/monitors/cross_app_monitor.rb
@@ -22,10 +22,12 @@ module NewRelic
         CONTENT_LENGTH_HEADER_KEY = 'HTTP_CONTENT_LENGTH'.freeze
 
         def on_finished_configuring(events)
-          Deprecator.deprecate('cross_application_tracer')
-          ::NewRelic::Agent.logger.warn(
-            "[DEPRECATED] Cross application tracing is enabled. Distributed tracing is replacing cross application tracing as the default means of tracing between services. To continue using cross application tracing, enable it with `cross_application_tracer.enabled: true` and `distributed_tracing.enabled: false`"
-          )
+          if CrossAppTracing.cross_app_enabled?
+            Deprecator.deprecate('cross_application_tracer')
+            ::NewRelic::Agent.logger.warn(
+              "[DEPRECATED] Cross application tracing is enabled. Distributed tracing is replacing cross application tracing as the default means of tracing between services. To continue using cross application tracing, enable it with `cross_application_tracer.enabled: true` and `distributed_tracing.enabled: false`"
+            )
+          end
 
           register_event_listeners(events)
         end


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
Adds a check for if CAT is enabled before logging the CAT deprecation warning.

# Related Github Issue
closes #827

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
Github Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
