### PR TITLE
Remove all pinned racc versions for jruby

### DIFF
--- a/test/environments/rails42/Gemfile
+++ b/test/environments/rails42/Gemfile
@@ -13,7 +13,6 @@ platforms :jruby do
   gem "activerecord-jdbcmysql-adapter", "~>1.3.0"
   gem "activerecord-jdbcsqlite3-adapter", "~>1.3.0"
   gem "jruby-openssl"
-  gem 'racc', '<= 1.5.2'
 end
 
 platforms :ruby, :rbx do

--- a/test/environments/rails51/Gemfile
+++ b/test/environments/rails51/Gemfile
@@ -13,7 +13,6 @@ platforms :jruby do
   gem "activerecord-jdbcmysql-adapter", "~> 51.0"
   gem "activerecord-jdbcsqlite3-adapter", "~> 51.0"
   gem "jruby-openssl"
-  gem 'racc', '<= 1.5.2'
 end
 
 platforms :ruby, :rbx do

--- a/test/multiverse/suites/activemerchant/Envfile
+++ b/test/multiverse/suites/activemerchant/Envfile
@@ -9,8 +9,6 @@ if RUBY_VERSION >= '3.0.0'
     gem 'nokogiri'
     gem 'minitest', '~> 5.1.0'
 
-    gem 'racc', '<= 1.5.2' if RUBY_PLATFORM == 'java'
-
     # Need to load newrelic_rpm after ActiveMerchant Gateways are required
     gem 'newrelic_rpm', :require => false, :path => File.expand_path('../../../../')
   RB
@@ -24,8 +22,6 @@ if RUBY_VERSION >= '2.5.0' && RUBY_VERSION < '3.0.0'
     gem 'activesupport', '~> 4.2.0'
     gem 'nokogiri'
     gem 'minitest', '~> 5.1.0'
-
-    gem 'racc', '<= 1.5.2' if RUBY_PLATFORM == 'java'
 
     # Need to load newrelic_rpm after ActiveMerchant Gateways are required
     gem 'newrelic_rpm', :require => false, :path => File.expand_path('../../../../')
@@ -41,8 +37,6 @@ if RUBY_VERSION >= '2.3.0' && RUBY_VERSION < '3.0.0'
     gem 'nokogiri'
     gem 'minitest', '~> 5.1.0'
 
-    gem 'racc', '<= 1.5.2' if RUBY_PLATFORM == 'java'
-
     # Need to load newrelic_rpm after ActiveMerchant Gateways are required
     gem 'newrelic_rpm', :require => false, :path => File.expand_path('../../../../')
   RB
@@ -57,8 +51,6 @@ if RUBY_VERSION < '2.4.0'
 
     gem 'activesupport', '~>4.0.4'
     gem 'nokogiri', '~>1.6.1'
-
-    gem 'racc', '<= 1.5.2' if RUBY_PLATFORM == 'java'
 
     # Need to load newrelic_rpm after ActiveMerchant Gateways are required
     gem 'newrelic_rpm', :require => false, :path => File.expand_path('../../../../')

--- a/test/multiverse/suites/rails/Envfile
+++ b/test/multiverse/suites/rails/Envfile
@@ -1,7 +1,6 @@
 if RUBY_VERSION >= '2.5.0'
   gemfile <<-RB
     gem 'rails', '~> 6.1.0'
-    gem 'racc', '<= 1.5.2' if RUBY_PLATFORM == 'java'
     gem 'haml', '~>5.0.0'
     gem 'haml-rails', '2.0.0'
     gem 'minitest', '5.2.3'
@@ -13,7 +12,6 @@ if RUBY_VERSION >= '2.5.0' && RUBY_VERSION < '3.0.0'
 
   gemfile <<-RB
     gem 'rails', '6.0.0'
-    gem 'racc', '<= 1.5.2' if RUBY_PLATFORM == 'java'
     gem 'haml', '~>5.0.0'
     gem 'haml-rails', '2.0.0'
     gem 'minitest', '5.2.3'
@@ -25,7 +23,6 @@ if RUBY_VERSION >= '2.2.2' && RUBY_VERSION < '3.0.0'
 
   gemfile <<-RB
     gem 'rails', '5.2.2'
-    gem 'racc', '<= 1.5.2' if RUBY_PLATFORM == 'java'
     gem 'haml', '~>5.0.0'
     gem 'haml-rails', '~>1.0.0'
     gem 'minitest', '5.2.3'
@@ -33,7 +30,6 @@ if RUBY_VERSION >= '2.2.2' && RUBY_VERSION < '3.0.0'
 
   gemfile <<-RB
     gem 'rails', '~>5.1.0'
-    gem 'racc', '<= 1.5.2' if RUBY_PLATFORM == 'java'
     gem 'haml', '~>5.0.0'
     gem 'haml-rails', '~>1.0.0'
     gem 'minitest', '5.2.3'
@@ -41,7 +37,6 @@ if RUBY_VERSION >= '2.2.2' && RUBY_VERSION < '3.0.0'
 
   gemfile <<-RB
     gem 'rails', '~>5.0.0'
-    gem 'racc', '<= 1.5.2' if RUBY_PLATFORM == 'java'
     gem 'haml', '~>5.0.0'
     gem 'haml-rails', '~>1.0.0'
     gem 'minitest', '5.2.3'
@@ -51,7 +46,6 @@ end
 if RUBY_VERSION < '2.4.0'
   gemfile <<-RB
     gem 'rails', '~>4.2.1'
-    gem 'racc', '<= 1.5.2' if RUBY_PLATFORM == 'java'
     gem 'haml', '~>5.0.0'
     gem 'haml-rails', '~>1.0.0'
     gem 'minitest', '5.2.3'
@@ -60,7 +54,6 @@ if RUBY_VERSION < '2.4.0'
 
   gemfile <<-RB
     gem 'rails', '~>4.1.10'
-    gem 'racc', '<= 1.5.2' if RUBY_PLATFORM == 'java'
     # Multiverse has an incompatibility with Minitest 5.3.0, so lock here for
     # now
     gem 'haml', '~>5.0.0'
@@ -71,7 +64,6 @@ if RUBY_VERSION < '2.4.0'
 
   gemfile <<-RB
     gem 'rails', '~>4.0.13'
-    gem 'racc', '<= 1.5.2' if RUBY_PLATFORM == 'java'
     gem 'haml', '~>5.0.0'
     gem 'haml-rails', '~>1.0.0'
     gem 'nokogiri', '< 1.7' if RUBY_VERSION < '2.1.0' # nokogiri 1.7.0 only supports >= 2.1.0
@@ -79,7 +71,6 @@ if RUBY_VERSION < '2.4.0'
 
   gemfile <<-RB
     gem 'rails', '~>3.2.22.2'
-    gem 'racc', '<= 1.5.2' if RUBY_PLATFORM == 'java'
     gem 'i18n', '~>0.6.11'
     gem 'haml', '4.0.2'   # Getting load issues with haml 4.0.3
     gem 'minitest_tu_shim', :require => false
@@ -87,7 +78,6 @@ if RUBY_VERSION < '2.4.0'
 
   gemfile <<-RB
     gem 'rails', '~>3.2.22.2'
-    gem 'racc', '<= 1.5.2' if RUBY_PLATFORM == 'java'
     gem 'i18n', '~>0.6.11'
     gem 'sinatra', '~> 1.4.5'
     gem 'haml', '4.0.2'   # Getting load issues with haml 4.0.3

--- a/test/multiverse/suites/rails_prepend/Envfile
+++ b/test/multiverse/suites/rails_prepend/Envfile
@@ -4,7 +4,6 @@ if RUBY_VERSION >= '2.5.0'  && RUBY_VERSION < '3.0.0'
     gem 'haml', '~>5.0.0'
     gem 'newrelic_prepender', path: File.expand_path('../newrelic_prepender', __FILE__)
     gem 'minitest', '5.2.3'
-    gem 'racc', '<= 1.5.2' if RUBY_PLATFORM == 'java'
   RB
 end
 
@@ -14,14 +13,12 @@ if RUBY_VERSION >= '2.2.2' && RUBY_VERSION < '3.0.0'
     gem 'haml', '~>5.0.0'
     gem 'newrelic_prepender', path: File.expand_path('../newrelic_prepender', __FILE__)
     gem 'minitest', '5.2.3'
-    gem 'racc', '<= 1.5.2' if RUBY_PLATFORM == 'java'
   RB
 
   gemfile <<-RB
     gem 'rails', '~>5.1.0'
     gem 'haml', '~>5.0.0'
     gem 'newrelic_prepender', path: File.expand_path('../newrelic_prepender', __FILE__)
-    gem 'racc', '<= 1.5.2' if RUBY_PLATFORM == 'java'
     gem 'minitest', '5.2.3'
   RB
 
@@ -29,7 +26,6 @@ if RUBY_VERSION >= '2.2.2' && RUBY_VERSION < '3.0.0'
     gem 'rails', '~>5.0.0'
     gem 'haml', '~>5.0.0'
     gem 'newrelic_prepender', path: File.expand_path('../newrelic_prepender', __FILE__)
-    gem 'racc', '<= 1.5.2' if RUBY_PLATFORM == 'java'
     gem 'minitest', '5.2.3'
   RB
 end
@@ -42,7 +38,6 @@ if RUBY_VERSION < '2.4.0'
     gem 'minitest', '5.2.3'
     gem 'nokogiri', '< 1.7' if RUBY_VERSION < '2.1.0' # nokogiri 1.7.0 only supports >= 2.1.0
     gem 'thor', '< 0.20.1' if RUBY_PLATFORM == 'java' # unpredictable thor errors
-    gem 'racc', '<= 1.5.2' if RUBY_PLATFORM == 'java'
     RB
 
   gemfile <<-RB
@@ -54,7 +49,6 @@ if RUBY_VERSION < '2.4.0'
     gem 'minitest', '5.2.3'
     gem 'nokogiri', '< 1.7' if RUBY_VERSION < '2.1.0' # nokogiri 1.7.0 only supports >= 2.1.0
     gem 'thor', '< 0.20.1' if RUBY_PLATFORM == 'java' # unpredictable thor errors
-    gem 'racc', '<= 1.5.2' if RUBY_PLATFORM == 'java'
   RB
 
   gemfile <<-RB
@@ -63,6 +57,5 @@ if RUBY_VERSION < '2.4.0'
     gem 'newrelic_prepender', path: File.expand_path('../newrelic_prepender', __FILE__)
     gem 'nokogiri', '< 1.7' if RUBY_VERSION < '2.1.0' # nokogiri 1.7.0 only supports >= 2.1.0
     gem 'thor', '< 0.20.1' if RUBY_PLATFORM == 'java' # unpredictable thor errors
-    gem 'racc', '<= 1.5.2' if RUBY_PLATFORM == 'java'
   RB
 end


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
The issue with the newest racc version on jruby has been resolved https://github.com/ruby/racc/issues/172, so this PR will revert the changes we made in https://github.com/newrelic/newrelic-ruby-agent/pull/812 to work around the error.



# Related Github Issue


# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
Github Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
