### PR TITLE
Add deprecated flag to error_collector.ignore_errors

### DIFF
--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -1313,6 +1313,7 @@ module NewRelic
           :default => 'ActionController::RoutingError,Sinatra::NotFound',
           :public => true,
           :type => String,
+          :deprecated => true, 
           :allowed_from_server => true,
           :dynamic_name => true,
           :description => 'Use `error_collector.ignore_classes` instead. Specify a comma-delimited list of error classes that the agent should ignore.'


### PR DESCRIPTION
While working on a GTSE ticket, I noticed [the documentation for `error_collector.ignore_errors`](https://docs.newrelic.com/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration/#error_collector-ignore_errors) marked this setting as deprecated, but the deprecated flag was not included on default_source.