### PR TITLE
Scrub non-unicode characters from logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
     Template rendering using [Tilt](https://github.com/rtomayko/tilt) is now instrumented. See [PR #847](https://github.com/newrelic/newrelic-ruby-agent/pull/847) for details.
 
+  * **Bugfix: Scrub non-unicode characters from DecoratingLogger**
+
+    To prevent `JSON::GeneratorErrors`, the DecoratingLogger replaces non-unicode characters with the replacement character: �. Thank you Jonathan del Strother (@jdelStrother) for bringing this to our attention!
 
   ## v8.1.0
 

--- a/lib/new_relic/agent/logging.rb
+++ b/lib/new_relic/agent/logging.rb
@@ -33,6 +33,7 @@ module NewRelic
         COLON = ':'.freeze
         COMMA = ','.freeze
         CLOSING_BRACE = '}'.freeze
+        REPLACEMENT_CHAR = '�'
 
         def initialize
           Agent.config.register_callback :app_name do
@@ -86,14 +87,10 @@ module NewRelic
           message << QUOTE << key << QUOTE << COLON << QUOTE << value << QUOTE
         end
 
-        def escape message
-          message = message.inspect unless message.is_a?(String)
-          message.encode(
-            Encoding::UTF_8,
-            invalid: :replace,
-            undef: :replace,
-            replace: "�"
-          ).to_json
+        def escape(message)
+          message = message.to_s unless message.is_a?(String)
+          message = message.scrub(REPLACEMENT_CHAR) unless message.valid_encoding?
+          message.to_json
         end
 
         def clear_tags!

--- a/lib/new_relic/agent/logging.rb
+++ b/lib/new_relic/agent/logging.rb
@@ -87,11 +87,13 @@ module NewRelic
         end
 
         def escape message
-          if String === message
-            message.to_json
-          else
-            message.inspect.to_json
-          end
+          message = message.inspect unless message.is_a?(String)
+          message.encode(
+            Encoding::UTF_8,
+            invalid: :replace,
+            undef: :replace,
+            replace: "�"
+          ).to_json
         end
 
         def clear_tags!

--- a/test/new_relic/agent/logging_test.rb
+++ b/test/new_relic/agent/logging_test.rb
@@ -78,7 +78,7 @@ module NewRelic
           'carriage_return' => "message with a carriage return \r",
           'tab' => "message with a tab \t ",
           'unicode' => "message with a unicode snowman ☃ ",
-          'unicode_hex' => "message with a unicode snowman \u2603  "
+          'unicode_hex' => "message with a unicode snowman \u2603  ",
         }
         messages_to_escape.each do |name, message|
           define_method "test_escape_message_#{name}" do
@@ -88,6 +88,16 @@ module NewRelic
           end
         end
 
+        def test_to_replace_non_utf_8_chars
+          message = 'message with a non-unicode code '
+          input = "#{message} \xb3"
+          expectation = "#{message} #{DecoratingFormatter::REPLACEMENT_CHAR}"
+          logger = DecoratingLogger.new @output
+
+          logger.info input
+          assert_equal expectation,
+            last_message['message']
+        end
 
         if RUBY_VERSION >= '2.4.0'
           def test_constructor_arguments_level


### PR DESCRIPTION
# Overview
Adds a call to`#scrub` with a replacement character to avoid raising a `JSON::GeneratorError` when non-unicode characters are included in log messages.

`#scrub` was chosen over `#encode` due to better performance when running benchmark tests.

# Related Github Issue
Closes #842 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
