### PR TITLE
[TILT-2] Tilt::Template#render instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # New Relic Ruby Agent Release Notes #
 
-  ## v8.1.0
+  ## v8.2.0
 
   * **New Instrumentation for Tilt gem**
 
     Template rendering using [Tilt](https://github.com/rtomayko/tilt) is now instrumented. See [PR #847](https://github.com/newrelic/newrelic-ruby-agent/pull/847) for details.
+
+
+  ## v8.1.0
 
   * **Instrumentation for Ruby standard library Logger**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
   ## v8.1.0
 
+  * **New Instrumentation for Tilt gem**
+
+    Template rendering using [Tilt](https://github.com/rtomayko/tilt) is now instrumented. See [PR #847](https://github.com/newrelic/newrelic-ruby-agent/pull/847) for details.
+
   * **Instrumentation for Ruby standard library Logger**
 
     The agent will now automatically instrument Logger, recording number of lines and size of logging output, with breakdown by severity.

--- a/lib/new_relic/agent/instrumentation/tilt.rb
+++ b/lib/new_relic/agent/instrumentation/tilt.rb
@@ -9,7 +9,8 @@ require_relative 'tilt/prepend'
 DependencyDetection.defer do
   named :tilt
 
-  depends_on { defined?(::Tilt) }
+  # prior to 0.8.0, the prepare method was known as compile
+  depends_on { defined?(::Tilt) && ::Tilt::VERSION >= '0.8.0' }
 
   executes do
     ::NewRelic::Agent.logger.info  "Installing Tilt instrumentation"

--- a/lib/new_relic/agent/instrumentation/tilt.rb
+++ b/lib/new_relic/agent/instrumentation/tilt.rb
@@ -12,14 +12,14 @@ DependencyDetection.defer do
   depends_on { defined?(::Tilt) }
 
   executes do
-    ::NewRelic::Agent.logger.info  "Installing Tilt instrumentation"
+    ::NewRelic::Agent.logger.info("Installing Tilt instrumentation")
   end
 
   executes do
     if use_prepend?
       prepend_instrument ::Tilt::Template, NewRelic::Agent::Instrumentation::Tilt::Prepend
     else
-      chain_instrument NewRelic::Agent::Instrumentation::Tilt
+      chain_instrument NewRelic::Agent::Instrumentation::Tilt::Chain
     end
   end
 end

--- a/lib/new_relic/agent/instrumentation/tilt.rb
+++ b/lib/new_relic/agent/instrumentation/tilt.rb
@@ -12,7 +12,7 @@ DependencyDetection.defer do
   depends_on { defined?(::Tilt) }
 
   executes do
-    ::NewRelic::Agent.logger.info("Installing Tilt instrumentation")
+    ::NewRelic::Agent.logger.info('Installing Tilt instrumentation')
   end
 
   executes do

--- a/lib/new_relic/agent/instrumentation/tilt.rb
+++ b/lib/new_relic/agent/instrumentation/tilt.rb
@@ -9,8 +9,7 @@ require_relative 'tilt/prepend'
 DependencyDetection.defer do
   named :tilt
 
-  # prior to 0.8.0, the prepare method was known as compile
-  depends_on { defined?(::Tilt) && ::Tilt::VERSION >= '0.8.0' }
+  depends_on { defined?(::Tilt) }
 
   executes do
     ::NewRelic::Agent.logger.info  "Installing Tilt instrumentation"

--- a/lib/new_relic/agent/instrumentation/tilt/chain.rb
+++ b/lib/new_relic/agent/instrumentation/tilt/chain.rb
@@ -5,7 +5,18 @@
 module NewRelic::Agent::Instrumentation
   module Tilt
     def self.instrument!
-      # no-op
+      ::Tilt::Template.module_eval do
+        include NewRelic::Agent::Instrumentation::Tilt
+
+        def initialize_with_new_relic(*args, &block)
+          initialize_with_tracing(*args) {
+            initialize_without_newrelic(*args, &block)
+          }
+        end
+
+        alias initialize_without_newrelic initialize
+        alias initialize initialize_with_new_relic
+      end
     end
   end
 end

--- a/lib/new_relic/agent/instrumentation/tilt/chain.rb
+++ b/lib/new_relic/agent/instrumentation/tilt/chain.rb
@@ -4,18 +4,20 @@
 
 module NewRelic::Agent::Instrumentation
   module Tilt
-    def self.instrument!
-      ::Tilt::Template.module_eval do
-        include NewRelic::Agent::Instrumentation::Tilt
+    module Chain
+      def self.instrument!
+        ::Tilt::Template.module_eval do
+          include NewRelic::Agent::Instrumentation::Tilt
 
-        def render_with_new_relic(*args, &block)
-          render_with_tracing(*args) {
-            render_without_newrelic(*args, &block)
-          }
+          def render_with_new_relic(*args, &block)
+            render_with_tracing(*args) {
+              render_without_newrelic(*args, &block)
+            }
+          end
+
+          alias render_without_newrelic render
+          alias render render_with_new_relic
         end
-
-        alias render_without_newrelic render
-        alias render render_with_new_relic
       end
     end
   end

--- a/lib/new_relic/agent/instrumentation/tilt/chain.rb
+++ b/lib/new_relic/agent/instrumentation/tilt/chain.rb
@@ -8,14 +8,14 @@ module NewRelic::Agent::Instrumentation
       ::Tilt::Template.module_eval do
         include NewRelic::Agent::Instrumentation::Tilt
 
-        def initialize_with_new_relic(*args, &block)
-          initialize_with_tracing(*args) {
-            initialize_without_newrelic(*args, &block)
+        def render_with_new_relic(*args, &block)
+          render_with_tracing(*args) {
+            render_without_newrelic(*args, &block)
           }
         end
 
-        alias initialize_without_newrelic initialize
-        alias initialize initialize_with_new_relic
+        alias render_without_newrelic render
+        alias render render_with_new_relic
       end
     end
   end

--- a/lib/new_relic/agent/instrumentation/tilt/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/tilt/instrumentation.rb
@@ -11,10 +11,19 @@ module NewRelic
           "View/#{klass}/#{file}/Rendering"
         end
 
+        # Sinatra uses #caller_locations for the file name in Tilt (unlike Rails/Rack)
+        # So here we are only grabbing the file name and name of directory it is in
+        def create_filename_for_metric(file)
+          return file unless defined?(::Sinatra) && defined?(::Sinatra::Base)
+          file.split('/')[-2..-1].join('/')
+        rescue NoMethodError
+          file
+        end
+
         def render_with_tracing(*args, &block)
           begin
             finishable = Tracer.start_segment(
-              name: metric_name(self.class, self.file)
+              name: metric_name(self.class, create_filename_for_metric(self.file))
             )
             begin
               yield

--- a/lib/new_relic/agent/instrumentation/tilt/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/tilt/instrumentation.rb
@@ -6,7 +6,120 @@ module NewRelic
   module Agent
     module Instrumentation
       module Tilt
+
+        def prepare_with_tracing
+          # Trace stuff
+          # get the template name?
+          # require 'pry'; binding.pry
+          finishable = Tracer.start_segment(name: 'Tilt/prepare')
+          yield
+          finishable.finish
+        rescue => e
+          log_notification_error(e, '', 'start')
+        end
       end
     end
   end
 end
+
+=begin
+        def start(name, id, payload) #THREAD_LOCAL_ACCESS
+          parent = segment_stack[id].last
+          metric_name = format_metric_name(name, payload, parent)
+
+          event = ActionViewEvent.new(metric_name, payload[:identifier])
+          if state.is_execution_traced? && recordable?(name, metric_name)
+            event.finishable = Tracer.start_segment(name: metric_name)
+          end
+          push_segment id, event
+        rescue => e
+          log_notification_error(e, name, 'start')
+        end
+
+        def finish(name, id, payload)
+          if segment = pop_segment(id)
+            if exception = exception_object(payload)
+              segment.notice_error exception
+            end
+            segment.finish
+          end
+        rescue => e
+          log_notification_error(e, name, 'finish')
+        end
+
+        def format_metric_name(event_name, payload, parent)
+          return parent.name if parent \
+             && (payload[:virtual_path] \
+              || (parent.identifier =~ /template$/))
+
+          if payload.key?(:virtual_path)
+            identifier = payload[:virtual_path]
+          else
+            identifier = payload[:identifier]
+          end
+
+          "View/#{metric_path(event_name, identifier)}/#{metric_action(event_name)}"
+        end
+
+        # Nearly every "render_blah.action_view" event has a child
+        # in the form of "!render_blah.action_view".  The children
+        # are the ones we want to record.  There are a couple
+        # special cases of events without children.
+        def recordable?(event_name, metric_name)
+          event_name[0] == '!' \
+              || metric_name == 'View/text template/Rendering' \
+              || metric_name == "View/#{::NewRelic::Agent::UNKNOWN_METRIC}/Partial"
+        end
+
+        RENDER_TEMPLATE_EVENT_NAME   = 'render_template.action_view'.freeze
+        RENDER_PARTIAL_EVENT_NAME    = 'render_partial.action_view'.freeze
+        RENDER_COLLECTION_EVENT_NAME = 'render_collection.action_view'.freeze
+
+        def metric_action(name)
+          case name
+          when /#{RENDER_TEMPLATE_EVENT_NAME}$/ then 'Rendering'
+          when RENDER_PARTIAL_EVENT_NAME        then 'Partial'
+          when RENDER_COLLECTION_EVENT_NAME     then 'Partial'
+          end
+        end
+
+        def metric_path(name, identifier)
+          # Rails 5 sets identifier to nil for empty collections,
+          # so do not mistake rendering a collection for rendering a file.
+          if identifier.nil? && name != RENDER_COLLECTION_EVENT_NAME
+            'file'
+          elsif identifier =~ /template$/
+            identifier
+          elsif identifier && (parts = identifier.split('/')).size > 1
+            parts[-2..-1].join('/')
+          else
+            ::NewRelic::Agent::UNKNOWN_METRIC
+          end
+        end
+      end
+
+      # This class holds state information between calls to `start`
+      # and `finish` for ActiveSupport events that we do not want to track
+      # as a transaction or segment.
+      class ActionViewEvent
+        attr_reader :name, :identifier
+        attr_accessor :finishable
+
+        def initialize(name, identifier)
+          @name = name
+          @identifier = identifier
+          @finishable = nil
+        end
+
+        def finish
+          @finishable.finish if @finishable
+        end
+
+        def notice_error error
+          @finishable.notice_error error if @finishable
+        end
+      end
+    end
+
+  end
+=end

--- a/lib/new_relic/agent/instrumentation/tilt/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/tilt/instrumentation.rb
@@ -6,120 +6,23 @@ module NewRelic
   module Agent
     module Instrumentation
       module Tilt
-
-        def prepare_with_tracing
-          # Trace stuff
-          # get the template name?
-          # require 'pry'; binding.pry
-          finishable = Tracer.start_segment(name: 'Tilt/prepare')
-          yield
-          finishable.finish
-        rescue => e
-          log_notification_error(e, '', 'start')
+        # Template name, etc. isn't available until Render. Those things are set in initialize.
+        # I'm uncertain about whether
+        def initialize_with_tracing(*args, &block)
+          begin
+            finishable = Tracer.start_segment(name: "#{self.class}#initialize")
+            yield
+            finishable.finish
+          rescue StandardError => error
+            binding.pry
+            NewRelic::Agent.logger.error(
+              "Error while executing Tilt::Template#initialize",
+              error
+            )
+            NewRelic::Agent.logger.log_exception(:error, error)
+          end
         end
       end
     end
   end
 end
-
-=begin
-        def start(name, id, payload) #THREAD_LOCAL_ACCESS
-          parent = segment_stack[id].last
-          metric_name = format_metric_name(name, payload, parent)
-
-          event = ActionViewEvent.new(metric_name, payload[:identifier])
-          if state.is_execution_traced? && recordable?(name, metric_name)
-            event.finishable = Tracer.start_segment(name: metric_name)
-          end
-          push_segment id, event
-        rescue => e
-          log_notification_error(e, name, 'start')
-        end
-
-        def finish(name, id, payload)
-          if segment = pop_segment(id)
-            if exception = exception_object(payload)
-              segment.notice_error exception
-            end
-            segment.finish
-          end
-        rescue => e
-          log_notification_error(e, name, 'finish')
-        end
-
-        def format_metric_name(event_name, payload, parent)
-          return parent.name if parent \
-             && (payload[:virtual_path] \
-              || (parent.identifier =~ /template$/))
-
-          if payload.key?(:virtual_path)
-            identifier = payload[:virtual_path]
-          else
-            identifier = payload[:identifier]
-          end
-
-          "View/#{metric_path(event_name, identifier)}/#{metric_action(event_name)}"
-        end
-
-        # Nearly every "render_blah.action_view" event has a child
-        # in the form of "!render_blah.action_view".  The children
-        # are the ones we want to record.  There are a couple
-        # special cases of events without children.
-        def recordable?(event_name, metric_name)
-          event_name[0] == '!' \
-              || metric_name == 'View/text template/Rendering' \
-              || metric_name == "View/#{::NewRelic::Agent::UNKNOWN_METRIC}/Partial"
-        end
-
-        RENDER_TEMPLATE_EVENT_NAME   = 'render_template.action_view'.freeze
-        RENDER_PARTIAL_EVENT_NAME    = 'render_partial.action_view'.freeze
-        RENDER_COLLECTION_EVENT_NAME = 'render_collection.action_view'.freeze
-
-        def metric_action(name)
-          case name
-          when /#{RENDER_TEMPLATE_EVENT_NAME}$/ then 'Rendering'
-          when RENDER_PARTIAL_EVENT_NAME        then 'Partial'
-          when RENDER_COLLECTION_EVENT_NAME     then 'Partial'
-          end
-        end
-
-        def metric_path(name, identifier)
-          # Rails 5 sets identifier to nil for empty collections,
-          # so do not mistake rendering a collection for rendering a file.
-          if identifier.nil? && name != RENDER_COLLECTION_EVENT_NAME
-            'file'
-          elsif identifier =~ /template$/
-            identifier
-          elsif identifier && (parts = identifier.split('/')).size > 1
-            parts[-2..-1].join('/')
-          else
-            ::NewRelic::Agent::UNKNOWN_METRIC
-          end
-        end
-      end
-
-      # This class holds state information between calls to `start`
-      # and `finish` for ActiveSupport events that we do not want to track
-      # as a transaction or segment.
-      class ActionViewEvent
-        attr_reader :name, :identifier
-        attr_accessor :finishable
-
-        def initialize(name, identifier)
-          @name = name
-          @identifier = identifier
-          @finishable = nil
-        end
-
-        def finish
-          @finishable.finish if @finishable
-        end
-
-        def notice_error error
-          @finishable.notice_error error if @finishable
-        end
-      end
-    end
-
-  end
-=end

--- a/lib/new_relic/agent/instrumentation/tilt/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/tilt/instrumentation.rb
@@ -7,10 +7,15 @@ module NewRelic
     module Instrumentation
       module Tilt
 
+        def metric_name(klass, file)
+          "View/#{klass}/#{file}/Rendering"
+        end
+
         def render_with_tracing(*args, &block)
           begin
-           finishable = Tracer.start_segment(name: "#{self.class}#render")
-
+            finishable = Tracer.start_segment(
+              name: metric_name(self.class, self.file)
+            )
             begin
               yield
             rescue => error

--- a/lib/new_relic/agent/instrumentation/tilt/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/tilt/instrumentation.rb
@@ -6,20 +6,19 @@ module NewRelic
   module Agent
     module Instrumentation
       module Tilt
-        # Template name, etc. isn't available until Render. Those things are set in initialize.
-        # I'm uncertain about whether
-        def initialize_with_tracing(*args, &block)
+
+        def render_with_tracing(*args, &block)
           begin
-            finishable = Tracer.start_segment(name: "#{self.class}#initialize")
-            yield
-            finishable.finish
-          rescue StandardError => error
-            binding.pry
-            NewRelic::Agent.logger.error(
-              "Error while executing Tilt::Template#initialize",
-              error
-            )
-            NewRelic::Agent.logger.log_exception(:error, error)
+           finishable = Tracer.start_segment(name: "#{self.class}#render")
+
+            begin
+              yield
+            rescue => error
+              NewRelic::Agent.notice_error(error)
+              raise
+            end
+          ensure
+            finishable.finish if finishable
           end
         end
       end

--- a/lib/new_relic/agent/instrumentation/tilt/prepend.rb
+++ b/lib/new_relic/agent/instrumentation/tilt/prepend.rb
@@ -6,9 +6,8 @@ module NewRelic::Agent::Instrumentation
   module Tilt::Prepend
     include NewRelic::Agent::Instrumentation::Tilt
 
-    def initialize(*args)
-      # require 'pry'; binding.pry
-      prepare_with_tracing { super }
+    def initialize(*args, &block)
+      initialize_with_tracing { super }
     end
   end
 end

--- a/lib/new_relic/agent/instrumentation/tilt/prepend.rb
+++ b/lib/new_relic/agent/instrumentation/tilt/prepend.rb
@@ -5,5 +5,10 @@
 module NewRelic::Agent::Instrumentation
   module Tilt::Prepend
     include NewRelic::Agent::Instrumentation::Tilt
+
+    def initialize(*args)
+      # require 'pry'; binding.pry
+      prepare_with_tracing { super }
+    end
   end
 end

--- a/lib/new_relic/agent/instrumentation/tilt/prepend.rb
+++ b/lib/new_relic/agent/instrumentation/tilt/prepend.rb
@@ -6,8 +6,8 @@ module NewRelic::Agent::Instrumentation
   module Tilt::Prepend
     include NewRelic::Agent::Instrumentation::Tilt
 
-    def initialize(*args, &block)
-      initialize_with_tracing { super }
+    def render(*args, &block)
+      render_with_tracing { super }
     end
   end
 end

--- a/test/multiverse/suites/tilt/Envfile
+++ b/test/multiverse/suites/tilt/Envfile
@@ -14,20 +14,9 @@ else
   RB
 end
 
-# Add last release for each major version here
-tilt_versions = ['1.4.1']
-
-tilt_versions.each do |version|
-  if RUBY_VERSION >= '3.0.0'
-    gemfile <<-RB
-      gem 'tilt', '#{version}'
-      gem 'webrick'
-      gem 'haml'
-    RB
-  else
-    gemfile <<-RB
-      gem 'tilt', '#{version}'
-      gem 'haml'
-    RB
-  end
+if RUBY_VERSION < '3.0.0'
+  gemfile <<-RB
+    gem 'tilt', '1.4.1'
+    gem 'haml'
+  RB
 end

--- a/test/multiverse/suites/tilt/Envfile
+++ b/test/multiverse/suites/tilt/Envfile
@@ -5,10 +5,12 @@ if RUBY_VERSION >= '3.0.0'
   gemfile <<-RB
     gem 'tilt'
     gem 'webrick'
+    gem 'haml'
   RB
 else
   gemfile <<-RB
     gem 'tilt'
+    gem 'haml'
   RB
 end
 
@@ -20,6 +22,7 @@ tilt_versions.each do |version|
     gemfile <<-RB
       gem 'tilt', '#{version}'
       gem 'webrick'
+      gem 'haml'
     RB
   else
     gemfile <<-RB

--- a/test/multiverse/suites/tilt/config/newrelic.yml
+++ b/test/multiverse/suites/tilt/config/newrelic.yml
@@ -6,7 +6,7 @@ development:
   monitor_mode: true
   license_key: bootstrap_newrelic_admin_license_key_000
   instrumentation:
-      tilt: <%= $instrumentation_method %>
+    tilt: <%= $instrumentation_method %>
   app_name: test
   log_level: debug
   host: 127.0.0.1

--- a/test/multiverse/suites/tilt/layout.haml
+++ b/test/multiverse/suites/tilt/layout.haml
@@ -1,0 +1,4 @@
+%head
+  %title Tilt Test Application
+%body
+  = yield

--- a/test/multiverse/suites/tilt/test.erb
+++ b/test/multiverse/suites/tilt/test.erb
@@ -1,0 +1,3 @@
+<body>
+  <h1>Hello from ERB!</h1>
+</body>

--- a/test/multiverse/suites/tilt/test.haml
+++ b/test/multiverse/suites/tilt/test.haml
@@ -1,0 +1,1 @@
+%h1 Hello from Haml!

--- a/test/multiverse/suites/tilt/tilt_instrumentation_test.rb
+++ b/test/multiverse/suites/tilt/tilt_instrumentation_test.rb
@@ -3,7 +3,6 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 
 class TiltInstrumentationTest < Minitest::Test
-  include MultiverseHelpers
 
   def setup
     @stats_engine = NewRelic::Agent.instance.stats_engine
@@ -21,7 +20,7 @@ class TiltInstrumentationTest < Minitest::Test
     "View/Tilt::HamlTemplate/#{filename}/Rendering"
   end
 
-  ### Render Tests ###
+  ### Tilt::Template#render tests ###
   def test_records_metrics_for_haml_template
     in_transaction do
       haml_template
@@ -120,7 +119,11 @@ class TiltInstrumentationTest < Minitest::Test
 
   ### File name parsing tests ###
   def call_create_filename_for_metric(filename)
-    Class.new.extend(NewRelic::Agent::Instrumentation::Tilt).create_filename_for_metric(filename)
+    Class.new.extend(
+      NewRelic::Agent::Instrumentation::Tilt
+    ).create_filename_for_metric(
+      filename
+    )
   end
 
   def non_nested_path

--- a/test/multiverse/suites/tilt/tilt_instrumentation_test.rb
+++ b/test/multiverse/suites/tilt/tilt_instrumentation_test.rb
@@ -6,13 +6,106 @@ class TiltInstrumentationTest < Minitest::Test
   include MultiverseHelpers
 
   def setup
+    @stats_engine = NewRelic::Agent.instance.stats_engine
   end
 
   def teardown
+    NewRelic::Agent.instance.stats_engine.clear_stats
   end
 
-  ### Tests
-  def test_tilt_multiverse
-    # no-op
+  def haml_template
+    Tilt.new('test.haml')
+  end
+
+  def haml_initialize_metric
+    'Tilt::HamlTemplate#initialize'
+  end
+
+  ### Initialize Tests ###
+  def test_records_metrics_for_haml_template
+    in_transaction do
+      haml_template
+    end
+
+    expected = { call_count: 1 }
+    assert_metrics_recorded(haml_initialize_metric => expected)
+  end
+
+  def test_records_metrics_for_erb_template
+    in_transaction do
+      Tilt.new('test.erb')
+    end
+
+    expected = { call_count: 1 }
+    assert_metrics_recorded('Tilt::ERBTemplate#initialize' => expected)
+  end
+
+  def test_records_metrics_for_nested_templates
+    in_transaction do
+      Tilt.new('layout.haml').render {
+        haml_template
+      }
+    end
+
+    expected = { call_count: 2 }
+    assert_metrics_recorded(haml_initialize_metric => expected)
+  end
+
+  def test_records_scoped_metric
+    test_transaction = 'test_txn'
+
+    in_transaction(test_transaction) do
+      haml_template
+    end
+
+    expected = { :call_count => 1 }
+    assert_metrics_recorded(
+      [haml_initialize_metric, test_transaction] => expected
+    )
+  end
+
+  def test_records_transaction_level_error
+    skip 'Not sure how to raise or capure an error here. Need to determine what should happen...'
+    exception_class = TypeError
+    txn = nil
+    Tilt::Template.any_instance.stubs(:initialize).raises(exception_class)
+
+    in_transaction do |test_txn|
+      txn = test_txn
+      haml_template
+    end
+
+    assert_transaction_noticed_error txn, exception_class.name
+  end
+
+  def test_records_nothing_if_tracing_disabled
+    NewRelic::Agent.disable_all_tracing do
+      in_transaction do
+        haml_template
+      end
+    end
+
+    assert_metrics_not_recorded(haml_initialize_metric)
+  end
+
+  def test_creates_transaction_node_for_initialize
+    in_transaction do
+      haml_template
+    end
+
+    last_node = nil
+    last_transaction_trace.root_node.each_node{|s| last_node = s }
+    NewRelic::Agent.shutdown
+
+    assert_equal(haml_initialize_metric,
+                 last_node.metric_name)
+  end
+
+  # Tilt doesn't exactly use partials, but it does accept blocks to a render node
+  # Which effectively do the same thing as yielding partials
+  # See: https://code.tutsplus.com/tutorials/ruby-for-newbies-the-tilt-gem--net-20027
+  # Under heading, "Yielding for More Power"
+  # I liked this test idea and am leaving it here to add with the render changes
+  def test_creates_nested_partial_node_within_render_node
   end
 end


### PR DESCRIPTION
# Overview
This instrumentation creates new metrics with the style of: `View/#{class_name}/#{file_path}/Rendering`
An example metric would look like `View/Tilt::HamlTemplate/blog/layout.html/Rendering` 

Traces and spans related to view rendering within Tilt should be nested within the action that causes the template to render.

If a template is rendered within the block of another template rendering call, it will appear as nested within the outer template. 

### Example
```ruby 
require 'tilt'
require 'haml'

def index
  Tilt.new('layout.haml').render {
    Tilt.new('body.haml')
  }
end
```

Should result in a nested span that looks like this: 
<img width="1495" alt="Screen Shot 2021-11-11 at 4 52 41 PM" src="https://user-images.githubusercontent.com/87386821/141390064-beeea947-4f94-41ec-a85f-810ac70dc484.png">



## Branch Name/Background 
This project began with the intention of instrumenting `Tilt::Template#prepare`, to discover this is a protected method. I decided to pivot to instrument `#initialize` instead, for the time being. 

With initial testing in the UI, I was uncertain whether anything of additional value will be captured through `#initialize` that cannot be captured using `#render`.

After talking with @tannalynn, we decided to opt-out of instrumenting `#initialize` and instrument `#render` instead so that it is on-par with our ActionView instrumentation. 

# Related Github Issue
Closes #836 
Closes #835

# Testing
Multiverse tests added to verify functionality for prepend, chain, disabled recording of metrics 
Tested with Rails calling a Haml view, and did not see a duplicated metric for Tilt, just the existing ActionView metric.

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance