### PR TITLE
Do not record span events when transaction is ignored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
     Template rendering using [Tilt](https://github.com/rtomayko/tilt) is now instrumented. See [PR #847](https://github.com/newrelic/newrelic-ruby-agent/pull/847) for details.
 
+  * **Bugfix: Span Events recorded when using newrelic_ignore**
+
+    Previously, the agent was incorrectly recording span events only on transactions that should be ignored. This fix will prevent any span events from being created for transactions using newrelic_ignore, or ignored through the `rules.ignore_url_regexes` configuration option.
+  
 
   ## v8.1.0
 

--- a/infinite_tracing/lib/infinite_tracing/agent_integrations/datastore_segment.rb
+++ b/infinite_tracing/lib/infinite_tracing/agent_integrations/datastore_segment.rb
@@ -8,6 +8,9 @@ module NewRelic
     class Transaction
       class DatastoreSegment
         def record_span_event
+          # don't record a span event if the transaction is ignored
+          return if transaction.ignore?
+
           tracer = ::NewRelic::Agent.agent.infinite_tracer
           tracer << Proc.new { SpanEventPrimitive.for_datastore_segment self }
         end

--- a/infinite_tracing/lib/infinite_tracing/agent_integrations/external_request_segment.rb
+++ b/infinite_tracing/lib/infinite_tracing/agent_integrations/external_request_segment.rb
@@ -8,6 +8,9 @@ module NewRelic
     class Transaction
       class ExternalRequestSegment
         def record_span_event
+          # don't record a span event if the transaction is ignored
+          return if transaction.ignore?
+          
           tracer = ::NewRelic::Agent.agent.infinite_tracer
           tracer << Proc.new { SpanEventPrimitive.for_external_request_segment self }
         end

--- a/infinite_tracing/lib/infinite_tracing/agent_integrations/segment.rb
+++ b/infinite_tracing/lib/infinite_tracing/agent_integrations/segment.rb
@@ -13,6 +13,9 @@ module NewRelic
         end
 
         def record_span_event
+          # don't record a span event if the transaction is ignored
+          return if transaction.ignore?
+
           tracer = ::NewRelic::Agent.agent.infinite_tracer
           tracer << Proc.new { SpanEventPrimitive.for_segment self }
         end

--- a/infinite_tracing/test/infinite_tracing/agent_integrations/datastore_segment_test.rb
+++ b/infinite_tracing/test/infinite_tracing/agent_integrations/datastore_segment_test.rb
@@ -96,6 +96,25 @@ module NewRelic
           assert_equal 2, span_events.size
         end
 
+        def test_ignored_transaction_does_not_record_span_event
+          span_events = generate_and_stream_segments do
+            in_web_transaction('wat') do |txn|
+              txn.stubs(:ignore?).returns(true)
+
+              segment = Tracer.start_datastore_segment(
+                product: "SQLite",
+                operation: "select",
+                port_path_or_id: 1337807
+              )
+
+              segment.start
+              advance_process_time(1.0)
+              segment.finish
+            end
+          end
+
+          assert_equal 0, span_events.size
+        end
       end
     end
   end

--- a/infinite_tracing/test/infinite_tracing/agent_integrations/external_request_segment_test.rb
+++ b/infinite_tracing/test/infinite_tracing/agent_integrations/external_request_segment_test.rb
@@ -86,6 +86,25 @@ module NewRelic
           assert_equal 2, span_events.size
         end
 
+        def test_ignored_transaction_does_not_record_span_event
+          span_events = generate_and_stream_segments do
+            in_transaction('wat') do |txn|
+              txn.stubs(:ignore?).returns(true)
+
+              segment = Transaction::ExternalRequestSegment.new \
+                "Typhoeus",
+                 "http://remotehost.com/blogs/index",
+                 "GET"
+
+              txn.add_segment segment
+              segment.start
+              advance_process_time(1.0)
+              segment.finish
+            end
+          end
+
+          assert_equal 0, span_events.size
+        end
       end
     end
   end

--- a/infinite_tracing/test/infinite_tracing/agent_integrations/segment_test.rb
+++ b/infinite_tracing/test/infinite_tracing/agent_integrations/segment_test.rb
@@ -72,6 +72,22 @@ module NewRelic
           assert_equal 2, span_events.size
         end
 
+        def test_ignored_transaction_does_not_record_span_event
+          span_events = generate_and_stream_segments do
+            in_transaction('wat') do |txn|
+              txn.stubs(:ignore?).returns(true)
+
+              segment = Transaction::Segment.new 'Ummm'
+              txn.add_segment segment
+              segment.start
+              advance_process_time(1.0)
+              segment.finish
+            end
+          end
+
+          assert_equal 0, span_events.size
+        end
+
         def test_streams_multiple_segments
           total_spans = 5
           segments = []

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -1814,10 +1814,7 @@ module NewRelic
           :type         => Array,
           :allowed_from_server => true,
           :transform    => DefaultSource.method(:convert_to_regexp_list),
-          :description  => 'Define transactions you want the agent to ignore, by specifying a list of patterns matching the URI you want to ignore.' \
-            '*Note:* This will only ignore transaction events, not spans or traces from the same transation. See documentation on ' \
-            '(Ignoring Specific Transactions)[https://docs.newrelic.com/docs/agents/ruby-agent/api-guides/ignoring-specific-transactions/#config-ignoring] ' \
-            'for more details.'
+          :description  => 'Define transactions you want the agent to ignore, by specifying a list of patterns matching the URI you want to ignore.' 
         },
         :'synthetics.traces_limit' => {
           :default      => 20,

--- a/lib/new_relic/agent/transaction/datastore_segment.rb
+++ b/lib/new_relic/agent/transaction/datastore_segment.rb
@@ -138,6 +138,9 @@ module NewRelic
         end
 
         def record_span_event
+          # don't record a span event if the transaction is ignored
+          return if transaction.ignore?
+          
           aggregator = ::NewRelic::Agent.agent.span_event_aggregator
           priority   = transaction.priority
 

--- a/lib/new_relic/agent/transaction/external_request_segment.rb
+++ b/lib/new_relic/agent/transaction/external_request_segment.rb
@@ -250,6 +250,9 @@ module NewRelic
         end
 
         def record_span_event
+          # don't record a span event if the transaction is ignored
+          return if transaction.ignore?
+
           aggregator = ::NewRelic::Agent.agent.span_event_aggregator
           priority   = transaction.priority
           aggregator.record(priority: priority) do

--- a/lib/new_relic/agent/transaction/segment.rb
+++ b/lib/new_relic/agent/transaction/segment.rb
@@ -79,6 +79,9 @@ module NewRelic
         end
 
         def record_span_event
+          # don't record a span event if the transaction is ignored
+          return if transaction.ignore?
+
           aggregator = ::NewRelic::Agent.agent.span_event_aggregator
           priority   = transaction.priority
 

--- a/test/multiverse/suites/rails/ignore_test.rb
+++ b/test/multiverse/suites/rails/ignore_test.rb
@@ -17,6 +17,10 @@ class IgnoredController < ApplicationController
   def action_to_ignore_apdex
     render body:  "This too"
   end
+  
+  def action_not_ignored
+    render body:  "Not this!"
+  end
 end
 
 class ParentController < ApplicationController
@@ -83,5 +87,14 @@ class IgnoredActionsTest < ActionDispatch::IntegrationTest
 
     last_span_events = NewRelic::Agent.agent.span_event_aggregator.harvest![1]
     assert_empty last_span_events
+  end
+
+  def test_ignored_by_ignore_url_regexes_does_not_record_span_events
+    with_config(:rules => { :ignore_url_regexes => ['/ignored/action_not_ignored'] }) do
+      get '/ignored/action_not_ignored'
+
+      last_span_events = NewRelic::Agent.agent.span_event_aggregator.harvest![1]
+      assert_empty last_span_events
+    end
   end
 end

--- a/test/multiverse/suites/rails/ignore_test.rb
+++ b/test/multiverse/suites/rails/ignore_test.rb
@@ -77,4 +77,11 @@ class IgnoredActionsTest < ActionDispatch::IntegrationTest
 
     assert_metrics_not_recorded("Apdex")
   end
+
+  def test_ignored_transaction_does_not_record_span_events
+    get '/ignored/action_to_ignore'
+
+    last_span_events = NewRelic::Agent.agent.span_event_aggregator.harvest![1]
+    assert_empty last_span_events
+  end
 end

--- a/test/new_relic/agent/transaction/datastore_segment_test.rb
+++ b/test/new_relic/agent/transaction/datastore_segment_test.rb
@@ -210,6 +210,25 @@ module NewRelic
           assert_empty last_span_events
         end
 
+        def test_ignored_transaction_does_not_record_span_event
+          in_web_transaction('wat') do |txn|
+            txn.stubs(:ignore?).returns(true)
+
+            segment = Tracer.start_datastore_segment(
+              product: "SQLite",
+              operation: "select",
+              port_path_or_id: 1337807
+            )
+
+            segment.start
+            advance_process_time 1.0
+            segment.finish
+          end
+
+          last_span_events = NewRelic::Agent.agent.span_event_aggregator.harvest![1]
+          assert_empty last_span_events
+        end
+
         def test_sampled_segment_records_span_event
           trace_id      = nil
           txn_guid      = nil

--- a/test/new_relic/agent/transaction/segment_test.rb
+++ b/test/new_relic/agent/transaction/segment_test.rb
@@ -213,6 +213,21 @@ module NewRelic
           assert_empty last_span_events
         end
 
+        def test_ignored_transaction_does_not_record_span_events
+          in_transaction('wat') do |txn|
+            txn.stubs(:ignore?).returns(true)
+            
+            segment = Segment.new 'Ummm'
+            txn.add_segment segment
+            segment.start
+            advance_process_time 1.0
+            segment.finish
+          end
+
+          last_span_events = NewRelic::Agent.agent.span_event_aggregator.harvest![1]
+          assert_empty last_span_events
+        end
+
         def test_sampled_segment_records_span_event
           trace_id  = nil
           txn_guid  = nil


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview

`newrelic_ignore` is supposed to make it so that the agent doesn't record anything in the ignored transaction. This appears to work properly in almost all areas, except span events. As far as I can tell, this has never worked in span events since there is no check there to see if the transaction is ignored or not. Our [documentation](https://docs.newrelic.com/docs/apm/agents/ruby-agent/api-guides/ignoring-specific-transactions/#ignore) does state that events will not be recorded when using `newrelic_ignore` though, so this does appear to be a bug rather than an intentional choice.

I have added checks on if the transaction should be ignored in the `record_span_event` methods for each type of segment. That method happens when the segment is completing, it takes the segment and transforms it into a span and sticks it in the span event aggregator (or passes it to the infinite tracing buffer). Now this method will simply return when the current transaction should be ignored.

I ran the unit tests after making these changes and no tests failed, which means this behavior has no associated tests (yikes). So I will need to add some tests to check for that. But i'm starting the PR now because I wanted to get the CI started to see if any multiverse failures pop up.

# Related Github Issue
closes #853

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
