### PR TITLE
Add Ruby 3.1.0-preview1 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        ruby-version: [2.2.10, 2.3.8, 2.4.10, 2.5.9, 2.6.8, 2.7.4, 3.0.2, jruby-9.2.19.0]
+        ruby-version: [2.2.10, 2.3.8, 2.4.10, 2.5.9, 2.6.8, 2.7.4, 3.0.2, 3.1.0-preview1, jruby-9.2.19.0]
     steps:
       - uses: actions/checkout@v2
 
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: [2.2.10, 2.3.8, 2.4.10, 2.5.9, 2.6.8, 2.7.4, 3.0.2, jruby-9.2.19.0]
+        ruby-version: [2.2.10, 2.3.8, 2.4.10, 2.5.9, 2.6.8, 2.7.4, 3.0.2, 3.1.0-preview1, jruby-9.2.19.0]
 
     steps:
       - uses: actions/checkout@v2
@@ -64,7 +64,10 @@ jobs:
                 "rails": "norails,rails61,rails60"
               },
               "3.0.2": {
-                "rails": "norails"
+                "rails": "norails,rails61,rails60"
+              },
+              "3.1.0-preview1": {
+                "rails": "norails,rails61,rails60"
               },
               "jruby-9.2.19.0": {
                 "rails": "norails,rails51,rails42"
@@ -124,7 +127,7 @@ jobs:
       fail-fast: false
       matrix:
         multiverse: ["agent;background;background_2;database", "httpclients;httpclients_2", "frameworks;rails;rest"]
-        ruby-version: [2.2.10, 2.3.8, 2.4.10, 2.5.9, 2.6.8, 2.7.4, 3.0.2]
+        ruby-version: [2.2.10, 2.3.8, 2.4.10, 2.5.9, 2.6.8, 2.7.4, 3.0.2, 3.1.0-preview1]
 
     steps:
       - uses: actions/checkout@v2
@@ -157,7 +160,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: [2.5.9, 2.6.8, 2.7.4, 3.0.2]
+        ruby-version: [2.5.9, 2.6.8, 2.7.4, 3.0.2, 3.1.0-preview1]
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
                 "rails": "norails,rails61,rails60"
               },
               "3.1.0-preview1": {
-                "rails": "norails,rails61,rails60"
+                "rails": "norails,rails61"
               },
               "jruby-9.2.19.0": {
                 "rails": "norails,rails51,rails42"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # New Relic Ruby Agent Release Notes #
 
+  ## 8.3.0
+
+  * **Updated the agent to support Ruby 3.1.0-preview1**
+
+    Most of the changes involved updating the multiverse suite to exclude runs for older versions of instrumented gems that are not compatible with Ruby 3.1. In addition, Infinite Tracing was updated to accommodate `YAML::unsafe_load` for Psych 4 support.
+
   ## v8.2.0
 
   * **New Instrumentation for Tilt gem**
@@ -21,7 +27,7 @@
   * **Bugfix: Span Events recorded when using newrelic_ignore**
 
     Previously, the agent was incorrectly recording span events only on transactions that should be ignored. This fix will prevent any span events from being created for transactions using newrelic_ignore, or ignored through the `rules.ignore_url_regexes` configuration option.
-  
+
   * **Bugfix: Print deprecation warning for Cross-Application Tracing if enabled**
 
     Prior to this change, the deprecation warning would log whenever the agent started up, regardless of configuration. Thank you @alpha-san for bringing this to our attention!
@@ -29,7 +35,7 @@
   * **Bugfix: Scrub non-unicode characters from DecoratingLogger**
 
     To prevent `JSON::GeneratorErrors`, the DecoratingLogger replaces non-unicode characters with the replacement character: �. Thank you @jdelStrother for bringing this to our attention!
-    
+
   * **Bugfix: Distributed tracing headers emitted errors when agent was not connected**
 
     Previously, when the agent had not yet connected it would fail to create a trace context payload and emit an error, "TypeError: no implicit conversion of nil into String," to the agent logs. The correct behavior in this situation is to not create these headers due to the lack of required information. Now, the agent will not attempt to create trace context payloads until it has connected. Thank you @Izzette for bringing this to our attention!

--- a/infinite_tracing/test/support/fixtures.rb
+++ b/infinite_tracing/test/support/fixtures.rb
@@ -12,5 +12,9 @@ end
 def span_event_fixture fixture_name
   fixture_filename = File.join(fixtures_path, "span_events", "#{fixture_name}.yml")
   assert File.exist?(fixture_filename), "Missing Span Event Fixture: #{fixture_name}. Looked for #{fixture_filename}"
-  YAML::load File.read(fixture_filename)
+  if YAML.respond_to?(:unsafe_load)
+    YAML::unsafe_load File.read(fixture_filename)
+  else
+    YAML::load File.read(fixture_filename)
+  end
 end

--- a/test/environments/rails60/Gemfile
+++ b/test/environments/rails60/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gem 'rake', '~> 12.3.3'
 
-gem 'rails', '6.0.4'
+gem 'rails', '6.0.4.1'
 
 gem 'minitest', '5.2.3'
 gem 'mocha', '~> 1.1.0', :require => false

--- a/test/environments/rails61/Gemfile
+++ b/test/environments/rails61/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 
 gem 'rake', '~> 12.3.3'
 gem 'rack', '>= 2.1.4'
-gem 'rails', '6.1.4'
+gem 'rails', '6.1.4.1'
 
 gem 'minitest', '5.2.3'
 gem 'mocha', '~> 1.1.0', require: false

--- a/test/multiverse/suites/httpclient/Envfile
+++ b/test/multiverse/suites/httpclient/Envfile
@@ -6,20 +6,28 @@ gemfile <<-RB
 RB
 instrumentation_methods :chain, :prepend
 
-HTTPCLIENT_VERSIONS = %w(2.8.3
+if RUBY_VERSION >= '3.1.0'
+  # versions below 2.8.3 use `timeout`, which does not exist in Ruby 3.1
+  gemfile <<-RB
+    gem 'httpclient', '~> 2.8.3'
+    gem 'rack'
+    gem 'json', :platforms => [:rbx, :mri_18]
+    #{ruby3_gem_webrick}
+  RB
+else
+  HTTPCLIENT_VERSIONS = %w(2.8.3
                          2.6.0
                          2.5.3
                          2.4.0
                          2.3.4
                          2.2.0)
 
-HTTPCLIENT_VERSIONS.each do |httpclient_version|
-  gemfile <<-RB
-    gem 'httpclient', '~> #{httpclient_version}'
-    gem 'rack'
-    gem 'json', :platforms => [:rbx, :mri_18]
-    #{ruby3_gem_webrick}
-  RB
+  HTTPCLIENT_VERSIONS.each do |httpclient_version|
+    gemfile <<-RB
+      gem 'httpclient', '~> #{httpclient_version}'
+      gem 'rack'
+      gem 'json', :platforms => [:rbx, :mri_18]
+      #{ruby3_gem_webrick}
+    RB
+  end
 end
-
-# vim: ft=ruby

--- a/test/multiverse/suites/memcache/Envfile
+++ b/test/multiverse/suites/memcache/Envfile
@@ -11,6 +11,8 @@ if RUBY_VERSION >= '2.5.0'
 end
 
 %w(1.8.5 1.5.0).each do |version|
+  # v 1.5.0 uses `timeout`, which does not exist in Ruby 3.1
+  next if RUBY_VERSION >= '3.1.0' && version == '1.5.0'
   gemfile <<-RB
     gem 'memcache-client', '~> #{version}', :require => 'memcache'
   RB

--- a/test/multiverse/suites/rails/Envfile
+++ b/test/multiverse/suites/rails/Envfile
@@ -8,7 +8,7 @@ if RUBY_VERSION >= '2.5.0'
   RB
 end
 
-if RUBY_VERSION >= '2.5.0' && RUBY_VERSION < '3.1.0'
+if RUBY_VERSION >= '2.5.0' && RUBY_VERSION < '3.0.0'
   gemfile <<-RB
     gem 'rails', '6.0.0'
     gem 'haml', '~>5.0.0'

--- a/test/multiverse/suites/rails/Envfile
+++ b/test/multiverse/suites/rails/Envfile
@@ -8,19 +8,16 @@ if RUBY_VERSION >= '2.5.0'
   RB
 end
 
-if RUBY_VERSION >= '2.5.0' && RUBY_VERSION < '3.0.0'
-
+if RUBY_VERSION >= '2.5.0' && RUBY_VERSION < '3.1.0'
   gemfile <<-RB
     gem 'rails', '6.0.0'
     gem 'haml', '~>5.0.0'
     gem 'haml-rails', '2.0.0'
     gem 'minitest', '5.2.3'
   RB
-
 end
 
 if RUBY_VERSION >= '2.2.2' && RUBY_VERSION < '3.0.0'
-
   gemfile <<-RB
     gem 'rails', '5.2.2'
     gem 'haml', '~>5.0.0'

--- a/test/multiverse/suites/sidekiq/Envfile
+++ b/test/multiverse/suites/sidekiq/Envfile
@@ -25,6 +25,11 @@ def ruby3_compatible? sidekiq_version
   sidekiq_version.split(" ")[-1].to_i > 3
 end
 
+# Sidekiq 4.2.10 does not support Ruby 3.1 YAML parsing
+def ruby3_1_compatible? sidekiq_version
+  sidekiq_version.split(" ")[-1].to_i > 4
+end
+
 # skip Sidekiq 3.5.3 on JRuby due to an error in Sidekiq's shutdown:
 # https://github.com/mperham/sidekiq/issues/2703
 def jruby_compatible? sidekiq_version
@@ -32,6 +37,7 @@ def jruby_compatible? sidekiq_version
 end
 
 SIDEKIQ_VERSIONS.each do |sidekiq_version, timers_version|
+  next if RUBY_VERSION >= "3.1.0" && !ruby3_1_compatible?(sidekiq_version)
   next if RUBY_VERSION < "3.0.0" && !ruby2_compatible?(sidekiq_version)
   next if RUBY_VERSION >= "3.0.0" && !ruby3_compatible?(sidekiq_version)
   next if RUBY_PLATFORM == "java" && !jruby_compatible?(sidekiq_version)

--- a/test/performance/lib/performance/instrumentation/gc_stats.rb
+++ b/test/performance/lib/performance/instrumentation/gc_stats.rb
@@ -5,7 +5,7 @@
 module Performance
   module Instrumentation
     class MRIGCStats < Instrumentor
-      platforms :mri_22, :mri_23, :mri_24, :mri_25, :mri_26, :mri_27, :mri_30
+      platforms :mri_22, :mri_23, :mri_24, :mri_25, :mri_26, :mri_27, :mri_30, :mri_31
       on_by_default
 
       def before(*)

--- a/test/performance/lib/performance/instrumentation/stackprof.rb
+++ b/test/performance/lib/performance/instrumentation/stackprof.rb
@@ -5,7 +5,7 @@
 module Performance
   module Instrumentation
     class StackProfProfile < Instrumentor
-      platforms :mri_22, :mri_23, :mri_24, :mri_25, :mri_26, :mri_27, :mri_30
+      platforms :mri_22, :mri_23, :mri_24, :mri_25, :mri_26, :mri_27, :mri_30, :mri_31
 
       def self.setup
         require 'tmpdir'

--- a/test/performance/lib/performance/platform.rb
+++ b/test/performance/lib/performance/platform.rb
@@ -25,6 +25,7 @@ module Performance
       when :mri_26  then !jruby? && RUBY_VERSION =~ /^2\.6\./
       when :mri_27  then !jruby? && RUBY_VERSION =~ /^2\.7\./
       when :mri_30  then !jruby? && RUBY_VERSION =~ /^3\.0\./
+      when :mri_31  then !jruby? && RUBY_VERSION =~ /^3\.1\./
       end
     end
 


### PR DESCRIPTION
Address test failures found when running Ruby 3.1.0-preview1 against the CI. 

Todo: 
- [x] Add Ruby 3.1 to performance testing setup. See #798 