### PR TITLE
Prevent distributed tracing headers from emitting errors when agent not connected

### DIFF
--- a/lib/new_relic/agent/distributed_tracing/trace_context_payload.rb
+++ b/lib/new_relic/agent/distributed_tracing/trace_context_payload.rb
@@ -110,15 +110,15 @@ module NewRelic
       end
 
       def to_s
-        result = version.to_s
-        result << DELIMITER << parent_type_id.to_s
-        result << DELIMITER << parent_account_id
-        result << DELIMITER << parent_app_id
+        result = version.to_s # required
+        result << DELIMITER << parent_type_id.to_s # required 
+        result << DELIMITER << parent_account_id # required 
+        result << DELIMITER << parent_app_id # required 
         result << DELIMITER << (id || NewRelic::EMPTY_STR)
         result << DELIMITER << (transaction_id || NewRelic::EMPTY_STR)
         result << DELIMITER << (sampled ? TRUE_CHAR : FALSE_CHAR)
         result << DELIMITER << sprintf("%.6f", priority)
-        result << DELIMITER << timestamp.to_s
+        result << DELIMITER << timestamp.to_s # required 
         result
       end
     end

--- a/lib/new_relic/agent/transaction/distributed_tracer.rb
+++ b/lib/new_relic/agent/transaction/distributed_tracer.rb
@@ -73,6 +73,7 @@ module NewRelic
         end
 
         def insert_headers headers
+          return unless NewRelic::Agent.agent.connected?
           insert_trace_context_header headers
           insert_distributed_trace_header headers
           insert_cross_app_header headers

--- a/test/new_relic/agent/distributed_tracing/trace_context_cross_agent_test.rb
+++ b/test/new_relic/agent/distributed_tracing/trace_context_cross_agent_test.rb
@@ -13,6 +13,7 @@ module NewRelic
 
         def setup
           NewRelic::Agent::DistributedTracePayload.stubs(:connected?).returns(true)
+          NewRelic::Agent::Agent.any_instance.stubs(:connected?).returns(true)
           NewRelic::Agent::Harvester.any_instance.stubs(:harvest_thread_enabled?).returns(false)
           NewRelic::Agent::Transaction::DistributedTracer.any_instance.stubs(:trace_context_active?).returns(true)
           @request_monitor = DistributedTracing::Monitor.new(EventListener.new)
@@ -20,6 +21,10 @@ module NewRelic
         end
 
         def teardown
+          NewRelic::Agent::DistributedTracePayload.unstub(:connected?)
+          NewRelic::Agent::Agent.any_instance.unstub(:connected?)
+          NewRelic::Agent::Harvester.any_instance.unstub(:harvest_thread_enabled?)
+          NewRelic::Agent::Transaction::DistributedTracer.any_instance.unstub(:trace_context_active?)
           reset_buffers_and_caches
         end
 

--- a/test/new_relic/http_client_test_cases.rb
+++ b/test/new_relic/http_client_test_cases.rb
@@ -253,20 +253,25 @@ module HttpClientTestCases
   # X-NewRelic-ID with a value equal to the encoded cross_app_id.
 
   def test_adds_a_request_header_to_outgoing_requests_if_xp_enabled
+    NewRelic::Agent::Agent.any_instance.stubs(:connected?).returns(true)
     with_config(:"cross_application_tracer.enabled" => true, :'distributed_tracing.enabled' => false) do
       in_transaction { get_response }
       assert_equal "VURQV1BZRkZdXUFT", server.requests.last["HTTP_X_NEWRELIC_ID"]
     end
+    NewRelic::Agent::Agent.any_instance.unstub(:connected?)
   end
 
   def test_adds_a_request_header_to_outgoing_requests_if_old_xp_config_is_present
+    NewRelic::Agent::Agent.any_instance.stubs(:connected?).returns(true)
     with_config(:cross_application_tracing => true, :'distributed_tracing.enabled' => false) do
       in_transaction { get_response }
       assert_equal "VURQV1BZRkZdXUFT", server.requests.last["HTTP_X_NEWRELIC_ID"]
     end
+    NewRelic::Agent::Agent.any_instance.unstub(:connected?)
   end
 
   def test_adds_newrelic_transaction_header
+    NewRelic::Agent::Agent.any_instance.stubs(:connected?).returns(true)
     with_config(:cross_application_tracing => true, :'distributed_tracing.enabled' => false) do
       guid      = nil
       path_hash = nil
@@ -286,6 +291,7 @@ module HttpClientTestCases
       assert_equal(guid,      decoded[2])
       assert_equal(path_hash, decoded[3])
     end
+    NewRelic::Agent::Agent.any_instance.unstub(:connected?)
   end
 
   def test_agent_doesnt_add_a_request_header_to_outgoing_requests_if_xp_disabled
@@ -543,6 +549,7 @@ module HttpClientTestCases
     # Test cases that don't involve outgoing calls are done elsewhere
     if test_case['outboundRequests']
       define_method("test_#{test_case['name']}") do
+        NewRelic::Agent::Agent.any_instance.stubs(:connected?).returns(true)
         config = {
           :app_name => test_case['appName'],
           :'cross_application_tracer.enabled' => true,
@@ -577,6 +584,7 @@ module HttpClientTestCases
           test_case['expectedIntrinsicFields'],
           test_case['nonExpectedIntrinsicFields']
         )
+        NewRelic::Agent::Agent.any_instance.unstub(:connected?)
       end
     end
   end


### PR DESCRIPTION
Co-authored-by: Kayla Reopelle (she/her) <kaylareopelle@users.noreply.github.com>

_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
Previously the agent would fail to create trace context payload and emit an error to the agent logs when the agent had not yet connected. The correct behavior in this situation is to not create these headers due to lack of required info needed from new relic servers after the agent connects. This change has been made and we have added a test to check this scenario.

# Related Github Issue
closes #801

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
Github Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
