### PR TITLE
Run #encode on ASCII-8BIT encoded log messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # New Relic Ruby Agent Release Notes #
 
+  ## v8.3.0
+
+  * **Bugfix: Correctly encode ASCII-8BIT log messages**
+
+    The encoding update for the DecoratingLogger in v8.2.0 did not account for ASCII-8BIT encoded characters qualifying as `valid_encoding?`. Now, ASCII-8BIT characters will be encoded as UTF-8 and include replacement characters as needed. We're very grateful for @nikajukic's collaboration and submission of a test case to resolve this issue.
+
   ## v8.2.0
 
   * **New Instrumentation for Tilt gem**
@@ -17,7 +23,7 @@
   * **Bugfix: Span Events recorded when using newrelic_ignore**
 
     Previously, the agent was incorrectly recording span events only on transactions that should be ignored. This fix will prevent any span events from being created for transactions using newrelic_ignore, or ignored through the `rules.ignore_url_regexes` configuration option.
-  
+
   * **Bugfix: Print deprecation warning for Cross-Application Tracing if enabled**
 
     Prior to this change, the deprecation warning would log whenever the agent started up, regardless of configuration. Thank you @alpha-san for bringing this to our attention!

--- a/lib/new_relic/agent/logging.rb
+++ b/lib/new_relic/agent/logging.rb
@@ -89,7 +89,14 @@ module NewRelic
 
         def escape(message)
           message = message.to_s unless message.is_a?(String)
-          message = message.scrub(REPLACEMENT_CHAR) unless message.valid_encoding?
+          unless message.valid_encoding?
+            message = message.encode(
+              Encoding::UTF_8,
+              invalid: :replace,
+              undef: :replace,
+              replace: REPLACEMENT_CHAR
+            )
+          end
           message.to_json
         end
 

--- a/lib/new_relic/agent/logging.rb
+++ b/lib/new_relic/agent/logging.rb
@@ -89,7 +89,7 @@ module NewRelic
 
         def escape(message)
           message = message.to_s unless message.is_a?(String)
-          unless message.valid_encoding?
+          unless message.encoding == Encoding::UTF_8 && message.valid_encoding?
             message = message.encode(
               Encoding::UTF_8,
               invalid: :replace,

--- a/test/new_relic/agent/logging_test.rb
+++ b/test/new_relic/agent/logging_test.rb
@@ -95,8 +95,17 @@ module NewRelic
           logger = DecoratingLogger.new @output
 
           logger.info input
-          assert_equal expectation,
-            last_message['message']
+          assert_equal expectation, last_message['message']
+        end
+
+        def test_to_replace_ascii_8bit_chars
+          message = 'message with an ASCII-8BIT character'
+          input = "#{message} #{"č".force_encoding(Encoding::ASCII_8BIT)}"
+          expectation = "#{message} #{DecoratingFormatter::REPLACEMENT_CHAR}#{DecoratingFormatter::REPLACEMENT_CHAR}"
+          logger = DecoratingLogger.new @output
+
+          logger.info input
+          assert_equal expectation, last_message['message']
         end
 
         if RUBY_VERSION >= '2.4.0'


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
* Update `NewRelic::Agent::Logging::DecoratingFormatter#escape` to use `String#encoding` instead of `String#scrub`.
* Include test case for `Encoding::ASCII_8BIT` written by @nikajukic
* Update condition to call `#encoding` to look for both `valid_encoding?` and `Encoding::UTF_8`

# Related Github Issue
Closes #863 

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
Github Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions, it is strongly recommended to add additional tests which
exercise your changes. 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label before acceptance
