### PR TITLE
Update CI to run on latest supported Ruby versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        ruby-version: [2.2.10, 2.3.8, 2.4.10, 2.5.9, 2.6.8, 2.7.4, 3.0.2, jruby-9.2.19.0]
+        ruby-version: [2.2.10, 2.3.8, 2.4.10, 2.5.9, 2.6.9, 2.7.5, 3.0.3, jruby-9.2.19.0]
     steps:
       - uses: actions/checkout@v2
 
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: [2.2.10, 2.3.8, 2.4.10, 2.5.9, 2.6.8, 2.7.4, 3.0.2, jruby-9.2.19.0]
+        ruby-version: [2.2.10, 2.3.8, 2.4.10, 2.5.9, 2.6.9, 2.7.5, 3.0.3, jruby-9.2.19.0]
 
     steps:
       - uses: actions/checkout@v2
@@ -57,13 +57,13 @@ jobs:
               "2.5.9": {
                 "rails": "norails,rails61,rails60,rails52,rails51,rails42,rails32"
               },
-              "2.6.8": {
+              "2.6.9": {
                 "rails": "norails,rails61,rails60,rails52,rails51,rails42"
               },
-              "2.7.4": {
+              "2.7.5": {
                 "rails": "norails,rails61,rails60"
               },
-              "3.0.2": {
+              "3.0.3": {
                 "rails": "norails"
               },
               "jruby-9.2.19.0": {
@@ -124,7 +124,7 @@ jobs:
       fail-fast: false
       matrix:
         multiverse: ["agent;background;background_2;database", "httpclients;httpclients_2", "frameworks;rails;rest"]
-        ruby-version: [2.2.10, 2.3.8, 2.4.10, 2.5.9, 2.6.8, 2.7.4, 3.0.2]
+        ruby-version: [2.2.10, 2.3.8, 2.4.10, 2.5.9, 2.6.9, 2.7.5, 3.0.3]
 
     steps:
       - uses: actions/checkout@v2
@@ -157,7 +157,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: [2.5.9, 2.6.8, 2.7.4, 3.0.2]
+        ruby-version: [2.5.9, 2.6.9, 2.7.5, 3.0.3]
     steps:
       - uses: actions/checkout@v2
 

--- a/test/multiverse/suites/sidekiq/Envfile
+++ b/test/multiverse/suites/sidekiq/Envfile
@@ -21,12 +21,8 @@ def ruby2_compatible? sidekiq_version
 end
 
 # older connection pool gems do not work with Ruby 3.0
+# Sidekiq 4.2.10 does not support Ruby 3.0.3/3.1+ YAML parsing
 def ruby3_compatible? sidekiq_version
-  sidekiq_version.split(" ")[-1].to_i > 3
-end
-
-# Sidekiq 4.2.10 does not support Ruby 3.1 YAML parsing
-def ruby3_1_compatible? sidekiq_version
   sidekiq_version.split(" ")[-1].to_i > 4
 end
 
@@ -37,7 +33,6 @@ def jruby_compatible? sidekiq_version
 end
 
 SIDEKIQ_VERSIONS.each do |sidekiq_version, timers_version|
-  next if RUBY_VERSION >= "3.1.0" && !ruby3_1_compatible?(sidekiq_version)
   next if RUBY_VERSION < "3.0.0" && !ruby2_compatible?(sidekiq_version)
   next if RUBY_VERSION >= "3.0.0" && !ruby3_compatible?(sidekiq_version)
   next if RUBY_PLATFORM == "java" && !jruby_compatible?(sidekiq_version)


### PR DESCRIPTION
# Overview
Ruby 2.6.9, 2.7.5, and 3.0.3 were released on November 24, 2021. 

This PR adds them to the CI and makes adjustments to the code as needed to get the existing tests to pass.

# Related Github Issue
Closes: #866 

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
Github Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
