### PR TITLE
Use float division for #exponential_backoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # New Relic Ruby Agent Release Notes #
 
+  ## v8.3.0
+
+  * **Bugfix: Update AdaptiveSampler#sampled? algorithm**
+
+    One of the clauses in `AdaptiveSampler#sampled?` would always return false due to Integer division returning a result of zero. This method has been updated to use Float division instead, to exponentially back off the number of samples required. This may increase the number of traces collected for transactions. A huge thank you to @romul for bringing this to our attention and breaking down the problem!
+
   ## v8.2.0
 
   * **New Instrumentation for Tilt gem**
@@ -21,7 +27,7 @@
   * **Bugfix: Span Events recorded when using newrelic_ignore**
 
     Previously, the agent was incorrectly recording span events only on transactions that should be ignored. This fix will prevent any span events from being created for transactions using newrelic_ignore, or ignored through the `rules.ignore_url_regexes` configuration option.
-  
+
   * **Bugfix: Print deprecation warning for Cross-Application Tracing if enabled**
 
     Prior to this change, the deprecation warning would log whenever the agent started up, regardless of configuration. Thank you @alpha-san for bringing this to our attention!
@@ -29,7 +35,7 @@
   * **Bugfix: Scrub non-unicode characters from DecoratingLogger**
 
     To prevent `JSON::GeneratorErrors`, the DecoratingLogger replaces non-unicode characters with the replacement character: �. Thank you @jdelStrother for bringing this to our attention!
-    
+
   * **Bugfix: Distributed tracing headers emitted errors when agent was not connected**
 
     Previously, when the agent had not yet connected it would fail to create a trace context payload and emit an error, "TypeError: no implicit conversion of nil into String," to the agent logs. The correct behavior in this situation is to not create these headers due to the lack of required information. Now, the agent will not attempt to create trace context payloads until it has connected. Thank you @Izzette for bringing this to our attention!

--- a/lib/new_relic/agent/adaptive_sampler.rb
+++ b/lib/new_relic/agent/adaptive_sampler.rb
@@ -29,7 +29,8 @@ module NewRelic
           elsif @sampled_count < @target
             rand(@seen_last) < @target
           else
-            rand(@seen) < (@target ** (@target / @sampled_count) - @target ** 0.5)
+            # you've met the target and need to exponentially back off
+            rand(@seen) < exponential_backoff
           end
 
           @sampled_count += 1 if sampled
@@ -37,6 +38,10 @@ module NewRelic
 
           sampled
         end
+      end
+
+      def exponential_backoff
+        @target ** (@target.to_f / @sampled_count) - @target ** 0.5
       end
 
       def stats

--- a/test/new_relic/agent/adaptive_sampler_test.rb
+++ b/test/new_relic/agent/adaptive_sampler_test.rb
@@ -52,6 +52,14 @@ module NewRelic
           assert_equal 500, period
         end
       end
+
+      def test_exponential_backoff_can_be_nonzero_value
+        sampler = NewRelic::Agent.instance.adaptive_sampler
+        # 19 is the mathematical maximum for a nonzero value for the default @target = 10
+        sampler.instance_variable_set(:@sampled_count, 19)
+        result = sampler.exponential_backoff
+        assert result > 0, 'Exponential backoff value was not greater than zero'
+      end
     end
   end
 end


### PR DESCRIPTION
Co-authored by: Tanna McClure <tannalynn@github.com>

_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
It was reported that our AdaptiveSampler sampling algorithm was using integer division rather than floats: 
```ruby
# lib/new_relic/agent/adaptive_sampler.rb#L32
# except from `AdaptiveSampler#sampled?` 
rand(@seen) < (@target ** (@target / @sampled_count) - @target ** 0.5)
```
@target and @sampled_count will always be Integers, causing the middle part of the formula to be floored by Ruby, resulting in zero. The entire formula could then only return zero or a negative number. This would cause the comparison to always evaluate false.

Our solution coerces @target into a float to allow non-zero values and a potentially truthy evaluation.

These changes are supported by a new test case to validate the non-zero return value. 

# Related Github Issue
Closes: #869 

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
Github Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
