### PR TITLE
Bugfix: Add ControllerInstrumentation::Shims for Sinatra

### DIFF
--- a/infinite_tracing/newrelic-infinite_tracing.gemspec
+++ b/infinite_tracing/newrelic-infinite_tracing.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
   s.version = NewRelic::VERSION::STRING
   s.required_ruby_version = '>= 2.5.0'
   s.required_rubygems_version = Gem::Requirement.new("> 1.3.1") if s.respond_to? :required_rubygems_version=
-  s.authors = [ "Tanna McClure", "Kayla Reopelle", "James Bunch" ]
+  s.authors = ["Tanna McClure", "Kayla Reopelle", "James Bunch"]
   s.licenses = ['Apache-2.0']
   s.description = <<-EOS
 The New Relic Ruby agent requires the gem newrelic_rpm, and it includes distributed

--- a/lib/new_relic/agent/parameter_filtering.rb
+++ b/lib/new_relic/agent/parameter_filtering.rb
@@ -12,20 +12,16 @@ module NewRelic
       if defined?(Rails) && Gem::Version.new(::Rails::VERSION::STRING) >= Gem::Version.new('5.0.0')
         Rails.application.config.to_prepare do
           RAILS_FILTER_CLASS = if defined?(ActiveSupport::ParameterFilter)
-             ActiveSupport::ParameterFilter
+            ActiveSupport::ParameterFilter
           elsif defined?(ActionDispatch::Http::ParameterFilter)
             ActionDispatch::Http::ParameterFilter
-          else
-            nil
           end
         end
       else
         RAILS_FILTER_CLASS = if defined?(ActiveSupport::ParameterFilter)
-           ActiveSupport::ParameterFilter
+          ActiveSupport::ParameterFilter
         elsif defined?(ActionDispatch::Http::ParameterFilter)
           ActionDispatch::Http::ParameterFilter
-        else
-          nil
         end
       end
 

--- a/lib/new_relic/control/frameworks/sinatra.rb
+++ b/lib/new_relic/control/frameworks/sinatra.rb
@@ -8,6 +8,12 @@ module NewRelic
     module Frameworks
       # Contains basic control logic for Sinatra
       class Sinatra < NewRelic::Control::Frameworks::Ruby
+        protected
+
+        def install_shim
+          super
+          ::Sinatra::Base.class_eval { include NewRelic::Agent::Instrumentation::ControllerInstrumentation::Shim }
+        end
       end
     end
   end

--- a/newrelic_rpm.gemspec
+++ b/newrelic_rpm.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.version = NewRelic::VERSION::STRING
   s.required_ruby_version = '>= 2.2.0'
   s.required_rubygems_version = Gem::Requirement.new("> 1.3.1") if s.respond_to? :required_rubygems_version=
-  s.authors = [ "Tanna McClure", "Kayla Reopelle", "James Bunch" ]
+  s.authors = ["Tanna McClure", "Kayla Reopelle", "James Bunch"]
   s.licenses = ['Apache-2.0']
   s.description = <<-EOS
 New Relic is a performance management system, developed by New Relic,

--- a/test/helpers/minitest.rb
+++ b/test/helpers/minitest.rb
@@ -26,10 +26,10 @@ class Minitest::Test
   def setup_thread_tracking
     set_threads = Proc.new do
       @__thread_count = ruby_threads.count
-      @__threads = ruby_threads.map{|rt| Hometown.for(rt).backtrace[0]}
+      @__threads = ruby_threads.map { |rt| Hometown.for(rt).backtrace[0] }
     end
 
-    # Rails 7 changes when active record loads and the threads get created. 
+    # Rails 7 changes when active record loads and the threads get created.
     # In order to keep the thread count consistent we need to wrap it in Rails.application.executor.wrap on rails 7+
     if defined?(Rails) && Gem::Version.new(::Rails::VERSION::STRING) >= Gem::Version.new('7.0.0')
       Rails.application.executor.wrap do

--- a/test/multiverse/suites/agent_only/start_up_test.rb
+++ b/test/multiverse/suites/agent_only/start_up_test.rb
@@ -115,23 +115,19 @@ RUBY
     end
   end
 
-  # Older rubies have a lot of warnings that we don't care much about. Track it
-  # going forward from Ruby 2.1.
-  if RUBY_VERSION >= "2.1"
-    def test_no_warnings
-      with_environment('NEW_RELIC_TRANSACTION_TRACER_TRANSACTION_THRESHOLD' => '-10',
-        'NEW_RELIC_PORT' => $collector.port.to_s) do
-        output = `bundle exec ruby -w script/warnings.rb 2>&1`
-        expected_noise = [GIT_NOISE, NET_HTTP_NOISE]
+  def test_no_warnings
+    with_environment('NEW_RELIC_TRANSACTION_TRACER_TRANSACTION_THRESHOLD' => '-10',
+      'NEW_RELIC_PORT' => $collector.port.to_s) do
+      output = `bundle exec ruby -w script/warnings.rb 2>&1`
+      expected_noise = [GIT_NOISE, NET_HTTP_NOISE]
 
-        expected_noise << JRUBY_9000_NOISE if jruby_9000
-        expected_noise << BUNDLER_NOISE if bundler_rubygem_conflicts?
+      expected_noise << JRUBY_9000_NOISE if jruby_9000
+      expected_noise << BUNDLER_NOISE if bundler_rubygem_conflicts?
 
-        expected_noise.flatten.each { |noise| output.gsub!(noise, "") }
-        output.strip!
+      expected_noise.flatten.each { |noise| output.gsub!(noise, "") }
+      output.strip!
 
-        assert_equal NewRelic::VERSION::STRING, output
-      end
+      assert_equal NewRelic::VERSION::STRING, output
     end
   end
 
@@ -151,4 +147,8 @@ RUBY
     Gem::Version.new(Gem::VERSION) == Gem::Version.new("2.6.6") and
       Gem::Version.new(Bundler::VERSION) == Gem::Version.new("1.12.5")
   end
+
+  # manual_start / agent disabled
+  # start it within a sinatra app
+  # defined?(newrelic_ignore)
 end

--- a/test/multiverse/suites/agent_only/start_up_test.rb
+++ b/test/multiverse/suites/agent_only/start_up_test.rb
@@ -147,8 +147,4 @@ RUBY
     Gem::Version.new(Gem::VERSION) == Gem::Version.new("2.6.6") and
       Gem::Version.new(Bundler::VERSION) == Gem::Version.new("1.12.5")
   end
-
-  # manual_start / agent disabled
-  # start it within a sinatra app
-  # defined?(newrelic_ignore)
 end

--- a/test/multiverse/suites/mongo/helpers/mongo_server.rb
+++ b/test/multiverse/suites/mongo/helpers/mongo_server.rb
@@ -118,9 +118,9 @@ class MongoServer
 
   def mongod_version
     @mongod_version ||= begin
-                          version = Regexp.last_match(1) if `#{mongod_path} --version` =~ /^db version v([0-9.]+)/
-                          Gem::Version.new(version || 0)
-                        end
+      version = Regexp.last_match(1) if `#{mongod_path} --version` =~ /^db version v([0-9.]+)/
+      Gem::Version.new(version || 0)
+    end
   end
 
   def mongod_path

--- a/test/multiverse/suites/sinatra_agent_disabled/Envfile
+++ b/test/multiverse/suites/sinatra_agent_disabled/Envfile
@@ -1,0 +1,28 @@
+rack_test_version = RUBY_VERSION < "2.2.2" ? "< 0.8.0" : ">= 0.8.0"
+
+if RUBY_VERSION >= '2.3.0'
+  gemfile <<-RB
+    gem 'sinatra', '~> 2.1.0'
+    gem 'rack',    '~> 2.2.0'
+    gem 'rack-test', '#{rack_test_version}', :require => 'rack/test'
+    #{ruby3_gem_webrick}
+  RB
+end
+
+if RUBY_VERSION >= '2.2.0'
+  gemfile <<-RB
+    gem 'sinatra', '~> 2.0.0'
+    gem 'rack',    '~> 2.0.0'
+    gem 'rack-test', '#{rack_test_version}', :require => 'rack/test'
+    #{ruby3_gem_webrick}
+  RB
+end
+
+gemfile <<-RB
+  gem 'sinatra', '~> 1.4.8'
+  gem 'rack',    '~> 1.5.0'
+  gem 'rack-test', '#{rack_test_version}', :require => 'rack/test'
+  #{ruby3_gem_webrick}
+RB
+
+# vim: ft=ruby

--- a/test/multiverse/suites/sinatra_agent_disabled/config/newrelic.yml
+++ b/test/multiverse/suites/sinatra_agent_disabled/config/newrelic.yml
@@ -1,0 +1,20 @@
+---
+development:
+  error_collector:
+    enabled: true
+  apdex_t: 0.5
+  agent_enabled: false
+  monitor_mode: false
+  license_key: bootstrap_newrelic_admin_license_key_000
+  ca_bundle_path: ../../../config/test.cert.crt
+  app_name: test
+  host: localhost
+  api_host: localhost
+  port: <%= $collector && $collector.port %>
+  transaction_tracer:
+    record_sql: obfuscated
+    enabled: true
+    stack_trace_threshold: 0.5
+    transaction_threshold: 1.0
+  capture_params: false
+  disable_serialization: false

--- a/test/multiverse/suites/sinatra_agent_disabled/shim_test.rb
+++ b/test/multiverse/suites/sinatra_agent_disabled/shim_test.rb
@@ -1,0 +1,50 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+
+require 'sinatra'
+
+class MiddlewareApp < Sinatra::Base
+  get '/middle' do
+    "From the middlewarez"
+  end
+end
+
+class SinatraAgentDisabledTestCase < Minitest::Test
+
+  def teardown
+    NewRelic::Agent.instance.shutdown
+    NewRelic::Agent.drop_buffered_data
+  end
+
+  def assert_shims_defined
+    # class method shim
+    assert MiddlewareApp.respond_to?(:newrelic_ignore), "Class method newrelic_ignore not defined"
+    assert MiddlewareApp.respond_to?(:newrelic_ignore_apdex), "Class method newrelic_ignore_apdex not defined"
+    assert MiddlewareApp.respond_to?(:newrelic_ignore_enduser), "Class method newrelic_ignore_enduser not defined"
+
+    # instance method shims
+    assert MiddlewareApp.instance_methods.include?(:new_relic_trace_controller_action), "Instance method new_relic_trace_controller_action not defined"
+    assert MiddlewareApp.instance_methods.include?(:perform_action_with_newrelic_trace), "Instance method perform_action_with_newrelic_trace not defined"
+  end
+
+  def test_shims_exist_when_agent_enabled_false
+    NewRelic::Agent.manual_start(:agent_enabled => false)
+    assert_shims_defined
+  end
+
+  # Only one of these tests are enabled because the shims are installed before
+  # the tests are run. New code needs to be added to simulate a startup
+  # environment where the shims would not be present to exercise all config
+  # options could require shim installation.
+
+  # def test_shims_exist_when_enabled_false
+  #   # NewRelic::Agent.manual_start(:enabled => false)
+  #   assert_shims_defined
+  # end
+
+  # def test_shims_exist_when_monitor_mode_false
+  #   # NewRelic::Agent.manual_start(:monitor_mode => false)
+  #   assert_shims_defined
+  # end
+end

--- a/test/multiverse/suites/sinatra_agent_disabled/shim_test.rb
+++ b/test/multiverse/suites/sinatra_agent_disabled/shim_test.rb
@@ -32,18 +32,5 @@ class SinatraAgentDisabledTestCase < Minitest::Test
     assert_shims_defined
   end
 
-  # Only one of these tests are enabled because the shims are installed before
-  # the tests are run. New code needs to be added to simulate a startup
-  # environment where the shims would not be present to exercise all config
-  # options could require shim installation.
 
-  # def test_shims_exist_when_enabled_false
-  #   # NewRelic::Agent.manual_start(:enabled => false)
-  #   assert_shims_defined
-  # end
-
-  # def test_shims_exist_when_monitor_mode_false
-  #   # NewRelic::Agent.manual_start(:monitor_mode => false)
-  #   assert_shims_defined
-  # end
 end

--- a/test/multiverse/suites/sinatra_agent_disabled/shim_test.rb
+++ b/test/multiverse/suites/sinatra_agent_disabled/shim_test.rb
@@ -11,7 +11,6 @@ class MiddlewareApp < Sinatra::Base
 end
 
 class SinatraAgentDisabledTestCase < Minitest::Test
-
   def teardown
     NewRelic::Agent.instance.shutdown
     NewRelic::Agent.drop_buffered_data

--- a/test/new_relic/license_test.rb
+++ b/test/new_relic/license_test.rb
@@ -59,7 +59,7 @@ class LicenseTest < Minitest::Test
       # skip directories
       !File.file?(path) ||
       # skip binary files and js files
-      %w| .sqlite3 .log .png .ico .gif .pdf .gem .js |.include?(File.extname(path)) ||
+      %w[ .sqlite3 .log .png .ico .gif .pdf .gem .js ].include?(File.extname(path)) ||
       # skip this file
       File.expand_path(__FILE__) == path ||
       # skip tmp directories overall


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
The `NewRelic::Control::Frameworks` sub-classes are responsible for the behavior of identified frameworks when the agent is disabled during startup. The `NewRelic::Agent::Instrumentation::ControllerInstrumentation::Shim` class creates empty methods with the same names as methods directly called within customer applications. Though the Rails subclasses of `NewRelic::Control::Frameworks`  added the `NewRelic::Agent::Instrumentation::ControllerInstrumentation::Shim` class to the appropriate ancestor chain, the Sinatra class did not.

This PR adds the shims to Sinatra to prevent crashes when shimmed methods are called in an environment where the agent is disabled using `agent_enabled: false`, `enabled: false`, and `monitor_mode: false`. 

Changes include:
* Add ControllerInstrumentation::Shims to Sinatra 
* Remove Ruby 2.1 wrapper from test
* Rubocop linting 

# Related Github Issue
Closes #901 

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
Github Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
