### PR TITLE
rake test:env - support more than 6 arguments

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -31,10 +31,10 @@ namespace :test do
     Performance::Runner.new(options).run_and_report
   end
 
-  desc "Run agent within existing mini environments"
-  task :env, [:env1, :env2, :env3, :env4, :env5, :env6] => [] do |t, args|
+  desc "Run agent within existing mini environment(s): env[name1,name2,name3,etc.]"
+  task :env do |t, args|
     require File.expand_path(File.join(File.dirname(__FILE__), 'test', 'environments', 'lib', 'environments', 'runner'))
-    Environments::Runner.new(args.map { |_, v| v }).run_and_report
+    Environments::Runner.new(args.to_a).run_and_report
   end
 
   Rake::TestTask.new(:intentional_fail) do |t|


### PR DESCRIPTION
# Overview
Redefine the `test:env` rake target so that it will accept any number of
input arguments (as previously defined the maximum number was 6), while
also updating the target's `desc` value to help retain useful usage
information.

# Related Github Issue
resolves #908 

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
Github Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
