### PR TITLE
jruby 9.3 fixes

### DIFF
--- a/lib/new_relic/language_support.rb
+++ b/lib/new_relic/language_support.rb
@@ -22,7 +22,8 @@ module NewRelic
     end
 
     def object_space_usable?
-      if defined?(::JRuby) && JRuby.respond_to?(:runtime)
+      if jruby?
+        require 'jruby'
         JRuby.runtime.is_object_space_enabled
       else
         defined?(::ObjectSpace)

--- a/test/new_relic/language_support_test.rb
+++ b/test/new_relic/language_support_test.rb
@@ -7,12 +7,14 @@ require File.expand_path(File.join(File.dirname(__FILE__), '..', 'test_helper'))
 class NewRelic::LanguageSupportTest < Minitest::Test
   def test_object_space_usable_on_jruby_with_object_space_enabled
     return unless NewRelic::LanguageSupport.jruby?
+    require 'jruby'
     JRuby.objectspace = true
     assert_truthy NewRelic::LanguageSupport.object_space_usable?
   end
 
   def test_object_space_not_usable_on_jruby_with_object_space_disabled
     return unless NewRelic::LanguageSupport.jruby?
+    require 'jruby'
     JRuby.objectspace = false
     assert_falsy NewRelic::LanguageSupport.object_space_usable?
   end


### PR DESCRIPTION
# Overview
this PR fixes compatibility with jruby 9.3+

usually, programs don't need to access ```JRuby.runtime``` directly, so it's no longer available automatically since jruby 9.3

for special cases like accessing object space, we need to load the runtime explicitly. This change is backward compatible.

# Related Github Issue
https://github.com/newrelic/newrelic-ruby-agent/issues/788 https://github.com/newrelic/newrelic-ruby-agent/pull/784

# Testing
the current CI on this project is more complex than I originally thought, many tested libraries are very outdated, rails 3 doesn't work well on jruby 9.3 anymore and I think there's one new bug in jruby's autoload... so CI switch should be done separately.

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
