### PR TITLE
[ci] update jruby-openssl

### DIFF
--- a/test/multiverse/lib/multiverse/suite.rb
+++ b/test/multiverse/lib/multiverse/suite.rb
@@ -285,7 +285,7 @@ module Multiverse
     end
 
     def jruby_openssl_line
-      "gem 'jruby-openssl', '~> 0.9.10', :require => false, :platforms => [:jruby]"
+      "gem 'jruby-openssl', '~> 0.11.0', :require => false, :platforms => [:jruby]"
     end
 
     def minitest_line

--- a/test/multiverse/suites/config_file_loading/Envfile
+++ b/test/multiverse/suites/config_file_loading/Envfile
@@ -6,7 +6,7 @@ gemfile <<-RB
   gem 'fakefs', '0.5.4', :require => 'fakefs/safe' # 0.5.4 required for 1.8.7 compatibility.
 
   # Because we delay the agent, order of jruby-openssl matters
-  gem 'jruby-openssl', '~> 0.9.10', :platforms => [:jruby]
+  gem 'jruby-openssl', '~> 0.11.0', :platforms => [:jruby]
 
   if RUBY_VERSION >= '2.4.0'
     gem 'psych', '4.0.0'
@@ -22,7 +22,7 @@ gemfile <<-RB
   gem 'fakefs', '0.5.4', :require => 'fakefs/safe' # 0.5.4 required for 1.8.7 compatibility.
 
   # Because we delay the agent, order of jruby-openssl matters
-  gem 'jruby-openssl', '~> 0.9.10', :platforms => [:jruby]
+  gem 'jruby-openssl', '~> 0.11.0', :platforms => [:jruby]
 
   if RUBY_VERSION >= '2.4.0'
     gem 'psych', '3.3.0'


### PR DESCRIPTION
# Overview
jruby-openssl 0.9.10 doesn't work on java 9+, this PR changes the version to the latest

# Related Github Issue
-

# Testing
-

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
