### PR TITLE
[ci] update jdbc adapters

### DIFF
--- a/test/environments/rails52/Gemfile
+++ b/test/environments/rails52/Gemfile
@@ -11,6 +11,8 @@ gem 'sprockets', '3.7.2'
 
 platforms :jruby do
   gem "jruby-openssl"
+  gem "activerecord-jdbcmysql-adapter", "~> 52.0"
+  gem "activerecord-jdbcsqlite3-adapter", "~> 52.0"
 end
 
 platforms :ruby, :rbx do

--- a/test/environments/rails60/Gemfile
+++ b/test/environments/rails60/Gemfile
@@ -12,6 +12,8 @@ gem 'sprockets', '3.7.2'
 
 platforms :jruby do
   gem "jruby-openssl"
+  gem "activerecord-jdbcmysql-adapter", "~> 60.0"
+  gem "activerecord-jdbcsqlite3-adapter", "~> 60.0"
 end
 
 platforms :ruby, :rbx do

--- a/test/environments/rails61/Gemfile
+++ b/test/environments/rails61/Gemfile
@@ -16,6 +16,8 @@ gem 'sprockets', '3.7.2'
 
 platforms :jruby do
   gem 'jruby-openssl'
+  gem "activerecord-jdbcmysql-adapter", "~> 61.0"
+  gem "activerecord-jdbcsqlite3-adapter", "~> 61.0"
 end
 
 platforms :ruby, :rbx do


### PR DESCRIPTION
# Overview
this PR adds suitable versions of jdbc adapters to rails 5.2 - 6.1 gemfiles

* rails 7 isn't supported on jruby yet

# Related Github Issue
-

# Testing
-

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
