### PR TITLE
Run active record tests on ruby 3.0+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,6 +161,8 @@ jobs:
         env:
           DB_PORT: 3306
           MYSQL_PASSWORD: root
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_USERNAME: postgres
 
       - name: Annotate errors
         if: ${{ failure() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,8 @@ jobs:
         env:
           DB_PORT: 3306
           MYSQL_PASSWORD: root
+          POSTGRES_USERNAME: postgres
+          POSTGRES_PASSWORD: password
 
       - name: Annotate errors
         if: ${{ failure() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,9 @@ jobs:
     services:
       postgres:
         image: postgres:latest
+        env:
+          POSTGRES_USERNAME: postgres
+          POSTGRES_PASSWORD: password
         ports:
           - 5432:5432
         options: >-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,7 @@ jobs:
         image: postgres:latest
         env:
           POSTGRES_PASSWORD: postgres
+          POSTGRES_USERNAME: postgres
         ports:
           - 5432:5432
         options: >-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,9 +93,6 @@ jobs:
     services:
       postgres:
         image: postgres:latest
-        env:
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_USERNAME: postgres
         ports:
           - 5432:5432
         options: >-
@@ -161,8 +158,6 @@ jobs:
         env:
           DB_PORT: 3306
           MYSQL_PASSWORD: root
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_USERNAME: postgres
 
       - name: Annotate errors
         if: ${{ failure() }}
@@ -200,9 +195,6 @@ jobs:
     services:
       postgres:
         image: postgres:latest
-        env:
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_USERNAME: postgres
         ports:
           - 5432:5432
       redis:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,6 +198,13 @@ jobs:
     needs: build-ruby
     runs-on: ubuntu-18.04
     services:
+      postgres:
+        image: postgres:latest
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_USERNAME: postgres
+        ports:
+          - 5432:5432
       redis:
         image: redis
         ports:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,17 @@ jobs:
     needs: build-ruby
     runs-on: ubuntu-18.04
     services:
+      postgres:
+        image: postgres:latest
+        env:
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
       redis:
         image: redis
         ports:

--- a/test/environments/rails50/Gemfile
+++ b/test/environments/rails50/Gemfile
@@ -11,6 +11,8 @@ gem 'rack-test'
 gem 'sprockets', '3.7.2'
 
 platforms :jruby do
+  gem "activerecord-jdbcmysql-adapter", "~> 50.0"
+  gem "activerecord-jdbcsqlite3-adapter", "~> 50.0"
   gem "jruby-openssl"
 end
 

--- a/test/multiverse/lib/multiverse/runner.rb
+++ b/test/multiverse/lib/multiverse/runner.rb
@@ -88,7 +88,7 @@ module Multiverse
       "background" => ["delayed_job", "sidekiq", "resque"],
       "background_2" => ["rake"],
       "database" => ["datamapper", "mongo", "redis", "sequel"],
-      "rails" => ["active_record", "rails", "rails_prepend", "activemerchant"],
+      "rails" => ["active_record", "active_record_pg", "rails", "rails_prepend", "activemerchant"],
       "frameworks" => ["sinatra", "padrino", "grape"],
       "httpclients" => ["curb", "excon", "httpclient"],
       "httpclients_2" => ["typhoeus", "net_http", "httprb"],
@@ -107,6 +107,8 @@ module Multiverse
     end
 
     if RUBY_VERSION >= '3.0'
+      # this suite uses mysql2 which has issues on ruby 3.0+
+      # a new suite, active_record_pg, has been added to run active record tests on ruby 3.0+
       GROUPS['rails'].delete 'active_record'
       GROUPS['frameworks'].delete 'grape'
     end

--- a/test/multiverse/suites/active_record/Envfile
+++ b/test/multiverse/suites/active_record/Envfile
@@ -1,6 +1,6 @@
 if RUBY_PLATFORM == 'java'
   mysql_gem = 'activerecord-jdbcmysql-adapter'
-  mysql_vsn = '~>1.3.0'
+  mysql_vsn = '~> 1.3.0'
 else
   mysql_gem = 'mysql2'
 end
@@ -9,8 +9,8 @@ boilerplate_gems = <<-BOILERPLATE
   gem 'rack'
 BOILERPLATE
 
-if RUBY_VERSION >= '2.2.2' && RUBY_PLATFORM == 'java' 
-  mysql_vsn = '~>0.4.4'
+if RUBY_VERSION >= '2.2.2' && RUBY_PLATFORM == 'java'
+  mysql_vsn = '~> 0.4.4'
 
   gemfile <<-RB
     gem 'activerecord', '5.2.2'
@@ -35,7 +35,7 @@ if RUBY_VERSION >= '2.2.2' && RUBY_PLATFORM == 'java'
 end
 
 if RUBY_VERSION >= '2.2.2' && RUBY_PLATFORM != 'java'
-  mysql_vsn = '~>0.4.4'
+  mysql_vsn = '~> 0.4.4'
 
   gemfile <<-RB
     gem 'activerecord', '5.2.2'
@@ -60,7 +60,7 @@ if RUBY_VERSION >= '2.2.2' && RUBY_PLATFORM != 'java'
 end
 
 if RUBY_VERSION < '2.4.0'
-  mysql_vsn = '0.3.20' unless RUBY_PLATFORM == 'java'
+  mysql_vsn = '0.3.21' unless RUBY_PLATFORM == 'java'
 
   gemfile <<-RB
     gem 'activerecord', '~> 4.2.0'
@@ -87,12 +87,12 @@ end
 # known issues, including https://github.com/rails/rails/issues/18991, so
 # skip 3.x versions on 2.2.
 #
-# Only 3.2.22 fixes the above mentioned issue, so it's the only one 
+# Only 3.2.22 fixes the above mentioned issue, so it's the only one
 # surviving in our coverage of Rails 3.x series here.
 #
 if RUBY_VERSION < '2.3'
-  mysql_vsn = '0.3.20'
-  
+  mysql_vsn = '0.3.21' unless RUBY_PLATFORM == 'java'
+
   gemfile <<-RB
     gem 'rack'
     gem 'activerecord', '~> 3.2.22'

--- a/test/multiverse/suites/active_record/Envfile
+++ b/test/multiverse/suites/active_record/Envfile
@@ -91,9 +91,11 @@ end
 # surviving in our coverage of Rails 3.x series here.
 #
 if RUBY_VERSION < '2.3'
+  mysql_vsn = '0.3.20'
+  
   gemfile <<-RB
     gem 'rack'
     gem 'activerecord', '~> 3.2.22'
-    #{sqlite3_gem_and_version}
+    gem '#{mysql_gem}', '#{mysql_vsn}'
   RB
 end

--- a/test/multiverse/suites/active_record/Envfile
+++ b/test/multiverse/suites/active_record/Envfile
@@ -90,7 +90,7 @@ end
 # Only 3.2.22 fixes the above mentioned issue, so it's the only one 
 # surviving in our coverage of Rails 3.x series here.
 #
-if RUBY_VERSION <= '2.2.0'
+if RUBY_VERSION < '2.3'
   gemfile <<-RB
     gem 'rack'
     gem 'activerecord', '~> 3.2.22'

--- a/test/multiverse/suites/active_record_pg/.gitignore
+++ b/test/multiverse/suites/active_record_pg/.gitignore
@@ -1,0 +1,1 @@
+db/schema.rb

--- a/test/multiverse/suites/active_record_pg/Envfile
+++ b/test/multiverse/suites/active_record_pg/Envfile
@@ -1,0 +1,99 @@
+
+boilerplate_gems = <<-BOILERPLATE
+  gem 'rack'
+BOILERPLATE
+
+if RUBY_VERSION >= '2.7.0'
+  gemfile <<-RB
+    gem 'activerecord', '~> 6.1'
+    gem 'minitest', '~> 5.2.3'
+    gem 'pg'
+    gem 'webrick'
+    #{boilerplate_gems}
+  RB
+end
+
+if RUBY_VERSION >= '2.2.2' && RUBY_PLATFORM == 'java' 
+
+  gemfile <<-RB
+    gem 'activerecord', '5.2.2'
+    gem 'minitest', '~> 5.2.3'
+    gem 'activerecord-jdbcmysql-adapter', '~>52.0'
+    #{boilerplate_gems}
+  RB
+
+  gemfile <<-RB
+    gem 'activerecord', '~> 5.1.6'
+    gem 'minitest', '~> 5.2.3'
+    gem 'activerecord-jdbcmysql-adapter', '~>51.0'
+    #{boilerplate_gems}
+  RB
+
+  gemfile <<-RB
+    gem 'activerecord', '~> 5.0.0'
+    gem 'minitest', '~> 5.2.3'
+    gem 'activerecord-jdbcmysql-adapter', '~>50.0'
+    #{boilerplate_gems}
+  RB
+end
+
+if RUBY_VERSION >= '2.2.2' && RUBY_VERSION < '3.0.0' && RUBY_PLATFORM != 'java'
+
+  gemfile <<-RB
+    gem 'activerecord', '5.2.2'
+    gem 'minitest', '~> 5.2.3'
+    gem 'pg'
+    #{boilerplate_gems}
+  RB
+
+  gemfile <<-RB
+    gem 'activerecord', '~> 5.1.6'
+    gem 'minitest', '~> 5.2.3'
+    gem 'pg'
+    #{boilerplate_gems}
+  RB
+
+  gemfile <<-RB
+    gem 'activerecord', '~> 5.0.0'
+    gem 'minitest', '~> 5.2.3'
+    gem 'pg'
+    #{boilerplate_gems}
+  RB
+end
+
+if RUBY_VERSION < '2.4.0'
+  gemfile <<-RB
+    gem 'activerecord', '~> 4.2.0'
+    gem 'minitest', '~> 5.2.3'
+    gem 'pg'
+    #{boilerplate_gems}
+  RB
+
+  gemfile <<-RB
+    gem 'activerecord', '~> 4.1.6'
+    gem 'minitest', '~> 5.2.3'
+    gem 'pg'
+    #{boilerplate_gems}
+  RB
+
+  gemfile <<-RB
+    gem 'activerecord', '~> 4.0.11'
+    gem 'pg'
+    #{boilerplate_gems}
+  RB
+end
+
+# AR 3.x does not have official support for Ruby 2.2, and there are several
+# known issues, including https://github.com/rails/rails/issues/18991, so
+# skip 3.x versions on 2.2.
+#
+# Only 3.2.22 fixes the above mentioned issue, so it's the only one 
+# surviving in our coverage of Rails 3.x series here.
+#
+if RUBY_VERSION < '2.3'
+  gemfile <<-RB
+    gem 'rack'
+    gem 'activerecord', '~> 3.2.22'
+    #{sqlite3_gem_and_version}
+  RB
+end

--- a/test/multiverse/suites/active_record_pg/Envfile
+++ b/test/multiverse/suites/active_record_pg/Envfile
@@ -65,21 +65,28 @@ if RUBY_VERSION < '2.4.0'
   gemfile <<-RB
     gem 'activerecord', '~> 4.2.0'
     gem 'minitest', '~> 5.2.3'
-    gem 'pg'
+    gem 'pg', '~> 0.21'
     #{boilerplate_gems}
   RB
 
   gemfile <<-RB
     gem 'activerecord', '~> 4.1.6'
     gem 'minitest', '~> 5.2.3'
-    gem 'pg'
+    gem 'pg', '~> 0.21'
     #{boilerplate_gems}
   RB
 
   gemfile <<-RB
     gem 'activerecord', '~> 4.0.11'
-    gem 'pg'
+    gem 'pg', '~> 0.21'
     #{boilerplate_gems}
   RB
 end
 
+if RUBY_VERSION < '2.3'
+  gemfile <<-RB
+    gem 'rack'
+    gem 'activerecord', '~> 3.2.22'
+    gem 'pg', '~> 0.21'
+  RB
+end

--- a/test/multiverse/suites/active_record_pg/Envfile
+++ b/test/multiverse/suites/active_record_pg/Envfile
@@ -27,7 +27,7 @@ if RUBY_VERSION >= '2.7.0'
   RB
 end
 
-if RUBY_VERSION >= '2.2.2' && RUBY_PLATFORM == 'java'
+if RUBY_VERSION >= '2.5.0' && RUBY_PLATFORM == 'java'
 
   gemfile <<-RB
     gem 'activerecord', '~> 6.0.0'

--- a/test/multiverse/suites/active_record_pg/Envfile
+++ b/test/multiverse/suites/active_record_pg/Envfile
@@ -18,21 +18,21 @@ if RUBY_VERSION >= '2.2.2' && RUBY_PLATFORM == 'java'
   gemfile <<-RB
     gem 'activerecord', '5.2.2'
     gem 'minitest', '~> 5.2.3'
-    gem 'activerecord-jdbcmysql-adapter', '~>52.0'
+    gem 'activerecord-jdbcpostgresql-adapter', '~>52.0', :platform => :jruby
     #{boilerplate_gems}
   RB
 
   gemfile <<-RB
     gem 'activerecord', '~> 5.1.6'
     gem 'minitest', '~> 5.2.3'
-    gem 'activerecord-jdbcmysql-adapter', '~>51.0'
+    gem 'activerecord-jdbcpostgresql-adapter', '~>51.0'
     #{boilerplate_gems}
   RB
 
   gemfile <<-RB
     gem 'activerecord', '~> 5.0.0'
     gem 'minitest', '~> 5.2.3'
-    gem 'activerecord-jdbcmysql-adapter', '~>50.0'
+    gem 'acactiverecord-jdbcpostgresql-adapter', '~>50.0'
     #{boilerplate_gems}
   RB
 end

--- a/test/multiverse/suites/active_record_pg/Envfile
+++ b/test/multiverse/suites/active_record_pg/Envfile
@@ -1,61 +1,69 @@
 
 boilerplate_gems = <<-BOILERPLATE
   gem 'rack'
+  gem 'minitest', '~> 5.2.3'
 BOILERPLATE
 
 if RUBY_VERSION >= '2.7.0'
   gemfile <<-RB
     gem 'activerecord', '~> 6.1'
-    gem 'minitest', '~> 5.2.3'
+    gem 'pg'
+    gem 'webrick'
+    #{boilerplate_gems}
+  RB
+
+  gemfile <<-RB
+    gem 'activerecord', '~> 6.0'
+    gem 'pg'
+    gem 'webrick'
+    #{boilerplate_gems}
+  RB
+
+  gemfile <<-RB
+    gem 'activerecord', '~> 7.0'
     gem 'pg'
     gem 'webrick'
     #{boilerplate_gems}
   RB
 end
 
-if RUBY_VERSION >= '2.2.2' && RUBY_PLATFORM == 'java' 
+if RUBY_VERSION >= '2.2.2' && RUBY_PLATFORM == 'java'
 
   gemfile <<-RB
     gem 'activerecord', '5.2.2'
-    gem 'minitest', '~> 5.2.3'
     gem 'activerecord-jdbcpostgresql-adapter', '~>52.0', :platform => :jruby
     #{boilerplate_gems}
   RB
 
   gemfile <<-RB
     gem 'activerecord', '~> 5.1.6'
-    gem 'minitest', '~> 5.2.3'
-    gem 'activerecord-jdbcpostgresql-adapter', '~>51.0'
+    gem 'activerecord-jdbcpostgresql-adapter', '~>51.0',  :platform => :jruby
     #{boilerplate_gems}
   RB
 
   gemfile <<-RB
     gem 'activerecord', '~> 5.0.0'
-    gem 'minitest', '~> 5.2.3'
-    gem 'acactiverecord-jdbcpostgresql-adapter', '~>50.0'
+    gem 'activerecord-jdbcpostgresql-adapter', '~>50.0',  :platform => :jruby
     #{boilerplate_gems}
   RB
 end
 
-if RUBY_VERSION >= '2.2.2' && RUBY_VERSION < '3.0.0' && RUBY_PLATFORM != 'java'
+if RUBY_VERSION >= '2.4.0' && RUBY_VERSION < '3.0.0' && RUBY_PLATFORM != 'java'
 
   gemfile <<-RB
     gem 'activerecord', '5.2.2'
-    gem 'minitest', '~> 5.2.3'
     gem 'pg'
     #{boilerplate_gems}
   RB
 
   gemfile <<-RB
     gem 'activerecord', '~> 5.1.6'
-    gem 'minitest', '~> 5.2.3'
     gem 'pg'
     #{boilerplate_gems}
   RB
 
   gemfile <<-RB
     gem 'activerecord', '~> 5.0.0'
-    gem 'minitest', '~> 5.2.3'
     gem 'pg'
     #{boilerplate_gems}
   RB

--- a/test/multiverse/suites/active_record_pg/Envfile
+++ b/test/multiverse/suites/active_record_pg/Envfile
@@ -60,33 +60,3 @@ if RUBY_VERSION >= '2.2.2' && RUBY_VERSION < '3.0.0' && RUBY_PLATFORM != 'java'
     #{boilerplate_gems}
   RB
 end
-
-if RUBY_VERSION < '2.4.0'
-  gemfile <<-RB
-    gem 'activerecord', '~> 4.2.0'
-    gem 'minitest', '~> 5.2.3'
-    gem 'pg', '~> 0.21'
-    #{boilerplate_gems}
-  RB
-
-  gemfile <<-RB
-    gem 'activerecord', '~> 4.1.6'
-    gem 'minitest', '~> 5.2.3'
-    gem 'pg', '~> 0.21'
-    #{boilerplate_gems}
-  RB
-
-  gemfile <<-RB
-    gem 'activerecord', '~> 4.0.11'
-    gem 'pg', '~> 0.21'
-    #{boilerplate_gems}
-  RB
-end
-
-if RUBY_VERSION < '2.3'
-  gemfile <<-RB
-    gem 'rack'
-    gem 'activerecord', '~> 3.2.22'
-    gem 'pg', '~> 0.21'
-  RB
-end

--- a/test/multiverse/suites/active_record_pg/Envfile
+++ b/test/multiverse/suites/active_record_pg/Envfile
@@ -83,17 +83,3 @@ if RUBY_VERSION < '2.4.0'
   RB
 end
 
-# AR 3.x does not have official support for Ruby 2.2, and there are several
-# known issues, including https://github.com/rails/rails/issues/18991, so
-# skip 3.x versions on 2.2.
-#
-# Only 3.2.22 fixes the above mentioned issue, so it's the only one 
-# surviving in our coverage of Rails 3.x series here.
-#
-if RUBY_VERSION < '2.3'
-  gemfile <<-RB
-    gem 'rack'
-    gem 'activerecord', '~> 3.2.22'
-    #{sqlite3_gem_and_version}
-  RB
-end

--- a/test/multiverse/suites/active_record_pg/Envfile
+++ b/test/multiverse/suites/active_record_pg/Envfile
@@ -30,20 +30,14 @@ end
 if RUBY_VERSION >= '2.2.2' && RUBY_PLATFORM == 'java'
 
   gemfile <<-RB
-    gem 'activerecord', '5.2.2'
-    gem 'activerecord-jdbcpostgresql-adapter', '~>52.0', :platform => :jruby
+    gem 'activerecord', '~> 6.0.0'
+    gem 'activerecord-jdbcpostgresql-adapter', '~> 60.0', :platform => :jruby
     #{boilerplate_gems}
   RB
 
   gemfile <<-RB
-    gem 'activerecord', '~> 5.1.6'
-    gem 'activerecord-jdbcpostgresql-adapter', '~>51.0',  :platform => :jruby
-    #{boilerplate_gems}
-  RB
-
-  gemfile <<-RB
-    gem 'activerecord', '~> 5.0.0'
-    gem 'activerecord-jdbcpostgresql-adapter', '~>50.0',  :platform => :jruby
+    gem 'activerecord', '~> 6.1.0'
+    gem 'activerecord-jdbcpostgresql-adapter', '~> 61.0',  :platform => :jruby
     #{boilerplate_gems}
   RB
 end

--- a/test/multiverse/suites/active_record_pg/Envfile
+++ b/test/multiverse/suites/active_record_pg/Envfile
@@ -27,20 +27,42 @@ if RUBY_VERSION >= '2.7.0'
   RB
 end
 
-if RUBY_VERSION >= '2.5.0' && RUBY_PLATFORM == 'java'
+# Removing JRuby from CI until we can understand why initialization fails on GitHub Actions
+# if RUBY_VERSION >= '2.2.2' && RUBY_PLATFORM == 'java'
 
-  gemfile <<-RB
-    gem 'activerecord', '~> 6.0.0'
-    gem 'activerecord-jdbcpostgresql-adapter', '~> 60.0', :platform => :jruby
-    #{boilerplate_gems}
-  RB
+#   gemfile <<-RB
+#     gem 'activerecord', '~> 5.0.0'
+#     gem 'activerecord-jdbcpostgresql-adapter', '~> 50.0', :platform => :jruby
+#     #{boilerplate_gems}
+#   RB
 
-  gemfile <<-RB
-    gem 'activerecord', '~> 6.1.0'
-    gem 'activerecord-jdbcpostgresql-adapter', '~> 61.0',  :platform => :jruby
-    #{boilerplate_gems}
-  RB
-end
+#   gemfile <<-RB
+#     gem 'activerecord', '~> 5.1.0'
+#     gem 'activerecord-jdbcpostgresql-adapter', '~> 51.0',  :platform => :jruby
+#     #{boilerplate_gems}
+#   RB
+
+#   gemfile <<-RB
+#     gem 'activerecord', '~> 5.2.0'
+#     gem 'activerecord-jdbcpostgresql-adapter', '~> 52.0',  :platform => :jruby
+#     #{boilerplate_gems}
+#   RB
+# end
+
+# if RUBY_VERSION >= '2.5.0' && RUBY_PLATFORM == 'java'
+
+#   gemfile <<-RB
+#     gem 'activerecord', '~> 6.0.0'
+#     gem 'activerecord-jdbcpostgresql-adapter', '~> 60.0', :platform => :jruby
+#     #{boilerplate_gems}
+#   RB
+
+#   gemfile <<-RB
+#     gem 'activerecord', '~> 6.1.0'
+#     gem 'activerecord-jdbcpostgresql-adapter', '~> 61.0',  :platform => :jruby
+#     #{boilerplate_gems}
+#   RB
+# end
 
 if RUBY_VERSION >= '2.4.0' && RUBY_VERSION < '3.0.0' && RUBY_PLATFORM != 'java'
 

--- a/test/multiverse/suites/active_record_pg/Rakefile
+++ b/test/multiverse/suites/active_record_pg/Rakefile
@@ -1,0 +1,9 @@
+require File.expand_path('config/database')
+
+desc "Setup for ActiveRecord"
+task :environment do
+  if defined?(DatabaseTasks)
+    ActiveRecord::Base.configurations = DatabaseTasks.database_configuration
+    ActiveRecord::Base.establish_connection DatabaseTasks.env.to_sym
+  end
+end

--- a/test/multiverse/suites/active_record_pg/active_record_test.rb
+++ b/test/multiverse/suites/active_record_pg/active_record_test.rb
@@ -1,0 +1,652 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+
+require File.expand_path(File.join(__FILE__, "..", "app", "models", "models"))
+
+class ActiveRecordInstrumentationTest < Minitest::Test
+  include MultiverseHelpers
+  setup_and_teardown_agent
+
+  module VersionHelpers
+    def active_record_major_version
+      if defined?(::ActiveRecord::VERSION::MAJOR)
+        ::ActiveRecord::VERSION::MAJOR.to_i
+      else
+        2
+      end
+    end
+
+    def active_record_minor_version
+      if defined?(::ActiveRecord::VERSION::MINOR)
+        ::ActiveRecord::VERSION::MINOR.to_i
+      else
+        1
+      end
+    end
+
+    def active_record_version
+      if defined?(::ActiveRecord::VERSION::MINOR)
+        Gem::Version.new(::ActiveRecord::VERSION::STRING)
+      else
+        Gem::Version.new("2.1.0") # Can't tell between 2.1 and 2.2. Meh.
+      end
+    end
+  end
+
+  include VersionHelpers
+  extend VersionHelpers
+
+  def after_setup
+    super
+    NewRelic::Agent.drop_buffered_data
+  end
+
+  def test_metrics_for_calculation_methods
+    in_web_transaction do
+      Order.count
+      Order.average(:id)
+      Order.minimum(:id)
+      Order.maximum(:id)
+      Order.sum(:id)
+    end
+
+    if active_record_major_version >= 3
+      assert_activerecord_metrics(Order, 'select', :call_count => 5)
+    else
+      assert_generic_rollup_metrics('select')
+    end
+  end
+
+  if active_record_version >= Gem::Version.new('3.2.0')
+    def test_metrics_for_pluck
+      in_web_transaction do
+        Order.pluck(:id)
+      end
+
+      assert_activerecord_metrics(Order, 'select')
+    end
+  end
+
+  if active_record_version >= Gem::Version.new('4.0.0')
+    def test_metrics_for_ids
+      in_web_transaction do
+        Order.ids
+      end
+
+      assert_activerecord_metrics(Order, 'select')
+    end
+  end
+
+  def test_metrics_for_create
+    in_web_transaction do
+      Order.create(:name => 'bob')
+    end
+
+    assert_activerecord_metrics(Order, 'create')
+  end
+
+  def test_metrics_for_create_via_association
+    in_web_transaction do
+      order = Order.create(:name => 'bob')
+      order.shipments.create
+      order.shipments.to_a
+    end
+
+    assert_activerecord_metrics(Order, 'create')
+  end
+
+  def test_metrics_for_find
+    in_web_transaction do
+      if active_record_major_version >= 4
+        Order.where(:name => 'foo').load
+      else
+        Order.find_all_by_name('foo')
+      end
+    end
+
+    assert_activerecord_metrics(Order, 'find')
+  end
+
+  def test_metrics_for_find_via_association
+    in_web_transaction do
+      order = Order.create(:name => 'bob')
+      order.shipments.create
+      order.shipments.to_a
+    end
+
+    assert_activerecord_metrics(Shipment, 'find')
+  end
+
+  def test_metrics_for_find_all
+    in_web_transaction do
+      case
+      when active_record_major_version >= 4
+        Order.all.load
+      when active_record_major_version >= 3
+        Order.all
+      else
+        Order.find(:all)
+      end
+    end
+
+    assert_activerecord_metrics(Order, 'find')
+  end
+
+  def test_metrics_for_find_via_named_scope
+    major_version = active_record_major_version
+    minor_version = active_record_minor_version
+    Order.class_eval do
+      if major_version >= 4
+        scope :jeffs, lambda { where(:name => 'Jeff') }
+      elsif major_version == 3 && minor_version >= 1
+        scope :jeffs, :conditions => {:name => 'Jeff'}
+      else
+        named_scope :jeffs, :conditions => {:name => 'Jeff'}
+      end
+    end
+
+    in_web_transaction do
+      if active_record_major_version >= 4
+        Order.jeffs.load
+      else
+        Order.jeffs.find(:all)
+      end
+    end
+
+    assert_activerecord_metrics(Order, 'find')
+  end
+
+  def test_metrics_for_exists
+    in_web_transaction do
+      Order.exists?(["name=?", "jeff"])
+    end
+
+    if active_record_major_version >= 6
+      assert_activerecord_metrics(Order, 'exists?')
+    else
+      assert_activerecord_metrics(Order, 'find')
+    end
+  end
+
+  def test_metrics_for_update_all
+    order1, order2 = nil
+
+    in_web_transaction do
+      order1 = Order.create(:name => 'foo')
+      order2 = Order.create(:name => 'foo')
+      Order.update_all(:name => 'zing')
+    end
+
+    assert_activerecord_metrics(Order, 'update')
+
+    assert_equal('zing', order1.reload.name)
+    assert_equal('zing', order2.reload.name)
+  end
+
+  def test_metrics_for_delete_all
+    in_web_transaction do
+      Order.create(:name => 'foo')
+      Order.create(:name => 'foo')
+      Order.delete_all
+    end
+
+    if active_record_major_version >= 3
+      assert_activerecord_metrics(Order, 'delete')
+    else
+      assert_generic_rollup_metrics('delete')
+    end
+  end
+
+  def test_metrics_for_relation_delete
+    in_web_transaction do
+      order = Order.create(:name => "lava")
+      Order.delete(order.id)
+    end
+
+    if active_record_major_version >= 3
+      assert_activerecord_metrics(Order, 'delete')
+    else
+      assert_generic_rollup_metrics('delete')
+    end
+  end
+
+  # delete and touch did not exist in AR 2.2
+  if active_record_version >= Gem::Version.new('3.0.0')
+    def test_metrics_for_delete
+      in_web_transaction do
+        order = Order.create("name" => "burt")
+        order.delete
+      end
+
+      assert_activerecord_metrics(Order, 'delete')
+    end
+
+    def test_metrics_for_touch
+      in_web_transaction do
+        order = Order.create("name" => "wendy")
+        order.touch
+      end
+
+      assert_activerecord_metrics(Order, 'update')
+    end
+  end
+
+  def test_metrics_for_relation_update
+    in_web_transaction do
+      order = Order.create(:name => 'foo')
+      Order.update(order.id, :name => 'qux')
+    end
+
+    assert_activerecord_metrics(Order, 'update')
+  end
+
+  def test_create_via_association_equal
+    in_web_transaction do
+      u = User.create(:name => 'thom yorke')
+      groups = [
+        Group.new(:name => 'radiohead'),
+        Group.new(:name => 'atoms for peace')
+      ]
+      u.groups = groups
+    end
+
+    if active_record_major_version >= 3
+      assert_activerecord_metrics(Group, 'create')
+    else
+      assert_generic_rollup_metrics('insert')
+    end
+  end
+
+  # Can be Mysql2::Error or ActiveRecord::RecordNotUnique
+  # depending on gem versions in play
+  def mysql_not_unique_error_class
+     /(PG::UniqueViolation)|(ActiveRecord::RecordNotUnique)|(ActiveRecord::JDBCError)/
+  end
+
+  def test_noticed_error_at_segment_and_txn_when_violating_unique_contraints
+    expected_error_class = mysql_not_unique_error_class
+    txn = nil
+    begin
+      in_web_transaction do |web_txn|
+        txn = web_txn
+        u = User.create(:name => 'thom yorke')
+        u2 = User.create(u.attributes)
+      end
+    rescue StandardError => e
+      # NOP -- allowing span and transaction to notice error
+    end
+
+    assert_segment_noticed_error txn, /create|insert/i, expected_error_class, /duplicate key/i
+    assert_transaction_noticed_error txn, expected_error_class
+  end
+
+  def test_noticed_error_only_at_segment_when_violating_unique_contraints
+    expected_error_class = mysql_not_unique_error_class
+    txn = nil
+    in_web_transaction do |web_txn|
+      begin
+        txn = web_txn
+        u = User.create(:name => 'thom yorke')
+        u2 = User.create(u.attributes)
+      rescue StandardError => e
+        # NOP -- allowing ONLY span to notice error
+      end
+    end
+
+    assert_segment_noticed_error txn, /create|insert/i, expected_error_class, /duplicate key/i
+
+    refute_transaction_noticed_error txn, expected_error_class
+  end
+
+  def test_create_via_association_shovel
+    in_web_transaction do
+      u = User.create(:name => 'thom yorke')
+      u.groups << Group.new(:name => 'radiohead')
+    end
+
+    if active_record_major_version >= 3
+      assert_activerecord_metrics(Group, 'create')
+    else
+      assert_generic_rollup_metrics('insert')
+    end
+  end
+
+  def test_create_via_association_create
+    in_web_transaction do
+      u = User.create(:name => 'thom yorke')
+      u.groups.create(:name => 'radiohead')
+    end
+
+    if active_record_major_version >= 3
+      assert_activerecord_metrics(Group, 'create')
+    else
+      assert_generic_rollup_metrics('insert')
+    end
+  end
+
+  def test_create_via_association_create_bang
+    in_web_transaction do
+      u = User.create(:name => 'thom yorke')
+      u.groups.create!(:name => 'radiohead')
+    end
+
+    if active_record_major_version >= 3
+      assert_activerecord_metrics(Group, 'create')
+    else
+      assert_generic_rollup_metrics('insert')
+    end
+  end
+
+  def test_destroy_via_dependent_destroy
+    in_web_transaction do
+      u = User.create(:name => 'robert')
+      u.aliases << Alias.new
+      u.destroy
+    end
+
+    assert_activerecord_metrics(User, 'delete')
+    assert_activerecord_metrics(Alias, 'delete')
+  end
+
+  # update & update! didn't become public until 4.0
+  if active_record_version >= Gem::Version.new('4.0.0')
+    def test_metrics_for_update
+      in_web_transaction do
+        order = Order.create(:name => "wendy")
+        order.update(:name => 'walter')
+      end
+
+      assert_activerecord_metrics(Order, 'update')
+    end
+
+    def test_metrics_for_update_bang
+      in_web_transaction do
+        order = Order.create(:name => "wendy")
+        order.update!(:name => 'walter')
+      end
+
+      assert_activerecord_metrics(Order, 'update')
+    end
+  end
+
+  def test_metrics_for_update_attribute
+    in_web_transaction do
+      order = Order.create(:name => "wendy")
+      order.update_attribute(:name, 'walter')
+    end
+
+    assert_activerecord_metrics(Order, 'update')
+  end
+
+  def test_metrics_for_save
+    in_web_transaction do
+      order = Order.create(:name => "wendy")
+      order.name = 'walter'
+      order.save
+    end
+
+    assert_activerecord_metrics(Order, 'update')
+  end
+
+  def test_metrics_for_save_bang
+    in_web_transaction do
+      order = Order.create(:name => "wendy")
+      order.name = 'walter'
+      order.save!
+    end
+
+    assert_activerecord_metrics(Order, 'update')
+  end
+
+  def test_nested_metrics_dont_get_model_name
+    in_web_transaction do
+      order = Order.create(:name => "wendy")
+      order.name = 'walter'
+      order.save!
+    end
+
+    assert_metrics_recorded(["Datastore/operation/Memcached/get"])
+    refute_metrics_match(/Memcached.*Order/)
+  end
+
+  def test_metrics_for_destroy
+    in_web_transaction do
+      order = Order.create("name" => "burt")
+      order.destroy
+    end
+
+    assert_activerecord_metrics(Order, 'delete')
+  end
+
+  def test_metrics_for_direct_sql_select
+    in_web_transaction do
+      conn = Order.connection
+      conn.select_rows("SELECT * FROM #{Order.table_name}")
+    end
+
+    assert_generic_rollup_metrics('select')
+  end
+
+  def test_metrics_for_direct_sql_other
+    in_web_transaction do
+      conn = Order.connection
+      conn.execute("begin")
+      conn.execute("commit")
+    end
+
+    assert_generic_rollup_metrics('other')
+  end
+
+  def test_metrics_for_direct_sql_show
+    if supports_show_tables?
+      in_web_transaction do
+        conn = Order.connection
+        conn.execute("show tables")
+      end
+
+      assert_generic_rollup_metrics('show')
+    end
+  end
+
+  def test_still_records_metrics_in_error_cases
+    # Let's trigger an active record SQL StatemntInvalid error
+    assert_raises ::ActiveRecord::StatementInvalid do
+      in_web_transaction do
+        Order.connection.select_rows "select * from askdjfhkajsdhflkjh"
+      end
+    end
+
+    assert_generic_rollup_metrics('select')
+  end
+
+  def test_passes_through_errors
+    to_raise = ActiveRecord::ActiveRecordError.new('preserve-me!')
+    actually_raised = assert_raises ActiveRecord::ActiveRecordError do
+      Order.transaction do
+        raise to_raise
+      end
+    end
+
+    assert_same to_raise, actually_raised
+  end
+
+  def test_only_supportability_metrics_recorded_with_disable_all_tracing
+    NewRelic::Agent.disable_all_tracing do
+      in_web_transaction('bogosity') do
+        Order.first
+      end
+    end
+    refute last_transaction_trace
+    assert_metrics_recorded_exclusive([
+      "Supportability/API/disable_all_tracing",
+      "Supportability/API/drop_buffered_data"
+    ])
+  end
+
+  def test_records_transaction_trace_nodes
+    in_web_transaction do
+      Order.first
+    end
+    sample = last_transaction_trace
+    metric = "Datastore/statement/#{current_product}/Order/find"
+    node = find_node_with_name(sample, metric)
+    assert_equal(metric, node.metric_name)
+
+    statement = node.params[:sql]
+    assert_match(/^SELECT /, statement.sql)
+
+    assert_match(statement.adapter.to_s, adapter.to_s)
+    refute_nil(statement.config)
+    refute_nil(statement.explainer)
+  end
+
+  def test_gathers_explain_plans
+    with_config(:'transaction_tracer.explain_threshold' => -0.1) do
+      in_web_transaction do
+        Order.first
+      end
+
+      sample = last_transaction_trace
+      metric = "Datastore/statement/#{current_product}/Order/find"
+      sql_node = find_node_with_name(sample, metric)
+
+      assert_match(/^SELECT /, sql_node.params[:sql].sql)
+
+      sample.prepare_to_send!
+      explanations = sql_node.params[:explain_plan]
+      if supports_explain_plans?
+        refute_nil explanations, "No explains in node: #{sql_node}"
+        assert_equal(2, explanations.size,
+          "No explains in node: #{sql_node}")
+      end
+    end
+  end
+
+  def test_sql_samplers_get_proper_metrics
+    with_config(:'transaction_tracer.explain_threshold' => -0.1) do
+      in_web_transaction do
+        Order.first
+      end
+
+      metric = "Datastore/statement/#{current_product}/Order/find"
+      refute_nil find_sql_trace(metric)
+    end
+  end
+
+  def test_records_metrics_on_background_transaction
+    in_transaction('back it up') do
+      Order.create(:name => 'bob')
+    end
+
+    assert_metrics_recorded(['Datastore/all', 'Datastore/allOther'])
+    assert_metrics_not_recorded(['Datastore/allWeb'])
+  end
+
+  def test_cached_calls_are_not_recorded_with_find
+    in_web_transaction do
+      order = Order.create(:name => 'Oberon')
+      Order.connection.cache do
+        Order.find(order.id)
+        Order.find(order.id)
+        Order.find(order.id)
+      end
+    end
+
+    assert_activerecord_metrics(Order, 'find', :call_count => 1)
+  end
+
+  def test_cached_calls_are_not_recorded_with_select_all
+    # If this is the first create, ActiveRecord needs to warm up,
+    # send some SQL SELECTS, etc.
+    in_web_transaction do
+      Order.create(:name => 'Oberon')
+    end
+    NewRelic::Agent.drop_buffered_data
+
+    # the actual test is here
+    query = "SELECT * FROM #{Order.table_name} WHERE name = 'Oberon'"
+    in_web_transaction do
+      Order.connection.cache do
+        Order.connection.select_all(query)
+        Order.connection.select_all(query)
+        Order.connection.select_all(query)
+      end
+    end
+
+    assert_metrics_recorded(
+      {"Datastore/operation/#{current_product}/select" => {:call_count => 1}}
+    )
+  end
+
+  def test_with_database_metric_name
+    in_web_transaction do
+      Order.create(:name => "eely")
+      NewRelic::Agent.with_database_metric_name('Eel', 'squirm') do
+        Order.connection.select_rows("SELECT id FROM #{Order.table_name}")
+      end
+    end
+
+    assert_metrics_recorded(
+      {
+        "Datastore/statement/#{current_product}/Eel/squirm" => {:call_count => 1},
+        "Datastore/operation/#{current_product}/squirm" => {:call_count => 1}
+      }
+    )
+  end
+
+  ## helpers
+
+  def adapter
+    #ActiveRecord::Base.configurations[NewRelic::Control.instance.env]['adapter']
+    #       ActiveRecord::Base.configs_for(env_name: NewRelic::Control.instance.env)['adapter']
+    #       ActiveRecord::Base.configs_for(env_name: RAILS_ENV)['adapter']
+    # require 'pry'; binding.pry
+    # Order.configurations[RAILS_ENV]['adapter']
+    adapter_string = ::NewRelic::Agent::DatabaseAdapter.value
+    adapter_string.downcase.to_sym
+  end
+
+  def supports_show_tables?
+    [:mysql, :postgres].include?(adapter)
+  end
+
+  def supports_explain_plans?
+    [:mysql, :postgres].include?(adapter)
+  end
+
+  def current_product
+    NewRelic::Agent::Instrumentation::ActiveRecordHelper::PRODUCT_NAMES[adapter.to_s]
+  end
+
+  def operation_for(op)
+    is_5_2 = active_record_version >= Gem::Version.new('5.2.0.beta1')
+
+    if op == 'create'
+      active_record_major_version >= 3 && !is_5_2 ? 'insert' : 'create'
+    elsif op == 'delete'
+      active_record_major_version >= 3 && !is_5_2 ? 'delete' : 'destroy'
+    else
+      op
+    end
+  end
+
+  def assert_activerecord_metrics(model, operation, stats = {})
+    operation = operation_for(operation) if ['create', 'delete'].include?(operation)
+
+    assert_metrics_recorded({
+      "Datastore/statement/#{current_product}/#{model}/#{operation}" => stats,
+      "Datastore/operation/#{current_product}/#{operation}" => {},
+      "Datastore/allWeb" => {},
+      "Datastore/all" => {}
+    })
+  end
+
+  def assert_generic_rollup_metrics(operation)
+    assert_metrics_recorded([
+      "Datastore/operation/#{current_product}/#{operation}",
+      "Datastore/allWeb",
+      "Datastore/all"
+    ])
+  end
+end

--- a/test/multiverse/suites/active_record_pg/app/models/models.rb
+++ b/test/multiverse/suites/active_record_pg/app/models/models.rb
@@ -1,0 +1,34 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+
+require 'new_relic/agent/datastores'
+
+class User < ActiveRecord::Base
+  has_many :aliases, :dependent => :destroy
+  has_and_belongs_to_many :groups
+end
+
+class Alias < ActiveRecord::Base
+  belongs_to :user
+end
+
+class Group < ActiveRecord::Base
+  has_and_belongs_to_many :users
+end
+
+class Order < ActiveRecord::Base
+  has_and_belongs_to_many :shipments, :join_table => 'order_shipments'
+
+  validate :touches_another_datastore
+
+  def touches_another_datastore
+    NewRelic::Agent::Datastores.wrap("Memcached", "get") do
+      # Fake hitting a cache during validation
+    end
+  end
+end
+
+class Shipment < ActiveRecord::Base
+  has_and_belongs_to_many :orders, :join_table => 'order_shipments'
+end

--- a/test/multiverse/suites/active_record_pg/app/models/models.rb
+++ b/test/multiverse/suites/active_record_pg/app/models/models.rb
@@ -3,6 +3,7 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 
 require 'new_relic/agent/datastores'
+require 'pg'
 
 class User < ActiveRecord::Base
   has_many :aliases, :dependent => :destroy

--- a/test/multiverse/suites/active_record_pg/app/models/models.rb
+++ b/test/multiverse/suites/active_record_pg/app/models/models.rb
@@ -4,6 +4,7 @@
 
 require 'new_relic/agent/datastores'
 require 'pg'
+require 'activerecord-jdbc-adapter' if defined? JRUBY_VERSION
 
 class User < ActiveRecord::Base
   has_many :aliases, :dependent => :destroy

--- a/test/multiverse/suites/active_record_pg/app/models/models.rb
+++ b/test/multiverse/suites/active_record_pg/app/models/models.rb
@@ -3,7 +3,7 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 
 require 'new_relic/agent/datastores'
-require 'pg'
+require 'pg' unless defined? JRUBY_VERSION
 require 'activerecord-jdbc-adapter' if defined? JRUBY_VERSION
 
 class User < ActiveRecord::Base

--- a/test/multiverse/suites/active_record_pg/ar_method_aliasing.rb
+++ b/test/multiverse/suites/active_record_pg/ar_method_aliasing.rb
@@ -1,0 +1,43 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+
+require 'rubygems'
+
+require 'active_record'
+require 'active_support/multibyte'
+
+require 'multiverse/color'
+
+require File.expand_path(File.join(__FILE__, "..", "app", "models", "models"))
+
+class InstrumentActiveRecordMethods < Minitest::Test
+  extend Multiverse::Color
+
+  include MultiverseHelpers
+  setup_and_teardown_agent
+
+  def test_basic_creation
+    a_user = User.new :name => "Bob"
+    assert a_user.new_record?
+    a_user.save!
+
+    assert User.connected?
+    assert a_user.persisted? if a_user.respond_to?(:persisted?)
+  end
+
+  def test_alias_collection_query_method
+    a_user = User.new :name => "Bob"
+    a_user.save!
+
+    a_user = User.first
+    assert User.connected?
+
+    an_alias = Alias.new :user_id => a_user.id, :aka => "the Blob"
+    assert an_alias.new_record?
+    an_alias.save!
+    assert an_alias.persisted? if a_user.respond_to?(:persisted?)
+    an_alias.destroy
+    assert an_alias.destroyed? if a_user.respond_to?(:destroyed?)
+  end
+end

--- a/test/multiverse/suites/active_record_pg/before_suite.rb
+++ b/test/multiverse/suites/active_record_pg/before_suite.rb
@@ -1,0 +1,28 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+
+def redefine_mysql_primary_key const_str
+  const = Object.const_get const_str rescue return
+  const[:primary_key] = "int(11) auto_increment PRIMARY KEY"
+end
+
+begin
+  load 'Rakefile'
+  Rake::Task['db:create'].invoke
+  Rake::Task['db:migrate'].invoke
+rescue => e
+  puts e
+  puts e.backtrace.join("\n\t")
+  raise
+end
+
+class Minitest::Test
+  def after_teardown
+    super
+    User.delete_all
+    Alias.delete_all
+    Order.delete_all
+    Shipment.delete_all
+  end
+end

--- a/test/multiverse/suites/active_record_pg/before_suite.rb
+++ b/test/multiverse/suites/active_record_pg/before_suite.rb
@@ -9,6 +9,7 @@ end
 
 begin
   load 'Rakefile'
+  Rake::Task['db:drop'].invoke
   Rake::Task['db:create'].invoke
   Rake::Task['db:migrate'].invoke
 rescue => e

--- a/test/multiverse/suites/active_record_pg/config/database.rb
+++ b/test/multiverse/suites/active_record_pg/config/database.rb
@@ -1,0 +1,83 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+
+require 'active_record'
+require 'erb'
+require 'newrelic_rpm'
+
+DependencyDetection.detect!
+
+db_dir = File.expand_path('../../db', __FILE__)
+config_dir = File.expand_path(File.dirname(__FILE__))
+
+if defined?(ActiveRecord::VERSION)
+  ENV['DATABASE_NAME'] = "multiverse_activerecord_#{ActiveRecord::VERSION::STRING}_#{RUBY_VERSION}_#{RUBY_ENGINE}".gsub(".", "_")
+else
+  ENV['DATABASE_NAME'] = "multiverse_activerecord_2_x_#{ENV["MULTIVERSE_ENV"]}_#{RUBY_VERSION}_#{RUBY_ENGINE}".gsub(".", "_")
+end
+
+config_raw = File.read(File.join(config_dir, 'database.yml'))
+config_erb = ERB.new(config_raw).result
+config_yml = if YAML.respond_to?(:unsafe_load)
+  YAML.unsafe_load(config_erb)
+else
+  YAML.load(config_erb)
+end
+
+# Rails 2.x didn't keep the Rails out of ActiveRecord much...
+RAILS_ENV = "test"
+RAILS_ROOT = File.join(db_dir, "..")
+
+ActiveRecord::Base.configurations = config_yml
+ActiveRecord::Base.establish_connection :test
+ActiveRecord::Base.logger = Logger.new(ENV["VERBOSE"] ? STDOUT : StringIO.new)
+
+begin
+  load 'active_record/railties/databases.rake'
+rescue LoadError, StandardError
+  load 'tasks/databases.rake'
+end
+
+if defined?(ActiveRecord::Tasks)
+  include ActiveRecord::Tasks
+
+  module Seeder
+    def self.load_seed
+      # Nope
+    end
+  end
+
+  DatabaseTasks.env = "test"
+  DatabaseTasks.db_dir = db_dir
+  DatabaseTasks.migrations_paths = File.join(db_dir, 'migrate')
+  DatabaseTasks.database_configuration = config_yml
+  DatabaseTasks.seed_loader = Seeder
+else
+  # Hattip to https://github.com/janko-m/sinatra-activerecord/blob/master/lib/sinatra/activerecord/rake/activerecord_3.rb
+  module Rails
+    extend self
+
+    def root
+      Pathname.new(Rake.application.original_dir)
+    end
+
+    def env
+      ActiveSupport::StringInquirer.new(ENV["RACK_ENV"] || "development")
+    end
+
+    def application
+      seed_loader = Object.new
+      seed_loader.instance_eval do
+        def load_seed
+          # Nope
+        end
+      end
+      seed_loader
+    end
+  end
+
+  Rake::Task.define_task("db:environment")
+  Rake::Task["db:load_config"].clear if Rake::Task.task_defined? "db:load_config"
+  Rake::Task.define_task("db:rails_env")
+end

--- a/test/multiverse/suites/active_record_pg/config/database.yml
+++ b/test/multiverse/suites/active_record_pg/config/database.yml
@@ -1,11 +1,16 @@
 default: &default
-  adapter: postgresql
+  adapter: <%=
+    if defined?(JRuby)
+      'jdbcpostgresql'
+    else
+      'postgresql'
+    end %>
   encoding: unicode
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   host: localhost
   username: <%= ENV.fetch("POSTGRES_USERNAME", "") %>
   password: <%= ENV.fetch("POSTGRES_PASSWORD", "") %>
-  database: pg_artest
+  database: <%= ENV.fetch("DATABASE_NAME", "rails_blog") %>
 
 development:
   <<: *default

--- a/test/multiverse/suites/active_record_pg/config/database.yml
+++ b/test/multiverse/suites/active_record_pg/config/database.yml
@@ -3,8 +3,8 @@ default: &default
   encoding: unicode
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   host: localhost
-  username: 
-  password: 
+  username: <%= ENV["POSTGRES_USERNAME"] %>
+  password: <%= ENV["POSTGRES_PASSWORD"] %>
   database: pg_artest
 
 development:

--- a/test/multiverse/suites/active_record_pg/config/database.yml
+++ b/test/multiverse/suites/active_record_pg/config/database.yml
@@ -3,8 +3,8 @@ default: &default
   encoding: unicode
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   host: localhost
-  username: <%= ENV["POSTGRES_USERNAME"] %>
-  password: <%= ENV["POSTGRES_PASSWORD"] %>
+  username: <%= ENV.fetch("POSTGRES_USERNAME", "") %>
+  password: <%= ENV.fetch("POSTGRES_PASSWORD", "") %>
   database: pg_artest
 
 development:

--- a/test/multiverse/suites/active_record_pg/config/database.yml
+++ b/test/multiverse/suites/active_record_pg/config/database.yml
@@ -8,8 +8,8 @@ default: &default
   encoding: unicode
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   host: localhost
-  username: <%= ENV.fetch("POSTGRES_USERNAME", "postgres") %>
-  password: <%= ENV.fetch("POSTGRES_PASSWORD", "password") %>
+  username: <%= ENV.fetch("POSTGRES_USERNAME", "") %>
+  password: <%= ENV.fetch("POSTGRES_PASSWORD", "") %>
   database: <%= ENV.fetch("DATABASE_NAME", "rails_blog") %>
 
 development:

--- a/test/multiverse/suites/active_record_pg/config/database.yml
+++ b/test/multiverse/suites/active_record_pg/config/database.yml
@@ -8,8 +8,8 @@ default: &default
   encoding: unicode
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   host: localhost
-  username: <%= ENV.fetch("POSTGRES_USERNAME", "") %>
-  password: <%= ENV.fetch("POSTGRES_PASSWORD", "") %>
+  username: <%= ENV.fetch("POSTGRES_USERNAME", "postgres") %>
+  password: <%= ENV.fetch("POSTGRES_PASSWORD", "password") %>
   database: <%= ENV.fetch("DATABASE_NAME", "rails_blog") %>
 
 development:

--- a/test/multiverse/suites/active_record_pg/config/database.yml
+++ b/test/multiverse/suites/active_record_pg/config/database.yml
@@ -1,0 +1,17 @@
+default: &default
+  adapter: postgresql
+  encoding: unicode
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  host: localhost
+  username: 
+  password: 
+  database: pg_artest
+
+development:
+  <<: *default
+
+test:
+  <<: *default
+
+production:
+  <<: *default

--- a/test/multiverse/suites/active_record_pg/config/newrelic.yml
+++ b/test/multiverse/suites/active_record_pg/config/newrelic.yml
@@ -1,0 +1,18 @@
+---
+development:
+  error_collector:
+    enabled: true
+  apdex_t: 0.5
+  monitor_mode: true
+  license_key: bootstrap_newrelic_admin_license_key_000
+  ca_bundle_path: ../../../config/test.cert.crt
+  app_name: test
+  host: localhost
+  api_host: localhost
+  port: <%= $collector && $collector.port %>
+  transaction_trace:
+    record_sql: obfuscated
+    enabled: true
+    stack_trace_threshold: 0.5
+    transaction_threshold: 1.0
+  capture_params: false

--- a/test/multiverse/suites/active_record_pg/db/migrate/20141105131800_create_users_and_aliases.rb
+++ b/test/multiverse/suites/active_record_pg/db/migrate/20141105131800_create_users_and_aliases.rb
@@ -1,0 +1,22 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+
+class CreateUsersAndAliases < ActiveRecord::VERSION::STRING >= "6.0.0" ? ActiveRecord::Migration[6.0] : ActiveRecord::Migration
+  def self.up
+    create_table :users do |t|
+      t.string :name, null: false
+    end
+    add_index :users, :name, unique: true
+
+    create_table :aliases do |t|
+      t.integer :user_id
+      t.string :aka
+    end
+  end
+
+  def self.down
+    drop_table :users
+    drop_table :aliases
+  end
+end

--- a/test/multiverse/suites/active_record_pg/db/migrate/20141105131800_create_users_and_aliases.rb
+++ b/test/multiverse/suites/active_record_pg/db/migrate/20141105131800_create_users_and_aliases.rb
@@ -2,7 +2,7 @@
 # This file is distributed under New Relic's license terms.
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 
-class CreateUsersAndAliases < ActiveRecord::VERSION::STRING >= "6.0.0" ? ActiveRecord::Migration[6.0] : ActiveRecord::Migration
+class CreateUsersAndAliases < ActiveRecord::VERSION::STRING >= "5.0.0" ? ActiveRecord::Migration["#{ActiveRecord::VERSION::STRING[0]}.0"] : ActiveRecord::Migration
   def self.up
     create_table :users do |t|
       t.string :name, null: false

--- a/test/multiverse/suites/active_record_pg/db/migrate/20141106082200_create_orders_and_shipments.rb
+++ b/test/multiverse/suites/active_record_pg/db/migrate/20141106082200_create_orders_and_shipments.rb
@@ -2,7 +2,7 @@
 # This file is distributed under New Relic's license terms.
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 
-class CreateUsersAndAliases < ActiveRecord::VERSION::STRING >= "5.0.0" ? ActiveRecord::Migration["#{ActiveRecord::VERSION::STRING[0]}.0"] : ActiveRecord::Migration
+class CreateOrdersAndShipments < ActiveRecord::VERSION::STRING >= "5.0.0" ? ActiveRecord::Migration["#{ActiveRecord::VERSION::STRING[0]}.0"] : ActiveRecord::Migration
   def self.up
     create_table :orders do |t|
       t.string :name

--- a/test/multiverse/suites/active_record_pg/db/migrate/20141106082200_create_orders_and_shipments.rb
+++ b/test/multiverse/suites/active_record_pg/db/migrate/20141106082200_create_orders_and_shipments.rb
@@ -14,6 +14,7 @@ class CreateOrdersAndShipments < ActiveRecord::VERSION::STRING >= "5.0.0" ? Acti
     create_table :order_shipments, :force => true, :id => false do |t|
       t.integer :order_id
       t.integer :shipment_id
+    end
   end
 
   def self.down

--- a/test/multiverse/suites/active_record_pg/db/migrate/20141106082200_create_orders_and_shipments.rb
+++ b/test/multiverse/suites/active_record_pg/db/migrate/20141106082200_create_orders_and_shipments.rb
@@ -2,7 +2,7 @@
 # This file is distributed under New Relic's license terms.
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 
-class CreateOrdersAndShipments < ActiveRecord::VERSION::STRING >= "5.0.0" ? ActiveRecord::Migration[6.0] : ActiveRecord::Migration
+class CreateUsersAndAliases < ActiveRecord::VERSION::STRING >= "5.0.0" ? ActiveRecord::Migration["#{ActiveRecord::VERSION::STRING[0]}.0"] : ActiveRecord::Migration
   def self.up
     create_table :orders do |t|
       t.string :name

--- a/test/multiverse/suites/active_record_pg/db/migrate/20141106082200_create_orders_and_shipments.rb
+++ b/test/multiverse/suites/active_record_pg/db/migrate/20141106082200_create_orders_and_shipments.rb
@@ -1,0 +1,24 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+
+class CreateOrdersAndShipments < ActiveRecord::VERSION::STRING >= "5.0.0" ? ActiveRecord::Migration[6.0] : ActiveRecord::Migration
+  def self.up
+    create_table :orders do |t|
+      t.string :name
+    end
+
+    create_table :shipments, :force => true do |t|
+    end
+
+    create_table :order_shipments, :force => true, :id => false do |t|
+      t.integer :order_id
+      t.integer :shipment_id
+  end
+
+  def self.down
+    drop_table :orders
+    drop_table :shipments
+    drop_table :order_shipments
+  end
+end

--- a/test/multiverse/suites/active_record_pg/db/migrate/20150413011200_add_timestamps_to_orders.rb
+++ b/test/multiverse/suites/active_record_pg/db/migrate/20150413011200_add_timestamps_to_orders.rb
@@ -1,0 +1,16 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+
+class AddTimestampsToOrders < ActiveRecord::VERSION::STRING >= "5.0.0" ? ActiveRecord::Migration[6.0] : ActiveRecord::Migration
+  def self.up
+    change_table(:orders) do |t|
+      t.timestamps
+    end
+  end
+
+  def self.down
+    remove_column :orders, :updated_at
+    remove_column :orders, :created_at
+  end
+end

--- a/test/multiverse/suites/active_record_pg/db/migrate/20150413011200_add_timestamps_to_orders.rb
+++ b/test/multiverse/suites/active_record_pg/db/migrate/20150413011200_add_timestamps_to_orders.rb
@@ -2,7 +2,7 @@
 # This file is distributed under New Relic's license terms.
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 
-class AddTimestampsToOrders < ActiveRecord::VERSION::STRING >= "5.0.0" ? ActiveRecord::Migration[6.0] : ActiveRecord::Migration
+class CreateUsersAndAliases < ActiveRecord::VERSION::STRING >= "5.0.0" ? ActiveRecord::Migration["#{ActiveRecord::VERSION::STRING[0]}.0"] : ActiveRecord::Migration
   def self.up
     change_table(:orders) do |t|
       t.timestamps

--- a/test/multiverse/suites/active_record_pg/db/migrate/20150413011200_add_timestamps_to_orders.rb
+++ b/test/multiverse/suites/active_record_pg/db/migrate/20150413011200_add_timestamps_to_orders.rb
@@ -2,7 +2,7 @@
 # This file is distributed under New Relic's license terms.
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 
-class CreateUsersAndAliases < ActiveRecord::VERSION::STRING >= "5.0.0" ? ActiveRecord::Migration["#{ActiveRecord::VERSION::STRING[0]}.0"] : ActiveRecord::Migration
+class AddTimestampsToOrders < ActiveRecord::VERSION::STRING >= "5.0.0" ? ActiveRecord::Migration["#{ActiveRecord::VERSION::STRING[0]}.0"] : ActiveRecord::Migration
   def self.up
     change_table(:orders) do |t|
       t.timestamps

--- a/test/multiverse/suites/active_record_pg/db/migrate/20150414084400_create_groups.rb
+++ b/test/multiverse/suites/active_record_pg/db/migrate/20150414084400_create_groups.rb
@@ -1,0 +1,21 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+
+class CreateGroups < ActiveRecord::VERSION::STRING >= "6.0.0" ? ActiveRecord::Migration[6.0] : ActiveRecord::Migration
+  def self.up
+    create_table :groups do |t|
+      t.string :name
+    end
+
+    create_table :groups_users, :id => false do |t|
+      t.integer :group_id
+      t.integer :user_id
+    end
+  end
+
+  def self.down
+    drop_table :groups
+    drop_table :groups_users
+  end
+end

--- a/test/multiverse/suites/active_record_pg/db/migrate/20150414084400_create_groups.rb
+++ b/test/multiverse/suites/active_record_pg/db/migrate/20150414084400_create_groups.rb
@@ -2,7 +2,7 @@
 # This file is distributed under New Relic's license terms.
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 
-class CreateUsersAndAliases < ActiveRecord::VERSION::STRING >= "5.0.0" ? ActiveRecord::Migration["#{ActiveRecord::VERSION::STRING[0]}.0"] : ActiveRecord::Migration
+class CreateGroups < ActiveRecord::VERSION::STRING >= "5.0.0" ? ActiveRecord::Migration["#{ActiveRecord::VERSION::STRING[0]}.0"] : ActiveRecord::Migration
   def self.up
     create_table :groups do |t|
       t.string :name

--- a/test/multiverse/suites/active_record_pg/db/migrate/20150414084400_create_groups.rb
+++ b/test/multiverse/suites/active_record_pg/db/migrate/20150414084400_create_groups.rb
@@ -2,7 +2,7 @@
 # This file is distributed under New Relic's license terms.
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 
-class CreateGroups < ActiveRecord::VERSION::STRING >= "6.0.0" ? ActiveRecord::Migration[6.0] : ActiveRecord::Migration
+class CreateUsersAndAliases < ActiveRecord::VERSION::STRING >= "5.0.0" ? ActiveRecord::Migration["#{ActiveRecord::VERSION::STRING[0]}.0"] : ActiveRecord::Migration
   def self.up
     create_table :groups do |t|
       t.string :name


### PR DESCRIPTION
# Overview
This PR adds a new multiverse suite `active_record_pg` that runs the active record tests with postgres instead of mysql like the `active_record` suite uses. Mysql2 gem is difficult to get working on ruby 3.0+, so we moved to Postgres for all ruby 3.0+ active record tests. 

# Changes 
* Run jruby tests on Rails 5.0, 5.2, 6.0, 6.1 
* Add Postgres service to the multiverse CI actions
* Add activerecord-jdbcmysql-adapter and activerecord-jdbcsqlite-adapter to active record suite
* Refine Postgresql tests to support Rails 7.0+

# Related Github Issue
#902

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
