### PR TITLE
Remove webrick from rails61 environment

### DIFF
--- a/test/environments/rails61/Gemfile
+++ b/test/environments/rails61/Gemfile
@@ -5,10 +5,6 @@ gem 'rake', '~> 12.3.3'
 gem 'rack', '>= 2.1.4'
 gem 'rails', '~> 6.1.0'
 
-if RUBY_VERSION >= '3.0.0'
-  gem 'webrick'
-end
-
 gem 'minitest', '5.2.3'
 gem 'mocha', '~> 1.1.0', require: false
 gem 'rack-test'


### PR DESCRIPTION
# Overview
Removes the `webrick` installation from the Rails61 test environment. It seems the web server getting picked up on some occasions is `webrick` instead of `passenger`. None of the other Rails environments have `webrick` installed at all. This addition may have been a premature fix to address the lack of `webrick` in Ruby 3+. 

# Related Github Issue

Closes #916 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
