### PR TITLE
Eliminate redefined constant warnings from ParamterFiltering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # New Relic Ruby Agent Release Notes #
 
+  ## v8.5.0
+
+  * **Eliminated warnings for redefined constants in ParamaterFiltering**
+
+    Fixed the ParameterFiltering constant definitions so that they are not redefined on multiple reloads of the module. Thank you to @TonyArra for bringing this issue to our attention.
+
+
+
   ## v8.4.0
 
   * **Provide basic support for Rails 7.0**

--- a/lib/new_relic/agent/parameter_filtering.rb
+++ b/lib/new_relic/agent/parameter_filtering.rb
@@ -7,18 +7,18 @@ module NewRelic
     module ParameterFiltering
       extend self
 
-      ACTION_DISPATCH_PARAMETER_FILTER = "action_dispatch.parameter_filter".freeze
+      ACTION_DISPATCH_PARAMETER_FILTER ||= "action_dispatch.parameter_filter".freeze 
 
       if defined?(Rails) && Gem::Version.new(::Rails::VERSION::STRING) >= Gem::Version.new('5.0.0')
         Rails.application.config.to_prepare do
-          RAILS_FILTER_CLASS = if defined?(ActiveSupport::ParameterFilter)
+          RAILS_FILTER_CLASS ||= if defined?(ActiveSupport::ParameterFilter)
             ActiveSupport::ParameterFilter
           elsif defined?(ActionDispatch::Http::ParameterFilter)
             ActionDispatch::Http::ParameterFilter
           end
         end
       else
-        RAILS_FILTER_CLASS = if defined?(ActiveSupport::ParameterFilter)
+        RAILS_FILTER_CLASS ||= if defined?(ActiveSupport::ParameterFilter)
           ActiveSupport::ParameterFilter
         elsif defined?(ActionDispatch::Http::ParameterFilter)
           ActionDispatch::Http::ParameterFilter


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
This PR updates the constants in the ParameterFiltering module so that they are not redefined when the module is reloaded. 

# Related Github Issue
closes #934

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
Github Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
