### PR TITLE
CI: Ubuntu 18->20, run MySQL as a service

### DIFF
--- a/.github/actions/build-ruby/dist/index.js
+++ b/.github/actions/build-ruby/dist/index.js
@@ -178,9 +178,9 @@ async function downgradeMySQL() {
   await Promise.all([promise1, promise2, promise3, promise4])
 
   // executes serially
-  await exec.exec('sudo', ['dpkg', '-i', `${pkgDir}/multiarch-support_2.27-3ubuntu1.2_amd64.deb`])
-  await exec.exec('sudo', ['dpkg', '-i', `${pkgDir}/libmysqlclient18_5.5.62-0+deb8u1_amd64.deb`])
-  await exec.exec('sudo', ['dpkg', '-i', `${pkgDir}/libmysqlclient-dev_5.5.62-0+deb8u1_amd64.deb`])
+  await exec.exec('sudo', ['dpkg', '-i', '--force-all', `${pkgDir}/multiarch-support_2.27-3ubuntu1.2_amd64.deb`])
+  await exec.exec('sudo', ['dpkg', '-i', '--force-all', `${pkgDir}/libmysqlclient18_5.5.62-0+deb8u1_amd64.deb`])
+  await exec.exec('sudo', ['dpkg', '-i', '--force-all', `${pkgDir}/libmysqlclient-dev_5.5.62-0+deb8u1_amd64.deb`])
 
   core.endGroup()
 }

--- a/.github/actions/build-ruby/index.js
+++ b/.github/actions/build-ruby/index.js
@@ -171,9 +171,9 @@ async function downgradeMySQL() {
   await Promise.all([promise1, promise2, promise3, promise4])
 
   // executes serially
-  await exec.exec('sudo', ['dpkg', '-i', `${pkgDir}/multiarch-support_2.27-3ubuntu1.2_amd64.deb`])
-  await exec.exec('sudo', ['dpkg', '-i', `${pkgDir}/libmysqlclient18_5.5.62-0+deb8u1_amd64.deb`])
-  await exec.exec('sudo', ['dpkg', '-i', `${pkgDir}/libmysqlclient-dev_5.5.62-0+deb8u1_amd64.deb`])
+  await exec.exec('sudo', ['dpkg', '-i', '--force-all', `${pkgDir}/multiarch-support_2.27-3ubuntu1.2_amd64.deb`])
+  await exec.exec('sudo', ['dpkg', '-i', '--force-all', `${pkgDir}/libmysqlclient18_5.5.62-0+deb8u1_amd64.deb`])
+  await exec.exec('sudo', ['dpkg', '-i', '--force-all', `${pkgDir}/libmysqlclient-dev_5.5.62-0+deb8u1_amd64.deb`])
 
   core.endGroup()
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,8 @@ jobs:
       mysql:
         image: mysql:5.7
         env:
-          MYSQL_HOST: 127.0.0.1
-          MYSQL_USER: root
           MYSQL_ALLOW_EMPTY_PASSWORD: yes
-          MYSQL_PASSWORD:
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
         ports:
           - "3306:3306"
     strategy:
@@ -100,6 +98,8 @@ jobs:
           timeout_minutes: 20
           max_attempts: 2
           command:  bundle exec rake test:env[${{ env.rails }}] TESTOPTS="--verbose"
+        env:
+          DB_PORT: ${{ job.services.mysql.ports[3306] }}
 
   multiverse:
     needs: build-ruby
@@ -166,6 +166,8 @@ jobs:
           timeout_minutes: 60
           max_attempts: 2
           command:  bundle exec rake test:multiverse[group="${{ matrix.multiverse }}",verbose]
+        env:
+          DB_PORT: ${{ job.services.mysql.ports[3306] }}
 
       - name: Annotate errors
         if: ${{ failure() }}
@@ -202,6 +204,8 @@ jobs:
           timeout_minutes: 40
           max_attempts: 6
           command:  bundle exec rake test:multiverse[group=infinite_tracing,verbose]
+        env:
+          DB_PORT: ${{ job.services.mysql.ports[3306] }}
 
       - name: Annotate errors
         if: ${{ failure() }}
@@ -271,6 +275,8 @@ jobs:
           timeout_minutes: 60
           max_attempts: 2
           command:  bundle exec rake test:multiverse[group=${{ matrix.multiverse }},verbose]
+        env:
+          DB_PORT: ${{ job.services.mysql.ports[3306] }}
 
       - name: Annotate errors
         if: ${{ failure() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,17 @@ on:
 
 jobs:
   build-ruby:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
+    services:
+      mysql:
+        image: mysql:5.7
+        env:
+          MYSQL_HOST: 127.0.0.1
+          MYSQL_USER: root
+          MYSQL_ALLOW_EMPTY_PASSWORD: yes
+          MYSQL_PASSWORD:
+        ports:
+          - "3306:3306"
     strategy:
       matrix:
         ruby-version: [2.2.10, 2.3.8, 2.4.10, 2.5.9, 2.6.9, 2.7.5, 3.0.3, 3.1.0, jruby-9.2.19.0]
@@ -25,7 +35,17 @@ jobs:
 
   unit-tests:
     needs: build-ruby
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
+    services:
+      mysql:
+        image: mysql:5.7
+        env:
+          MYSQL_HOST: 127.0.0.1
+          MYSQL_USER: root
+          MYSQL_ALLOW_EMPTY_PASSWORD: yes
+          MYSQL_PASSWORD:
+        ports:
+          - "3306:3306"
     strategy:
       fail-fast: false
       matrix:
@@ -74,23 +94,26 @@ jobs:
               }
             }
 
-      - name: Start mysql
-        run: sudo systemctl start mysql
-
       - name: Run Unit Tests
         uses: nick-invision/retry@v1.0.0
         with:
           timeout_minutes: 20
           max_attempts: 2
           command:  bundle exec rake test:env[${{ env.rails }}] TESTOPTS="--verbose"
-        env:
-          DB_PORT: 3306
-          MYSQL_PASSWORD: root
 
   multiverse:
     needs: build-ruby
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     services:
+      mysql:
+        image: mysql:5.7
+        env:
+          MYSQL_HOST: 127.0.0.1
+          MYSQL_USER: root
+          MYSQL_ALLOW_EMPTY_PASSWORD: yes
+          MYSQL_PASSWORD:
+        ports:
+          - "3306:3306"
       redis:
         image: redis
         ports:
@@ -137,18 +160,12 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby-version }}
 
-      - name: Start mysql
-        run: sudo systemctl start mysql
-
       - name: Run Multiverse Tests
         uses: nick-invision/retry@v1.0.0
         with:
           timeout_minutes: 60
           max_attempts: 2
           command:  bundle exec rake test:multiverse[group="${{ matrix.multiverse }}",verbose]
-        env:
-          DB_PORT: 3306
-          MYSQL_PASSWORD: root
 
       - name: Annotate errors
         if: ${{ failure() }}
@@ -156,7 +173,17 @@ jobs:
 
   infinite_tracing:
     needs: build-ruby
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
+    services:
+      mysql:
+        image: mysql:5.7
+        env:
+          MYSQL_HOST: 127.0.0.1
+          MYSQL_USER: root
+          MYSQL_ALLOW_EMPTY_PASSWORD: yes
+          MYSQL_PASSWORD:
+        ports:
+          - "3306:3306"
     strategy:
       fail-fast: false
       matrix:
@@ -182,8 +209,17 @@ jobs:
 
   jruby_multiverse:
     needs: build-ruby
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     services:
+      mysql:
+        image: mysql:5.7
+        env:
+          MYSQL_HOST: 127.0.0.1
+          MYSQL_USER: root
+          MYSQL_ALLOW_EMPTY_PASSWORD: yes
+          MYSQL_PASSWORD:
+        ports:
+          - "3306:3306"
       redis:
         image: redis
         ports:
@@ -229,18 +265,12 @@ jobs:
         with:
           ruby-version: jruby-9.2.19.0
 
-      - name: Start mysql
-        run: sudo systemctl start mysql
-
       - name: Run Multiverse Tests
         uses: nick-invision/retry@v1.0.0
         with:
           timeout_minutes: 60
           max_attempts: 2
           command:  bundle exec rake test:multiverse[group=${{ matrix.multiverse }},verbose]
-        env:
-          DB_PORT: 3306
-          MYSQL_PASSWORD: root
 
       - name: Annotate errors
         if: ${{ failure() }}


### PR DESCRIPTION
* Target Ubuntu 20.04 instead of 18.04
* Run MySQL as a separate service rather than on the same host that the
  rake tasks run

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
Github Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
