### PR TITLE
update tests for Rails 7.0.2

### DIFF
--- a/test/environments/rails70/Gemfile
+++ b/test/environments/rails70/Gemfile
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 source 'https://rubygems.org'
 
-gem 'rails', '~> 7.0.1'
+gem 'rails', '~> 7.0.2'
 gem "bootsnap", ">= 1.4.4", require: false
 
 gem 'minitest', '5.2.3'

--- a/test/multiverse/suites/rails/Envfile
+++ b/test/multiverse/suites/rails/Envfile
@@ -9,7 +9,7 @@ if RUBY_VERSION >= '2.7.0'
   RB
 
   gemfile <<-RB
-    gem 'rails', '~> 7.0.1'
+    gem 'rails', '~> 7.0.2'
     gem 'haml', '~>5.0.0'
     gem 'haml-rails', '2.0.0'
     #{ruby3_gem_webrick}

--- a/test/multiverse/suites/rails_prepend/Envfile
+++ b/test/multiverse/suites/rails_prepend/Envfile
@@ -1,6 +1,6 @@
 if RUBY_VERSION >= '2.7.0'
   gemfile <<-RB
-    gem 'rails', '~> 7.0.0'
+    gem 'rails', '~> 7.0.2'
     gem 'haml', '~> 5.0.0'
     gem 'newrelic_prepender', path: File.expand_path('../newrelic_prepender', __FILE__)
     gem 'minitest', '5.2.3'


### PR DESCRIPTION
Rails 7.0.2 has been released. Update the relevant tests to verify
compatibility.

https://rubyonrails.org/2022/2/8/Rails-7-0-2-has-been-released


# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
