### PR TITLE
Bugfix: Puma "can't add a new key into hash during iteration"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
   ## v8.5.0
 
+  * **Bugfix: Rails 5 + Puma errors in rack "can't add a new key into hash during iteration"**
+  
+    When using rails 5 with puma, the agent would intermittently cause rack to raise a `RuntimeError: can't add a new key into hash during iteration`. We have identified the source of the error in our instrumentation and corrected the behavior so it no longer interferes with rack. Thanks to @sasharevzin for bringing attention to this error and providing a reproduction of the issue for us to investigate.
+
   * **Eliminated warnings for redefined constants in ParamaterFiltering**
 
     Fixed the ParameterFiltering constant definitions so that they are not redefined on multiple reloads of the module. Thank you to @TonyArra for bringing this issue to our attention.

--- a/lib/new_relic/agent/instrumentation/middleware_tracing.rb
+++ b/lib/new_relic/agent/instrumentation/middleware_tracing.rb
@@ -106,7 +106,7 @@ module NewRelic
 
             result
           rescue Exception => e
-            # NewRelic::Agent.notice_error(e)
+            NewRelic::Agent.notice_error(e)
             raise e
           ensure
             finishable.finish if finishable

--- a/lib/new_relic/agent/instrumentation/middleware_tracing.rb
+++ b/lib/new_relic/agent/instrumentation/middleware_tracing.rb
@@ -45,7 +45,7 @@ module NewRelic
           opts[:apdex_start_time] = QueueTime.parse_frontend_timestamp(env)
           # this case is for the rare occasion that an app is using Puma::Rack
           # without having ::Rack as a dependency
-          opts[:request] = ::Rack::Request.new(env) if defined? ::Rack
+          opts[:request] = ::Rack::Request.new(env.dup) if defined? ::Rack
           opts
         end
 
@@ -106,7 +106,7 @@ module NewRelic
 
             result
           rescue Exception => e
-            NewRelic::Agent.notice_error(e)
+            # NewRelic::Agent.notice_error(e)
             raise e
           ensure
             finishable.finish if finishable


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
It was brought to our attention that this error continues to occur despite previous attempts to prevent this error. I believe I have identified the root cause and prevented this from occurring in the future. I was no longer able to see the error happening using the reproduction provided. 

During my investigation, I found similar issues in a couple other gems:
https://github.com/rack/rack/issues/589
https://github.com/getsentry/sentry-ruby/issues/1183
https://github.com/airbrake/airbrake/issues/233

# Related Github Issue
closes #933 (original #573)

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
Github Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
