### PR TITLE
NewRelic::VERSION optimisations

### DIFF
--- a/lib/new_relic/version.rb
+++ b/lib/new_relic/version.rb
@@ -5,20 +5,10 @@
 
 module NewRelic
   module VERSION # :nodoc:
-    def self.build_version_string(*parts)
-      parts.compact.join('.')
-    end
-
     MAJOR = 8
     MINOR = 4
     TINY = 0
 
-    begin
-      require File.join(File.dirname(__FILE__), 'build')
-    rescue LoadError
-      BUILD = nil
-    end
-
-    STRING = build_version_string(MAJOR, MINOR, TINY, BUILD)
+    STRING = "#{MAJOR}.#{MINOR}.#{TINY}"
   end
 end


### PR DESCRIPTION
when defining `NewRelic::VERSION::STRING`, don't bother loading a file
that won't be there, rescuing, compacting an array, splatting an arg
list, joining an array, etc.  Just build a string.

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
