### PR TITLE
multiverse runner: exact directory name matching

### DIFF
--- a/test/multiverse/README.md
+++ b/test/multiverse/README.md
@@ -95,16 +95,18 @@ The first time you run this command on a new Ruby installation, it will take qui
 
 ## Running Specific Tests and Environments
 
-Multiverse tests live in the test/multiverse directory and are organized into 'suites'. Generally speaking, a suite is a group of tests that share a common 3rd-party dependency (or set of dependencies). You can run a specific suite by providing a parameter (which gets loosely matched against suite names)
+Multiverse tests live in the test/multiverse directory and are organized into 'suites'. Generally speaking, a suite is a group of tests that share a common 3rd-party dependency (or set of dependencies). You can run one or more specific suites by providing a comma delimited list of suite names as parameters to the rake task:
 
     rake test:multiverse[agent_only]
+    # or
+    rake test:multiverse[rails,net_http]
 
-You can pass additional parameters to the test:multiverse rake task to control how tests are run:
+You can pass these additional parameters to the test:multiverse rake task to control how tests are run:
 
-- name= only tests with names matching string will be executed
-- env= only the Nth environment will be executed (may be specified multiple times)
-- file= only tests in specified file will be executed
-- debug environments for each suite will be executed in serial rather than parallel (the default), and the pry gem will be automatically included, so that you can use it to help debug tests.
+- `name=` only tests with names matching string will be executed
+- `env=` only the Nth environment will be executed (may be specified multiple times)
+- `file=` only tests in specified file will be executed
+- `debug` environments for each suite will be executed in serial rather than parallel (the default), and the pry gem will be automatically included, so that you can use it to help debug tests.
 
 ```
 rake test:multiverse[agent_only,name=test_resets_event_report_period_on_reconnect,env=0,debug]
@@ -112,7 +114,7 @@ rake test:multiverse[agent_only,name=test_resets_event_report_period_on_reconnec
 
 
 ### Cleanup
-Occasionally, it may be necessary to clean up your environment when migration scripts change or Gemfile lock files get out of sync.  Similar to Rails' rake assets:clobber, multiverse has a clobber task that will drop all multiverse databases in MySQL and remove all Gemfile.* and Gemfile.*.lock files housed under test/multiverse/suites/**
+Occasionally, it may be necessary to clean up your environment when migration scripts change or Gemfile lock files get out of sync.  Similar to Rails' `rake assets:clobber`, multiverse has a clobber task that will drop all multiverse databases in MySQL and remove all Gemfile.* and Gemfile.*.lock files housed under test/multiverse/suites/**
 
     rake test:multiverse:clobber
 

--- a/test/multiverse/lib/multiverse/runner.rb
+++ b/test/multiverse/lib/multiverse/runner.rb
@@ -147,7 +147,7 @@ module Multiverse
         # the directory is one of the suites included in one of the non-rest groups passed in
         (keys.include?("rest") && !GROUPS.values.flatten.include?(dir)) || (combined_groups.any? && combined_groups.include?(dir))
       else
-        dir.include?(filter)
+        dir.eql?(filter)
       end
     end
   end


### PR DESCRIPTION
the current consensus is that when a suite name "filter" is passed to
the multiverse rake task, that filter should require an exact match with
a suite directory name.

for example, with the following command:

```shell
bundle exec rake test:multiverse[active_record]
```

the desired result is to have the `active_record` suite ran, but the
`active_record_pg` suite be excluded.

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
