### PR TITLE
Silence stderr output on *BSD

### DIFF
--- a/lib/new_relic/agent/hostname.rb
+++ b/lib/new_relic/agent/hostname.rb
@@ -22,7 +22,7 @@ module NewRelic
       # we get back empty string.  So, solution here is to check for non-zero
       # exit status and retry the command without the -f flag.
       def self.get_fqdn
-        fqdn = %x(hostname -f).chomp!
+        fqdn = %x(hostname -f 2>/dev/null).chomp!
         fqdn = %x(hostname).chomp! unless $?.exitstatus.zero?
         fqdn
       rescue => e


### PR DESCRIPTION
Without this, all my cronjobs, servers etc will always output to stderr:
```
hostname: unknown option -- f
usage: hostname [-s] [name-of-host]
```