### PR TITLE
remove the echo statements from the label workflow

### DIFF
--- a/.github/workflows/label_community_cards.yml
+++ b/.github/workflows/label_community_cards.yml
@@ -8,10 +8,6 @@ jobs:
   Check_contributor_handle:
     runs-on: ubuntu-latest
     steps:
-      - name: View issue information
-        run: |
-          echo "Issue title: ${{ github.event.issue.title }}"
-          echo "Issue body: ${{ github.event.issue.body }}"
       - name: Label community issue
         uses: actions/github-script@v5
         with:


### PR DESCRIPTION
Remove the echo statements from the label workflow as per [GitHub's
recommendation](https://securitylab.github.com/advisories/GHSL-2020-183-checkstyle-checkstyle-workflow/)

