### PR TITLE
performance test enhancements

### DIFF
--- a/test/performance/Gemfile
+++ b/test/performance/Gemfile
@@ -1,9 +1,10 @@
 source 'https://rubygems.org'
 
 gem 'newrelic_rpm', :path => '../../..'
-gem 'rack'
-gem 'mocha'
 
-gem 'stackprof'
+gem 'mocha'
 gem 'pry'
 gem 'pry-nav'
+gem 'rack'
+gem 'redis'
+gem 'stackprof'

--- a/test/performance/lib/performance/baseline.rb
+++ b/test/performance/lib/performance/baseline.rb
@@ -4,7 +4,7 @@
 
 module Performance
   class Baseline
-    PERSIST_PATH = File.expand_path("~/.newrelic_rpm_baseline")
+    PERSIST_PATH = File.expand_path(ENV.fetch("NEWRELIC_RPM_BASELINE_FILE", "~/.newrelic_rpm_baseline"))
 
     attr_reader :results
 

--- a/test/performance/lib/performance/baseline_compare_reporter.rb
+++ b/test/performance/lib/performance/baseline_compare_reporter.rb
@@ -102,7 +102,7 @@ module Performance
         sprintf("#{prefix}%.1f%%", v)
       }
 
-      table = Table.new(rows) do
+      table = Table.new(rows, @options) do
         column :name
         column :before, &(FormattingHelpers.method(:format_duration))
         column :after, &(FormattingHelpers.method(:format_duration))

--- a/test/performance/lib/performance/console_reporter.rb
+++ b/test/performance/lib/performance/console_reporter.rb
@@ -16,7 +16,7 @@ module Performance
 
     def report
       report_summary
-      report_successful_results(successes) unless successes.empty?
+      report_successful_results(successes)
       report_failed_results
     end
 

--- a/test/performance/lib/performance/runner.rb
+++ b/test/performance/lib/performance/runner.rb
@@ -16,7 +16,8 @@ module Performance
       :brief => false,
       :tags => {},
       :dir => File.expand_path(File.join(File.dirname(__FILE__), '..', '..', 'suites')),
-      :agent_path => ENV['AGENT_PATH'] || File.join(File.dirname(__FILE__), '..', '..', '..', '..')
+      :agent_path => ENV['AGENT_PATH'] || File.join(File.dirname(__FILE__), '..', '..', '..', '..'),
+      :markdown => false
     }
 
     def initialize(options = {})

--- a/test/performance/lib/performance/table.rb
+++ b/test/performance/lib/performance/table.rb
@@ -50,8 +50,9 @@ module Performance
       end
     end
 
-    def initialize(rows, &blk)
+    def initialize(rows, options, &blk)
       @rows = rows
+      @options = options
 
       builder = Builder.new
       builder.instance_eval(&blk)
@@ -76,13 +77,25 @@ module Performance
       "| " + parts.join(" | ") + " |"
     end
 
+    def left_corner
+      @options[:markdown] ? '--' : '+-'
+    end
+
+    def right_corner
+      @options[:markdown] ? '--' : '-+'
+    end
+
+    def delimiter
+      @options[:markdown] ? '-|-' : '-+-'
+    end
+
     def render
       widths = column_widths
 
       blanks = widths.map { |w| "-" * w }
-      top = '+-' + blanks.join('-+-') + '-+'
-      separator = '|-' + blanks.join('-+-') + '-|'
-      bottom = '+-' + blanks.join('-+-') + '-+'
+      top = left_corner + blanks.join(delimiter) + right_corner
+      separator = '|-' + blanks.join(delimiter) + '-|'
+      bottom = left_corner + blanks.join(delimiter) + right_corner
 
       text_rows = []
 
@@ -97,9 +110,14 @@ module Performance
         text_rows << render_row(parts)
       end
 
-      puts top + "\n"
-      puts text_rows.join("\n" + separator + "\n")
-      puts bottom + "\n"
+      if @options[:markdown]
+        text_rows.insert(1, separator)
+        puts text_rows.join("\n")
+      else
+        puts top + "\n"
+        puts text_rows.join("\n" + separator + "\n")
+        puts bottom + "\n"
+      end
     end
   end
 end

--- a/test/performance/script/runner
+++ b/test/performance/script/runner
@@ -112,6 +112,10 @@ parser = OptionParser.new do |opts|
     options[:tags] ||= {}
     options[:tags][key] = value
   end
+
+  opts.on("-M", "--markdown", "Format the tabular output in Markdown") do
+    options[:markdown] = true
+  end
 end
 parser.parse!
 


### PR DESCRIPTION
enhancements for the performance tests:

* `redis` is a required gem, so add it to `Gemfile` and alphabetize the
  list
* Make the baseline output file location configurable via an environment
  variable while still defaulting to the user's home directory
* Add a `--markdown` / `-M` flag to generate the comparison table in
  Markdown format. Usage: `script/runner -C --markdown`
