### PR TITLE
remove browser_monitoring.auto_instrument dupe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # New Relic Ruby Agent Release Notes #
 
+  ## v8.6.0
+
+  * **Documentation: remove confusing duplicate RUM entry from newrelic.yml**
+
+    The `browser_monitoring.auto_instrument` configuration option to enable web page load timing (RUM) was confusingly listed twice in the newrelic.yml config file. This option is enabled by default. The newrelic.yml file has been updated to list the option only once. Many thanks to @robotfelix for bringing this to our attention with [Issue #955](https://github.com/newrelic/newrelic-ruby-agent/issues/955)
+
+
   ## v8.5.0
 
   * **AWS: Support IMDSv2 by using a token with metadata API calls**

--- a/newrelic.yml
+++ b/newrelic.yml
@@ -82,10 +82,6 @@ common: &default_settings
 # end.
 # browser_monitoring.attributes.include: []
 
-# If true, enables auto-injection of the JavaScript header for page load timing
-# (sometimes referred to as real user monitoring or RUM).
-# browser_monitoring.auto_instrument: false
-
 # This is true by default, this enables auto-injection of the JavaScript header
 # for page load timing (sometimes referred to as real user monitoring or RUM).
 # browser_monitoring.auto_instrument: true


### PR DESCRIPTION
removed duplicate `browser_monitoring.auto_instrument` from
`newrelic.yml`. This configuration option (for RUM) defaults to `true`
and is appropriately commented out in the config so as to not be
redundantly applied. The confusing duplicated config file entry with a
`false` value (also commented out) has now been removed.

resolves #955