### PR TITLE
Logging: Apply attribute value limit on messages

### DIFF
--- a/lib/new_relic/agent/log_event_aggregator.rb
+++ b/lib/new_relic/agent/log_event_aggregator.rb
@@ -22,7 +22,7 @@ module NewRelic
       METRICS_SUPPORTABILITY_FORMAT = "Supportability/Logging/Metrics/Ruby/%s".freeze
       FORWARDING_SUPPORTABILITY_FORMAT = "Supportability/Logging/Forwarding/Ruby/%s".freeze
       DECORATING_SUPPORTABILITY_FORMAT = "Supportability/Logging/LocalDecorating/Ruby/%s".freeze
-      MAX_BYTES = 32768 # 32 * 1024 = 1 kibibyte
+      MAX_BYTES = 32768 # 32 * 1024 bytes (32 kibibytes)
 
       named :LogEventAggregator
       buffer_class PrioritySampledBuffer
@@ -91,7 +91,7 @@ module NewRelic
       end
 
       def create_event priority, formatted_message, severity
-        formatted_message = truncate_message(formatted_message) if formatted_message.bytesize > MAX_BYTES
+        formatted_message = truncate_message(formatted_message)
 
         event = LinkingMetadata.append_trace_linking_metadata({
           LEVEL_KEY => severity,
@@ -208,7 +208,7 @@ module NewRelic
       end
 
       def truncate_message(message)
-        return if message.bytesize <= MAX_BYTES
+        return message if message.bytesize <= MAX_BYTES
         message.byteslice(0...MAX_BYTES)
       end
     end

--- a/test/new_relic/agent/log_event_aggregator_test.rb
+++ b/test/new_relic/agent/log_event_aggregator_test.rb
@@ -286,6 +286,7 @@ module NewRelic::Agent
       event = @aggregator.create_event(1, message, 'INFO')
 
       assert_equal(message, event[1]["message"])
+    end
 
     def test_does_not_record_if_message_is_nil
       @aggregator.record(nil, "DEBUG")

--- a/test/new_relic/agent/log_event_aggregator_test.rb
+++ b/test/new_relic/agent/log_event_aggregator_test.rb
@@ -265,5 +265,27 @@ module NewRelic::Agent
       assert_equal 1, size
       assert_equal expected, payload
     end
+
+    def test_create_event_truncates_message_when_exceeding_max_bytes
+      right_size_message = String.new("a" * LogEventAggregator::MAX_BYTES)
+      message = right_size_message + 'b'
+      event = @aggregator.create_event(1, message, 'INFO')
+
+      assert_equal(right_size_message, event[1]["message"])
+    end
+
+    def test_create_event_doesnt_truncate_message_when_at_max_bytes
+      message = String.new("a" * LogEventAggregator::MAX_BYTES)
+      event = @aggregator.create_event(1, message, 'INFO')
+
+      assert_equal(message, event[1]["message"])
+    end
+
+    def test_create_event_doesnt_truncate_message_when_below_max_bytes
+      message = String.new("a" * (LogEventAggregator::MAX_BYTES - 1))
+      event = @aggregator.create_event(1, message, 'INFO')
+
+      assert_equal(message, event[1]["message"])
+    end
   end
 end


### PR DESCRIPTION
# Overview
Adds a private method, `#truncate_message` to shorten messages to the maximum allowed bytes, 32 * 1024 (1 kibibyte). This method is called when an event is created if the message's bytesize exceeds the limit.

# Related Github Issue
Closes #997

# Testing
Adds unit tests for truncating the message if over the bytes and leaving the message as-is if equal to or less than the required bytes.