### PR TITLE
Logging: Don't send payloads with empty message attributes

### DIFF
--- a/lib/new_relic/agent/log_event_aggregator.rb
+++ b/lib/new_relic/agent/log_event_aggregator.rb
@@ -58,7 +58,7 @@ module NewRelic
 
         return unless enabled?
         return if @high_security
-        return if (formatted_message.nil? || formatted_message.empty?)
+        return if formatted_message.nil? || formatted_message.empty?
 
         txn = NewRelic::Agent::Transaction.tl_current
         priority = LogPriority.priority_for(txn)

--- a/lib/new_relic/agent/log_event_aggregator.rb
+++ b/lib/new_relic/agent/log_event_aggregator.rb
@@ -58,6 +58,7 @@ module NewRelic
 
         return unless enabled?
         return if @high_security
+        return if (formatted_message.nil? || formatted_message.empty?)
 
         txn = NewRelic::Agent::Transaction.tl_current
         priority = LogPriority.priority_for(txn)

--- a/test/new_relic/agent/log_event_aggregator_test.rb
+++ b/test/new_relic/agent/log_event_aggregator_test.rb
@@ -265,5 +265,17 @@ module NewRelic::Agent
       assert_equal 1, size
       assert_equal expected, payload
     end
+
+    def test_does_not_record_if_message_is_nil
+      @aggregator.record(nil, "DEBUG")
+      _, events = @aggregator.harvest!
+      assert_empty events
+    end
+
+    def test_does_not_record_if_message_empty_string
+      @aggregator.record('', "DEBUG")
+      _, events = @aggregator.harvest!
+      assert_empty events
+    end
   end
 end


### PR DESCRIPTION
# Overview
Adds a guard statement to `NewRelic::Agent::LogEventAggregator#record` to return if the `formatted_message` argument is `nil` or an empty string.

# Related Github Issue
Closes #984 

# Testing
Adds unit tests for not recording empty or nil messages