### PR TITLE
Logging: Add configuration options for logging

### DIFF
--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -354,21 +354,21 @@ module NewRelic
           :public => false,
           :type => String,
           :allowed_from_server => true,
-          :description => 'The [Entity GUID](/attribute-dictionary/span/entityguid) for the entity running this agent.'
+          :description => 'The [Entity GUID](/attribute-dictionary/span/entityguid) for the entity running your agent.'
         },
         :monitor_mode => {
           :default => value_of(:enabled),
           :public => true,
           :type => Boolean,
           :allowed_from_server => false,
-          :description => 'When `true`, the agent transmits data about your app to the New Relic [collector](/docs/using-new-relic/welcome-new-relic/get-started/glossary/#collector).'
+          :description => 'When `true`, the agent transmits data about your application to the New Relic [collector](/docs/using-new-relic/welcome-new-relic/get-started/glossary/#collector).'
         },
         :test_mode => {
           :default => false,
           :public => false,
           :type => Boolean,
           :allowed_from_server => false,
-          :description => 'Used in tests for agent to start up but not connect to collector. Formerly used `developer_mode` in test config for this purpose.'
+          :description => 'Used in tests for the agent to start up, but not connect to the collector. Formerly used `developer_mode` in test config for this purpose.'
         },
         :log_level => {
           :default => 'info',
@@ -1803,7 +1803,7 @@ module NewRelic
           :public => true,
           :type => String,
           :allowed_from_server => false,
-          :description => 'A dictionary of [label names](/docs/data-analysis/user-interface-functions/labels-categories-organize-your-apps-servers) and values that will be applied to the data sent from this agent. May also be expressed as a semicolon-delimited `;` string of colon-separated `:` pairs. For example, `<var>Server</var>:<var>One</var>;<var>Data Center</var>:<var>Primary</var>`.'
+          :description => 'A dictionary of [label names](/docs/data-analysis/user-interface-functions/labels-categories-organize-your-apps-servers) and values that will be applied to the data sent from your agent. May also be expressed as a semicolon-delimited `;` string of colon-separated `:` pairs. For example, `<var>Server</var>:<var>One</var>;<var>Data Center</var>:<var>Primary</var>`.'
         },
         :aggressive_keepalive => {
           :default => true,
@@ -1869,7 +1869,7 @@ module NewRelic
           :public => true,
           :type => Boolean,
           :allowed_from_server => false,
-          :description => 'If `true`, the agent captures log records emitted by this application.'
+          :description => 'If `true`, the agent captures log records emitted by your application.'
         },
         :'application_logging.forwarding.max_samples_stored' => {
           :default => 10000,
@@ -1884,7 +1884,7 @@ module NewRelic
           :public => true,
           :type => Boolean,
           :allowed_from_server => false,
-          :description => 'If `true`, the agent captures metrics related to logging for this application.'
+          :description => 'If `true`, the agent captures metrics related to logging for your application.'
         },
         :disable_grape_instrumentation => {
           :default => false,
@@ -2177,7 +2177,7 @@ module NewRelic
           :public => false,
           :type => String,
           :allowed_from_server => true,
-          :description => 'The account id associated with this application.'
+          :description => 'The account id associated with your application.'
         },
         :primary_application_id => {
           :default => nil,
@@ -2185,7 +2185,7 @@ module NewRelic
           :public => false,
           :type => String,
           :allowed_from_server => true,
-          :description => 'The primary id associated with this application.'
+          :description => 'The primary id associated with your application.'
         },
         :'distributed_tracing.enabled' => {
           :default => true,

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -1865,18 +1865,18 @@ module NewRelic
           :dynamic_name => true
         },
         :'application_logging.forwarding.enabled' => {
-          :default => true,
-          :public => true,
-          :type => Boolean,
-          :allowed_from_server => true,
-          :description => 'If `true`, the agent captures log records emitted by your application.'
+          :default      => false,
+          :public       => true,
+          :type         => Boolean,
+          :allowed_from_server => false,
+          :description  => 'If `true`, the agent captures log records emitted by this application.'
         },
         :'application_logging.forwarding.max_samples_stored' => {
-          :default => 2000,
-          :public => true,
-          :type => Integer,
-          :allowed_from_server => true,
-          :description => 'Specify a maximum number of log records to buffer in memory at a time.',
+          :default      => 10000,
+          :public       => true,
+          :type         => Integer,
+          :allowed_from_server => false,
+          :description  => 'Defines the maximum number of log records to buffer in memory at a time.',
           :dynamic_name => true
         },
         :disable_grape_instrumentation => {

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -1879,6 +1879,13 @@ module NewRelic
           :description  => 'Defines the maximum number of log records to buffer in memory at a time.',
           :dynamic_name => true
         },
+        :'application_logging.metrics.enabled' => {
+          :default      => true,
+          :public       => true,
+          :type         => Boolean,
+          :allowed_from_server => false,
+          :description  => 'If `true`, the agent captures metrics related to logging for this application.'
+        },
         :disable_grape_instrumentation => {
           :default => false,
           :public => false,

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -1865,26 +1865,26 @@ module NewRelic
           :dynamic_name => true
         },
         :'application_logging.forwarding.enabled' => {
-          :default      => false,
-          :public       => true,
-          :type         => Boolean,
+          :default => false,
+          :public => true,
+          :type => Boolean,
           :allowed_from_server => false,
-          :description  => 'If `true`, the agent captures log records emitted by this application.'
+          :description => 'If `true`, the agent captures log records emitted by this application.'
         },
         :'application_logging.forwarding.max_samples_stored' => {
-          :default      => 10000,
-          :public       => true,
-          :type         => Integer,
+          :default => 10000,
+          :public => true,
+          :type => Integer,
           :allowed_from_server => false,
-          :description  => 'Defines the maximum number of log records to buffer in memory at a time.',
+          :description => 'Defines the maximum number of log records to buffer in memory at a time.',
           :dynamic_name => true
         },
         :'application_logging.metrics.enabled' => {
-          :default      => true,
-          :public       => true,
-          :type         => Boolean,
+          :default => true,
+          :public => true,
+          :type => Boolean,
           :allowed_from_server => false,
-          :description  => 'If `true`, the agent captures metrics related to logging for this application.'
+          :description => 'If `true`, the agent captures metrics related to logging for this application.'
         },
         :disable_grape_instrumentation => {
           :default => false,

--- a/lib/new_relic/agent/log_event_aggregator.rb
+++ b/lib/new_relic/agent/log_event_aggregator.rb
@@ -173,7 +173,7 @@ module NewRelic
       # these until harvest before recording them
       def record_customer_metrics
         @counter_lock.synchronize do
-          return unless NewRelic::Agent.config[METRICS_ENABLED_KEY]
+          return unless NewRelic::Agent.config[:'application_logging.metrics.enabled']
           return unless @seen > 0
 
           NewRelic::Agent.increment_metric(LINES, @seen)

--- a/lib/new_relic/agent/log_event_aggregator.rb
+++ b/lib/new_relic/agent/log_event_aggregator.rb
@@ -173,6 +173,7 @@ module NewRelic
       # these until harvest before recording them
       def record_customer_metrics
         @counter_lock.synchronize do
+          return unless NewRelic::Agent.config[METRICS_ENABLED_KEY]
           return unless @seen > 0
 
           NewRelic::Agent.increment_metric(LINES, @seen)

--- a/lib/new_relic/agent/log_event_aggregator.rb
+++ b/lib/new_relic/agent/log_event_aggregator.rb
@@ -56,7 +56,7 @@ module NewRelic
           @seen_by_severity[severity] += 1
         end
 
-        return unless enabled?
+        return unless NewRelic::Agent.config[:'application_logging.forwarding.enabled']
         return if @high_security
 
         txn = NewRelic::Agent::Transaction.tl_current

--- a/lib/new_relic/agent/log_event_aggregator.rb
+++ b/lib/new_relic/agent/log_event_aggregator.rb
@@ -26,9 +26,9 @@ module NewRelic
       named :LogEventAggregator
       buffer_class PrioritySampledBuffer
 
-      # TODO use the right value when the collector starts reporting it
+      # TODO: use the right value when the collector starts reporting it
+      # capacity_key :'application_logging.forwarding.max_samples_stored'
       capacity_key :'custom_insights_events.max_samples_stored'
-      # capacity_key :'log_sending.max_samples_stored'
       enabled_key :'application_logging.forwarding.enabled'
 
       # Config keys

--- a/lib/new_relic/agent/log_event_aggregator.rb
+++ b/lib/new_relic/agent/log_event_aggregator.rb
@@ -172,8 +172,8 @@ module NewRelic
       # To avoid paying the cost of metric recording on every line, we hold
       # these until harvest before recording them
       def record_customer_metrics
+        return unless NewRelic::Agent.config[:'application_logging.metrics.enabled']
         @counter_lock.synchronize do
-          return unless NewRelic::Agent.config[:'application_logging.metrics.enabled']
           return unless @seen > 0
 
           NewRelic::Agent.increment_metric(LINES, @seen)

--- a/newrelic.yml
+++ b/newrelic.yml
@@ -26,6 +26,15 @@ common: &default_settings
 # All of the following configuration options are optional. Review them, and
 # uncomment or edit them if they appear relevant to your application needs.
 
+# If `true`, the agent captures log records emitted by this application.
+# application_logging.forwarding.enabled: false
+
+# Defines the maximum number of log records to buffer in memory at a time.
+# application_logging.forwarding.max_samples_stored: 10000
+
+# If `true`, the agent captures metrics related to logging for this application.
+# application_logging.metrics.enabled: true
+
 # If true, enables transaction event sampling.
 # transaction_events.enabled: true
 

--- a/test/multiverse/suites/agent_only/log_events_test.rb
+++ b/test/multiverse/suites/agent_only/log_events_test.rb
@@ -20,7 +20,7 @@ class LogEventsTest < Minitest::Test
 
       NewRelic::Agent.agent.send(:harvest_and_send_log_event_data)
     end
-    
+
     last_log = last_log_event
     assert_equal "Deadly", last_log["message"]
     assert_equal "FATAL", last_log["level"]

--- a/test/new_relic/agent/log_event_aggregator_test.rb
+++ b/test/new_relic/agent/log_event_aggregator_test.rb
@@ -84,8 +84,8 @@ module NewRelic::Agent
       end
 
       assert_metrics_recorded({
-        "Logging/lines" => { :call_count => 2 },
-        "Logging/lines/DEBUG" => { :call_count => 2 },
+        "Logging/lines" => {:call_count => 2},
+        "Logging/lines/DEBUG" => {:call_count => 2}
       })
     end
 
@@ -97,7 +97,7 @@ module NewRelic::Agent
 
       assert_metrics_not_recorded([
         "Logging/lines",
-        "Logging/lines/DEBUG",
+        "Logging/lines/DEBUG"
       ])
     end
 
@@ -254,11 +254,11 @@ module NewRelic::Agent
 
         # We are fine to count them, though....
         assert_metrics_recorded_exclusive({
-          "Logging/lines" => { :call_count => 9 },
-          "Logging/lines/DEBUG" => { :call_count => 9 },
-          "Supportability/Logging/Metrics/Ruby/enabled" => { :call_count => 1 }, # TODO: Clarify value for high security mode with Jason Clark
-          "Supportability/Logging/Forwarding/Ruby/enabled" => { :call_count => 1 },
-          "Supportability/Logging/LocalDecorating/Ruby/disabled" => { :call_count => 1 }
+          "Logging/lines" => {:call_count => 9},
+          "Logging/lines/DEBUG" => {:call_count => 9},
+          "Supportability/Logging/Metrics/Ruby/enabled" => {:call_count => 1}, # TODO: Clarify value for high security mode with Jason Clark
+          "Supportability/Logging/Forwarding/Ruby/enabled" => {:call_count => 1},
+          "Supportability/Logging/LocalDecorating/Ruby/disabled" => {:call_count => 1}
         },
           :ignore_filter => %r{^Supportability/API/})
       end

--- a/test/new_relic/agent/log_event_aggregator_test.rb
+++ b/test/new_relic/agent/log_event_aggregator_test.rb
@@ -77,6 +77,30 @@ module NewRelic::Agent
       end
     end
 
+    def test_records_customer_metrics_when_enabled
+      with_config LogEventAggregator::METRICS_ENABLED_KEY => true do
+        2.times { @aggregator.record("Are you counting this?", "DEBUG") }
+        @aggregator.harvest!
+      end
+
+      assert_metrics_recorded({
+        "Logging/lines" => { :call_count => 2 },
+        "Logging/lines/DEBUG" => { :call_count => 2 },
+      })
+    end
+
+    def test_doesnt_record_customer_metrics_when_disabled
+      with_config LogEventAggregator::METRICS_ENABLED_KEY => false do
+        2.times { @aggregator.record("Are you counting this?", "DEBUG") }
+        @aggregator.harvest!
+      end
+
+      assert_metrics_not_recorded([
+        "Logging/lines",
+        "Logging/lines/DEBUG",
+      ])
+    end
+
     def test_record_by_default_limit
       max_samples = NewRelic::Agent.config[CAPACITY_KEY]
       n = max_samples + 1
@@ -230,11 +254,11 @@ module NewRelic::Agent
 
         # We are fine to count them, though....
         assert_metrics_recorded_exclusive({
-          "Logging/lines" => {:call_count => 9},
-          "Logging/lines/DEBUG" => {:call_count => 9},
-          "Supportability/Logging/Metrics/Ruby/disabled" => {:call_count => 1},
-          "Supportability/Logging/Forwarding/Ruby/enabled" => {:call_count => 1},
-          "Supportability/Logging/LocalDecorating/Ruby/disabled" => {:call_count => 1}
+          "Logging/lines" => { :call_count => 9 },
+          "Logging/lines/DEBUG" => { :call_count => 9 },
+          "Supportability/Logging/Metrics/Ruby/enabled" => { :call_count => 1 }, # TODO: Clarify value for high security mode with Jason Clark
+          "Supportability/Logging/Forwarding/Ruby/enabled" => { :call_count => 1 },
+          "Supportability/Logging/LocalDecorating/Ruby/disabled" => { :call_count => 1 }
         },
           :ignore_filter => %r{^Supportability/API/})
       end

--- a/test/new_relic/marshalling_test_cases.rb
+++ b/test/new_relic/marshalling_test_cases.rb
@@ -156,18 +156,18 @@ module MarshallingTestCases
   def test_sends_log_events
     # Standard with other agents on millis, not seconds
     t0 = nr_freeze_process_time.to_f * 1000
-
     message = "A deadly message"
     severity = "FATAL"
 
-    with_around_hook do
-      NewRelic::Agent.agent.log_event_aggregator.record(message, severity)
+    with_config(:'application_logging.forwarding.enabled' => true) do
+      with_around_hook do
+        NewRelic::Agent.agent.log_event_aggregator.record(message, severity)
+      end
     end
 
     transmit_data
 
     result = $collector.calls_for('log_event_data')
-
     assert_equal 1, result.length
 
     common = result.first.common["attributes"]
@@ -181,6 +181,7 @@ module MarshallingTestCases
     refute_empty logs
 
     log = logs.find { |l| l["message"] == message && l["level"] == severity }
+
     refute_nil log
     assert_equal t0, log["timestamp"]
   end


### PR DESCRIPTION
# Overview
Finesse the config options with the correct `newrelic.yml` documentation, default values, and on/off switches in code: 
* `application_logging.metrics.enabled`
* `application_logging.forwarding.enabled`
* `application_logging.forwarding.max_samples_stored`

# Related Github Issue
Closes #983

# Testing 
Tests for the forwarding configs have been created as part of Jason C.'s initial PR. Tests have been added for the metrics config.