### PR TITLE
Logging: Create overall application logging enabled flag

### DIFF
--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -38,6 +38,12 @@ module NewRelic
         end
       end
 
+      def self.instrumentation_boolean_value_of(key)
+        Proc.new do
+          NewRelic::Agent.config[key] ? 'auto' : 'disabled'
+        end
+      end
+
       # Marks the config option as deprecated in the documentation once generated.
       # Does not appear in logs.
       def self.deprecated_description new_setting, description
@@ -1004,7 +1010,7 @@ module NewRelic
           :description => 'Controls auto-instrumentation of dalli gem for Memcache at start up.  May be one of [auto|prepend|chain|disabled].'
         },
         :'instrumentation.logger' => {
-          :default => "auto",
+          :default => instrumentation_boolean_value_of(:'application_logging.enabled'),
           :public => true,
           :type => String,
           :dynamic_name => true,
@@ -1865,7 +1871,7 @@ module NewRelic
           :dynamic_name => true
         },
         :'application_logging.enabled' => {
-          :default => true,
+          :default => false,
           :public => true,
           :type => Boolean,
           :allowed_from_server => false,
@@ -1890,7 +1896,7 @@ module NewRelic
           :default => true,
           :public => true,
           :type => Boolean,
-          :allowed_from_server => false,
+          :allowed_from_server => true,
           :description => 'If `true`, the agent captures metrics related to logging for your application.'
         },
         :disable_grape_instrumentation => {

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -38,7 +38,7 @@ module NewRelic
         end
       end
 
-      def self.instrumentation_boolean_value_of(key)
+      def self.instrumentation_value_from_boolean(key)
         Proc.new do
           NewRelic::Agent.config[key] ? 'auto' : 'disabled'
         end
@@ -1018,7 +1018,7 @@ module NewRelic
           :description => 'Controls auto-instrumentation of dalli gem for Memcache at start up.  May be one of [auto|prepend|chain|disabled].'
         },
         :'instrumentation.logger' => {
-          :default => instrumentation_boolean_value_of(:'application_logging.enabled'),
+          :default => instrumentation_value_from_boolean(:'application_logging.enabled'),
           :public => true,
           :type => String,
           :dynamic_name => true,

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -1871,7 +1871,7 @@ module NewRelic
           :dynamic_name => true
         },
         :'application_logging.enabled' => {
-          :default => false,
+          :default => true,
           :public => true,
           :type => Boolean,
           :allowed_from_server => false,

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -1864,6 +1864,13 @@ module NewRelic
           :description => 'Defines the maximum number of span events reported from a single harvest. Any Integer between 1 and 10000 is valid.',
           :dynamic_name => true
         },
+        :'application_logging.enabled' => {
+          :default => true,
+          :public => true,
+          :type => Boolean,
+          :allowed_from_server => false,
+          :description => 'If `true`, enables log decoration and the collection of log events and metrics.'
+        },
         :'application_logging.forwarding.enabled' => {
           :default => false,
           :public => true,

--- a/lib/new_relic/agent/instrumentation/logger.rb
+++ b/lib/new_relic/agent/instrumentation/logger.rb
@@ -24,7 +24,5 @@ DependencyDetection.defer do
     else
       chain_instrument NewRelic::Agent::Instrumentation::Logger
     end
-
-    ::NewRelic::Agent.increment_metric("Supportability/Logging/Ruby/Logger/enabled")
   end
 end

--- a/lib/new_relic/agent/instrumentation/logger.rb
+++ b/lib/new_relic/agent/instrumentation/logger.rb
@@ -9,7 +9,10 @@ require_relative 'logger/prepend'
 DependencyDetection.defer do
   named :logger
 
-  depends_on { defined?(::Logger) }
+  depends_on do
+    defined?(::Logger) &&
+      NewRelic::Agent.config[:'application_logging.enabled']
+  end
 
   executes do
     ::NewRelic::Agent.logger.info "Installing Logger instrumentation"
@@ -22,6 +25,6 @@ DependencyDetection.defer do
       chain_instrument NewRelic::Agent::Instrumentation::Logger
     end
 
-    ::NewRelic::Agent.increment_metric("Supportability/Logging/enabled/Ruby/Logger")
+    ::NewRelic::Agent.increment_metric("Supportability/Logging/Ruby/Logger/enabled")
   end
 end

--- a/lib/new_relic/agent/instrumentation/logger/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/logger/instrumentation.rb
@@ -29,6 +29,10 @@ module NewRelic
           @skip_instrumenting = false
         end
 
+        def self.enabled?
+          NewRelic::Agent.config[:'instrumentation.logger'] != 'disabled'
+        end
+
         def format_message_with_tracing(severity, datetime, progname, msg)
           formatted_message = yield
           return formatted_message if skip_instrumenting?

--- a/lib/new_relic/agent/log_event_aggregator.rb
+++ b/lib/new_relic/agent/log_event_aggregator.rb
@@ -172,7 +172,7 @@ module NewRelic
 
       def record_configuration_metric(format, key)
         state = NewRelic::Agent.config[key]
-        label = unless enabled?
+        label = if !enabled?
           "disabled"
         else
           state ? "enabled" : "disabled"

--- a/lib/new_relic/agent/log_event_aggregator.rb
+++ b/lib/new_relic/agent/log_event_aggregator.rb
@@ -29,7 +29,7 @@ module NewRelic
       buffer_class PrioritySampledBuffer
 
       capacity_key :'application_logging.forwarding.max_samples_stored'
-      enabled_key :'application_logging.forwarding.enabled'
+      enabled_key :'application_logging.enabled'
 
       # Config keys
       OVERALL_ENABLED_KEY = :'application_logging.enabled'
@@ -43,7 +43,7 @@ module NewRelic
         @seen = 0
         @seen_by_severity = Hash.new(0)
         @high_security = NewRelic::Agent.config[:high_security]
-        @instrumentation_logger_enabled = instrumentation_logger_enabled?
+        @instrumentation_logger_enabled = NewRelic::Agent::Instrumentation::Logger.enabled?
         register_for_done_configuring(events)
       end
 
@@ -172,7 +172,7 @@ module NewRelic
 
       def record_configuration_metric(format, key)
         state = NewRelic::Agent.config[key]
-        label = if !enabled?
+        label = unless enabled?
           "disabled"
         else
           state ? "enabled" : "disabled"
@@ -227,10 +227,6 @@ module NewRelic
       def truncate_message(message)
         return message if message.bytesize <= MAX_BYTES
         message.byteslice(0...MAX_BYTES)
-      end
-
-      def instrumentation_logger_enabled?
-        NewRelic::Agent.config[:'instrumentation.logger'] != 'disabled'
       end
     end
   end

--- a/test/multiverse/suites/logger/logger_instrumentation_test.rb
+++ b/test/multiverse/suites/logger/logger_instrumentation_test.rb
@@ -138,6 +138,18 @@ class LoggerInstrumentationTest < Minitest::Test
     refute_any_logging_instrumentation()
   end
 
+  def test_enabled_returns_false_when_disabled
+    with_config(:'instrumentation.logger' => 'disabled') do
+      refute NewRelic::Agent::Instrumentation::Logger.enabled?
+    end
+  end
+
+  def test_enabled_returns_true_when_enabled
+    with_config(:'instrumentation.logger' => 'auto') do
+      assert NewRelic::Agent::Instrumentation::Logger.enabled?
+    end
+  end
+
   def refute_any_logging_instrumentation
     _, logs = NewRelic::Agent.agent.log_event_aggregator.harvest!
     assert_empty logs

--- a/test/new_relic/agent/configuration/default_source_test.rb
+++ b/test/new_relic/agent/configuration/default_source_test.rb
@@ -253,16 +253,7 @@ module NewRelic::Agent::Configuration
       end
     end
 
-    def get_config_value_class(value)
-      type = value.class
-
-      if type == TrueClass || type == FalseClass
-        Boolean
-      else
-        type
-      end
-    end
-
+    # Tests self.instrumentation_value_from_boolean
     def test_instrumentation_logger_matches_application_logging_enabled
       with_config(:'application_logging.enabled' => true) do
         assert_equal 'auto', NewRelic::Agent.config['instrumentation.logger']
@@ -272,6 +263,16 @@ module NewRelic::Agent::Configuration
     def test_instrumentation_logger_matches_application_logging_disabled
       with_config(:'application_logging.enabled' => false) do
         assert_equal 'disabled', NewRelic::Agent.config['instrumentation.logger']
+      end
+    end
+
+    def get_config_value_class(value)
+      type = value.class
+
+      if type == TrueClass || type == FalseClass
+        Boolean
+      else
+        type
       end
     end
   end

--- a/test/new_relic/agent/configuration/default_source_test.rb
+++ b/test/new_relic/agent/configuration/default_source_test.rb
@@ -156,6 +156,12 @@ module NewRelic::Agent::Configuration
       end
     end
 
+    def test_application_logging_enabled_default
+      with_config(:'application_logging.enabled' => :foo) do
+        assert_equal :foo, NewRelic::Agent.config['application_logging.enabled']
+      end
+    end
+
     def test_agent_attribute_settings_convert_comma_delimited_strings_into_an_arrays
       types = %w[transaction_tracer. transaction_events. error_collector. browser_monitoring.]
       types << ''
@@ -254,6 +260,18 @@ module NewRelic::Agent::Configuration
         Boolean
       else
         type
+      end
+    end
+
+    def test_instrumentation_logger_matches_application_logging_enabled
+      with_config(:'application_logging.enabled' => true) do
+        assert_equal 'auto', NewRelic::Agent.config['instrumentation.logger']
+      end
+    end
+
+    def test_instrumentation_logger_matches_application_logging_disabled
+      with_config(:'application_logging.enabled' => false) do
+        assert_equal 'disabled', NewRelic::Agent.config['instrumentation.logger']
       end
     end
   end

--- a/test/new_relic/agent/log_event_aggregator_test.rb
+++ b/test/new_relic/agent/log_event_aggregator_test.rb
@@ -45,6 +45,7 @@ module NewRelic::Agent
 
     def test_records_enabled_metrics_on_startup
       with_config(
+        LogEventAggregator::OVERALL_ENABLED_KEY => true,
         LogEventAggregator::METRICS_ENABLED_KEY => true,
         LogEventAggregator::FORWARDING_ENABLED_KEY => true,
         LogEventAggregator::DECORATING_ENABLED_KEY => true
@@ -52,6 +53,7 @@ module NewRelic::Agent
         NewRelic::Agent.config.notify_server_source_added
 
         assert_metrics_recorded_exclusive({
+          "Supportability/Logging/Ruby/Logger/enabled" => {:call_count => 1},
           "Supportability/Logging/Metrics/Ruby/enabled" => {:call_count => 1},
           "Supportability/Logging/Forwarding/Ruby/enabled" => {:call_count => 1},
           "Supportability/Logging/LocalDecorating/Ruby/enabled" => {:call_count => 1}
@@ -62,6 +64,7 @@ module NewRelic::Agent
 
     def test_records_disabled_metrics_on_startup
       with_config(
+        LogEventAggregator::OVERALL_ENABLED_KEY => false,
         LogEventAggregator::METRICS_ENABLED_KEY => false,
         LogEventAggregator::FORWARDING_ENABLED_KEY => false,
         LogEventAggregator::DECORATING_ENABLED_KEY => false
@@ -69,6 +72,7 @@ module NewRelic::Agent
         NewRelic::Agent.config.notify_server_source_added
 
         assert_metrics_recorded_exclusive({
+          "Supportability/Logging/Ruby/Logger/disabled" => {:call_count => 1},
           "Supportability/Logging/Metrics/Ruby/disabled" => {:call_count => 1},
           "Supportability/Logging/Forwarding/Ruby/disabled" => {:call_count => 1},
           "Supportability/Logging/LocalDecorating/Ruby/disabled" => {:call_count => 1}
@@ -89,6 +93,21 @@ module NewRelic::Agent
       })
     end
 
+    def test_doesnt_record_customer_metrics_when_overall_disabled_and_metrics_enabled
+      with_config(
+        LogEventAggregator::OVERALL_ENABLED_KEY => false,
+        LogEventAggregator::METRICS_ENABLED_KEY => true
+      ) do
+        2.times { @aggregator.record("Are you counting this?", "DEBUG") }
+        @aggregator.harvest!
+      end
+
+      assert_metrics_not_recorded([
+        "Logging/lines",
+        "Logging/lines/DEBUG"
+      ])
+    end
+
     def test_doesnt_record_customer_metrics_when_disabled
       with_config LogEventAggregator::METRICS_ENABLED_KEY => false do
         2.times { @aggregator.record("Are you counting this?", "DEBUG") }
@@ -99,6 +118,17 @@ module NewRelic::Agent
         "Logging/lines",
         "Logging/lines/DEBUG"
       ])
+    end
+
+    def test_does_not_record_if_overall_disabled_and_forwarding_enabled
+      with_config(
+        :'application_logging.enabled' => false,
+        :'application_logging.forwarding.enabled' => true
+      ) do
+        @aggregator.record('Hello world!', "DEBUG")
+        _, events = @aggregator.harvest!
+        assert_empty events
+      end
     end
 
     def test_record_by_default_limit
@@ -256,8 +286,55 @@ module NewRelic::Agent
         assert_metrics_recorded_exclusive({
           "Logging/lines" => {:call_count => 9},
           "Logging/lines/DEBUG" => {:call_count => 9},
+          "Supportability/Logging/Ruby/Logger/enabled" => {:call_count => 1},
           "Supportability/Logging/Metrics/Ruby/enabled" => {:call_count => 1},
           "Supportability/Logging/Forwarding/Ruby/enabled" => {:call_count => 1},
+          "Supportability/Logging/LocalDecorating/Ruby/disabled" => {:call_count => 1}
+        },
+          :ignore_filter => %r{^Supportability/API/})
+      end
+    end
+
+    def test_overall_disabled
+      with_config(
+        LogEventAggregator::OVERALL_ENABLED_KEY => false
+      ) do
+        9.times { @aggregator.record("Are you counting this?", "DEBUG") }
+        _, items = @aggregator.harvest!
+
+        # Never aggregate logs
+        assert_empty items
+
+        # All settings should report as disabled regardless of config option
+        assert_metrics_recorded_exclusive({
+          "Supportability/Logging/Ruby/Logger/disabled" => {:call_count => 1},
+          "Supportability/Logging/Metrics/Ruby/disabled" => {:call_count => 1},
+          "Supportability/Logging/Forwarding/Ruby/disabled" => {:call_count => 1},
+          "Supportability/Logging/LocalDecorating/Ruby/disabled" => {:call_count => 1}
+        },
+          :ignore_filter => %r{^Supportability/API/})
+      end
+    end
+
+    def test_overall_disabled_in_high_security_mode
+      with_config(
+        CAPACITY_KEY => 5,
+        :high_security => true,
+        LogEventAggregator::OVERALL_ENABLED_KEY => false
+      ) do
+        # We refresh the high security setting on this notification
+        NewRelic::Agent.config.notify_server_source_added
+
+        9.times { @aggregator.record("Are you counting this?", "DEBUG") }
+        _, items = @aggregator.harvest!
+
+        # Never aggregate logs
+        assert_empty items
+
+        assert_metrics_recorded_exclusive({
+          "Supportability/Logging/Ruby/Logger/disabled" => {:call_count => 1},
+          "Supportability/Logging/Metrics/Ruby/disabled" => {:call_count => 1},
+          "Supportability/Logging/Forwarding/Ruby/disabled" => {:call_count => 1},
           "Supportability/Logging/LocalDecorating/Ruby/disabled" => {:call_count => 1}
         },
           :ignore_filter => %r{^Supportability/API/})

--- a/test/new_relic/agent/transaction_test.rb
+++ b/test/new_relic/agent/transaction_test.rb
@@ -3,7 +3,6 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 
 require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', 'test_helper'))
-require 'pry'
 module NewRelic::Agent
   class TransactionTest < Minitest::Test
     def setup
@@ -1634,7 +1633,10 @@ module NewRelic::Agent
     end
 
     def test_batches_logs_during_transaction
-      with_config(LogEventAggregator::enabled_keys.first => true) do
+      with_config(
+        LogEventAggregator::enabled_keys.first => true,
+        LogEventAggregator::FORWARDING_ENABLED_KEY => true
+      ) do
         NewRelic::Agent.config.notify_server_source_added
         in_transaction do
           NewRelic::Agent.agent.log_event_aggregator.record("A message", "FATAL")
@@ -1644,7 +1646,10 @@ module NewRelic::Agent
     end
 
     def test_ignores_logs_when_transaction_ignored
-      with_config(LogEventAggregator::enabled_keys.first => true) do
+      with_config(
+        LogEventAggregator::enabled_keys.first => true,
+        LogEventAggregator::FORWARDING_ENABLED_KEY => true
+        ) do
         NewRelic::Agent.config.notify_server_source_added
         in_transaction do |txn|
           txn.ignore!
@@ -1661,8 +1666,11 @@ module NewRelic::Agent
 
     def test_limits_batched_logs_during_transaction
       limit = 10
-      with_config(LogEventAggregator::enabled_keys.first => true,
-        LogEventAggregator::capacity_key => limit) do
+      with_config(
+        LogEventAggregator::enabled_keys.first => true,
+        LogEventAggregator::FORWARDING_ENABLED_KEY => true,
+        LogEventAggregator::capacity_key => limit
+      ) do
         NewRelic::Agent.config.notify_server_source_added
         in_transaction do
           100.times do

--- a/test/new_relic/agent/transaction_test.rb
+++ b/test/new_relic/agent/transaction_test.rb
@@ -1649,7 +1649,7 @@ module NewRelic::Agent
       with_config(
         LogEventAggregator::enabled_keys.first => true,
         LogEventAggregator::FORWARDING_ENABLED_KEY => true
-        ) do
+      ) do
         NewRelic::Agent.config.notify_server_source_added
         in_transaction do |txn|
           txn.ignore!


### PR DESCRIPTION
# Overview

Adds `application_logging.enabled` config option to toggle logging features
* The default value of `instrumentation.logger` is dependent on the default of `application_logging.enabled`
* Within the LogEventAggregator, the feature is `@enabled?` when both `instrumentation.logger` and `application_logging.enabled` have truthy values.
* When `application_logging.enabled` is false, all logging-related config options are disabled:
  * `application_logging.forwarding.enabled`
  * `application_logging.metrics.enabled`
  * The work to set `application_logging.local_decorating.enabled` with the overall toggle will be completed in #988
* When `application_logging.enabled` is false, supportability metrics will still be recorded
* When `application_logging.enabled` is true, all logging-related config options to use their own values to determine their enabled status

Adds supportability metric related to the overall toggle `Supportability/Logging/Ruby/Logger/{enabled | disabled}`. The spec states that the fourth argument should be the logging framework. The Ruby language has a built-in class called `Logger` the agent instruments that will always hold the framework value.

# Related Github Issue
Closes #978 

# Testing
Added unit tests to confirm the toggle works in the cases of:
* metric recording
* log event recording/harvest (forwarding)
* high security mode
* overall enabled/disabled functionality
* `instrumentation.logger` and `application_logging.enabled` relationship

# Q & A raised during development
* This setting is intended to relate to `instrumentation.logger`, added in v8.1.0 with logging metrics. Our instrumentation config options provide four strategies: `auto|prepend|chain|disabled`. The `auto`, `prepend`, and `chain` options would all map to a truthy value. The `disabled` option maps to a falsey value. This setting is not currently connected to `application_logging.enabled`, but likely should be. _Answer: There was a precedent with a method called #instrumentation_value_of that returned a string that matched the related setting's default value. This wasn't quite right for these purposes, so I created a new method #instrumentation_boolean_value_of_

* The EventAggregator class has a method, `enabled?` that should take the config option(s) assigned to `enabled_key` and return a boolean based on their setting. This is not working in the LogEventAggregator#record method after changing `enabled_key` from `application_logging.forwarding.enabled` to `application_logging.enabled`. _Answer: Add `NewRelic::Agent.config.notify_service_source_added` after the config changes so that the accurate value is returned from `enabled?`_