### PR TITLE
Logging: Implement data usage supportability metrics

### DIFF
--- a/lib/new_relic/agent/new_relic_service.rb
+++ b/lib/new_relic/agent/new_relic_service.rb
@@ -461,7 +461,7 @@ module NewRelic
       def handle_serialization_error(method, e)
         NewRelic::Agent.increment_metric("Supportability/serialization_failure")
         NewRelic::Agent.increment_metric("Supportability/serialization_failure/#{method}")
-        msg = "Failed to serialize #{method} data using #{@marshaller.class.to_s}: #{e.inspect}"
+        msg = "Failed to serialize #{method} data using #{@marshaller.class}: #{e.inspect}"
         error = SerializationError.new(msg)
         error.set_backtrace(e.backtrace)
         raise error
@@ -471,11 +471,11 @@ module NewRelic
         serialize_time = serialize_finish_ts && (serialize_finish_ts - start_ts)
         request_duration = response_check_ts && (response_check_ts - request_send_ts)
         if request_duration
-          NewRelic::Agent.record_metric("Supportability/Agent/Collector/#{method.to_s}/Duration", request_duration)
+          NewRelic::Agent.record_metric("Supportability/Agent/Collector/#{method}/Duration", request_duration)
         end
         if serialize_time
           NewRelic::Agent.record_metric("Supportability/invoke_remote_serialize", serialize_time)
-          NewRelic::Agent.record_metric("Supportability/invoke_remote_serialize/#{method.to_s}", serialize_time)
+          NewRelic::Agent.record_metric("Supportability/invoke_remote_serialize/#{method}", serialize_time)
         end
       end
 
@@ -490,7 +490,7 @@ module NewRelic
       def record_size_supportability_metrics(method, size_bytes, item_count)
         metrics = [
           "Supportability/Ruby/Collector/Output/Bytes",
-          "Supportability/Ruby/Collector/#{method.to_s}/Output/Bytes"
+          "Supportability/Ruby/Collector/#{method}/Output/Bytes"
         ]
         # we may not have an item count, in which case, just record 0 for the exclusive time
         item_count ||= 0

--- a/lib/new_relic/agent/new_relic_service.rb
+++ b/lib/new_relic/agent/new_relic_service.rb
@@ -489,8 +489,8 @@ module NewRelic
       # of items as arguments.
       def record_size_supportability_metrics(method, size_bytes, item_count)
         metrics = [
-          "Supportability/invoke_remote_size",
-          "Supportability/invoke_remote_size/#{method.to_s}"
+          "Supportability/Ruby/Collector/Output/Bytes",
+          "Supportability/Ruby/Collector/#{method.to_s}/Output/Bytes"
         ]
         # we may not have an item count, in which case, just record 0 for the exclusive time
         item_count ||= 0

--- a/test/new_relic/agent/new_relic_service_test.rb
+++ b/test/new_relic/agent/new_relic_service_test.rb
@@ -830,8 +830,8 @@ class NewRelicServiceTest < Minitest::Test
       'Supportability/Agent/Collector/foobar/Duration' => {:call_count => 1},
       'Supportability/invoke_remote_serialize' => {:call_count => 1},
       'Supportability/invoke_remote_serialize/foobar' => {:call_count => 1},
-      'Supportability/invoke_remote_size' => expected_values,
-      'Supportability/invoke_remote_size/foobar' => expected_values
+      'Supportability/Ruby/Collector/Output/Bytes' => expected_values,
+      'Supportability/Ruby/Collector/foobar/Output/Bytes' => expected_values
     )
   end
 
@@ -866,8 +866,8 @@ class NewRelicServiceTest < Minitest::Test
       'Supportability/Agent/Collector/foobar/Duration' => {:call_count => 1},
       'Supportability/invoke_remote_serialize' => {:call_count => 1},
       'Supportability/invoke_remote_serialize/foobar' => {:call_count => 1},
-      'Supportability/invoke_remote_size' => expected_values,
-      'Supportability/invoke_remote_size/foobar' => expected_values
+      'Supportability/Ruby/Collector/Output/Bytes' => expected_values,
+      'Supportability/Ruby/Collector/foobar/Output/Bytes' => expected_values
     )
   end
 
@@ -892,8 +892,8 @@ class NewRelicServiceTest < Minitest::Test
     assert_metrics_not_recorded([
       'Supportability/invoke_remote_serialize',
       'Supportability/invoke_remote_serialize/foobar',
-      'Supportability/invoke_remote_size',
-      'Supportability/invoke_remote_size/foobar'
+      'Supportability/Ruby/Collector/Output/Bytes',
+      'Supportability/Ruby/Collector/foobar/Output/Bytes'
     ])
   end
 


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
Updates existing metrics to the new format outlined in the [Data Usage Supportability Metrics Agent Spec (Internal)](https://source.datanerd.us/agents/agent-specs/blob/main/Data-Usage-Supportability-Metrics.md):
* `Supportability/invoke_remote_size` => `Supportability/{language}/Collector/Output/Bytes`
* `Supportability/invoke_remote_size/{method}` => `Supportability/{language}/Collector/{method}/Output/Bytes`

# Related Github Issue
Closes #976 

# Testing
Existing unit tests updated to use new format