### PR TITLE
Actually set proper things for faster harvest on logging data

### DIFF
--- a/lib/new_relic/agent.rb
+++ b/lib/new_relic/agent.rb
@@ -59,6 +59,7 @@ module NewRelic
     require 'new_relic/agent/logging'
     require 'new_relic/agent/distributed_tracing'
     require 'new_relic/agent/attribute_processing'
+    require 'new_relic/agent/linking_metadata'
 
     require 'new_relic/agent/instrumentation/controller_instrumentation'
 
@@ -726,20 +727,8 @@ module NewRelic
     # @api public
     def linking_metadata
       metadata = Hash.new
-      metadata[ENTITY_NAME_KEY] = config[:app_name][0]
-      metadata[ENTITY_TYPE_KEY] = ENTITY_TYPE
-      metadata[HOSTNAME_KEY] = Hostname.get
-
-      if entity_guid = config[:entity_guid]
-        metadata[ENTITY_GUID_KEY] = entity_guid
-      end
-
-      if trace_id = Tracer.current_trace_id
-        metadata[TRACE_ID_KEY] = trace_id
-      end
-      if span_id = Tracer.current_span_id
-        metadata[SPAN_ID_KEY] = span_id
-      end
+      LinkingMetadata.append_service_linking_metadata(metadata)
+      LinkingMetadata.append_trace_linking_metadata(metadata)
       metadata
     end
 

--- a/lib/new_relic/agent/agent.rb
+++ b/lib/new_relic/agent/agent.rb
@@ -25,6 +25,7 @@ require 'new_relic/agent/monitors'
 require 'new_relic/agent/transaction_event_recorder'
 require 'new_relic/agent/custom_event_aggregator'
 require 'new_relic/agent/span_event_aggregator'
+require 'new_relic/agent/log_event_aggregator'
 require 'new_relic/agent/sampler_collection'
 require 'new_relic/agent/javascript_instrumentor'
 require 'new_relic/agent/vm/monotonic_gc_profiler'
@@ -73,6 +74,7 @@ module NewRelic
         @transaction_event_recorder = TransactionEventRecorder.new @events
         @custom_event_aggregator = CustomEventAggregator.new @events
         @span_event_aggregator = SpanEventAggregator.new @events
+        @log_event_aggregator = LogEventAggregator.new @events
 
         @connect_state = :pending
         @connect_attempts = 0
@@ -146,6 +148,7 @@ module NewRelic
         attr_reader :monotonic_gc_profiler
         attr_reader :custom_event_aggregator
         attr_reader :span_event_aggregator
+        attr_reader :log_event_aggregator
         attr_reader :transaction_event_recorder
         attr_reader :attribute_filter
         attr_reader :adaptive_sampler
@@ -559,6 +562,7 @@ module NewRelic
           @transaction_event_recorder.drop_buffered_data
           @custom_event_aggregator.reset!
           @span_event_aggregator.reset!
+          @log_event_aggregator.reset!
           @sql_sampler.reset!
 
           if Agent.config[:clear_transaction_state_after_fork]
@@ -580,6 +584,7 @@ module NewRelic
             transmit_custom_event_data
             transmit_error_event_data
             transmit_span_event_data
+            transmit_log_event_data
           end
         end
 
@@ -607,6 +612,7 @@ module NewRelic
           CUSTOM_EVENT_DATA = "custom_event_data".freeze
           ERROR_EVENT_DATA = "error_event_data".freeze
           SPAN_EVENT_DATA = "span_event_data".freeze
+          LOG_EVENT_DATA = "log_event_data".freeze
 
           def create_and_run_event_loop
             data_harvest = :"#{Agent.config[:data_report_period]}_second_harvest"
@@ -628,6 +634,10 @@ module NewRelic
             end
             @event_loop.on(interval_for SPAN_EVENT_DATA) do
               transmit_span_event_data
+            end
+            @event_loop.on(interval_for CUSTOM_EVENT_DATA) do
+              # TODO: Change to log_event_data when present in collector response
+              transmit_log_event_data
             end
             @event_loop.on(:reset_log_once_keys) do
               ::NewRelic::Agent.logger.clear_already_logged
@@ -893,6 +903,7 @@ module NewRelic
           when :custom_event_data then @custom_event_aggregator
           when :span_event_data then span_event_aggregator
           when :sql_trace_data then @sql_sampler
+          when :log_event_data then @log_event_aggregator
           end
         end
 
@@ -1080,6 +1091,10 @@ module NewRelic
           harvest_and_send_from_container(span_event_aggregator, :span_event_data)
         end
 
+        def harvest_and_send_log_event_data
+          harvest_and_send_from_container(@log_event_aggregator, :log_event_data)
+        end
+
         def check_for_and_handle_agent_commands
           begin
             @agent_command_router.check_for_and_handle_agent_commands
@@ -1120,6 +1135,11 @@ module NewRelic
           transmit_single_data_type(:harvest_and_send_span_event_data, SPAN_EVENT)
         end
 
+        LOG_EVENT = "LogEvent".freeze
+        def transmit_log_event_data
+          transmit_single_data_type(:harvest_and_send_log_event_data, LOG_EVENT)
+        end
+
         def transmit_single_data_type(harvest_method, supportability_name)
           now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
@@ -1146,6 +1166,7 @@ module NewRelic
             harvest_and_send_slowest_sql
             harvest_and_send_timeslice_data
             harvest_and_send_span_event_data
+            harvest_and_send_log_event_data
 
             check_for_and_handle_agent_commands
             harvest_and_send_for_agent_commands
@@ -1174,6 +1195,7 @@ module NewRelic
               transmit_custom_event_data
               transmit_error_event_data
               transmit_span_event_data
+              transmit_log_event_data
 
               if @connected_pid == $$ && !@service.kind_of?(NewRelic::Agent::NewRelicService)
                 ::NewRelic::Agent.logger.debug "Sending New Relic service agent run shutdown message"

--- a/lib/new_relic/agent/agent_logger.rb
+++ b/lib/new_relic/agent/agent_logger.rb
@@ -6,6 +6,7 @@ require 'thread'
 require 'logger'
 require 'new_relic/agent/hostname'
 require 'new_relic/agent/log_once'
+require 'new_relic/agent/instrumentation/logger/instrumentation'
 
 module NewRelic
   module Agent
@@ -18,6 +19,7 @@ module NewRelic
         create_log(root, override_logger)
         set_log_level!
         set_log_format!
+        disable_log_instrumentation!
 
         gather_startup_logs
       end
@@ -167,6 +169,11 @@ module NewRelic
         @log.formatter = Proc.new do |severity, timestamp, progname, msg|
           "#{@prefix}[#{timestamp.strftime("%F %H:%M:%S %z")} #{@hostname} (#{$$})] #{severity} : #{msg}\n"
         end
+      end
+
+      # Don't allow agent logs into agent log forwarding for now
+      def disable_log_instrumentation!
+        NewRelic::Agent::Instrumentation::Logger.mark_skip_instrumenting(@log)
       end
 
       def gather_startup_logs

--- a/lib/new_relic/agent/audit_logger.rb
+++ b/lib/new_relic/agent/audit_logger.rb
@@ -5,6 +5,7 @@
 require 'logger'
 require 'fileutils'
 require 'new_relic/agent/hostname'
+require 'new_relic/agent/instrumentation/logger/instrumentation'
 
 module NewRelic
   module Agent
@@ -69,6 +70,9 @@ module NewRelic
         else
           @log = NewRelic::Agent::NullLogger.new
         end
+
+        # Never have agent log forwarding capture audits
+        NewRelic::Agent::Instrumentation::Logger.mark_skip_instrumenting(@log)
 
         @log.formatter = create_log_formatter
       end

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -1864,6 +1864,21 @@ module NewRelic
           :description => 'Defines the maximum number of span events reported from a single harvest. Any Integer between 1 and 10000 is valid.',
           :dynamic_name => true
         },
+        :'application_logging.forwarding.enabled' => {
+          :default => true,
+          :public => true,
+          :type => Boolean,
+          :allowed_from_server => true,
+          :description => 'If `true`, the agent captures log records emitted by your application.'
+        },
+        :'application_logging.forwarding.max_samples_stored' => {
+          :default => 2000,
+          :public => true,
+          :type => Integer,
+          :allowed_from_server => true,
+          :description => 'Specify a maximum number of log records to buffer in memory at a time.',
+          :dynamic_name => true
+        },
         :disable_grape_instrumentation => {
           :default => false,
           :public => false,

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -354,21 +354,21 @@ module NewRelic
           :public => false,
           :type => String,
           :allowed_from_server => true,
-          :description => 'The [Entity GUID](/attribute-dictionary/span/entityguid) for the entity running this agent.'
+          :description => 'The [Entity GUID](/attribute-dictionary/span/entityguid) for the entity running your agent.'
         },
         :monitor_mode => {
           :default => value_of(:enabled),
           :public => true,
           :type => Boolean,
           :allowed_from_server => false,
-          :description => 'When `true`, the agent transmits data about your app to the New Relic [collector](/docs/using-new-relic/welcome-new-relic/get-started/glossary/#collector).'
+          :description => 'When `true`, the agent transmits data about your application to the New Relic [collector](/docs/using-new-relic/welcome-new-relic/get-started/glossary/#collector).'
         },
         :test_mode => {
           :default => false,
           :public => false,
           :type => Boolean,
           :allowed_from_server => false,
-          :description => 'Used in tests for agent to start up but not connect to collector. Formerly used `developer_mode` in test config for this purpose.'
+          :description => 'Used in tests for the agent to start up, but not connect to the collector. Formerly used `developer_mode` in test config for this purpose.'
         },
         :log_level => {
           :default => 'info',
@@ -1803,7 +1803,7 @@ module NewRelic
           :public => true,
           :type => String,
           :allowed_from_server => false,
-          :description => 'A dictionary of [label names](/docs/data-analysis/user-interface-functions/labels-categories-organize-your-apps-servers) and values that will be applied to the data sent from this agent. May also be expressed as a semicolon-delimited `;` string of colon-separated `:` pairs. For example, `<var>Server</var>:<var>One</var>;<var>Data Center</var>:<var>Primary</var>`.'
+          :description => 'A dictionary of [label names](/docs/data-analysis/user-interface-functions/labels-categories-organize-your-apps-servers) and values that will be applied to the data sent from your agent. May also be expressed as a semicolon-delimited `;` string of colon-separated `:` pairs. For example, `<var>Server</var>:<var>One</var>;<var>Data Center</var>:<var>Primary</var>`.'
         },
         :aggressive_keepalive => {
           :default => true,
@@ -1865,19 +1865,26 @@ module NewRelic
           :dynamic_name => true
         },
         :'application_logging.forwarding.enabled' => {
-          :default => true,
+          :default => false,
           :public => true,
           :type => Boolean,
-          :allowed_from_server => true,
+          :allowed_from_server => false,
           :description => 'If `true`, the agent captures log records emitted by your application.'
         },
         :'application_logging.forwarding.max_samples_stored' => {
-          :default => 2000,
+          :default => 10000,
           :public => true,
           :type => Integer,
-          :allowed_from_server => true,
-          :description => 'Specify a maximum number of log records to buffer in memory at a time.',
+          :allowed_from_server => false,
+          :description => 'Defines the maximum number of log records to buffer in memory at a time.',
           :dynamic_name => true
+        },
+        :'application_logging.metrics.enabled' => {
+          :default => true,
+          :public => true,
+          :type => Boolean,
+          :allowed_from_server => false,
+          :description => 'If `true`, the agent captures metrics related to logging for your application.'
         },
         :disable_grape_instrumentation => {
           :default => false,
@@ -2170,7 +2177,7 @@ module NewRelic
           :public => false,
           :type => String,
           :allowed_from_server => true,
-          :description => 'The account id associated with this application.'
+          :description => 'The account id associated with your application.'
         },
         :primary_application_id => {
           :default => nil,
@@ -2178,7 +2185,7 @@ module NewRelic
           :public => false,
           :type => String,
           :allowed_from_server => true,
-          :description => 'The primary id associated with this application.'
+          :description => 'The primary id associated with your application.'
         },
         :'distributed_tracing.enabled' => {
           :default => true,

--- a/lib/new_relic/agent/configuration/event_harvest_config.rb
+++ b/lib/new_relic/agent/configuration/event_harvest_config.rb
@@ -11,14 +11,16 @@ module NewRelic
         EVENT_HARVEST_CONFIG_KEY_MAPPING = {
           :analytic_event_data => :'transaction_events.max_samples_stored',
           :custom_event_data => :'custom_insights_events.max_samples_stored',
-          :error_event_data => :'error_collector.max_event_samples_stored'
+          :error_event_data => :'error_collector.max_event_samples_stored',
+          :log_event_data => :'application_logging.forwarding.max_samples_stored'
         }
 
         # not including span_event_data here because spans are handled separately in transform_span_event_harvest_config
         EVENT_HARVEST_EVENT_REPORT_PERIOD_KEY_MAPPING = {
           :analytic_event_data => :'transaction_event_data',
           :custom_event_data => :'custom_event_data',
-          :error_event_data => :'error_event_data'
+          :error_event_data => :'error_event_data',
+          :log_event_data => :'log_event_data'
         }
 
         def from_config(config)

--- a/lib/new_relic/agent/instrumentation/logger.rb
+++ b/lib/new_relic/agent/instrumentation/logger.rb
@@ -21,5 +21,7 @@ DependencyDetection.defer do
     else
       chain_instrument NewRelic::Agent::Instrumentation::Logger
     end
+
+    ::NewRelic::Agent.increment_metric("Supportability/Logging/enabled/Ruby/Logger")
   end
 end

--- a/lib/new_relic/agent/instrumentation/logger/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/logger/instrumentation.rb
@@ -10,25 +10,23 @@ module NewRelic
           defined?(@skip_instrumenting) && @skip_instrumenting
         end
 
+        # We support setting this on loggers which might not have
+        # instrumentation installed yet. This lets us disable in AgentLogger
+        # and AuditLogger without them having to know the inner details.
+        def self.mark_skip_instrumenting(logger)
+          logger.instance_variable_set(:@skip_instrumenting, true)
+        end
+
+        def self.clear_skip_instrumenting(logger)
+          logger.instance_variable_set(:@skip_instrumenting, false)
+        end
+
         def mark_skip_instrumenting
           @skip_instrumenting = true
         end
 
         def clear_skip_instrumenting
           @skip_instrumenting = false
-        end
-
-        LINES = "Logging/lines".freeze
-        SIZE = "Logging/size".freeze
-
-        def line_metric_name_by_severity(severity)
-          @line_metrics ||= {}
-          @line_metrics[severity] ||= "Logging/lines/#{severity}".freeze
-        end
-
-        def size_metric_name_by_severity(severity)
-          @size_metrics ||= {}
-          @size_metrics[severity] ||= "Logging/size/#{severity}".freeze
         end
 
         def format_message_with_tracing(severity, datetime, progname, msg)
@@ -40,12 +38,9 @@ module NewRelic
             # methods within NewRelic::Agent, or we'll stack overflow!!
             mark_skip_instrumenting
 
-            NewRelic::Agent.increment_metric(LINES)
-            NewRelic::Agent.increment_metric(line_metric_name_by_severity(severity))
-
-            size = formatted_message.nil? ? 0 : formatted_message.bytesize
-            NewRelic::Agent.record_metric(SIZE, size)
-            NewRelic::Agent.record_metric(size_metric_name_by_severity(severity), size)
+            unless ::NewRelic::Agent.agent.nil?
+              ::NewRelic::Agent.agent.log_event_aggregator.record(formatted_message, severity)
+            end
 
             return formatted_message
           ensure

--- a/lib/new_relic/agent/linking_metadata.rb
+++ b/lib/new_relic/agent/linking_metadata.rb
@@ -1,0 +1,45 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+module NewRelic
+  module Agent
+    #
+    # This module contains helper methods related to gathering linking
+    # metadata for use with logs in context.
+    module LinkingMetadata
+      extend self
+
+      def append_service_linking_metadata metadata
+        raise ArgumentError, "Missing argument `metadata`" if metadata.nil?
+
+        config = ::NewRelic::Agent.config
+
+        metadata[ENTITY_NAME_KEY] = config[:app_name][0]
+        metadata[ENTITY_TYPE_KEY] = ENTITY_TYPE
+        metadata[HOSTNAME_KEY] = Hostname.get
+
+        if entity_guid = config[:entity_guid]
+          metadata[ENTITY_GUID_KEY] = entity_guid
+        end
+
+        metadata
+      end
+
+      def append_trace_linking_metadata metadata
+        raise ArgumentError, "Missing argument `metadata`" if metadata.nil?
+
+        if trace_id = Tracer.current_trace_id
+          metadata[TRACE_ID_KEY] = trace_id
+        end
+
+        if span_id = Tracer.current_span_id
+          metadata[SPAN_ID_KEY] = span_id
+        end
+
+        metadata
+      end
+    end
+  end
+end

--- a/lib/new_relic/agent/log_event_aggregator.rb
+++ b/lib/new_relic/agent/log_event_aggregator.rb
@@ -58,6 +58,7 @@ module NewRelic
 
         return unless enabled?
         return if @high_security
+        return if formatted_message.nil? || formatted_message.empty?
 
         txn = NewRelic::Agent::Transaction.tl_current
         priority = LogPriority.priority_for(txn)

--- a/lib/new_relic/agent/log_event_aggregator.rb
+++ b/lib/new_relic/agent/log_event_aggregator.rb
@@ -1,0 +1,208 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+
+require 'new_relic/agent/event_aggregator'
+require 'new_relic/agent/log_priority'
+
+module NewRelic
+  module Agent
+    class LogEventAggregator < EventAggregator
+      # Per-message keys
+      LEVEL_KEY = "level".freeze
+      MESSAGE_KEY = "message".freeze
+      TIMESTAMP_KEY = "timestamp".freeze
+      PRIORITY_KEY = "priority".freeze
+
+      # Metric keys
+      LINES = "Logging/lines".freeze
+      DROPPED_METRIC = "Logging/Forwarding/Dropped".freeze
+      SEEN_METRIC = "Supportability/Logging/Forwarding/Seen".freeze
+      SENT_METRIC = "Supportability/Logging/Forwarding/Sent".freeze
+      METRICS_SUPPORTABILITY_FORMAT = "Supportability/Logging/Metrics/Ruby/%s".freeze
+      FORWARDING_SUPPORTABILITY_FORMAT = "Supportability/Logging/Forwarding/Ruby/%s".freeze
+      DECORATING_SUPPORTABILITY_FORMAT = "Supportability/Logging/LocalDecorating/Ruby/%s".freeze
+
+      named :LogEventAggregator
+      buffer_class PrioritySampledBuffer
+
+      # TODO use the right value when the collector starts reporting it
+      capacity_key :'custom_insights_events.max_samples_stored'
+      # capacity_key :'log_sending.max_samples_stored'
+      enabled_key :'application_logging.forwarding.enabled'
+
+      # Config keys
+      OVERALL_ENABLED_KEY = :'application_logging.enabled'
+      METRICS_ENABLED_KEY = :'application_logging.metrics.enabled'
+      FORWARDING_ENABLED_KEY = enabled_keys.first
+      DECORATING_ENABLED_KEY = :'application_logging.local_decorating.enabled'
+
+      def initialize(events)
+        super(events)
+        @counter_lock = Mutex.new
+        @seen = 0
+        @seen_by_severity = Hash.new(0)
+        @high_security = NewRelic::Agent.config[:high_security]
+        register_for_done_configuring(events)
+      end
+
+      def capacity
+        @buffer.capacity
+      end
+
+      def record(formatted_message, severity)
+        @counter_lock.synchronize do
+          @seen += 1
+          @seen_by_severity[severity] += 1
+        end
+
+        return unless enabled?
+        return if @high_security
+
+        txn = NewRelic::Agent::Transaction.tl_current
+        priority = LogPriority.priority_for(txn)
+
+        if txn
+          return txn.add_log_event(create_event(priority, formatted_message, severity))
+        else
+          return @lock.synchronize do
+            @buffer.append(priority: priority) do
+              create_event(priority, formatted_message, severity)
+            end
+          end
+        end
+      rescue
+        nil
+      end
+
+      def record_batch txn, logs
+        # Ensure we have the same shared priority
+        priority = LogPriority.priority_for(txn)
+        logs.each do |log|
+          log.first[PRIORITY_KEY] = priority
+        end
+
+        @lock.synchronize do
+          logs.each do |log|
+            @buffer.append(event: log)
+          end
+        end
+      end
+
+      def create_event priority, formatted_message, severity
+        event = LinkingMetadata.append_trace_linking_metadata({
+          LEVEL_KEY => severity,
+          MESSAGE_KEY => formatted_message,
+          TIMESTAMP_KEY => Process.clock_gettime(Process::CLOCK_REALTIME) * 1000
+        })
+
+        [
+          {
+            PrioritySampledBuffer::PRIORITY_KEY => priority
+          },
+          event
+        ]
+      end
+
+      # Because our transmission format (MELT) is different than historical
+      # agent payloads, extract the munging here to keep the service focused
+      # on the general harvest + transmit instead of the format.
+      #
+      # Payload shape matches the publicly documented MELT format.
+      # https://docs.newrelic.com/docs/logs/log-api/introduction-log-api
+      #
+      # We have to keep the aggregated payloads in a separate shape, though, to
+      # work with the priority sampling buffers
+      def self.payload_to_melt_format(data)
+        common_attributes = LinkingMetadata.append_service_linking_metadata({})
+
+        # To save on unnecessary data transmission, trim the name and type
+        # that were sent by classic logs-in-context
+        common_attributes.delete(ENTITY_NAME_KEY)
+        common_attributes.delete(ENTITY_TYPE_KEY)
+
+        _, items = data
+        payload = [{
+          common: {attributes: common_attributes},
+          logs: items.map(&:last)
+        }]
+
+        return [payload, items.size]
+      end
+
+      def harvest!
+        record_customer_metrics()
+        super
+      end
+
+      def reset!
+        @counter_lock.synchronize do
+          @seen = 0
+          @seen_by_severity.clear
+        end
+        super
+      end
+
+      private
+
+      # We record once-per-connect metrics for enabled/disabled state at the
+      # point we consider the configuration stable (i.e. once we've gotten SSC)
+      def register_for_done_configuring(events)
+        events.subscribe(:server_source_configuration_added) do
+          @high_security = NewRelic::Agent.config[:high_security]
+
+          record_configuration_metric(METRICS_SUPPORTABILITY_FORMAT, METRICS_ENABLED_KEY)
+          record_configuration_metric(FORWARDING_SUPPORTABILITY_FORMAT, FORWARDING_ENABLED_KEY)
+          record_configuration_metric(DECORATING_SUPPORTABILITY_FORMAT, DECORATING_ENABLED_KEY)
+        end
+      end
+
+      def record_configuration_metric(format, key)
+        state = NewRelic::Agent.config[key]
+        label = state ? "enabled" : "disabled"
+        NewRelic::Agent.increment_metric(format % label)
+      end
+
+      def after_harvest metadata
+        dropped_count = metadata[:seen] - metadata[:captured]
+        note_dropped_events(metadata[:seen], dropped_count)
+        record_supportability_metrics(metadata[:seen], metadata[:captured], dropped_count)
+      end
+
+      # To avoid paying the cost of metric recording on every line, we hold
+      # these until harvest before recording them
+      def record_customer_metrics
+        @counter_lock.synchronize do
+          return unless @seen > 0
+
+          NewRelic::Agent.increment_metric(LINES, @seen)
+          @seen_by_severity.each do |(severity, count)|
+            NewRelic::Agent.increment_metric(line_metric_name_by_severity(severity), count)
+          end
+
+          @seen = 0
+          @seen_by_severity.clear
+        end
+      end
+
+      def line_metric_name_by_severity(severity)
+        @line_metrics ||= {}
+        @line_metrics[severity] ||= "Logging/lines/#{severity}".freeze
+      end
+
+      def note_dropped_events total_count, dropped_count
+        if dropped_count > 0
+          NewRelic::Agent.logger.warn("Dropped #{dropped_count} log events out of #{total_count}.")
+        end
+      end
+
+      def record_supportability_metrics total_count, captured_count, dropped_count
+        return unless total_count > 0
+
+        NewRelic::Agent.increment_metric(DROPPED_METRIC, dropped_count)
+        NewRelic::Agent.increment_metric(SEEN_METRIC, total_count)
+        NewRelic::Agent.increment_metric(SENT_METRIC, captured_count)
+      end
+    end
+  end
+end

--- a/lib/new_relic/agent/log_event_aggregator.rb
+++ b/lib/new_relic/agent/log_event_aggregator.rb
@@ -22,6 +22,7 @@ module NewRelic
       METRICS_SUPPORTABILITY_FORMAT = "Supportability/Logging/Metrics/Ruby/%s".freeze
       FORWARDING_SUPPORTABILITY_FORMAT = "Supportability/Logging/Forwarding/Ruby/%s".freeze
       DECORATING_SUPPORTABILITY_FORMAT = "Supportability/Logging/LocalDecorating/Ruby/%s".freeze
+      MAX_BYTES = 32768 # 32 * 1024 bytes (32 kibibytes)
 
       named :LogEventAggregator
       buffer_class PrioritySampledBuffer
@@ -91,6 +92,8 @@ module NewRelic
       end
 
       def create_event priority, formatted_message, severity
+        formatted_message = truncate_message(formatted_message)
+
         event = LinkingMetadata.append_trace_linking_metadata({
           LEVEL_KEY => severity,
           MESSAGE_KEY => formatted_message,
@@ -203,6 +206,11 @@ module NewRelic
         NewRelic::Agent.increment_metric(DROPPED_METRIC, dropped_count)
         NewRelic::Agent.increment_metric(SEEN_METRIC, total_count)
         NewRelic::Agent.increment_metric(SENT_METRIC, captured_count)
+      end
+
+      def truncate_message(message)
+        return message if message.bytesize <= MAX_BYTES
+        message.byteslice(0...MAX_BYTES)
       end
     end
   end

--- a/lib/new_relic/agent/log_event_aggregator.rb
+++ b/lib/new_relic/agent/log_event_aggregator.rb
@@ -27,9 +27,9 @@ module NewRelic
       named :LogEventAggregator
       buffer_class PrioritySampledBuffer
 
-      # TODO use the right value when the collector starts reporting it
+      # TODO: use the right value when the collector starts reporting it
+      # capacity_key :'application_logging.forwarding.max_samples_stored'
       capacity_key :'custom_insights_events.max_samples_stored'
-      # capacity_key :'log_sending.max_samples_stored'
       enabled_key :'application_logging.forwarding.enabled'
 
       # Config keys
@@ -57,7 +57,7 @@ module NewRelic
           @seen_by_severity[severity] += 1
         end
 
-        return unless enabled?
+        return unless NewRelic::Agent.config[:'application_logging.forwarding.enabled']
         return if @high_security
         return if formatted_message.nil? || formatted_message.empty?
 
@@ -176,6 +176,7 @@ module NewRelic
       # To avoid paying the cost of metric recording on every line, we hold
       # these until harvest before recording them
       def record_customer_metrics
+        return unless NewRelic::Agent.config[:'application_logging.metrics.enabled']
         @counter_lock.synchronize do
           return unless @seen > 0
 

--- a/lib/new_relic/agent/log_priority.rb
+++ b/lib/new_relic/agent/log_priority.rb
@@ -1,0 +1,20 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+
+require 'new_relic/agent/event_aggregator'
+
+# Stateless calculation of priority for a given log event
+module NewRelic
+  module Agent
+    module LogPriority
+      extend self
+
+      def priority_for(txn)
+        return txn.priority if txn
+
+        rand.round(NewRelic::PRIORITY_PRECISION)
+      end
+    end
+  end
+end

--- a/lib/new_relic/agent/new_relic_service.rb
+++ b/lib/new_relic/agent/new_relic_service.rb
@@ -177,18 +177,25 @@ module NewRelic
           :item_count => items.size)
       end
 
+      def log_event_data(data)
+        payload, size = LogEventAggregator.payload_to_melt_format(data)
+        invoke_remote(:log_event_data, payload, :item_count => size)
+      end
+
       def error_event_data(data)
         metadata, items = data
-        invoke_remote(:error_event_data, [@agent_id, *data], :item_count => items.size)
+        response = invoke_remote(:error_event_data, [@agent_id, *data], :item_count => items.size)
         NewRelic::Agent.record_metric("Supportability/Events/TransactionError/Sent", :count => items.size)
         NewRelic::Agent.record_metric("Supportability/Events/TransactionError/Seen", :count => metadata[:events_seen])
+        response
       end
 
       def span_event_data(data)
         metadata, items = data
-        invoke_remote(:span_event_data, [@agent_id, *data], :item_count => items.size)
+        response = invoke_remote(:span_event_data, [@agent_id, *data], :item_count => items.size)
         NewRelic::Agent.record_metric("Supportability/Events/SpanEvents/Sent", :count => items.size)
         NewRelic::Agent.record_metric("Supportability/Events/SpanEvents/Seen", :count => metadata[:events_seen])
+        response
       end
 
       # We do not compress if content is smaller than 64kb.  There are

--- a/lib/new_relic/agent/pipe_service.rb
+++ b/lib/new_relic/agent/pipe_service.rb
@@ -61,6 +61,10 @@ module NewRelic
         write_to_pipe(:sql_trace_data, sql) if sql
       end
 
+      def log_event_data(logs)
+        write_to_pipe(:log_event_data, logs) if logs
+      end
+
       def shutdown
         @pipe.close if @pipe
       end

--- a/newrelic.yml
+++ b/newrelic.yml
@@ -26,6 +26,15 @@ common: &default_settings
 # All of the following configuration options are optional. Review them, and
 # uncomment or edit them if they appear relevant to your application needs.
 
+# If `true`, the agent captures log records emitted by this application.
+# application_logging.forwarding.enabled: false
+
+# Defines the maximum number of log records to buffer in memory at a time.
+# application_logging.forwarding.max_samples_stored: 10000
+
+# If `true`, the agent captures metrics related to logging for this application.
+# application_logging.metrics.enabled: true
+
 # If true, enables transaction event sampling.
 # transaction_events.enabled: true
 

--- a/test/multiverse/suites/agent_only/audit_log_test.rb
+++ b/test/multiverse/suites/agent_only/audit_log_test.rb
@@ -26,6 +26,7 @@ class AuditLogTest < Minitest::Test
     run_agent do
       perform_actions
       assert_equal('', audit_log_contents)
+      assert_empty($collector.calls_for(:log_event_data))
     end
   end
 
@@ -33,6 +34,7 @@ class AuditLogTest < Minitest::Test
     run_agent(:'audit_log.enabled' => false) do
       perform_actions
       assert_equal('', audit_log_contents)
+      assert_empty($collector.calls_for(:log_event_data))
     end
   end
 
@@ -42,6 +44,7 @@ class AuditLogTest < Minitest::Test
       $collector.agent_data.each do |req|
         assert_audit_log_contains_object(audit_log_contents, req.body)
       end
+      assert_empty($collector.calls_for(:log_event_data))
     end
   end
 
@@ -53,5 +56,8 @@ class AuditLogTest < Minitest::Test
       nil, 1.5, state)
     NewRelic::Agent.instance.sql_sampler.on_finishing_transaction(state, 'txn')
     NewRelic::Agent.instance.send(:harvest_and_send_slowest_sql)
+
+    # We also trigger log event data sending because we shouldn't see any
+    NewRelic::Agent.instance.send(:harvest_and_send_log_event_data)
   end
 end

--- a/test/multiverse/suites/agent_only/event_data_collection_test.rb
+++ b/test/multiverse/suites/agent_only/event_data_collection_test.rb
@@ -13,7 +13,8 @@ class EventDataCollectionTest < Minitest::Test
         "analytic_event_data" => 1200,
         "custom_event_data" => 1000,
         "error_event_data" => 100,
-        "span_event_data" => 2000
+        "span_event_data" => 2000,
+        "log_event_data" => 10000
       }
     }
 
@@ -22,7 +23,7 @@ class EventDataCollectionTest < Minitest::Test
     assert_equal expected, single_connect_posted['event_harvest_config']
   end
 
-  def test_sets_event_report_period_on_connect_repsonse
+  def test_sets_event_report_period_on_connect_response
     connect_response = {
       "agent_run_id" => 1,
       "event_harvest_config" => {
@@ -30,7 +31,8 @@ class EventDataCollectionTest < Minitest::Test
         "harvest_limits" => {
           "analytic_event_data" => 1200,
           "custom_event_data" => 1000,
-          "error_event_data" => 100
+          "error_event_data" => 100,
+          "log_event_data" => 10000
         }
       }
     }
@@ -50,7 +52,8 @@ class EventDataCollectionTest < Minitest::Test
         "harvest_limits" => {
           "analytic_event_data" => 1200,
           "custom_event_data" => 1000,
-          "error_event_data" => 100
+          "error_event_data" => 100,
+          "log_event_data" => 10000
         }
       }
     }

--- a/test/multiverse/suites/agent_only/log_events_test.rb
+++ b/test/multiverse/suites/agent_only/log_events_test.rb
@@ -1,0 +1,66 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+
+class LogEventsTest < Minitest::Test
+  include MultiverseHelpers
+
+  setup_and_teardown_agent
+
+  def test_log_event_data_sent_in_transaction
+    trace_id = nil
+    span_id = nil
+    in_transaction do |txn|
+      NewRelic::Agent.agent.log_event_aggregator.reset!
+      NewRelic::Agent.agent.log_event_aggregator.record("Deadly", "FATAL")
+      trace_id = NewRelic::Agent::Tracer.current_trace_id
+      span_id = NewRelic::Agent::Tracer.current_span_id
+    end
+
+    NewRelic::Agent.agent.send(:harvest_and_send_log_event_data)
+
+    last_log = last_log_event
+    assert_equal "Deadly", last_log["message"]
+    assert_equal "FATAL", last_log["level"]
+    assert_equal trace_id, last_log["trace.id"]
+    assert_equal span_id, last_log["span.id"]
+
+    common = last_logs_common
+    assert_equal nil, common["attributes"]["entity.name"]
+    assert_equal nil, common["attributes"]["entity.type"]
+    assert_equal NewRelic::Agent::Hostname.get, common["attributes"]["hostname"]
+  end
+
+  def test_log_event_data_sent_no_transaction
+    NewRelic::Agent.agent.log_event_aggregator.reset!
+    NewRelic::Agent.agent.log_event_aggregator.record("Deadly", "FATAL")
+
+    NewRelic::Agent.agent.send(:harvest_and_send_log_event_data)
+
+    last_log = last_log_event
+    assert_equal "Deadly", last_log["message"]
+    assert_equal "FATAL", last_log["level"]
+    assert_equal nil, last_log["trace.id"]
+    assert_equal nil, last_log["span.id"]
+
+    common = last_logs_common
+    assert_equal nil, common["attributes"]["entity.name"]
+    assert_equal nil, common["attributes"]["entity.type"]
+    assert_equal NewRelic::Agent::Hostname.get, common["attributes"]["hostname"]
+  end
+
+  def last_log_event
+    post = last_log_post
+    assert_equal(1, post.logs.size)
+    post.logs.last
+  end
+
+  def last_logs_common
+    post = last_log_post
+    post.common
+  end
+
+  def last_log_post
+    $collector.calls_for(:log_event_data).first
+  end
+end

--- a/test/multiverse/suites/agent_only/log_events_test.rb
+++ b/test/multiverse/suites/agent_only/log_events_test.rb
@@ -10,14 +10,16 @@ class LogEventsTest < Minitest::Test
   def test_log_event_data_sent_in_transaction
     trace_id = nil
     span_id = nil
-    in_transaction do |txn|
-      NewRelic::Agent.agent.log_event_aggregator.reset!
-      NewRelic::Agent.agent.log_event_aggregator.record("Deadly", "FATAL")
-      trace_id = NewRelic::Agent::Tracer.current_trace_id
-      span_id = NewRelic::Agent::Tracer.current_span_id
-    end
+    with_config(:'application_logging.forwarding.enabled' => true) do
+      in_transaction do |txn|
+        NewRelic::Agent.agent.log_event_aggregator.reset!
+        NewRelic::Agent.agent.log_event_aggregator.record("Deadly", "FATAL")
+        trace_id = NewRelic::Agent::Tracer.current_trace_id
+        span_id = NewRelic::Agent::Tracer.current_span_id
+      end
 
-    NewRelic::Agent.agent.send(:harvest_and_send_log_event_data)
+      NewRelic::Agent.agent.send(:harvest_and_send_log_event_data)
+    end
 
     last_log = last_log_event
     assert_equal "Deadly", last_log["message"]
@@ -33,9 +35,10 @@ class LogEventsTest < Minitest::Test
 
   def test_log_event_data_sent_no_transaction
     NewRelic::Agent.agent.log_event_aggregator.reset!
-    NewRelic::Agent.agent.log_event_aggregator.record("Deadly", "FATAL")
-
-    NewRelic::Agent.agent.send(:harvest_and_send_log_event_data)
+    with_config(:'application_logging.forwarding.enabled' => true) do
+      NewRelic::Agent.agent.log_event_aggregator.record("Deadly", "FATAL")
+      NewRelic::Agent.agent.send(:harvest_and_send_log_event_data)
+    end
 
     last_log = last_log_event
     assert_equal "Deadly", last_log["message"]

--- a/test/multiverse/suites/high_security/high_security_test.rb
+++ b/test/multiverse/suites/high_security/high_security_test.rb
@@ -220,4 +220,12 @@ class HighSecurityTest < Minitest::Test
       refute_nil intrinsic_attributes['path_hash']
     end
   end
+
+  def test_blocks_log_capture
+    Logger.new(StringIO.new()).fatal("Ooops")
+
+    run_harvest
+
+    assert_empty $collector.calls_for("log_event_data")
+  end
 end

--- a/test/multiverse/suites/logger/config/newrelic.yml
+++ b/test/multiverse/suites/logger/config/newrelic.yml
@@ -16,3 +16,6 @@ development:
     stack_trace_threshold: 0.5
     transaction_threshold: 1.0
   capture_params: false
+  application_logging:
+    forwarding:
+      enabled: true

--- a/test/multiverse/suites/logger/logger_instrumentation_test.rb
+++ b/test/multiverse/suites/logger/logger_instrumentation_test.rb
@@ -15,10 +15,12 @@ class LoggerInstrumentationTest < Minitest::Test
     end
 
     NewRelic::Agent.instance.stats_engine.reset!
+    NewRelic::Agent.instance.log_event_aggregator.reset!
   end
 
   def teardown
     NewRelic::Agent.instance.stats_engine.reset!
+    NewRelic::Agent.instance.log_event_aggregator.reset!
   end
 
   LEVELS = [
@@ -35,7 +37,7 @@ class LoggerInstrumentationTest < Minitest::Test
       @logger.send(name, "A message")
       assert_equal(1, @written.string.lines.count)
       assert_match(/#{name.upcase}.*A message/, @written.string)
-      assert_logging_metrics(name.upcase)
+      assert_logging_instrumentation(name.upcase)
     end
 
     define_method("test_records_multiple_calls_#{name}") do
@@ -45,7 +47,7 @@ class LoggerInstrumentationTest < Minitest::Test
       assert_equal(2, @written.string.lines.count)
       assert_match(/#{name.upcase}.*A message/, @written.string)
       assert_match(/#{name.upcase}.*Another/, @written.string)
-      assert_logging_metrics(name.upcase, 2)
+      assert_logging_instrumentation(name.upcase, 2)
     end
 
     # logger#debug(Object.new)
@@ -53,7 +55,7 @@ class LoggerInstrumentationTest < Minitest::Test
       @logger.send(name, Object.new)
       assert_equal(1, @written.string.lines.count)
       assert_match(/#{name.upcase}.*<Object.*>/, @written.string)
-      assert_logging_metrics(name.upcase)
+      assert_logging_instrumentation(name.upcase)
     end
 
     # logger#debug { "message" }
@@ -64,7 +66,7 @@ class LoggerInstrumentationTest < Minitest::Test
 
       assert_equal(1, @written.string.lines.count)
       assert_match(/#{name.upcase}.*A message/, @written.string)
-      assert_logging_metrics(name.upcase)
+      assert_logging_instrumentation(name.upcase)
     end
 
     # logger#log(Logger::DEBUG, "message")
@@ -72,7 +74,7 @@ class LoggerInstrumentationTest < Minitest::Test
       @logger.log(level, "A message")
       assert_equal(1, @written.string.lines.count)
       assert_match(/#{name.upcase}.*A message/, @written.string)
-      assert_logging_metrics(name.upcase)
+      assert_logging_instrumentation(name.upcase)
     end
 
     # logger#log(Logger::DEBUG} { "message" }
@@ -80,7 +82,7 @@ class LoggerInstrumentationTest < Minitest::Test
       @logger.log(level) { "A message" }
       assert_equal(1, @written.string.lines.count)
       assert_match(/#{name.upcase}.*A message/, @written.string)
-      assert_logging_metrics(name.upcase)
+      assert_logging_instrumentation(name.upcase)
     end
 
     # logger#log(Logger::DEBUG, "message", "progname")
@@ -88,7 +90,7 @@ class LoggerInstrumentationTest < Minitest::Test
       @logger.log(level, "A message", "progname")
       assert_equal(1, @written.string.lines.count)
       assert_match(/#{name.upcase}.*progname.*A message/, @written.string)
-      assert_logging_metrics(name.upcase)
+      assert_logging_instrumentation(name.upcase)
     end
   end
 
@@ -96,35 +98,35 @@ class LoggerInstrumentationTest < Minitest::Test
     @logger.level = ::Logger::INFO
     @logger.debug("Won't see this")
     assert_equal(0, @written.string.lines.count)
-    refute_any_logging_metrics()
+    refute_any_logging_instrumentation()
   end
 
   def test_unknown
     @logger.unknown("A message")
     assert_equal(1, @written.string.lines.count)
     assert_match(/ANY.*A message/, @written.string)
-    assert_logging_metrics("ANY")
+    assert_logging_instrumentation("ANY")
   end
 
   def test_really_high_level
     @logger.log(1_000_000, "A message")
     assert_equal(1, @written.string.lines.count)
     assert_match(/ANY.*A message/, @written.string)
-    assert_logging_metrics("ANY")
+    assert_logging_instrumentation("ANY")
   end
 
   def test_really_high_level_with_progname
     @logger.log(1_000_000, "A message", "progname")
     assert_equal(1, @written.string.lines.count)
     assert_match(/ANY.*progname.*A message/, @written.string)
-    assert_logging_metrics("ANY")
+    assert_logging_instrumentation("ANY")
   end
 
   def test_nil_severity
     @logger.log(nil, "A message", "progname")
     assert_equal(1, @written.string.lines.count)
     assert_match(/ANY.*progname.*A message/, @written.string)
-    assert_logging_metrics("ANY")
+    assert_logging_instrumentation("ANY")
   end
 
   def test_skips_when_set
@@ -133,21 +135,30 @@ class LoggerInstrumentationTest < Minitest::Test
 
     assert_equal(1, @written.string.lines.count)
     assert_match(/ANY.*progname.*A message/, @written.string)
-    refute_any_logging_metrics()
+    refute_any_logging_instrumentation()
   end
 
-  def refute_any_logging_metrics
+  def refute_any_logging_instrumentation
+    _, logs = NewRelic::Agent.agent.log_event_aggregator.harvest!
+    assert_empty logs
+
     assert_metrics_recorded_exclusive([])
   end
 
-  def assert_logging_metrics(label, count = 1)
+  def assert_logging_instrumentation(level, count = 1)
+    # We count on Logger calls but actually write metrics on harvest to
+    # minimize impact in the hot path
+    _, logs = NewRelic::Agent.agent.log_event_aggregator.harvest!
+    logs_at_level = logs.select { |log| log.last["level"] == level }
+    assert_equal count, logs_at_level.count
+
     assert_metrics_recorded_exclusive({
       "Logging/lines" => {:call_count => count},
-      "Logging/lines/#{label}" => {:call_count => count},
-      "Logging/size" => {},
-      "Logging/size/#{label}" => {},
-      "Supportability/API/increment_metric" => {},
-      "Supportability/API/record_metric" => {}
-    })
+      "Logging/lines/#{level}" => {:call_count => count},
+      "Logging/Forwarding/Dropped" => {},
+      "Supportability/Logging/Forwarding/Seen" => {},
+      "Supportability/Logging/Forwarding/Sent" => {}
+    },
+      :ignore_filter => %r{^Supportability/API/})
   end
 end

--- a/test/multiverse/suites/mongo/mongo2_instrumentation_test.rb
+++ b/test/multiverse/suites/mongo/mongo2_instrumentation_test.rb
@@ -343,15 +343,10 @@ if NewRelic::Agent::Datastores::Mongo.is_supported_version? &&
               "Datastore/all" => {:call_count => 3},
               "Supportability/API/drop_buffered_data" => {:call_count => 1},
               "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all" => {:call_count => 1},
-              "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allWeb" => {:call_count => 1},
-              "Logging/lines" => {},
-              "Logging/lines/DEBUG" => {},
-              "Logging/size" => {},
-              "Logging/size/DEBUG" => {},
-              "Supportability/API/increment_metric" => {},
-              "Supportability/API/record_metric" => {}
+              "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allWeb" => {:call_count => 1}
             }
-            assert_metrics_recorded_exclusive expected
+            assert_metrics_recorded_exclusive(expected,
+              :ignore_filter => /^(Logging)/)
           end
 
           def test_batched_queries_have_node_per_query

--- a/test/multiverse/suites/rack/nested_non_rack_app_test.rb
+++ b/test/multiverse/suites/rack/nested_non_rack_app_test.rb
@@ -60,15 +60,9 @@ if NewRelic::Agent::Instrumentation::RackHelpers.rack_version_supported?
           "Nested/Controller/Rack/NestedNonRackAppTest::RailsishApp/call",
           ["Nested/Controller/Rack/NestedNonRackAppTest::RailsishApp/call", "Controller/NestedNonRackAppTest::RailsishApp/inner"],
           'DurationByCaller/Unknown/Unknown/Unknown/HTTP/all',
-          'DurationByCaller/Unknown/Unknown/Unknown/HTTP/allWeb',
-          'Logging/lines',
-          'Logging/lines/INFO',
-          'Logging/lines/WARN',
-          'Logging/size',
-          'Logging/size/INFO',
-          'Logging/size/WARN'
+          'DurationByCaller/Unknown/Unknown/Unknown/HTTP/allWeb'
         ],
-        :ignore_filter => /^Supportability/
+        :ignore_filter => /^(Supportability|Logging)/
       )
     end
   end

--- a/test/multiverse/suites/rack/rack_auto_instrumentation_test.rb
+++ b/test/multiverse/suites/rack/rack_auto_instrumentation_test.rb
@@ -147,15 +147,9 @@ if NewRelic::Agent::Instrumentation::RackHelpers.version_supported? && defined? 
           ["Middleware/Rack/MiddlewareOne/call", "Controller/Middleware/Rack/MiddlewareTwo/call"],
           ["Middleware/Rack/MiddlewareTwo/call", "Controller/Middleware/Rack/MiddlewareTwo/call"],
           'DurationByCaller/Unknown/Unknown/Unknown/HTTP/all',
-          'DurationByCaller/Unknown/Unknown/Unknown/HTTP/allWeb',
-          'Logging/lines',
-          'Logging/lines/INFO',
-          'Logging/lines/WARN',
-          'Logging/size',
-          'Logging/size/INFO',
-          'Logging/size/WARN'
+          'DurationByCaller/Unknown/Unknown/Unknown/HTTP/allWeb'
         ],
-        :ignore_filter => /^Supportability/
+        :ignore_filter => /^(Supportability|Logging)/
       )
     end
 

--- a/test/multiverse/suites/sinatra/sinatra_metric_explosion_test.rb
+++ b/test/multiverse/suites/sinatra/sinatra_metric_explosion_test.rb
@@ -88,7 +88,7 @@ class SinatraMetricExplosionTest < Minitest::Test
       name_beginnings_to_ignore.any? { |name| metric.start_with?(name) }
     end
 
-    assert_equal 17, metric_names.size, "Explosion detected in: #{metric_names.inspect}"
+    assert_equal 11, metric_names.size, "Explosion detected in: #{metric_names.inspect}"
   end
 
   def test_does_not_break_when_no_verb_matches

--- a/test/new_relic/agent/agent/connect_test.rb
+++ b/test/new_relic/agent/agent/connect_test.rb
@@ -162,7 +162,8 @@ class NewRelic::Agent::Agent::ConnectTest < Minitest::Test
         :analytic_event_data => default_source[:'analytics_events.max_samples_stored'],
         :custom_event_data => default_source[:'custom_insights_events.max_samples_stored'],
         :error_event_data => default_source[:'error_collector.max_event_samples_stored'],
-        :span_event_data => default_source[:'span_events.max_samples_stored']
+        :span_event_data => default_source[:'span_events.max_samples_stored'],
+        :log_event_data => default_source[:'application_logging.forwarding.max_samples_stored']
       }
     }
 
@@ -172,7 +173,12 @@ class NewRelic::Agent::Agent::ConnectTest < Minitest::Test
         'agent_run_id' => 23,
         'event_harvest_config' => {
           'report_period_ms' => 5000,
-          'harvest_limits' => {'analytic_event_data' => 833, 'custom_event_data' => 83, 'error_event_data' => 8}
+          'harvest_limits' => {
+            'analytic_event_data' => 833,
+            'custom_event_data' => 83,
+            'error_event_data' => 8,
+            'log_event_data' => 833
+          }
         }
       })\
       # every call to :connect should pass the same expected event_harvest_config payload

--- a/test/new_relic/agent/agent_logger_test.rb
+++ b/test/new_relic/agent/agent_logger_test.rb
@@ -357,6 +357,32 @@ class AgentLoggerTest < Minitest::Test
     assert_logged "thoughts", "thoughts"
   end
 
+  def test_doesnt_write_log_event_aggregator
+    message = "Oops shouldn't have logged"
+    with_config(:'log_file_path' => 'stdout') do
+      NewRelic::Agent.agent.log_event_aggregator.reset!
+
+      logger = create_basic_logger
+      logger.fatal(message)
+
+      _, logs = NewRelic::Agent.agent.log_event_aggregator.harvest!
+      assert_empty logs.select { |log| log.last["message"].include?(message) }
+    end
+  end
+
+  def test_doesnt_write_log_event_aggregator_with_null_logger
+    message = "Oops shouldn't have logged"
+    with_config(:agent_enabled => false) do
+      NewRelic::Agent.agent.log_event_aggregator.reset!
+
+      logger = create_basic_logger
+      logger.fatal(message)
+
+      _, logs = NewRelic::Agent.agent.log_event_aggregator.harvest!
+      assert_empty logs.select { |log| log.last["message"].include?(message) }
+    end
+  end
+
   #
   # Helpers
   #

--- a/test/new_relic/agent/audit_logger_test.rb
+++ b/test/new_relic/agent/audit_logger_test.rb
@@ -203,6 +203,20 @@ class AuditLoggerTest < Minitest::Test
     end
   end
 
+  def test_doesnt_write_log_event_aggregator
+    with_config(:'log_file_path' => 'stdout') do
+      NewRelic::Agent.agent.log_event_aggregator.reset!
+
+      logger = NewRelic::Agent::AuditLogger.new
+      logger.log_request(@uri, @dummy_data, @marshaller)
+
+      _, logs = NewRelic::Agent.agent.log_event_aggregator.harvest!
+      audits = logs.select { |log| log.last["message"].include?("REQUEST") }
+
+      assert_empty audits
+    end
+  end
+
   def capturing_stdout
     orig = $stdout.dup
     output = ""

--- a/test/new_relic/agent/configuration/event_harvest_config_test.rb
+++ b/test/new_relic/agent/configuration/event_harvest_config_test.rb
@@ -13,13 +13,15 @@ module NewRelic::Agent::Configuration
       config.add_config_for_testing(:'custom_insights_events.max_samples_stored' => 1000)
       config.add_config_for_testing(:'error_collector.max_event_samples_stored' => 1000)
       config.add_config_for_testing(:'span_events.max_event_samples_stored' => 2000)
+      config.add_config_for_testing(:'application_logging.forwarding.max_samples_stored' => 2000)
 
       expected = {
         :harvest_limits => {
           :analytic_event_data => 1000,
           :custom_event_data => 1000,
           :error_event_data => 1000,
-          :span_event_data => 2000
+          :span_event_data => 2000,
+          :log_event_data => 2000,
         }
       }
 
@@ -33,7 +35,8 @@ module NewRelic::Agent::Configuration
           'harvest_limits' => {
             'analytic_event_data' => 833,
             'custom_event_data' => 83,
-            'error_event_data' => 8
+            'error_event_data' => 8,
+            'log_event_data' => 833,
           }
         },
         'span_event_harvest_config' => {
@@ -52,7 +55,9 @@ module NewRelic::Agent::Configuration
         :'event_report_period.error_event_data' => 5,
         :'span_events.max_samples_stored' => 89,
         :'event_report_period.span_event_data' => 80000,
-        :event_report_period => 5
+        :event_report_period => 5,
+        :'application_logging.forwarding.max_samples_stored' => 833,
+        :'event_report_period.log_event_data' => 5,
       }
       assert_equal expected, EventHarvestConfig.to_config_hash(connect_reply)
     end
@@ -64,7 +69,8 @@ module NewRelic::Agent::Configuration
           'harvest_limits' => {
             'analytic_event_data' => 833,
             'custom_event_data' => 83,
-            'error_event_data' => 8
+            'error_event_data' => 8,
+            'log_event_data' => 833
           }
         }
       }
@@ -76,7 +82,9 @@ module NewRelic::Agent::Configuration
         :'event_report_period.custom_event_data' => 5,
         :'error_collector.max_event_samples_stored' => 8,
         :'event_report_period.error_event_data' => 5,
-        :event_report_period => 5
+        :event_report_period => 5,
+        :'application_logging.forwarding.max_samples_stored' => 833,
+        :'event_report_period.log_event_data' => 5,
       }
       assert_equal expected, EventHarvestConfig.to_config_hash(connect_reply)
     end

--- a/test/new_relic/agent/error_trace_aggregator_test.rb
+++ b/test/new_relic/agent/error_trace_aggregator_test.rb
@@ -181,14 +181,7 @@ module NewRelic
         error_trace_aggregator.notice_agent_error(DifficultToDebugAgentError.new)
         error_trace_aggregator.notice_agent_error(AnotherToughAgentError.new)
 
-        assert_metrics_recorded_exclusive([
-          'Logging/lines',
-          'Logging/lines/INFO',
-          'Logging/size',
-          'Logging/size/INFO',
-          'Supportability/API/increment_metric',
-          'Supportability/API/record_metric'
-        ])
+        assert_metrics_recorded_exclusive([])
       end
 
       def test_notice_agent_error_set_noticed_error_attributes

--- a/test/new_relic/agent/linking_metadata_test.rb
+++ b/test/new_relic/agent/linking_metadata_test.rb
@@ -1,0 +1,95 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+
+require File.expand_path('../../../test_helper', __FILE__)
+require 'new_relic/agent/linking_metadata'
+
+module NewRelic::Agent
+  module LinkingMetadata
+    class LinkingMetadataTest < Minitest::Test
+      def setup
+        @config = nil
+        Hostname.stubs(:get).returns("localhost")
+        reset_buffers_and_caches
+      end
+
+      def teardown
+        NewRelic::Agent.config.remove_config(@config) if @config
+        NewRelic::Agent.config.reset_to_defaults
+        reset_buffers_and_caches
+      end
+
+      def test_service_metadata_requires_hash
+        assert_raises(ArgumentError) do
+          LinkingMetadata.append_service_linking_metadata(nil)
+        end
+      end
+
+      def test_service_metadata_without_guid
+        apply_config({
+          :app_name => ["Test app", "Another name"]
+        })
+
+        result = Hash.new
+        LinkingMetadata.append_service_linking_metadata(result)
+
+        expected = {
+          "entity.name" => "Test app",
+          "entity.type" => "SERVICE",
+          "hostname" => "localhost"
+        }
+        assert_equal(expected, result)
+      end
+
+      def test_service_metadata_with_guid
+        apply_config({
+          :app_name => ["Test app", "Another name"],
+          :entity_guid => "GUID"
+        })
+
+        result = Hash.new
+        LinkingMetadata.append_service_linking_metadata(result)
+
+        expected = {
+          "entity.guid" => "GUID",
+          "entity.name" => "Test app",
+          "entity.type" => "SERVICE",
+          "hostname" => "localhost"
+        }
+        assert_equal(expected, result)
+      end
+
+      def test_trace_metadata_empty
+        assert_raises(ArgumentError) do
+          LinkingMetadata.append_trace_linking_metadata(nil)
+        end
+      end
+
+      def test_trace_metadata_empty
+        result = Hash.new
+        LinkingMetadata.append_trace_linking_metadata(result)
+        assert_empty(result)
+      end
+
+      def test_trace_metadata_with_ids
+        Tracer.stubs(:current_trace_id).returns("trace_id")
+        Tracer.stubs(:current_span_id).returns("span_id")
+
+        result = Hash.new
+        LinkingMetadata.append_trace_linking_metadata(result)
+
+        expected = {
+          "trace.id" => "trace_id",
+          "span.id" => "span_id"
+        }
+        assert_equal(expected, result)
+      end
+
+      def apply_config(config)
+        @config = config
+        NewRelic::Agent.config.add_config_for_testing(@config)
+      end
+    end
+  end
+end

--- a/test/new_relic/agent/log_event_aggregator_test.rb
+++ b/test/new_relic/agent/log_event_aggregator_test.rb
@@ -265,5 +265,17 @@ module NewRelic::Agent
       assert_equal 1, size
       assert_equal expected, payload
     end
+
+    def test_does_not_record_if_message_is_nil
+      @aggregator.record(nil, "DEBUG")
+      _, events = @aggregator.harvest!
+      assert_empty events
+    end
+
+    def test_does_not_record_if_message_empty_string
+      @aggregator.record('', "DEBUG")
+      _, events = @aggregator.harvest!
+      assert_empty events
+    end
   end
 end

--- a/test/new_relic/agent/log_event_aggregator_test.rb
+++ b/test/new_relic/agent/log_event_aggregator_test.rb
@@ -266,6 +266,28 @@ module NewRelic::Agent
       assert_equal expected, payload
     end
 
+    def test_create_event_truncates_message_when_exceeding_max_bytes
+      right_size_message = String.new("a" * LogEventAggregator::MAX_BYTES)
+      message = right_size_message + 'b'
+      event = @aggregator.create_event(1, message, 'INFO')
+
+      assert_equal(right_size_message, event[1]["message"])
+    end
+
+    def test_create_event_doesnt_truncate_message_when_at_max_bytes
+      message = String.new("a" * LogEventAggregator::MAX_BYTES)
+      event = @aggregator.create_event(1, message, 'INFO')
+
+      assert_equal(message, event[1]["message"])
+    end
+
+    def test_create_event_doesnt_truncate_message_when_below_max_bytes
+      message = String.new("a" * (LogEventAggregator::MAX_BYTES - 1))
+      event = @aggregator.create_event(1, message, 'INFO')
+
+      assert_equal(message, event[1]["message"])
+    end
+
     def test_does_not_record_if_message_is_nil
       @aggregator.record(nil, "DEBUG")
       _, events = @aggregator.harvest!

--- a/test/new_relic/agent/log_event_aggregator_test.rb
+++ b/test/new_relic/agent/log_event_aggregator_test.rb
@@ -1,0 +1,269 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+
+require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', 'test_helper'))
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'data_container_tests'))
+
+require 'new_relic/agent/log_event_aggregator'
+
+module NewRelic::Agent
+  class LogEventAggregatorTest < Minitest::Test
+    def setup
+      nr_freeze_process_time
+      @aggregator = NewRelic::Agent.agent.log_event_aggregator
+      @aggregator.reset!
+
+      @enabled_config = {LogEventAggregator::FORWARDING_ENABLED_KEY => true}
+      NewRelic::Agent.config.add_config_for_testing(@enabled_config)
+
+      # Callbacks for enabled only happen on SSC addition
+      NewRelic::Agent.config.notify_server_source_added
+
+      NewRelic::Agent.instance.stats_engine.reset!
+    end
+
+    def teardown
+      NewRelic::Agent.config.remove_config(@enabled_config)
+    end
+
+    CAPACITY_KEY = LogEventAggregator.capacity_key
+
+    # Helpers for DataContainerTests
+
+    def create_container
+      @aggregator
+    end
+
+    def populate_container(container, n)
+      n.times do |i|
+        container.record("A log message", ::Logger::Severity.constants.sample.to_s)
+      end
+    end
+
+    include NewRelic::DataContainerTests
+
+    def test_records_enabled_metrics_on_startup
+      with_config(
+        LogEventAggregator::METRICS_ENABLED_KEY => true,
+        LogEventAggregator::FORWARDING_ENABLED_KEY => true,
+        LogEventAggregator::DECORATING_ENABLED_KEY => true
+      ) do
+        NewRelic::Agent.config.notify_server_source_added
+
+        assert_metrics_recorded_exclusive({
+          "Supportability/Logging/Metrics/Ruby/enabled" => {:call_count => 1},
+          "Supportability/Logging/Forwarding/Ruby/enabled" => {:call_count => 1},
+          "Supportability/Logging/LocalDecorating/Ruby/enabled" => {:call_count => 1}
+        },
+          :ignore_filter => %r{^Supportability/API/})
+      end
+    end
+
+    def test_records_disabled_metrics_on_startup
+      with_config(
+        LogEventAggregator::METRICS_ENABLED_KEY => false,
+        LogEventAggregator::FORWARDING_ENABLED_KEY => false,
+        LogEventAggregator::DECORATING_ENABLED_KEY => false
+      ) do
+        NewRelic::Agent.config.notify_server_source_added
+
+        assert_metrics_recorded_exclusive({
+          "Supportability/Logging/Metrics/Ruby/disabled" => {:call_count => 1},
+          "Supportability/Logging/Forwarding/Ruby/disabled" => {:call_count => 1},
+          "Supportability/Logging/LocalDecorating/Ruby/disabled" => {:call_count => 1}
+        },
+          :ignore_filter => %r{^Supportability/API/})
+      end
+    end
+
+    def test_record_by_default_limit
+      max_samples = NewRelic::Agent.config[CAPACITY_KEY]
+      n = max_samples + 1
+      n.times do |i|
+        @aggregator.record("Take it to the limit", "FATAL")
+      end
+
+      metadata, results = @aggregator.harvest!
+      assert_equal(n, metadata[:events_seen])
+      assert_equal(max_samples, metadata[:reservoir_size])
+      assert_equal(max_samples, results.size)
+    end
+
+    def test_record_in_transaction
+      max_samples = NewRelic::Agent.config[CAPACITY_KEY]
+      n = max_samples + 1
+      n.times do |i|
+        in_transaction do
+          @aggregator.record("Take it to the limit", "FATAL")
+        end
+      end
+
+      metadata, results = @aggregator.harvest!
+      assert_equal(n, metadata[:events_seen])
+      assert_equal(max_samples, metadata[:reservoir_size])
+      assert_equal(max_samples, results.size)
+    end
+
+    def test_record_in_transaction_prioritizes_sampling
+      # There can be only one
+      with_config(CAPACITY_KEY => 1) do
+        in_transaction do |txn|
+          txn.sampled = false
+          @aggregator.record("Deadly", "FATAL")
+        end
+
+        in_transaction do |txn|
+          txn.sampled = true
+          @aggregator.record("Buggy", "DEBUG")
+        end
+
+        metadata, results = @aggregator.harvest!
+
+        assert_equal(2, metadata[:events_seen])
+        assert_equal(1, metadata[:reservoir_size])
+        assert_equal(1, results.size)
+        assert_equal("Buggy", results.first.last["message"], "Favor sampled")
+      end
+    end
+
+    def test_record_in_transaction_prioritizes
+      # There can be only one
+      with_config(CAPACITY_KEY => 1) do
+        in_transaction do |txn|
+          txn.priority = 0.5
+          @aggregator.record("Deadly", "FATAL")
+        end
+
+        in_transaction do |txn|
+          txn.priority = 0.9
+          @aggregator.record("Buggy", "DEBUG")
+        end
+
+        metadata, results = @aggregator.harvest!
+
+        assert_equal(2, metadata[:events_seen])
+        assert_equal(1, metadata[:reservoir_size])
+        assert_equal(1, results.size)
+        assert_equal("Buggy", results.first.last["message"])
+      end
+    end
+
+    def test_record_without_transaction_randomizes
+      # There can be only one
+      with_config(CAPACITY_KEY => 1) do
+        LogPriority.stubs(:rand).returns(0.9)
+        @aggregator.record("Buggy", "DEBUG")
+
+        LogPriority.stubs(:rand).returns(0.1)
+        @aggregator.record("Deadly", "FATAL")
+
+        metadata, results = @aggregator.harvest!
+
+        assert_equal(2, metadata[:events_seen])
+        assert_equal(1, metadata[:reservoir_size])
+        assert_equal(1, results.size)
+        assert_equal("Buggy", results.first.last["message"])
+      end
+    end
+
+    def test_lowering_limit_truncates_buffer
+      orig_max_samples = NewRelic::Agent.config[CAPACITY_KEY]
+
+      orig_max_samples.times do |i|
+        @aggregator.record("Truncation happens", "WARN")
+      end
+
+      new_max_samples = orig_max_samples - 10
+      with_config(CAPACITY_KEY => new_max_samples) do
+        metadata, results = @aggregator.harvest!
+        assert_equal(new_max_samples, metadata[:reservoir_size])
+        assert_equal(orig_max_samples, metadata[:events_seen])
+        assert_equal(new_max_samples, results.size)
+      end
+    end
+
+    def test_record_adds_timestamp
+      t0 = Process.clock_gettime(Process::CLOCK_REALTIME) * 1000
+      message = "Time keeps slippin' away"
+      @aggregator.record(message, "INFO")
+
+      _, events = @aggregator.harvest!
+
+      assert_equal(1, events.size)
+      event = events.first
+
+      assert_equal({
+        'level' => "INFO",
+        'message' => message,
+        'timestamp' => t0
+      },
+        event.last)
+    end
+
+    def test_records_metrics_on_harvest
+      with_config CAPACITY_KEY => 5 do
+        9.times { @aggregator.record("Are you counting this?", "DEBUG") }
+        @aggregator.harvest!
+
+        assert_metrics_recorded_exclusive({
+          "Logging/lines" => {:call_count => 9},
+          "Logging/lines/DEBUG" => {:call_count => 9},
+          "Logging/Forwarding/Dropped" => {:call_count => 4},
+          "Supportability/Logging/Forwarding/Seen" => {:call_count => 9},
+          "Supportability/Logging/Forwarding/Sent" => {:call_count => 5}
+        },
+          :ignore_filter => %r{^Supportability/API/})
+      end
+    end
+
+    def test_high_security_mode
+      with_config CAPACITY_KEY => 5, :high_security => true do
+        # We refresh the high security setting on this notification
+        NewRelic::Agent.config.notify_server_source_added
+
+        9.times { @aggregator.record("Are you counting this?", "DEBUG") }
+        _, items = @aggregator.harvest!
+
+        # Never aggregate logs
+        assert_empty items
+
+        # We are fine to count them, though....
+        assert_metrics_recorded_exclusive({
+          "Logging/lines" => {:call_count => 9},
+          "Logging/lines/DEBUG" => {:call_count => 9},
+          "Supportability/Logging/Metrics/Ruby/disabled" => {:call_count => 1},
+          "Supportability/Logging/Forwarding/Ruby/enabled" => {:call_count => 1},
+          "Supportability/Logging/LocalDecorating/Ruby/disabled" => {:call_count => 1}
+        },
+          :ignore_filter => %r{^Supportability/API/})
+      end
+    end
+
+    def test_basic_conversion_to_melt_format
+      LinkingMetadata.stubs(:append_service_linking_metadata).returns({
+        "entity.guid" => "GUID",
+        "entity.name" => "Hola"
+      })
+
+      log_data = [
+        {
+          events_seen: 0,
+          reservoir_size: 0
+        },
+        [
+          [{"priority": 1}, {"message": "This is a mess"}]
+        ]
+      ]
+
+      payload, size = LogEventAggregator.payload_to_melt_format(log_data)
+      expected = [{
+        common: {attributes: {"entity.guid" => "GUID"}},
+        logs: [{"message": "This is a mess"}]
+      }]
+
+      assert_equal 1, size
+      assert_equal expected, payload
+    end
+  end
+end

--- a/test/new_relic/agent/log_priority_test.rb
+++ b/test/new_relic/agent/log_priority_test.rb
@@ -1,0 +1,22 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+
+require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', 'test_helper'))
+
+require 'new_relic/agent/log_priority'
+
+module NewRelic::Agent
+  class LogPriorityTest < Minitest::Test
+    def test_uses_transaction_if_its_there
+      txn = in_transaction do |txn|
+        assert_equal txn.priority, LogPriority.priority_for(txn)
+      end
+    end
+
+    def test_random_value_if_no_transction
+      LogPriority.stubs(:rand).returns(0.1)
+      assert_equal 0.1, LogPriority.priority_for(nil)
+    end
+  end
+end

--- a/test/new_relic/agent/monitors/cross_app_monitor_test.rb
+++ b/test/new_relic/agent/monitors/cross_app_monitor_test.rb
@@ -161,12 +161,7 @@ module NewRelic::Agent
         'Supportability/API/drop_buffered_data',
         'OtherTransactionTotalTime',
         'OtherTransactionTotalTime/transaction',
-        'Logging/lines',
-        'Logging/lines/WARN',
-        'Logging/size',
-        'Logging/size/WARN',
         'Supportability/API/record_metric',
-        'Supportability/API/increment_metric',
         'Supportability/Deprecated/cross_application_tracer'
       ])
     end

--- a/test/new_relic/agent/new_relic_service_test.rb
+++ b/test/new_relic/agent/new_relic_service_test.rb
@@ -461,10 +461,22 @@ class NewRelicServiceTest < Minitest::Test
     assert_equal 'some analytic events', response
   end
 
-  def error_event_data
+  def test_error_event_data
     @http_handle.respond_to(:error_event_data, 'some error events')
     response = @service.error_event_data([{}, []])
     assert_equal 'some error events', response
+  end
+
+  def test_span_event_data
+    @http_handle.respond_to(:span_event_data, 'some span events')
+    response = @service.span_event_data([{}, []])
+    assert_equal 'some span events', response
+  end
+
+  def test_log_event_data
+    @http_handle.respond_to(:log_event_data, 'some log events')
+    response = @service.log_event_data([{}, []])
+    assert_equal 'some log events', response
   end
 
   # Although thread profiling is only available in some circumstances, the

--- a/test/new_relic/agent/pipe_service_test.rb
+++ b/test/new_relic/agent/pipe_service_test.rb
@@ -105,6 +105,14 @@ class PipeServiceTest < Minitest::Test
       assert_equal [payload_with_newline], received_data[:transaction_sample_data]
     end
 
+    def test_log_event_data
+      payload = [{}, [[{"priority" => 1}, {"message" => "yo"}]]]
+      received_data = data_from_forked_process do
+        @service.log_event_data(payload)
+      end
+      assert_equal payload, received_data[:log_event_data]
+    end
+
     def test_multiple_writes_to_pipe
       pid = Process.fork do
         metric_data0 = generate_metric_data('Custom/something')

--- a/test/new_relic/agent/transaction/segment_test.rb
+++ b/test/new_relic/agent/transaction/segment_test.rb
@@ -165,14 +165,8 @@ module NewRelic
             "OtherTransactionTotalTime/test",
             "DurationByCaller/Unknown/Unknown/Unknown/Unknown/all",
             "Supportability/API/recording_web_transaction?",
-            "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther",
-            'Logging/lines',
-            'Logging/lines/INFO',
-            'Logging/size',
-            'Logging/size/INFO',
-            'Supportability/API/increment_metric',
-            'Supportability/API/record_metric'
-          ]
+            "DurationByCaller/Unknown/Unknown/Unknown/Unknown/allOther"
+          ], :ignore_filter => %r{^(Supportability/Logging|Supportability/API)}
         end
 
         def test_segment_can_disable_scoped_metric_recording_with_unscoped_as_frozen_array

--- a/test/new_relic/agent/transaction_test.rb
+++ b/test/new_relic/agent/transaction_test.rb
@@ -1632,5 +1632,45 @@ module NewRelic::Agent
         file_descriptors.map { |fd| IO::new(fd).close }
       end
     end
+
+    def test_batches_logs_during_transaction
+      with_config(LogEventAggregator::enabled_keys.first => true) do
+        NewRelic::Agent.config.notify_server_source_added
+        in_transaction do
+          NewRelic::Agent.agent.log_event_aggregator.record("A message", "FATAL")
+          assert_equal 1, Transaction.tl_current.logs.size
+        end
+      end
+    end
+
+    def test_ignores_logs_when_transaction_ignored
+      with_config(LogEventAggregator::enabled_keys.first => true) do
+        NewRelic::Agent.config.notify_server_source_added
+        in_transaction do |txn|
+          txn.ignore!
+
+          NewRelic::Agent.agent.log_event_aggregator.reset!
+          NewRelic::Agent.agent.log_event_aggregator.record("A message", "FATAL")
+          assert_equal 1, Transaction.tl_current.logs.size
+        end
+      end
+
+      _, items = NewRelic::Agent.agent.log_event_aggregator.harvest!
+      assert_empty items
+    end
+
+    def test_limits_batched_logs_during_transaction
+      limit = 10
+      with_config(LogEventAggregator::enabled_keys.first => true,
+        LogEventAggregator::capacity_key => limit) do
+        NewRelic::Agent.config.notify_server_source_added
+        in_transaction do
+          100.times do
+            NewRelic::Agent.agent.log_event_aggregator.record("A message", "FATAL")
+          end
+          assert_equal limit, Transaction.tl_current.logs.size
+        end
+      end
+    end
   end
 end

--- a/test/new_relic/marshalling_test_cases.rb
+++ b/test/new_relic/marshalling_test_cases.rb
@@ -156,18 +156,18 @@ module MarshallingTestCases
   def test_sends_log_events
     # Standard with other agents on millis, not seconds
     t0 = nr_freeze_process_time.to_f * 1000
-
     message = "A deadly message"
     severity = "FATAL"
 
-    with_around_hook do
-      NewRelic::Agent.agent.log_event_aggregator.record(message, severity)
+    with_config(:'application_logging.forwarding.enabled' => true) do
+      with_around_hook do
+        NewRelic::Agent.agent.log_event_aggregator.record(message, severity)
+      end
     end
 
     transmit_data
 
     result = $collector.calls_for('log_event_data')
-
     assert_equal 1, result.length
 
     common = result.first.common["attributes"]
@@ -181,6 +181,7 @@ module MarshallingTestCases
     refute_empty logs
 
     log = logs.find { |l| l["message"] == message && l["level"] == severity }
+
     refute_nil log
     assert_equal t0, log["timestamp"]
   end

--- a/test/new_relic/marshalling_test_cases.rb
+++ b/test/new_relic/marshalling_test_cases.rb
@@ -66,7 +66,7 @@ module MarshallingTestCases
     event[0].delete("priority")
 
     assert_equal "Transaction", event[0]["type"]
-    assert_equal t0.to_f, event[0]["timestamp"]
+    assert_equal t0, event[0]["timestamp"]
     assert_equal "TestTransaction/do_it", event[0]["name"]
     assert_equal 0.0, event[0]["duration"]
     assert_equal false, event[0]["error"]
@@ -151,6 +151,38 @@ module MarshallingTestCases
     assert_equal event[2], {}
 
     assert_equal event.size, 3
+  end
+
+  def test_sends_log_events
+    # Standard with other agents on millis, not seconds
+    t0 = nr_freeze_process_time.to_f * 1000
+
+    message = "A deadly message"
+    severity = "FATAL"
+
+    with_around_hook do
+      NewRelic::Agent.agent.log_event_aggregator.record(message, severity)
+    end
+
+    transmit_data
+
+    result = $collector.calls_for('log_event_data')
+
+    assert_equal 1, result.length
+
+    common = result.first.common["attributes"]
+    refute_nil common["hostname"]
+
+    # Excluding these explicitly vs classic logs-in-context to save space
+    assert_nil common["entity.name"]
+    assert_nil common["entity.type"]
+
+    logs = result.first.logs
+    refute_empty logs
+
+    log = logs.find { |l| l["message"] == message && l["level"] == severity }
+    refute_nil log
+    assert_equal t0, log["timestamp"]
   end
 
   class Transactioner

--- a/test/performance/suites/logging.rb
+++ b/test/performance/suites/logging.rb
@@ -22,4 +22,14 @@ class LoggingTest < Performance::TestCase
       logger.info EXAMPLE_MESSAGE
     end
   end
+
+  def test_logger_instrumentation_in_transaction
+    io = StringIO.new
+    logger = ::Logger.new io
+    measure do
+      in_transaction do
+        logger.info EXAMPLE_MESSAGE
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Overview
Start setting the `event_harvest_config.harvest_limits.log_event_data` key in the connect payload properly so we can opt into the fast harvest when it's available.

I'd completely misunderstood before looking at the code how those values are sent so this is needed on the agent-side.

# Testing
At the moment apart from all the automated tests passing this shouldn't show any real difference. Once connect is fixed up to handle the new value, we should see it coming back in the response and we can then wire up the agent's use of that setting.

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
