### PR TITLE
Logging: Add log decoration

### DIFF
--- a/lib/new_relic/agent.rb
+++ b/lib/new_relic/agent.rb
@@ -60,6 +60,7 @@ module NewRelic
     require 'new_relic/agent/distributed_tracing'
     require 'new_relic/agent/attribute_processing'
     require 'new_relic/agent/linking_metadata'
+    require 'new_relic/agent/local_log_decorator'
 
     require 'new_relic/agent/instrumentation/controller_instrumentation'
 

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -1907,6 +1907,13 @@ module NewRelic
           :allowed_from_server => true,
           :description => 'If `true`, the agent captures metrics related to logging for your application.'
         },
+        :'application_logging.local_decorating.enabled' => {
+          :default => false,
+          :public => true,
+          :type => Boolean,
+          :allowed_from_server => false,
+          :description => 'If `true`, the agent captures metrics related to logging for your application.'
+        },
         :disable_grape_instrumentation => {
           :default => false,
           :public => false,

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -1912,7 +1912,7 @@ module NewRelic
           :public => true,
           :type => Boolean,
           :allowed_from_server => false,
-          :description => 'If `true`, the agent captures metrics related to logging for your application.'
+          :description => 'If `true`, the agent decorates logs with metadata to link to entities, hosts, traces, and spans.'
         },
         :disable_grape_instrumentation => {
           :default => false,

--- a/lib/new_relic/agent/instrumentation/logger/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/logger/instrumentation.rb
@@ -47,7 +47,7 @@ module NewRelic
               formatted_message = LocalLogDecorator.decorate(formatted_message)
             end
 
-            return formatted_message
+            formatted_message
           ensure
             clear_skip_instrumenting
           end

--- a/lib/new_relic/agent/instrumentation/logger/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/logger/instrumentation.rb
@@ -44,6 +44,7 @@ module NewRelic
 
             unless ::NewRelic::Agent.agent.nil?
               ::NewRelic::Agent.agent.log_event_aggregator.record(formatted_message, severity)
+              formatted_message = LocalLogDecorator.decorate(formatted_message)
             end
 
             return formatted_message

--- a/lib/new_relic/agent/local_log_decorator.rb
+++ b/lib/new_relic/agent/local_log_decorator.rb
@@ -1,0 +1,29 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+module NewRelic
+  module Agent
+    #
+    # This module contains helper methods related to decorating log messages
+    module LocalLogDecorator
+      extend self
+
+      def decorate(message)
+        return message unless decorating_enabled?
+        metadata = NewRelic::Agent.linking_metadata
+        formatted_metadata = " NR-LINKING|#{metadata["entity.guid"]}|#{metadata["hostname"]}|#{metadata["trace.id"]}|#{metadata["span.id"]}|"
+        message.partition("\n").insert(1, formatted_metadata).join
+      end
+
+      private
+
+      def decorating_enabled?
+        NewRelic::Agent.config[:'application_logging.enabled'] &&
+          NewRelic::Agent::Instrumentation::Logger.enabled? &&
+          NewRelic::Agent.config[:'application_logging.local_decorating.enabled']
+      end
+    end
+  end
+end

--- a/lib/new_relic/agent/log_event_aggregator.rb
+++ b/lib/new_relic/agent/log_event_aggregator.rb
@@ -61,9 +61,9 @@ module NewRelic
           end
         end
 
+        return if formatted_message.nil? || formatted_message.empty?
         return unless NewRelic::Agent.config[:'application_logging.forwarding.enabled']
         return if @high_security
-        return if formatted_message.nil? || formatted_message.empty?
 
         txn = NewRelic::Agent::Transaction.tl_current
         priority = LogPriority.priority_for(txn)

--- a/newrelic.yml
+++ b/newrelic.yml
@@ -35,6 +35,9 @@ common: &default_settings
 # If `true`, the agent captures metrics related to logging for this application.
 # application_logging.metrics.enabled: true
 
+# If `true`, the agent decorates logs with metadata to link to entities, hosts, traces, and spans.
+# application_logging.local_decorating.enabled: false
+
 # If true, enables transaction event sampling.
 # transaction_events.enabled: true
 

--- a/test/agent_helper.rb
+++ b/test/agent_helper.rb
@@ -235,7 +235,7 @@ def assert_stats_has_values_with_call_count(expected_value, actual_value, msg)
   if expected_value.to_s =~ /([<>]=?)\s*(\d+)/
     operator = Regexp.last_match(1).to_sym
     count = Regexp.last_match(2).to_i
-    assert_operator(count, operator, actual_value, msg)
+    assert_operator(actual_value, operator, count, msg)
   # == comparison
   else
     assert_equal(expected_value, actual_value, msg)

--- a/test/multiverse/suites/logger/logger_instrumentation_test.rb
+++ b/test/multiverse/suites/logger/logger_instrumentation_test.rb
@@ -92,6 +92,20 @@ class LoggerInstrumentationTest < Minitest::Test
       assert_match(/#{name.upcase}.*progname.*A message/, @written.string)
       assert_logging_instrumentation(name.upcase)
     end
+
+    define_method("test_decorates_message_when_enabled_#{name}") do
+      with_config(:'application_logging.local_decorating.enabled' => true) do
+        @logger.log(level) { "A message" }
+        assert_includes @written.string, 'NR-LINKING'
+      end
+    end
+
+    define_method("test_does_not_decorate_message_when_disabled_#{name}") do
+      with_config(:'application_logging.local_decorating.enabled' => false) do
+        @logger.log(level) { "A message" }
+        refute_includes @written.string, 'NR-LINKING'
+      end
+    end
   end
 
   def test_still_skips_levels

--- a/test/new_relic/agent/local_log_decorator_test.rb
+++ b/test/new_relic/agent/local_log_decorator_test.rb
@@ -1,0 +1,81 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+
+require File.expand_path('../../../test_helper', __FILE__)
+require 'new_relic/agent/local_log_decorator'
+
+module NewRelic::Agent
+  module LocalLogDecorator
+    class LocalLogDecoratorTest < Minitest::Test
+      MESSAGE = 'message'.freeze
+      METADATA_STRING = 'NR-LINKING|GUID|localhost|trace_id|span_id|'
+
+      def setup
+        @enabled_config = {
+          :entity_guid => 'GUID',
+          :'application_logging.local_decorating.enabled' => true,
+          :'application_logging.enabled' => true,
+          :'instrumentation.logger' => 'auto'
+        }
+        NewRelic::Agent.config.add_config_for_testing(@enabled_config)
+      end
+
+      def teardown
+        NewRelic::Agent.config.remove_config(@enabled_config)
+      end
+
+      def metadata_stubs
+        NewRelic::Agent::Hostname.stubs(:get).returns('localhost')
+        Tracer.stubs(:current_trace_id).returns('trace_id')
+        Tracer.stubs(:current_span_id).returns('span_id')
+      end
+
+      def test_does_not_decorate_if_local_decoration_disabled
+        with_config(
+          :'application_logging.local_decorating.enabled' => false,
+          :'application_logging.enabled' => true,
+          :'instrumentation.logger' => 'disabled'
+        ) do
+          decorated_message = LocalLogDecorator.decorate(MESSAGE)
+          assert_equal MESSAGE, decorated_message
+        end
+      end
+
+      def test_does_not_decorate_if_instrumentation_logger_disabled
+        with_config(
+          :'instrumentation.logger' => 'disabled',
+          :'application_logging.enabled' => true,
+          :'application_logging.local_decorating.enabled' => true
+        ) do
+          decorated_message = LocalLogDecorator.decorate(MESSAGE)
+          assert_equal MESSAGE, decorated_message
+        end
+      end
+
+      def test_does_not_decorate_if_application_logging_disabled
+        with_config(
+          :'instrumentation.logger' => 'disabled',
+          :'application_logging.enabled' => false,
+          :'application_logging.local_decorating.enabled' => true
+        ) do
+          decorated_message = LocalLogDecorator.decorate(MESSAGE)
+          assert_equal MESSAGE, decorated_message
+        end
+      end
+
+      def test_decorates_if_enabled
+        metadata_stubs
+        decorated_message = LocalLogDecorator.decorate(MESSAGE)
+        assert_equal decorated_message, "#{MESSAGE} #{METADATA_STRING}"
+      end
+
+      def test_decorate_puts_metadata_at_end_of_first_newline
+        metadata_stubs
+        message = "This is a test of the Emergency Alert System\n this is only a test...."
+        decorated_message = LocalLogDecorator.decorate(message)
+        assert_equal decorated_message, "This is a test of the Emergency Alert System #{METADATA_STRING}\n this is only a test...."
+      end
+    end
+  end
+end

--- a/test/performance/suites/logging.rb
+++ b/test/performance/suites/logging.rb
@@ -23,6 +23,28 @@ class LoggingTest < Performance::TestCase
     end
   end
 
+  def test_local_log_decoration
+    io = StringIO.new
+    logger = ::Logger.new io
+    measure do
+      with_config(:'application_logging.local_decorating.enabled' => true) do
+        logger.info EXAMPLE_MESSAGE
+      end
+    end
+  end
+
+  def test_local_log_decoration_in_transaction
+    io = StringIO.new
+    logger = ::Logger.new io
+    measure do
+      with_config(:'application_logging.local_decorating.enabled' => true) do
+        in_transaction do
+          logger.info EXAMPLE_MESSAGE
+        end
+      end
+    end
+  end
+
   def test_logger_instrumentation_in_transaction
     io = StringIO.new
     logger = ::Logger.new io


### PR DESCRIPTION
# Overview
Add local log decoration with linking metadata when `application_logging.local_decoration.enabled` is true.

# Related Github Issue
Closes #988 

# Testing
* Adds unit tests for new class, LocalLogDecorator
* Adds integration tests to Logger instrumentation
* Adds performance tests for log decorating 