### PR TITLE
tests: allow call counts to be operator based

### DIFF
--- a/test/multiverse/suites/active_record_pg/active_record_test.rb
+++ b/test/multiverse/suites/active_record_pg/active_record_test.rb
@@ -50,7 +50,7 @@ class ActiveRecordInstrumentationTest < Minitest::Test
     if active_record_major_version >= 7
       assert_activerecord_metrics(Order, 'find')
     else
-      assert_activerecord_metrics(Order, 'select', :call_count => 5)
+      assert_activerecord_metrics(Order, 'select', call_count: '>= 5')
     end
   end
 


### PR DESCRIPTION
minitest: When defining an expected "call count" value, support the
inclusion of any one of the ">", "<", ">=", and "<=" operators instead
of always requiring an exact "==" style match.

to demonstrate this new functionality, the ActiveRecord test for
Postgres SELECT statements has been updated to use ">=" and permit the
extra schema/type cache query calls to be present and permitted by the
test.

resolves #969 

This will provide immediate an immediate resolution for #969 (flaky/flickering test) while we continue to discuss whether the query/type cache calls should be ignored in the first place. The results of that discussion will be tracked with a separate Issue.
