### PR TITLE
agent_helper: fix for 'assert_operator' usage

### DIFF
--- a/test/agent_helper.rb
+++ b/test/agent_helper.rb
@@ -235,7 +235,7 @@ def assert_stats_has_values_with_call_count(expected_value, actual_value, msg)
   if expected_value.to_s =~ /([<>]=?)\s*(\d+)/
     operator = Regexp.last_match(1).to_sym
     count = Regexp.last_match(2).to_i
-    assert_operator(count, operator, actual_value, msg)
+    assert_operator(actual_value, operator, count, msg)
   # == comparison
   else
     assert_equal(expected_value, actual_value, msg)


### PR DESCRIPTION
TestUnit's `assert_operator` takes arguments in the order that makes
sense when read left to right: `[6, :>=, 5]`, and we had the first and
third values swapped.

fixes buggy syntax introduced by #1013 