### PR TITLE
Logging: Mark ActiveSupport::Logger.broadcast arguments as @skip_instrumenting

### DIFF
--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -1914,8 +1914,9 @@ module NewRelic
           :allowed_from_server => false,
           :description => 'If `true`, the agent decorates logs with metadata to link to entities, hosts, traces, and spans.'
         },
-        :'instrumentation.active_support.logger' => {
+        :'instrumentation.active_support_logger' => {
           :default => instrumentation_value_from_boolean(:'application_logging.enabled'),
+          :dynamic_name => true,
           :public => true,
           :type => String,
           :allowed_from_server => false,

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -1914,6 +1914,13 @@ module NewRelic
           :allowed_from_server => false,
           :description => 'If `true`, the agent decorates logs with metadata to link to entities, hosts, traces, and spans.'
         },
+        :'instrumentation.active_support.logger' => {
+          :default => instrumentation_value_from_boolean(:'application_logging.enabled'),
+          :public => true,
+          :type => String,
+          :allowed_from_server => false,
+          :description => 'Controls auto-instrumentation of ActiveSupport::Logger at start up.  May be one of [auto|prepend|chain|disabled].'
+        },
         :disable_grape_instrumentation => {
           :default => false,
           :public => false,

--- a/lib/new_relic/agent/instrumentation/active_support_logger.rb
+++ b/lib/new_relic/agent/instrumentation/active_support_logger.rb
@@ -1,0 +1,26 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+
+require_relative 'active_support_logger/instrumentation'
+require_relative 'active_support_logger/chain'
+require_relative 'active_support_logger/prepend'
+
+DependencyDetection.defer do
+  named :'active_support.logger'
+
+  depends_on { defined?(::ActiveSupport::Logger) }
+
+  executes do
+    ::NewRelic::Agent.logger.info 'Installing ActiveSupport::Logger instrumentation'
+  end
+
+  executes do
+    if use_prepend?
+      # the only method currently instrumented is a class method
+      prepend_instrument ::ActiveSupport::Logger.singleton_class, NewRelic::Agent::Instrumentation::ActiveSupportLogger::Prepend
+    else
+      chain_instrument NewRelic::Agent::Instrumentation::ActiveSupportLogger::Chain
+    end
+  end
+end

--- a/lib/new_relic/agent/instrumentation/active_support_logger.rb
+++ b/lib/new_relic/agent/instrumentation/active_support_logger.rb
@@ -13,9 +13,7 @@ DependencyDetection.defer do
 
   executes do
     ::NewRelic::Agent.logger.info 'Installing ActiveSupport::Logger instrumentation'
-  end
 
-  executes do
     if use_prepend?
       # the only method currently instrumented is a class method
       prepend_instrument ::ActiveSupport::Logger.singleton_class, NewRelic::Agent::Instrumentation::ActiveSupportLogger::Prepend

--- a/lib/new_relic/agent/instrumentation/active_support_logger.rb
+++ b/lib/new_relic/agent/instrumentation/active_support_logger.rb
@@ -7,7 +7,7 @@ require_relative 'active_support_logger/chain'
 require_relative 'active_support_logger/prepend'
 
 DependencyDetection.defer do
-  named :'active_support.logger'
+  named :active_support_logger
 
   depends_on { defined?(::ActiveSupport::Logger) }
 

--- a/lib/new_relic/agent/instrumentation/active_support_logger/chain.rb
+++ b/lib/new_relic/agent/instrumentation/active_support_logger/chain.rb
@@ -1,0 +1,23 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+
+module NewRelic::Agent::Instrumentation
+  module ActiveSupportLogger
+    module Chain
+      def instrument!
+        ::ActiveSupport::Logger.module_eval do
+          include NewRelic::Agent::Instrumentation::ActiveSupportLogger
+          def broadcast_with_new_relic(logger)
+            broadcast_with_tracing(logger) {
+              broadcast_without_newrelic(logger)
+            }
+          end
+
+          alias broadcast_without_newrelic broadcast
+          alias broadcast broadcast_with_new_relic
+        end
+      end
+    end
+  end
+end

--- a/lib/new_relic/agent/instrumentation/active_support_logger/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/active_support_logger/instrumentation.rb
@@ -1,0 +1,20 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+
+module NewRelic
+  module Agent
+    module Instrumentation
+      module ActiveSupportLogger
+        # Mark @skip_instrumenting on any broadcasted loggers to instrument Rails.logger only
+        def broadcast_with_tracing(logger)
+          NewRelic::Agent::Instrumentation::Logger.mark_skip_instrumenting(logger)
+          yield
+        rescue => error
+          NewRelic::Agent.notice_error(error)
+          raise
+        end
+      end
+    end
+  end
+end

--- a/lib/new_relic/agent/instrumentation/active_support_logger/prepend.rb
+++ b/lib/new_relic/agent/instrumentation/active_support_logger/prepend.rb
@@ -1,0 +1,12 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+
+module NewRelic::Agent::Instrumentation
+  module ActiveSupportLogger::Prepend
+    include NewRelic::Agent::Instrumentation::ActiveSupportLogger
+    def broadcast(logger)
+      broadcast_with_tracing(logger) { super }
+    end
+  end
+end

--- a/lib/new_relic/agent/instrumentation/logger.rb
+++ b/lib/new_relic/agent/instrumentation/logger.rb
@@ -16,9 +16,7 @@ DependencyDetection.defer do
 
   executes do
     ::NewRelic::Agent.logger.info "Installing Logger instrumentation"
-  end
 
-  executes do
     if use_prepend?
       prepend_instrument ::Logger, NewRelic::Agent::Instrumentation::Logger::Prepend
     else

--- a/newrelic.yml
+++ b/newrelic.yml
@@ -325,6 +325,10 @@ common: &default_settings
 # May be one of [auto|prepend|chain|disabled].
 # instrumentation.logger: auto
 
+# Controls auto-instrumentation of ActiveSupport::Logger at start up.
+# May be one of [auto|prepend|chain|disabled].
+# instrumentation.active_support.logger: auto
+
 # Controls auto-instrumentation of memcache-client gem for Memcache at start up.
 # May be one of [auto|prepend|chain|disabled].
 # instrumentation.memcache_client: auto

--- a/test/multiverse/suites/rails/active_support_logger_test.rb
+++ b/test/multiverse/suites/rails/active_support_logger_test.rb
@@ -1,0 +1,39 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+
+require './app'
+
+class ActiveSupportLoggerTest < Minitest::Test
+  include MultiverseHelpers
+  setup_and_teardown_agent
+
+  def setup
+    @output = StringIO.new
+    @logger = Logger.new(@output)
+    @broadcasted_output = StringIO.new
+    @broadcasted_logger = ActiveSupport::Logger.new(@broadcasted_output)
+    @logger.extend ActiveSupport::Logger.broadcast(@broadcasted_logger)
+
+    @aggregator = NewRelic::Agent.agent.log_event_aggregator
+    @aggregator.reset!
+  end
+
+  def test_broadcasted_logger_marked_skip_instrumenting
+    assert @broadcasted_logger.instance_variable_get(:@skip_instrumenting)
+    assert_nil @logger.instance_variable_get(:@skip_instrumenting)
+  end
+
+  def test_logs_not_forwarded_by_broadcasted_logger
+    message = 'Can you hear me, Major Tom?'
+
+    @logger.add Logger::DEBUG, message
+
+    assert @output.string.include?(message)
+    assert @broadcasted_output.string.include?(message)
+
+    # LogEventAggregator sees the log only once
+    assert_equal 1, @aggregator.instance_variable_get(:@seen)
+    assert_equal @aggregator.instance_variable_get(:@seen_by_severity), {"DEBUG" => 1}
+  end
+end


### PR DESCRIPTION
# Overview
The Rails server command has an option, `--log_to_stdout`, that defaults true in development and when the server is not daemonized. The output gets doubled by a method called `ActiveSupport::Logger.broadcast`, that sends all logs to both `development.log` and `STDOUT`. This caused our logging instrumentation to forward emitted logs twice.

This PR prepends/aliases `ActiveSupport::Logger.broadcast` to mark any logger passed to the method with `@skip_instrumenting`. This instance variable is currently used by our Logging instrumentation to skip the NewRelic loggers `newrelic_agent.log` and `newrelic_audit.log`.

# Related Github Issue
Closes #1005

# Testing
Added integration tests with ActiveSupport::Logger