### PR TITLE
Fix test failures from env variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 
     The `browser_monitoring.auto_instrument` configuration option to enable web page load timing (RUM) was confusingly listed twice in the newrelic.yml config file. This option is enabled by default. The newrelic.yml file has been updated to list the option only once. Many thanks to @robotfelix for bringing this to our attention with [Issue #955](https://github.com/newrelic/newrelic-ruby-agent/issues/955).
 
+  * **Bugfix: fix unit test failures when New Relic environment variables are present**
+
+    Previously, unit tests would fail with unexpected invocation errors when `NEW_RELIC_LICENSE_KEY` and `NEW_RELIC_HOST` environment variables were present. Now, tests will discard these environment variables before running.
 
   ## v8.5.0
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -49,3 +49,8 @@ end
 # This is the public method recommended for plugin developers to share our
 # agent helpers. Use it so we don't accidentally break it.
 NewRelic::Agent.require_test_helper
+
+# If these are set, many tests fail. We delete them from this process.
+# This is an example of a test fail: unexpected invocation: #<Mock:0x28438>.sync=(true) (MiniTest::Assertion)
+ENV.delete('NEW_RELIC_LICENSE_KEY')
+ENV.delete('NEW_RELIC_HOST')


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
 Previously, unit tests would fail with unexpected invocation errors when `NEW_RELIC_LICENSE_KEY` and `NEW_RELIC_HOST` environment variables were present. For example: `unexpected invocation: #<Mock:0x28438>.sync=(true) (MiniTest::Assertion)`

Now, tests will discard these environment variables before running. This doesn't remove environment variables from the actual machine, just for the ruby process.

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
