### PR TITLE
Logging: Add entity name to log events and local log decoration

### DIFF
--- a/lib/new_relic/agent/local_log_decorator.rb
+++ b/lib/new_relic/agent/local_log_decorator.rb
@@ -1,10 +1,10 @@
 # encoding: utf-8
 # This file is distributed under New Relic's license terms.
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
 
 module NewRelic
   module Agent
-    #
     # This module contains helper methods related to decorating log messages
     module LocalLogDecorator
       extend self

--- a/lib/new_relic/agent/local_log_decorator.rb
+++ b/lib/new_relic/agent/local_log_decorator.rb
@@ -13,7 +13,9 @@ module NewRelic
         return message unless decorating_enabled?
 
         metadata = NewRelic::Agent.linking_metadata
-        formatted_metadata = " NR-LINKING|#{metadata[ENTITY_GUID_KEY]}|#{metadata[HOSTNAME_KEY]}|#{metadata[TRACE_ID_KEY]}|#{metadata[SPAN_ID_KEY]}|#{escape_entity_name(metadata[ENTITY_NAME_KEY])}|"
+        formatted_metadata = " NR-LINKING|#{metadata[ENTITY_GUID_KEY]}|#{metadata[HOSTNAME_KEY]}|" \
+                             "#{metadata[TRACE_ID_KEY]}|#{metadata[SPAN_ID_KEY]}|" \
+                             "#{escape_entity_name(metadata[ENTITY_NAME_KEY])}|"
 
         message.partition("\n").insert(1, formatted_metadata).join
       end

--- a/lib/new_relic/agent/local_log_decorator.rb
+++ b/lib/new_relic/agent/local_log_decorator.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 # This file is distributed under New Relic's license terms.
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
-# frozen_string_literal: true
 
 module NewRelic
   module Agent
@@ -12,8 +11,10 @@ module NewRelic
 
       def decorate(message)
         return message unless decorating_enabled?
+
         metadata = NewRelic::Agent.linking_metadata
-        formatted_metadata = " NR-LINKING|#{metadata["entity.guid"]}|#{metadata["hostname"]}|#{metadata["trace.id"]}|#{metadata["span.id"]}|#{metadata["entity.name"]}|"
+        formatted_metadata = " NR-LINKING|#{metadata[ENTITY_GUID_KEY]}|#{metadata[HOSTNAME_KEY]}|#{metadata[TRACE_ID_KEY]}|#{metadata[SPAN_ID_KEY]}|#{escape_entity_name(metadata[ENTITY_NAME_KEY])}|"
+
         message.partition("\n").insert(1, formatted_metadata).join
       end
 
@@ -23,6 +24,10 @@ module NewRelic
         NewRelic::Agent.config[:'application_logging.enabled'] &&
           NewRelic::Agent::Instrumentation::Logger.enabled? &&
           NewRelic::Agent.config[:'application_logging.local_decorating.enabled']
+      end
+
+      def escape_entity_name(entity_name = nil)
+        URI::Parser.new.escape(entity_name)
       end
     end
   end

--- a/lib/new_relic/agent/local_log_decorator.rb
+++ b/lib/new_relic/agent/local_log_decorator.rb
@@ -13,7 +13,7 @@ module NewRelic
       def decorate(message)
         return message unless decorating_enabled?
         metadata = NewRelic::Agent.linking_metadata
-        formatted_metadata = " NR-LINKING|#{metadata["entity.guid"]}|#{metadata["hostname"]}|#{metadata["trace.id"]}|#{metadata["span.id"]}|"
+        formatted_metadata = " NR-LINKING|#{metadata["entity.guid"]}|#{metadata["hostname"]}|#{metadata["trace.id"]}|#{metadata["span.id"]}|#{metadata["entity.name"]}|"
         message.partition("\n").insert(1, formatted_metadata).join
       end
 

--- a/lib/new_relic/agent/local_log_decorator.rb
+++ b/lib/new_relic/agent/local_log_decorator.rb
@@ -26,8 +26,9 @@ module NewRelic
           NewRelic::Agent.config[:'application_logging.local_decorating.enabled']
       end
 
-      def escape_entity_name(entity_name = nil)
-        URI::Parser.new.escape(entity_name)
+      def escape_entity_name(entity_name)
+        return unless entity_name
+        URI::DEFAULT_PARSER.escape(entity_name)
       end
     end
   end

--- a/lib/new_relic/agent/log_event_aggregator.rb
+++ b/lib/new_relic/agent/log_event_aggregator.rb
@@ -124,9 +124,8 @@ module NewRelic
       def self.payload_to_melt_format(data)
         common_attributes = LinkingMetadata.append_service_linking_metadata({})
 
-        # To save on unnecessary data transmission, trim the name and type
-        # that were sent by classic logs-in-context
-        common_attributes.delete(ENTITY_NAME_KEY)
+        # To save on unnecessary data transmission, trim the entity.type
+        # sent by classic logs-in-context
         common_attributes.delete(ENTITY_TYPE_KEY)
 
         _, items = data

--- a/test/multiverse/suites/agent_only/log_events_test.rb
+++ b/test/multiverse/suites/agent_only/log_events_test.rb
@@ -28,7 +28,6 @@ class LogEventsTest < Minitest::Test
     assert_equal span_id, last_log["span.id"]
 
     common = last_logs_common
-    assert_equal nil, common["attributes"]["entity.name"]
     assert_equal nil, common["attributes"]["entity.type"]
     assert_equal NewRelic::Agent::Hostname.get, common["attributes"]["hostname"]
   end
@@ -47,7 +46,6 @@ class LogEventsTest < Minitest::Test
     assert_equal nil, last_log["span.id"]
 
     common = last_logs_common
-    assert_equal nil, common["attributes"]["entity.name"]
     assert_equal nil, common["attributes"]["entity.type"]
     assert_equal NewRelic::Agent::Hostname.get, common["attributes"]["hostname"]
   end

--- a/test/new_relic/agent/local_log_decorator_test.rb
+++ b/test/new_relic/agent/local_log_decorator_test.rb
@@ -9,10 +9,11 @@ module NewRelic::Agent
   module LocalLogDecorator
     class LocalLogDecoratorTest < Minitest::Test
       MESSAGE = 'message'.freeze
-      METADATA_STRING = 'NR-LINKING|GUID|localhost|trace_id|span_id|test|'
+      METADATA_STRING = 'NR-LINKING|GUID|localhost|trace_id|span_id|app|'
 
       def setup
         @enabled_config = {
+          :app_name => 'app',
           :entity_guid => 'GUID',
           :'application_logging.local_decorating.enabled' => true,
           :'application_logging.enabled' => true,
@@ -75,6 +76,13 @@ module NewRelic::Agent
         message = "This is a test of the Emergency Alert System\n this is only a test...."
         decorated_message = LocalLogDecorator.decorate(message)
         assert_equal decorated_message, "This is a test of the Emergency Alert System #{METADATA_STRING}\n this is only a test...."
+      end
+
+      def test_URI_encodes_entity_name
+        with_config(app_name: "My App | Production") do
+          decorated_message = LocalLogDecorator.decorate(MESSAGE)
+          assert_includes decorated_message, "My%20App%20%7C%20Production"
+        end
       end
     end
   end

--- a/test/new_relic/agent/local_log_decorator_test.rb
+++ b/test/new_relic/agent/local_log_decorator_test.rb
@@ -84,6 +84,13 @@ module NewRelic::Agent
           assert_includes decorated_message, "My%20App%20%7C%20Production"
         end
       end
+
+      def test_safe_without_entity_name
+        with_config(app_name: nil) do
+          decorated_message = LocalLogDecorator.decorate(MESSAGE)
+          assert_includes decorated_message, '||'
+        end
+      end
     end
   end
 end

--- a/test/new_relic/agent/local_log_decorator_test.rb
+++ b/test/new_relic/agent/local_log_decorator_test.rb
@@ -9,7 +9,7 @@ module NewRelic::Agent
   module LocalLogDecorator
     class LocalLogDecoratorTest < Minitest::Test
       MESSAGE = 'message'.freeze
-      METADATA_STRING = 'NR-LINKING|GUID|localhost|trace_id|span_id|'
+      METADATA_STRING = 'NR-LINKING|GUID|localhost|trace_id|span_id|test|'
 
       def setup
         @enabled_config = {

--- a/test/new_relic/agent/log_event_aggregator_test.rb
+++ b/test/new_relic/agent/log_event_aggregator_test.rb
@@ -379,7 +379,7 @@ module NewRelic::Agent
 
       payload, size = LogEventAggregator.payload_to_melt_format(log_data)
       expected = [{
-        common: {attributes: {"entity.guid" => "GUID"}},
+        common: {attributes: {"entity.guid" => "GUID", "entity.name" => "Hola"}},
         logs: [{"message": "This is a mess"}]
       }]
 

--- a/test/new_relic/marshalling_test_cases.rb
+++ b/test/new_relic/marshalling_test_cases.rb
@@ -173,8 +173,7 @@ module MarshallingTestCases
     common = result.first.common["attributes"]
     refute_nil common["hostname"]
 
-    # Excluding these explicitly vs classic logs-in-context to save space
-    assert_nil common["entity.name"]
+    # Excluding this explicitly vs classic logs-in-context to save space
     assert_nil common["entity.type"]
 
     logs = result.first.logs


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
* Append `entity.name` to the linking metadata used by the `LocalLogDecorator`
* Remove the `#delete` call on the constant holding `entity.name` information

# Related Github Issue
Closes #1031

# Testing
Existing tests updated to include the new attribute