### PR TITLE
Curb instrumentation method_with_tracing fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
   ## v8.6.0
 
+  * **Bugfix: Curb - satify method_with_tracing's verb argument requirement**
+
+    When Curb instrumentation is used (either via prepend or chain), be sure to always pass the verb argument over to `method_with_tracing` which requires it. Thank you to @knarewski for bringing this issue to our attention, for providing a means of reproducing an error, and for providing a fix. That fix has been replicated by the agent team with permission. See [Issue 1033](https://github.com/newrelic/newrelic-ruby-agent/issues/1033) for more details.
+
   * **Improve the usage of the 'hostname' executable and other executables**
 
     In all places where a call to an executable binary is made (currently this is done only for the 'hostname' and 'uname' binaries), leverage a new helper method when making the call. This new helper will a) not attempt to execute the binary if it cannot be found, and b) prevent STDERR/STDOUT content from appearing anywhere except New Relic's own logs if the New Relic logger is set to the 'debug' level. When calling 'hostname', fall back to `Socket.gethostname` if the 'hostname' binary cannot be found. When calling 'uname', fall back on using a value of 'unknown' if the 'uname' command fails. Many thanks to @metaskills and @brcarp for letting us know that Ruby AWS Lambda functions can't invoke 'hostname' and for providing ideas and feedback with [Issue #697](https://github.com/newrelic/newrelic-ruby-agent/issues/697).
@@ -13,6 +17,7 @@
   * **Bugfix: fix unit test failures when New Relic environment variables are present**
 
     Previously, unit tests would fail with unexpected invocation errors when `NEW_RELIC_LICENSE_KEY` and `NEW_RELIC_HOST` environment variables were present. Now, tests will discard these environment variables before running.
+
 
   ## v8.5.0
 

--- a/lib/new_relic/agent/instrumentation/curb/chain.rb
+++ b/lib/new_relic/agent/instrumentation/curb/chain.rb
@@ -51,7 +51,7 @@ module NewRelic::Agent::Instrumentation
 
           # Record the HTTP verb for future #perform calls
           def method_with_newrelic verb
-            method_with_tracing { method_without_newrelic(verb) }
+            method_with_tracing(verb) { method_without_newrelic(verb) }
           end
 
           alias_method :method_without_newrelic, :method

--- a/lib/new_relic/agent/instrumentation/curb/prepend.rb
+++ b/lib/new_relic/agent/instrumentation/curb/prepend.rb
@@ -34,7 +34,7 @@ module NewRelic
             end
 
             def method verb
-              method_with_tracing { super }
+              method_with_tracing(verb) { super }
             end
 
             def header_str

--- a/test/multiverse/suites/curb/Envfile
+++ b/test/multiverse/suites/curb/Envfile
@@ -20,7 +20,7 @@ end
 # https://github.com/taf2/curb#version-compatibility-chart
 def curb_gem_version
   if curl_version.between? 7.58, Float::INFINITY
-    '~> 0.9.8'
+    '~> 1.0.0'
   elsif curl_version.between? 7.56, 7.60
     '0.9.7'
   elsif curl_version.between? 7.51, 7.59

--- a/test/multiverse/suites/curb/curb_test.rb
+++ b/test/multiverse/suites/curb/curb_test.rb
@@ -141,6 +141,11 @@ class CurbTest < Minitest::Test
     assert_equal "External/Multiple/Curb::Multi/perform", last_node.metric_name
   end
 
+  # https://github.com/newrelic/newrelic-ruby-agent/issues/1033
+  def test_method_with_tracing_passes_the_verb_downstream
+    assert Curl::Easy.new.method(:to_s).call.is_a?(String), 'Failed to create #to_s method'
+  end
+
   #
   # Helper functions
   #


### PR DESCRIPTION
To address an issue apparently dating back to when the Curb
instrumentation was first split into separate "prepend" and "chain"
approaches, be sure to pass a verb argument to `method_with_tracing`,
which requires it.

Thank you to @knarewski for bringing this issue to our attention,
for providing a means of reproducing an error, and for providing a fix.

resolves #1033
