### PR TITLE
logger stdout/stderr check: check for IO class

### DIFF
--- a/lib/new_relic/agent/log_event_aggregator.rb
+++ b/lib/new_relic/agent/log_event_aggregator.rb
@@ -245,7 +245,7 @@ module NewRelic
         return unless @loggers.keys.size > 1
 
         @loggers.each do |logger, dev|
-          logger.mark_skip_instrumenting if dev.respond_to?(:tty?) && dev.tty?
+          logger.mark_skip_instrumenting if dev.class == IO
         end
       end
     end


### PR DESCRIPTION
instead of checking with #tty?, check if #class equals IO

Local dev testing and Docker based testing seemed fine with the TTY check, but GitHub Actions failed the tests with it.