### PR TITLE
Logging: Set severity as "UNKNOWN" if nil or empty

### DIFF
--- a/lib/new_relic/agent/log_event_aggregator.rb
+++ b/lib/new_relic/agent/log_event_aggregator.rb
@@ -54,6 +54,8 @@ module NewRelic
       def record(formatted_message, severity)
         return unless enabled?
 
+        severity = "UNKNOWN" if severity.nil? || severity.empty?
+
         if NewRelic::Agent.config[METRICS_ENABLED_KEY]
           @counter_lock.synchronize do
             @seen += 1

--- a/test/new_relic/agent/log_event_aggregator_test.rb
+++ b/test/new_relic/agent/log_event_aggregator_test.rb
@@ -122,7 +122,7 @@ module NewRelic::Agent
       assert_metrics_not_recorded([
         "Logging/lines",
         "Logging/lines/DEBUG"
-        ])
+      ])
     end
 
     def test_logs_with_nil_severity_use_unknown


### PR DESCRIPTION
# Overview
As per the agent specs, set the log event severity as "UNKNOWN" is the severity is empty or nil.

# Related Github Issue
Closes #1042 

# Testing
Unit tests added for this change

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
