### PR TITLE
Update script to generate config html docs

### DIFF
--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -329,7 +329,7 @@ module NewRelic
           :public => true,
           :type => String,
           :allowed_from_server => false,
-          :description => 'Your New Relic [license key](/docs/accounts-partnerships/accounts/account-setup/license-key).'
+          :description => 'Your New Relic [license key](/docs/apis/intro-apis/new-relic-api-keys/#ingest-license-key).'
         },
         :agent_enabled => {
           :default => DefaultSource.agent_enabled,
@@ -367,7 +367,7 @@ module NewRelic
           :public => true,
           :type => Boolean,
           :allowed_from_server => false,
-          :description => 'When `true`, the agent transmits data about your application to the New Relic [collector](/docs/using-new-relic/welcome-new-relic/get-started/glossary/#collector).'
+          :description => 'When `true`, the agent transmits data about your app to the New Relic [collector](/docs/using-new-relic/welcome-new-relic/get-started/glossary/#collector).'
         },
         :test_mode => {
           :default => false,
@@ -438,18 +438,19 @@ module NewRelic
           :allowed_from_server => false,
           :description => 'When `true`, the agent captures HTTP request parameters ' \
             'and attaches them to transaction traces, traced errors, and ' \
-            '[`TransactionError` events](/attribute-dictionary?attribute_name=&events_tids%5B%5D=8241)'\
+            '[`TransactionError` events](/attribute-dictionary?attribute_name=&events_tids%5B%5D=8241).'\
             "\n" \
-            '<div class="callout-warning">' \
             "\n" \
-            'When using the `capture_params` setting, the Ruby agent will not attempt ' \
+            '    <Callout variant="caution">' \
+            "\n" \
+            '      When using the `capture_params` setting, the Ruby agent will not attempt ' \
             'to filter secret information. <b>Recommendation:</b> To filter secret information from ' \
             'request parameters, use the [`attributes.include` setting](/docs/agents/ruby-agent/attributes/enable-disable-attributes-ruby) ' \
             'instead. For more information, see the ' \
             '<a href="/docs/agents/ruby-agent/attributes/ruby-attribute-examples#ex_req_params">' \
             'Ruby attribute examples</a>.' \
             "\n" \
-            '</div>'
+            '    </Callout>'
         },
         :config_path => {
           :default => DefaultSource.config_path,
@@ -815,7 +816,33 @@ module NewRelic
           :public => true,
           :type => Boolean,
           :allowed_from_server => false,
-          :description => 'If `true`, disables agent middleware for Sinatra. This middleware is responsible for advanced feature support such as [cross application tracing](/docs/apm/transactions/cross-application-traces/cross-application-tracing), [page load timing](/docs/browser/new-relic-browser/getting-started/new-relic-browser), and [error collection](/docs/apm/applications-menu/events/view-apm-error-analytics).'
+          :description => 'If `true`, disables agent middleware for Sinatra. This middleware is responsible for advanced feature support such as [cross application tracing](/docs/apm/transactions/cross-application-traces/cross-application-tracing), [page load timing](/docs/browser/new-relic-browser/getting-started/new-relic-browser), and [error collection](/docs/apm/applications-menu/events/view-apm-error-analytics).'\
+          "\n" \
+          "\n" \
+          '    <Callout variant="important">' \
+          "\n" \
+          '      Cross application tracing is deprecated in favor of [distributed tracing](https://docs.newrelic.com/docs/apm/distributed-tracing/getting-started/introduction-distributed-tracing). Distributed tracing is on by default for Ruby agent versions 8.0.0 and above. Middlewares are not required to support distributed tracing.' \
+          "\n" \
+          "\n" \
+          '      To continue using cross application tracing, update the following options in your `newrelic.yml` configuration file:'\
+          "\n" \
+          "\n" \
+          '      ```'\
+          "\n" \
+          '      # newrelic.yml'\
+          "\n" \
+          "\n" \
+          '        cross_application_tracer:'\
+          "\n" \
+          '          enabled: true'\
+          "\n" \
+          '        distributed_tracing:'\
+          "\n" \
+          '          enabled: false'\
+          "\n" \
+          '      ```'\
+          "\n" \
+          '    </Callout>'
         },
         :disable_view_instrumentation => {
           :default => false,
@@ -1166,11 +1193,9 @@ module NewRelic
 
   By default, this is set to `obfuscated`, which strips out the numeric and string literals.
 
-  <ul>
-    <li>If you do not want the agent to capture query information, set this to `none`.</li>
-    <li>If you want the agent to capture all query information in its original form, set this to `raw`.</li>
-    <li>When you enable [high security mode](/docs/agents/manage-apm-agents/configuration/high-security-mode), this is automatically set to `obfuscated`.</li>
-  </ul>
+  - If you do not want the agent to capture query information, set this to `none`.
+  - If you want the agent to capture all query information in its original form, set this to `raw`.
+  - When you enable [high security mode](/docs/agents/manage-apm-agents/configuration/high-security-mode), this is automatically set to `obfuscated`.
   '
         },
         :'transaction_tracer.record_redis_arguments' => {
@@ -1334,7 +1359,14 @@ module NewRelic
           :deprecated => true,
           :allowed_from_server => true,
           :dynamic_name => true,
-          :description => 'Use `error_collector.ignore_classes` instead. Specify a comma-delimited list of error classes that the agent should ignore.'
+          :description => 'Use `error_collector.ignore_classes` instead. Specify a comma-delimited list of error classes that the agent should ignore.' \
+          "\n" \
+          "\n" \
+          '    <Callout variant="caution">' \
+          "\n" \
+          '      Server side configuration takes precedence for this setting over all environment configurations. This differs from all other configuration settings where environment variable take precedence over server side configuration.'\
+          "\n" \
+          '    </Callout>'
         },
         :'error_collector.ignore_classes' => {
           :default => [],
@@ -1342,7 +1374,14 @@ module NewRelic
           :type => Array,
           :allowed_from_server => true,
           :dynamic_name => true,
-          :description => 'A list of error classes that the agent should ignore. *Note: this setting cannot be set via environment variable.*'
+          :description => 'A list of error classes that the agent should ignore.' \
+          "\n" \
+          "\n" \
+          '  <Callout variant="caution">' \
+          "\n" \
+          '    This option can\'t be set via environment variable.'\
+          "\n" \
+          '  </Callout>'
         },
         :'error_collector.ignore_messages' => {
           :default => {},
@@ -1350,7 +1389,14 @@ module NewRelic
           :type => Hash,
           :allowed_from_server => true,
           :dynamic_name => true,
-          :description => 'A map of error classes to a list of messages. When an error of one of the classes specified here occurs, if its error message contains one of the strings corresponding to it here, that error will be ignored. *Note: this setting cannot be set via environment variable.*'
+          :description => 'A map of error classes to a list of messages. When an error of one of the classes specified here occurs, if its error message contains one of the strings corresponding to it here, that error will be ignored.' \
+          "\n" \
+          "\n" \
+          '  <Callout variant="caution">' \
+          "\n" \
+          '    This option can\'t be set via environment variable.'\
+          "\n" \
+          '  </Callout>'
         },
         :'error_collector.ignore_status_codes' => {
           :default => '',
@@ -1366,7 +1412,14 @@ module NewRelic
           :type => Array,
           :allowed_from_server => true,
           :dynamic_name => true,
-          :description => 'A list of error classes that the agent should treat as expected. *Note: this setting cannot be set via environment variable.*'
+          :description => 'A list of error classes that the agent should treat as expected.' \
+          "\n" \
+          "\n" \
+          '  <Callout variant="caution">' \
+          "\n" \
+          '    This option can\'t be set via environment variable.'\
+          "\n" \
+          '  </Callout>'
         },
         :'error_collector.expected_messages' => {
           :default => {},
@@ -1374,7 +1427,14 @@ module NewRelic
           :type => Hash,
           :allowed_from_server => true,
           :dynamic_name => true,
-          :description => 'A map of error classes to a list of messages. When an error of one of the classes specified here occurs, if its error message contains one of the strings corresponding to it here, that error will be treated as expected. *Note: this setting cannot be set via environment variable.*'
+          :description => 'A map of error classes to a list of messages. When an error of one of the classes specified here occurs, if its error message contains one of the strings corresponding to it here, that error will be treated as expected.' \
+          "\n" \
+          "\n" \
+          '  <Callout variant="caution">' \
+          "\n" \
+          '    This option can\'t be set via environment variable.'\
+          "\n" \
+          '  </Callout>'
         },
         :'error_collector.expected_status_codes' => {
           :default => '',
@@ -1817,7 +1877,7 @@ module NewRelic
           :public => true,
           :type => String,
           :allowed_from_server => false,
-          :description => 'A dictionary of [label names](/docs/data-analysis/user-interface-functions/labels-categories-organize-your-apps-servers) and values that will be applied to the data sent from your agent. May also be expressed as a semicolon-delimited `;` string of colon-separated `:` pairs. For example, `<var>Server</var>:<var>One</var>;<var>Data Center</var>:<var>Primary</var>`.'
+          :description => 'A dictionary of [label names](/docs/data-analysis/user-interface-functions/labels-categories-organize-your-apps-servers) and values that will be applied to the data sent from this agent. May also be expressed as a semicolon-delimited `;` string of colon-separated `:` pairs. For example, `<var>Server</var>:<var>One</var>;<var>Data Center</var>:<var>Primary</var>`.'
         },
         :aggressive_keepalive => {
           :default => true,
@@ -1875,7 +1935,7 @@ module NewRelic
           :public => true,
           :type => Integer,
           :allowed_from_server => true,
-          :description => 'Defines the maximum number of span events reported from a single harvest. Any Integer between 1 and 10000 is valid.',
+          :description => 'Specify a maximum number of custom events to buffer in memory at a time.',
           :dynamic_name => true
         },
         :'application_logging.enabled' => {
@@ -2272,7 +2332,7 @@ module NewRelic
           :public => true,
           :type => Integer,
           :allowed_from_server => true,
-          :description => 'Defines the maximum number of span events reported from a single harvest.'
+          :description => 'Defines the maximum number of span events reported from a single harvest. Any Integer between 1 and 10000 is valid.'
         },
         :'exclude_newrelic_header' => {
           :default => false,

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -820,33 +820,24 @@ module NewRelic
           :public => true,
           :type => Boolean,
           :allowed_from_server => false,
-          :description => 'If `true`, disables agent middleware for Sinatra. This middleware is responsible for advanced feature support such as [cross application tracing](/docs/apm/transactions/cross-application-traces/cross-application-tracing), [page load timing](/docs/browser/new-relic-browser/getting-started/new-relic-browser), and [error collection](/docs/apm/applications-menu/events/view-apm-error-analytics).'\
-          "\n" \
-          "\n" \
-          '    <Callout variant="important">' \
-          "\n" \
-          '      Cross application tracing is deprecated in favor of [distributed tracing](https://docs.newrelic.com/docs/apm/distributed-tracing/getting-started/introduction-distributed-tracing). Distributed tracing is on by default for Ruby agent versions 8.0.0 and above. Middlewares are not required to support distributed tracing.' \
-          "\n" \
-          "\n" \
-          '      To continue using cross application tracing, update the following options in your `newrelic.yml` configuration file:'\
-          "\n" \
-          "\n" \
-          '      ```'\
-          "\n" \
-          '      # newrelic.yml'\
-          "\n" \
-          "\n" \
-          '        cross_application_tracer:'\
-          "\n" \
-          '          enabled: true'\
-          "\n" \
-          '        distributed_tracing:'\
-          "\n" \
-          '          enabled: false'\
-          "\n" \
-          '      ```'\
-          "\n" \
-          '    </Callout>'
+          :description => <<~DESCRIPTION
+          If `true`, disables agent middleware for Sinatra. This middleware is responsible for advanced feature support such as [cross application tracing](/docs/apm/transactions/cross-application-traces/cross-application-tracing), [page load timing](/docs/browser/new-relic-browser/getting-started/new-relic-browser), and [error collection](/docs/apm/applications-menu/events/view-apm-error-analytics).
+
+              <Callout variant="important">
+                Cross application tracing is deprecated in favor of [distributed tracing](https://docs.newrelic.com/docs/apm/distributed-tracing/getting-started/introduction-distributed-tracing). Distributed tracing is on by default for Ruby agent versions 8.0.0 and above. Middlewares are not required to support distributed tracing.
+
+                To continue using cross application tracing, update the following options in your `newrelic.yml` configuration file:
+
+                ```
+                # newrelic.yml
+
+                  cross_application_tracer:
+                    enabled: true
+                  distributed_tracing:
+                    enabled: false
+                ```
+              </Callout>
+          DESCRIPTION
         },
         :disable_view_instrumentation => {
           :default => false,

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -1404,11 +1404,11 @@ A list of error classes that the agent should ignore.
           :allowed_from_server => true,
           :dynamic_name => true,
           :description => <<-DESCRIPTION
-          A map of error classes to a list of messages. When an error of one of the classes specified here occurs, if its error message contains one of the strings corresponding to it here, that error will be ignored.
+A map of error classes to a list of messages. When an error of one of the classes specified here occurs, if its error message contains one of the strings corresponding to it here, that error will be ignored.
 
-            <Callout variant="caution">
-              This option can't be set via environment variable.
-            </Callout>
+  <Callout variant="caution">
+    This option can't be set via environment variable.
+  </Callout>
           DESCRIPTION
         },
         :'error_collector.ignore_status_codes' => {
@@ -1426,11 +1426,11 @@ A list of error classes that the agent should ignore.
           :allowed_from_server => true,
           :dynamic_name => true,
           :description => <<-DESCRIPTION
-          A list of error classes that the agent should treat as expected.
+A list of error classes that the agent should treat as expected.
 
-            <Callout variant="caution">
-              This option can't be set via environment variable.
-            </Callout>
+  <Callout variant="caution">
+    This option can't be set via environment variable.
+  </Callout>
           DESCRIPTION
         },
         :'error_collector.expected_messages' => {
@@ -1440,11 +1440,11 @@ A list of error classes that the agent should ignore.
           :allowed_from_server => true,
           :dynamic_name => true,
           :description => <<-DESCRIPTION
-          A map of error classes to a list of messages. When an error of one of the classes specified here occurs, if its error message contains one of the strings corresponding to it here, that error will be treated as expected.
+A map of error classes to a list of messages. When an error of one of the classes specified here occurs, if its error message contains one of the strings corresponding to it here, that error will be treated as expected.
 
-            <Callout variant="caution">
-              This option can't be set via environment variable.
-            </Callout>
+  <Callout variant="caution">
+    This option can't be set via environment variable.
+  </Callout>
           DESCRIPTION
         },
         :'error_collector.expected_status_codes' => {

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -333,6 +333,7 @@ module NewRelic
         },
         :agent_enabled => {
           :default => DefaultSource.agent_enabled,
+          :documentation_default => true,
           :public => true,
           :type => Boolean,
           :allowed_from_server => false,
@@ -364,6 +365,7 @@ module NewRelic
         },
         :monitor_mode => {
           :default => value_of(:enabled),
+          :documentation_default => true,
           :public => true,
           :type => Boolean,
           :allowed_from_server => false,
@@ -543,6 +545,7 @@ module NewRelic
         },
         :'strip_exception_messages.enabled' => {
           :default => value_of(:high_security),
+          :documentation_default => false,
           :public => true,
           :type => Boolean,
           :allowed_from_server => false,
@@ -760,6 +763,7 @@ module NewRelic
         },
         :'audit_log.path' => {
           :default => DefaultSource.audit_log_path,
+          :documentation_default => 'config/newrelic_audit.log',
           :public => true,
           :type => String,
           :allowed_from_server => false,
@@ -867,6 +871,7 @@ module NewRelic
         },
         :disable_activerecord_instrumentation => {
           :default => value_of(:skip_ar_instrumentation),
+          :documentation_default => false,
           :public => true,
           :type => Boolean,
           :allowed_from_server => false,
@@ -890,6 +895,7 @@ module NewRelic
         },
         :'instrumentation.net_http' => {
           :default => instrumentation_value_of(:disable_net_http, :prepend_net_instrumentation),
+          :documentation_default => 'auto',
           :public => true,
           :type => String,
           :dynamic_name => true,
@@ -898,6 +904,7 @@ module NewRelic
         },
         :'instrumentation.typhoeus' => {
           :default => instrumentation_value_of(:disable_typhoeus),
+          :documentation_default => 'auto',
           :public => true,
           :type => String,
           :dynamic_name => true,
@@ -906,6 +913,7 @@ module NewRelic
         },
         :'instrumentation.bunny' => {
           :default => instrumentation_value_of(:disable_bunny),
+          :documentation_default => 'auto',
           :public => true,
           :type => String,
           :dynamic_name => true,
@@ -914,6 +922,7 @@ module NewRelic
         },
         :'instrumentation.httprb' => {
           :default => instrumentation_value_of(:disable_httprb),
+          :documentation_default => 'auto',
           :public => true,
           :type => String,
           :dynamic_name => true,
@@ -922,6 +931,7 @@ module NewRelic
         },
         :'instrumentation.resque' => {
           :default => instrumentation_value_of(:disable_resque),
+          :documentation_default => 'auto',
           :public => true,
           :type => String,
           :dynamic_name => true,
@@ -930,6 +940,7 @@ module NewRelic
         },
         :'instrumentation.redis' => {
           :default => instrumentation_value_of(:disable_redis),
+          :documentation_default => 'auto',
           :public => true,
           :type => String,
           :dynamic_name => true,
@@ -938,6 +949,7 @@ module NewRelic
         },
         :'instrumentation.rake' => {
           :default => instrumentation_value_of(:disable_rake),
+          :documentation_default => 'auto',
           :public => :true,
           :type => String,
           :dynamic_name => true,
@@ -946,6 +958,7 @@ module NewRelic
         },
         :'instrumentation.mongo' => {
           :default => instrumentation_value_of(:disable_mongo),
+          :documentation_default => 'enabled',
           :public => :true,
           :type => String,
           :dynamic_name => true,
@@ -954,6 +967,7 @@ module NewRelic
         },
         :'instrumentation.delayed_job' => {
           :default => instrumentation_value_of(:disable_dj),
+          :documentation_default => 'auto',
           :public => true,
           :type => String,
           :dynamic_name => true,
@@ -962,6 +976,7 @@ module NewRelic
         },
         :'instrumentation.httpclient' => {
           :default => instrumentation_value_of(:disable_httpclient),
+          :documentation_default => 'auto',
           :public => true,
           :type => String,
           :dynamic_name => true,
@@ -970,6 +985,7 @@ module NewRelic
         },
         :'instrumentation.curb' => {
           :default => instrumentation_value_of(:disable_curb),
+          :documentation_default => 'auto',
           :public => true,
           :type => String,
           :dynamic_name => true,
@@ -978,6 +994,7 @@ module NewRelic
         },
         :'instrumentation.sinatra' => {
           :default => instrumentation_value_of(:disable_sinatra),
+          :documentation_default => 'auto',
           :public => :true,
           :type => String,
           :dynamic_name => true,
@@ -986,6 +1003,7 @@ module NewRelic
         },
         :'instrumentation.rack' => {
           :default => instrumentation_value_of(:disable_rack),
+          :documentation_default => 'auto',
           :public => true,
           :type => String,
           :dynamic_name => true,
@@ -996,6 +1014,7 @@ module NewRelic
         },
         :'instrumentation.rack_urlmap' => {
           :default => instrumentation_value_of(:disable_rack_urlmap),
+          :documentation_default => 'auto',
           :public => true,
           :type => String,
           :dynamic_name => true,
@@ -1004,6 +1023,7 @@ module NewRelic
         },
         :'instrumentation.puma_rack' => {
           :default => instrumentation_value_of(:disable_puma_rack), # TODO: change to value_of(:'instrumentation.rack') when we remove :disable_puma_rack in 8.0)
+          :documentation_default => 'auto',
           :public => true,
           :type => String,
           :dynamic_name => true,
@@ -1014,6 +1034,7 @@ module NewRelic
         },
         :'instrumentation.puma_rack_urlmap' => {
           :default => instrumentation_value_of(:disable_puma_rack_urlmap), # TODO: change to value_of(:'instrumentation.rack_urlmap') when we remove :disable_puma_rack_urlmap in 8.0)
+          :documentation_default => 'auto',
           :public => true,
           :type => String,
           :dynamic_name => true,
@@ -1022,6 +1043,7 @@ module NewRelic
         },
         :'instrumentation.memcached' => {
           :default => instrumentation_value_of(:disable_memcached),
+          :documentation_default => 'auto',
           :public => true,
           :type => String,
           :dynamic_name => true,
@@ -1030,6 +1052,7 @@ module NewRelic
         },
         :'instrumentation.memcache_client' => {
           :default => instrumentation_value_of(:disable_memcache_client),
+          :documentation_default => 'auto',
           :public => true,
           :type => String,
           :dynamic_name => true,
@@ -1038,6 +1061,7 @@ module NewRelic
         },
         :'instrumentation.memcache' => {
           :default => instrumentation_value_of(:disable_dalli),
+          :documentation_default => 'auto',
           :public => true,
           :type => String,
           :dynamic_name => true,
@@ -1046,6 +1070,7 @@ module NewRelic
         },
         :'instrumentation.logger' => {
           :default => instrumentation_value_from_boolean(:'application_logging.enabled'),
+          :documentation_default => 'auto',
           :public => true,
           :type => String,
           :dynamic_name => true,
@@ -1093,6 +1118,7 @@ module NewRelic
         },
         :disable_memcached => {
           :default => value_of(:disable_memcache_instrumentation),
+          :documentation_default => false,
           :public => true,
           :type => Boolean,
           :deprecated => true,
@@ -1101,6 +1127,7 @@ module NewRelic
         },
         :disable_memcache_client => {
           :default => value_of(:disable_memcache_instrumentation),
+          :documentation_default => false,
           :public => true,
           :type => Boolean,
           :deprecated => true,
@@ -1109,6 +1136,7 @@ module NewRelic
         },
         :disable_dalli => {
           :default => value_of(:disable_memcache_instrumentation),
+          :documentation_default => false,
           :public => true,
           :type => Boolean,
           :deprecated => true,
@@ -1117,6 +1145,7 @@ module NewRelic
         },
         :disable_dalli_cas_client => {
           :default => value_of(:disable_memcache_instrumentation),
+          :documentation_default => false,
           :public => true,
           :type => Boolean,
           :deprecated => true,
@@ -1290,6 +1319,7 @@ module NewRelic
         },
         :'slow_sql.enabled' => {
           :default => value_of(:'transaction_tracer.enabled'),
+          :documentation_default => true,
           :public => true,
           :type => Boolean,
           :allowed_from_server => true,
@@ -1297,6 +1327,7 @@ module NewRelic
         },
         :'slow_sql.explain_threshold' => {
           :default => value_of(:'transaction_tracer.explain_threshold'),
+          :documentation_default => 0.5,
           :public => true,
           :type => Float,
           :allowed_from_server => true,
@@ -1304,6 +1335,7 @@ module NewRelic
         },
         :'slow_sql.explain_enabled' => {
           :default => value_of(:'transaction_tracer.explain_enabled'),
+          :documentation_default => true,
           :public => true,
           :type => Boolean,
           :allowed_from_server => true,
@@ -1311,6 +1343,7 @@ module NewRelic
         },
         :'slow_sql.record_sql' => {
           :default => value_of(:'transaction_tracer.record_sql'),
+          :documentation_default => 'obfuscated',
           :public => true,
           :type => String,
           :allowed_from_server => true,
@@ -1453,6 +1486,7 @@ module NewRelic
         },
         :'error_collector.capture_events' => {
           :default => value_of(:'error_collector.enabled'),
+          :documentation_default => true,
           :public => true,
           :type => Boolean,
           :allowed_from_server => true,
@@ -1510,6 +1544,7 @@ module NewRelic
         },
         :'browser_monitoring.auto_instrument' => {
           :default => value_of(:'rum.enabled'),
+          :documentation_default => true,
           :public => true,
           :type => Boolean,
           :allowed_from_server => true,
@@ -1610,6 +1645,7 @@ module NewRelic
         },
         :'thread_profiler.enabled' => {
           :default => DefaultSource.thread_profiler_enabled,
+          :documentation_default => false,
           :public => true,
           :type => Boolean,
           :allowed_from_server => true,
@@ -1647,6 +1683,7 @@ module NewRelic
         },
         :'transaction_events.enabled' => {
           :default => value_of(:'analytics_events.enabled'),
+          :documentation_default => true,
           :public => true,
           :type => Boolean,
           :allowed_from_server => true,
@@ -1654,6 +1691,7 @@ module NewRelic
         },
         :'transaction_events.max_samples_stored' => {
           :default => value_of(:'analytics_events.max_samples_stored'),
+          :documentation_default => 1200,
           :public => true,
           :type => Integer,
           :allowed_from_server => true,
@@ -1757,6 +1795,7 @@ module NewRelic
         },
         :'instrumentation.excon' => {
           :default => instrumentation_value_of(:disable_excon),
+          :documentation_default => 'enabled',
           :public => :true,
           :type => String,
           :dynamic_name => true,
@@ -1802,6 +1841,7 @@ module NewRelic
         },
         :disable_puma_rack => {
           :default => value_of(:disable_rack),
+          :documentation_default => false,
           :public => true,
           :type => Boolean,
           :dynamic_name => true,
@@ -1811,6 +1851,7 @@ module NewRelic
         },
         :disable_puma_rack_urlmap => {
           :default => value_of(:disable_rack_urlmap),
+          :documentation_default => false,
           :public => true,
           :type => Boolean,
           :dynamic_name => true,
@@ -1976,6 +2017,7 @@ module NewRelic
         },
         :'instrumentation.active_support_logger' => {
           :default => instrumentation_value_from_boolean(:'application_logging.enabled'),
+          :documentation_default => 'auto',
           :dynamic_name => true,
           :public => true,
           :type => String,
@@ -2002,6 +2044,7 @@ module NewRelic
         },
         :'instrumentation.grape' => {
           :default => instrumentation_value_of(:disable_grape_instrumentation),
+          :documentation_default => 'auto',
           :public => :true,
           :type => String,
           :dynamic_name => true,
@@ -2017,6 +2060,7 @@ module NewRelic
         },
         :'transaction_tracer.attributes.enabled' => {
           :default => value_of(:'transaction_tracer.capture_attributes'),
+          :documentation_default => true,
           :public => true,
           :type => Boolean,
           :allowed_from_server => false,
@@ -2024,6 +2068,7 @@ module NewRelic
         },
         :'transaction_events.attributes.enabled' => {
           :default => value_of(:'analytics_events.capture_attributes'),
+          :documentation_default => true,
           :public => true,
           :type => Boolean,
           :allowed_from_server => false,
@@ -2031,6 +2076,7 @@ module NewRelic
         },
         :'error_collector.attributes.enabled' => {
           :default => value_of(:'error_collector.capture_attributes'),
+          :documentation_default => true,
           :public => true,
           :type => Boolean,
           :allowed_from_server => false,
@@ -2038,6 +2084,7 @@ module NewRelic
         },
         :'browser_monitoring.attributes.enabled' => {
           :default => value_of(:'browser_monitoring.capture_attributes'),
+          :documentation_default => false,
           :public => true,
           :type => Boolean,
           :allowed_from_server => false,

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -438,12 +438,12 @@ module NewRelic
           :public => true,
           :type => Boolean,
           :allowed_from_server => false,
-          :description => <<~DESCRIPTION
-          When `true`, the agent captures HTTP request parameters and attaches them to transaction traces, traced errors, and [`TransactionError` events](/attribute-dictionary?attribute_name=&events_tids%5B%5D=8241).
+          :description => <<-DESCRIPTION
+When `true`, the agent captures HTTP request parameters and attaches them to transaction traces, traced errors, and [`TransactionError` events](/attribute-dictionary?attribute_name=&events_tids%5B%5D=8241).
 
-              <Callout variant="caution">
-                When using the `capture_params` setting, the Ruby agent will not attempt to filter secret information. <b>Recommendation:</b> To filter secret information from request parameters, use the [`attributes.include` setting](/docs/agents/ruby-agent/attributes/enable-disable-attributes-ruby) instead. For more information, see the <a href="/docs/agents/ruby-agent/attributes/ruby-attribute-examples#ex_req_params">Ruby attribute examples</a>.
-              </Callout>
+    <Callout variant="caution">
+      When using the `capture_params` setting, the Ruby agent will not attempt to filter secret information. <b>Recommendation:</b> To filter secret information from request parameters, use the [`attributes.include` setting](/docs/agents/ruby-agent/attributes/enable-disable-attributes-ruby) instead. For more information, see the <a href="/docs/agents/ruby-agent/attributes/ruby-attribute-examples#ex_req_params">Ruby attribute examples</a>.
+    </Callout>
           DESCRIPTION
         },
         :config_path => {
@@ -812,23 +812,23 @@ module NewRelic
           :public => true,
           :type => Boolean,
           :allowed_from_server => false,
-          :description => <<~DESCRIPTION
-          If `true`, disables agent middleware for Sinatra. This middleware is responsible for advanced feature support such as [cross application tracing](/docs/apm/transactions/cross-application-traces/cross-application-tracing), [page load timing](/docs/browser/new-relic-browser/getting-started/new-relic-browser), and [error collection](/docs/apm/applications-menu/events/view-apm-error-analytics).
+          :description => <<-DESCRIPTION
+If `true`, disables agent middleware for Sinatra. This middleware is responsible for advanced feature support such as [cross application tracing](/docs/apm/transactions/cross-application-traces/cross-application-tracing), [page load timing](/docs/browser/new-relic-browser/getting-started/new-relic-browser), and [error collection](/docs/apm/applications-menu/events/view-apm-error-analytics).
 
-              <Callout variant="important">
-                Cross application tracing is deprecated in favor of [distributed tracing](https://docs.newrelic.com/docs/apm/distributed-tracing/getting-started/introduction-distributed-tracing). Distributed tracing is on by default for Ruby agent versions 8.0.0 and above. Middlewares are not required to support distributed tracing.
+    <Callout variant="important">
+      Cross application tracing is deprecated in favor of [distributed tracing](https://docs.newrelic.com/docs/apm/distributed-tracing/getting-started/introduction-distributed-tracing). Distributed tracing is on by default for Ruby agent versions 8.0.0 and above. Middlewares are not required to support distributed tracing.
 
-                To continue using cross application tracing, update the following options in your `newrelic.yml` configuration file:
+      To continue using cross application tracing, update the following options in your `newrelic.yml` configuration file:
 
-                ```
-                # newrelic.yml
+      ```
+      # newrelic.yml
 
-                  cross_application_tracer:
-                    enabled: true
-                  distributed_tracing:
-                    enabled: false
-                ```
-              </Callout>
+        cross_application_tracer:
+          enabled: true
+        distributed_tracing:
+          enabled: false
+      ```
+    </Callout>
           DESCRIPTION
         },
         :disable_view_instrumentation => {
@@ -1375,12 +1375,12 @@ module NewRelic
           :deprecated => true,
           :allowed_from_server => true,
           :dynamic_name => true,
-          :description => <<~DESCRIPTION
-          Use `error_collector.ignore_classes` instead. Specify a comma-delimited list of error classes that the agent should ignore.
+          :description => <<-DESCRIPTION
+Use `error_collector.ignore_classes` instead. Specify a comma-delimited list of error classes that the agent should ignore.
 
-              <Callout variant="caution">
-                Server side configuration takes precedence for this setting over all environment configurations. This differs from all other configuration settings where environment variable take precedence over server side configuration.
-              </Callout>
+    <Callout variant="caution">
+      Server side configuration takes precedence for this setting over all environment configurations. This differs from all other configuration settings where environment variable take precedence over server side configuration.
+    </Callout>
           DESCRIPTION
         },
         :'error_collector.ignore_classes' => {
@@ -1389,12 +1389,12 @@ module NewRelic
           :type => Array,
           :allowed_from_server => true,
           :dynamic_name => true,
-          :description => <<~DESCRIPTION
-          A list of error classes that the agent should ignore.
+          :description => <<-DESCRIPTION
+A list of error classes that the agent should ignore.
 
-            <Callout variant="caution">
-              This option can't be set via environment variable.
-            </Callout>
+  <Callout variant="caution">
+    This option can't be set via environment variable.
+  </Callout>
           DESCRIPTION
         },
         :'error_collector.ignore_messages' => {

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -1403,7 +1403,7 @@ A list of error classes that the agent should ignore.
           :type => Hash,
           :allowed_from_server => true,
           :dynamic_name => true,
-          :description => <<~DESCRIPTION
+          :description => <<-DESCRIPTION
           A map of error classes to a list of messages. When an error of one of the classes specified here occurs, if its error message contains one of the strings corresponding to it here, that error will be ignored.
 
             <Callout variant="caution">
@@ -1425,7 +1425,7 @@ A list of error classes that the agent should ignore.
           :type => Array,
           :allowed_from_server => true,
           :dynamic_name => true,
-          :description => <<~DESCRIPTION
+          :description => <<-DESCRIPTION
           A list of error classes that the agent should treat as expected.
 
             <Callout variant="caution">
@@ -1439,7 +1439,7 @@ A list of error classes that the agent should ignore.
           :type => Hash,
           :allowed_from_server => true,
           :dynamic_name => true,
-          :description => <<~DESCRIPTION
+          :description => <<-DESCRIPTION
           A map of error classes to a list of messages. When an error of one of the classes specified here occurs, if its error message contains one of the strings corresponding to it here, that error will be treated as expected.
 
             <Callout variant="caution">

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -438,21 +438,13 @@ module NewRelic
           :public => true,
           :type => Boolean,
           :allowed_from_server => false,
-          :description => 'When `true`, the agent captures HTTP request parameters ' \
-            'and attaches them to transaction traces, traced errors, and ' \
-            '[`TransactionError` events](/attribute-dictionary?attribute_name=&events_tids%5B%5D=8241).'\
-            "\n" \
-            "\n" \
-            '    <Callout variant="caution">' \
-            "\n" \
-            '      When using the `capture_params` setting, the Ruby agent will not attempt ' \
-            'to filter secret information. <b>Recommendation:</b> To filter secret information from ' \
-            'request parameters, use the [`attributes.include` setting](/docs/agents/ruby-agent/attributes/enable-disable-attributes-ruby) ' \
-            'instead. For more information, see the ' \
-            '<a href="/docs/agents/ruby-agent/attributes/ruby-attribute-examples#ex_req_params">' \
-            'Ruby attribute examples</a>.' \
-            "\n" \
-            '    </Callout>'
+          :description => <<~DESCRIPTION
+          When `true`, the agent captures HTTP request parameters and attaches them to transaction traces, traced errors, and [`TransactionError` events](/attribute-dictionary?attribute_name=&events_tids%5B%5D=8241).
+
+              <Callout variant="caution">
+                When using the `capture_params` setting, the Ruby agent will not attempt to filter secret information. <b>Recommendation:</b> To filter secret information from request parameters, use the [`attributes.include` setting](/docs/agents/ruby-agent/attributes/enable-disable-attributes-ruby) instead. For more information, see the <a href="/docs/agents/ruby-agent/attributes/ruby-attribute-examples#ex_req_params">Ruby attribute examples</a>.
+              </Callout>
+          DESCRIPTION
         },
         :config_path => {
           :default => DefaultSource.config_path,
@@ -1383,14 +1375,13 @@ module NewRelic
           :deprecated => true,
           :allowed_from_server => true,
           :dynamic_name => true,
-          :description => 'Use `error_collector.ignore_classes` instead. Specify a comma-delimited list of error classes that the agent should ignore.' \
-          "\n" \
-          "\n" \
-          '    <Callout variant="caution">' \
-          "\n" \
-          '      Server side configuration takes precedence for this setting over all environment configurations. This differs from all other configuration settings where environment variable take precedence over server side configuration.'\
-          "\n" \
-          '    </Callout>'
+          :description => <<~DESCRIPTION
+          Use `error_collector.ignore_classes` instead. Specify a comma-delimited list of error classes that the agent should ignore.
+
+              <Callout variant="caution">
+                Server side configuration takes precedence for this setting over all environment configurations. This differs from all other configuration settings where environment variable take precedence over server side configuration.
+              </Callout>
+          DESCRIPTION
         },
         :'error_collector.ignore_classes' => {
           :default => [],
@@ -1398,14 +1389,13 @@ module NewRelic
           :type => Array,
           :allowed_from_server => true,
           :dynamic_name => true,
-          :description => 'A list of error classes that the agent should ignore.' \
-          "\n" \
-          "\n" \
-          '  <Callout variant="caution">' \
-          "\n" \
-          '    This option can\'t be set via environment variable.'\
-          "\n" \
-          '  </Callout>'
+          :description => <<~DESCRIPTION
+          A list of error classes that the agent should ignore.
+
+            <Callout variant="caution">
+              This option can't be set via environment variable.
+            </Callout>
+          DESCRIPTION
         },
         :'error_collector.ignore_messages' => {
           :default => {},
@@ -1413,14 +1403,13 @@ module NewRelic
           :type => Hash,
           :allowed_from_server => true,
           :dynamic_name => true,
-          :description => 'A map of error classes to a list of messages. When an error of one of the classes specified here occurs, if its error message contains one of the strings corresponding to it here, that error will be ignored.' \
-          "\n" \
-          "\n" \
-          '  <Callout variant="caution">' \
-          "\n" \
-          '    This option can\'t be set via environment variable.'\
-          "\n" \
-          '  </Callout>'
+          :description => <<~DESCRIPTION
+          A map of error classes to a list of messages. When an error of one of the classes specified here occurs, if its error message contains one of the strings corresponding to it here, that error will be ignored.
+
+            <Callout variant="caution">
+              This option can't be set via environment variable.
+            </Callout>
+          DESCRIPTION
         },
         :'error_collector.ignore_status_codes' => {
           :default => '',
@@ -1436,14 +1425,13 @@ module NewRelic
           :type => Array,
           :allowed_from_server => true,
           :dynamic_name => true,
-          :description => 'A list of error classes that the agent should treat as expected.' \
-          "\n" \
-          "\n" \
-          '  <Callout variant="caution">' \
-          "\n" \
-          '    This option can\'t be set via environment variable.'\
-          "\n" \
-          '  </Callout>'
+          :description => <<~DESCRIPTION
+          A list of error classes that the agent should treat as expected.
+
+            <Callout variant="caution">
+              This option can't be set via environment variable.
+            </Callout>
+          DESCRIPTION
         },
         :'error_collector.expected_messages' => {
           :default => {},
@@ -1451,14 +1439,13 @@ module NewRelic
           :type => Hash,
           :allowed_from_server => true,
           :dynamic_name => true,
-          :description => 'A map of error classes to a list of messages. When an error of one of the classes specified here occurs, if its error message contains one of the strings corresponding to it here, that error will be treated as expected.' \
-          "\n" \
-          "\n" \
-          '  <Callout variant="caution">' \
-          "\n" \
-          '    This option can\'t be set via environment variable.'\
-          "\n" \
-          '  </Callout>'
+          :description => <<~DESCRIPTION
+          A map of error classes to a list of messages. When an error of one of the classes specified here occurs, if its error message contains one of the strings corresponding to it here, that error will be treated as expected.
+
+            <Callout variant="caution">
+              This option can't be set via environment variable.
+            </Callout>
+          DESCRIPTION
         },
         :'error_collector.expected_status_codes' => {
           :default => '',

--- a/lib/tasks/config.rake
+++ b/lib/tasks/config.rake
@@ -111,7 +111,7 @@ namespace :newrelic do
     def format_default_value(spec)
       return spec[:documentation_default] if !spec[:documentation_default].nil?
       if spec[:default].is_a?(Proc)
-        return '(Dynamic)'
+        '(Dynamic)'
       else
         "#{spec[:default].inspect}"
       end

--- a/lib/tasks/config.rake
+++ b/lib/tasks/config.rake
@@ -20,7 +20,8 @@ namespace :newrelic do
     }
 
     NAME_OVERRIDES = {
-      "slow_sql" => "Slow SQL"
+      "slow_sql" => "Slow SQL",
+      "custom_insights_events" => "Custom Events"
     }
 
     def output(format)
@@ -52,7 +53,7 @@ namespace :newrelic do
           :key => key,
           :type => format_type(value[:type]),
           :description => format_description(value),
-          :default => format_default_value(value, key),
+          :default => format_default_value(value),
           :env_var => format_env_var(key)
         }
       end
@@ -107,20 +108,13 @@ namespace :newrelic do
       description
     end
 
-    def format_default_value(spec, key)
+    def format_default_value(spec)
+      return spec[:documentation_default] if !spec[:documentation_default].nil?
       if spec[:default].is_a?(Proc)
-        return '(Dynamic)' unless default_value_auto?(key)
-        '"auto"'
+        return '(Dynamic)'
       else
         "#{spec[:default].inspect}"
       end
-    end
-
-    # currently the only 'instrumentation.XXXX' configs that
-    # do not use a default of auto are mongo and excon
-    def default_value_auto?(key)
-      return false if key.match(/mongo/) || key.match(/excon/)
-      key.match(/^instrumentation/)
     end
 
     def format_env_var(key)


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
I updated a bunch of wordings and other things that were changed on the docs site so that we are matching that.
I also updated the config rake task to allow grouping for config options with more than 2 parts (ex: `application_logging.forwarding.enabled`). 
I also updated the script to use `documentation_default` from the default_source configs if that field is present. 

# Related Github Issue
 #810

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
Github Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
