### PR TITLE
tests: don't install 'memcached' for Ruby 3.2

### DIFF
--- a/test/multiverse/suites/memcache/Envfile
+++ b/test/multiverse/suites/memcache/Envfile
@@ -20,7 +20,7 @@ end
   RB
 end
 
-unless RUBY_PLATFORM == 'java'
+unless RUBY_PLATFORM == 'java' || RUBY_VERSION >= '3.2.0'
   gemfile <<-RB
     gem 'memcached', '~> 1.8.0'
   RB


### PR DESCRIPTION
for memcached tests, don't bother to install the 'memcached' gem for
Ruby 3.2. we can likely discard this gem entirely in future, but for now
we'll scope the removal to Ruby 3.2 to avoid gem build issues.
