### PR TITLE
pipe service: address Ruby 3.2 warning

### DIFF
--- a/lib/new_relic/agent/pipe_service.rb
+++ b/lib/new_relic/agent/pipe_service.rb
@@ -10,8 +10,7 @@ module NewRelic
 
       def initialize(channel_id)
         @channel_id = channel_id
-        @collector = NewRelic::Control::Server.new(:name => 'parent',
-          :port => 0)
+        @collector = NewRelic::Control::Server.new({name: 'parent', port: 0})
         @pipe = NewRelic::Agent::PipeChannelManager.channels[@channel_id]
         if @pipe && @pipe.parent_pid != $$
           @pipe.after_fork_in_child


### PR DESCRIPTION
Pipe service - address the Ruby 3.2 `Struct#initialize` warning

> warning: Passing only keyword arguments to Struct#initialize will behave differently from Ruby 3.2. Please use a Hash literal like .new({k: v}) instead of .new(k: v).