### PR TITLE
config tests: update FakeFS usage for Ruby 3.2+

### DIFF
--- a/test/multiverse/suites/config_file_loading/Envfile
+++ b/test/multiverse/suites/config_file_loading/Envfile
@@ -1,9 +1,15 @@
 omit_collector!
 
+fakefs_require = RUBY_VERSION >= '3.2.0' ? false : 'fakefs/safe'
+
 gemfile <<-RB
   # stub file system so we can test that newrelic.yml can be loaded from
   # various places.
-  gem 'fakefs', '0.5.4', :require => 'fakefs/safe' # 0.5.4 required for 1.8.7 compatibility.
+  if RUBY_VERSION >= '2.4.0'
+    gem 'fakefs', '1.4.1', :require => false
+  else
+    gem 'fakefs', '0.5.4', :require => false # 0.5.4 required for 1.8.7 compatibility.
+  end
 
   # Because we delay the agent, order of jruby-openssl matters
   gem 'jruby-openssl', '~> 0.11.0', :platforms => [:jruby]
@@ -19,7 +25,11 @@ RB
 gemfile <<-RB
   # stub file system so we can test that newrelic.yml can be loaded from
   # various places.
-  gem 'fakefs', '0.5.4', :require => 'fakefs/safe' # 0.5.4 required for 1.8.7 compatibility.
+  if RUBY_VERSION >= '2.4.0'
+    gem 'fakefs', '1.4.1', :require => false
+  else
+    gem 'fakefs', '0.5.4', :require => false # 0.5.4 required for 1.8.7 compatibility.
+  end
 
   # Because we delay the agent, order of jruby-openssl matters
   gem 'jruby-openssl', '~> 0.11.0', :platforms => [:jruby]

--- a/test/multiverse/suites/config_file_loading/Envfile
+++ b/test/multiverse/suites/config_file_loading/Envfile
@@ -1,7 +1,5 @@
 omit_collector!
 
-fakefs_require = RUBY_VERSION >= '3.2.0' ? false : 'fakefs/safe'
-
 gemfile <<-RB
   # stub file system so we can test that newrelic.yml can be loaded from
   # various places.

--- a/test/multiverse/suites/config_file_loading/config_file_loading_test.rb
+++ b/test/multiverse/suites/config_file_loading/config_file_loading_test.rb
@@ -35,6 +35,13 @@ class ConfigFileLoadingTest < Minitest::Test
     # require the agent before we're in FakeFS so require doesn't hit the fake
     require 'newrelic_rpm'
 
+    # We defer the requiring of FakeFS until here to prevent it from causing
+    # issues with FileUtils calls being made by 3rd parties (Bundler, Rake,
+    # etc.) before this file is loaded.
+    # See #Caveats here: https://github.com/fakefs/fakefs/commit/11e80d2ec36e6f8a89e090fad29be69e20aa337d
+    require 'fakefs'
+    require 'fakefs/safe'
+
     # Use a fake file system so we don't damage the real one.
     FakeFS.activate!
     FakeFS::FileSystem.clear


### PR DESCRIPTION
These changes get the config file tests working with Ruby 3.2+

* For Ruby v2.4.0+ (lowest version supported), start using the latest
  version of FakeFS, v1.4.1
* For all Rubies, don't allow Bundler to require FakeFS when `Envfile`
  gets processed. This prevents a known collision issue with `FileUtils`
  that the FakeFS README lists under "Caveats".
