### PR TITLE
delayed job tests: use a newer sqlite3 version

### DIFF
--- a/test/multiverse/suites/delayed_job/Envfile
+++ b/test/multiverse/suites/delayed_job/Envfile
@@ -5,7 +5,7 @@ boilerplate_gems = <<-SQLITE
   if RUBY_PLATFORM == 'java'
     gem 'activerecord-jdbcsqlite3-adapter', "~> 60.4"
   else
-    gem 'sqlite3', '~> 1.3.13'
+    gem 'sqlite3', '~> 1.4.2'
   end
 SQLITE
 

--- a/test/multiverse/suites/delayed_job/Envfile
+++ b/test/multiverse/suites/delayed_job/Envfile
@@ -4,8 +4,10 @@ boilerplate_gems = <<-SQLITE
   gem 'rack'
   if RUBY_PLATFORM == 'java'
     gem 'activerecord-jdbcsqlite3-adapter', "~> 60.4"
-  else
+  elsif RUBY_VERSION >= '2.5.0'
     gem 'sqlite3', '~> 1.4.2'
+  else
+    gem 'sqlite3', '~> 1.3.13'
   end
 SQLITE
 


### PR DESCRIPTION
for the delayed job tests, use sqlite3 v1.4.2 instead of v1.3.13

this addresses a compilation issue with Ruby 3.2 and the new version
should be backwards compatible with older Rubies as well.
