### PR TITLE
CI: upgrade CRubies for CVE-2022-28739

### DIFF
--- a/.github/actions/build-ruby/action.yml
+++ b/.github/actions/build-ruby/action.yml
@@ -5,7 +5,7 @@ inputs:
   ruby-version:
     description: 'Ruby version'
     required: true
-    default: '2.7.5'
+    default: '2.7.6'
   dependencies:
     description: 'A list of ubuntu package names to install'
     required: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        ruby-version: [2.2.10, 2.3.8, 2.4.10, 2.5.9, 2.6.9, 2.7.5, 3.0.3, 3.1.0, jruby-9.3.4.0]
+        ruby-version: [2.2.10, 2.3.8, 2.4.10, 2.5.9, 2.6.10, 2.7.6, 3.0.4, 3.1.2, jruby-9.3.4.0]
     steps:
       - uses: actions/checkout@v2
 
@@ -49,7 +49,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: [2.2.10, 2.3.8, 2.4.10, 2.5.9, 2.6.9, 2.7.5, 3.0.3, 3.1.0, jruby-9.3.4.0]
+        ruby-version: [2.2.10, 2.3.8, 2.4.10, 2.5.9, 2.6.10, 2.7.6, 3.0.4, 3.1.2, jruby-9.3.4.0]
 
     steps:
       - uses: actions/checkout@v2
@@ -77,16 +77,16 @@ jobs:
               "2.5.9": {
                 "rails": "norails,rails61,rails60,rails52,rails51,rails42,rails32"
               },
-              "2.6.9": {
+              "2.6.10": {
                 "rails": "norails,rails61,rails60,rails52,rails51,rails42"
               },
-              "2.7.5": {
+              "2.7.6": {
                 "rails": "norails,rails61,rails60,rails70"
               },
-              "3.0.3": {
+              "3.0.4": {
                 "rails": "norails,rails61,rails60,rails70"
               },
-              "3.1.0": {
+              "3.1.2": {
                 "rails": "norails,rails61,rails70"
               },
               "jruby-9.3.4.0": {
@@ -162,7 +162,7 @@ jobs:
       fail-fast: false
       matrix:
         multiverse: ["agent;background;background_2;database", "httpclients;httpclients_2", "frameworks;rails;rest"]
-        ruby-version: [2.2.10, 2.3.8, 2.4.10, 2.5.9, 2.6.9, 2.7.5, 3.0.3, 3.1.0]
+        ruby-version: [2.2.10, 2.3.8, 2.4.10, 2.5.9, 2.6.10, 2.7.6, 3.0.4, 3.1.2]
 
     steps:
       - uses: actions/checkout@v2
@@ -200,7 +200,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: [2.5.9, 2.6.9, 2.7.5, 3.0.3, 3.1.0]
+        ruby-version: [2.5.9, 2.6.10, 2.7.6, 3.0.4, 3.1.2]
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
Upgrade CRubies 2.6+ to their latest minor versions in order to address
[CVE-2022-28739](https://www.ruby-lang.org/en/news/2022/04/12/buffer-overrun-in-string-to-float-cve-2022-28739/)
which involes a String-to-Float conversion buffer overrun.

Versions 3.0.4 and 3.1.2 also deliver fixes for [CVE-2022-28738](https://www.ruby-lang.org/en/news/2022/04/12/double-free-in-regexp-compilation-cve-2022-28738/)