### PR TITLE
tests: assume Ruby 2.2.10+

### DIFF
--- a/test/environments/rails42/Gemfile
+++ b/test/environments/rails42/Gemfile
@@ -26,4 +26,3 @@ gem "newrelic_rpm", :path => "../../.."
 gem 'pry', '~> 0.12.2'
 gem 'pry-nav'
 gem 'hometown', '~> 0.2.5'
-gem 'nokogiri', '< 1.7' if RUBY_VERSION < '2.1.0' # nokogiri 1.7.0 only supports >= 2.1.0

--- a/test/multiverse/lib/multiverse/runner.rb
+++ b/test/multiverse/lib/multiverse/runner.rb
@@ -98,7 +98,7 @@ module Multiverse
     }
 
     # Would like to reinstate but requires investigation, see RUBY-1749
-    if RUBY_VERSION >= '2.1' and RUBY_VERSION < '2.3'
+    if RUBY_VERSION < '2.3'
       GROUPS['background_2'].delete 'rake'
     end
 
@@ -114,7 +114,7 @@ module Multiverse
     end
 
     def excluded?(suite)
-      return true if suite == 'rake' and RUBY_VERSION >= '2.1' and RUBY_VERSION < '2.3'
+      return true if suite == 'rake' and RUBY_VERSION < '2.3'
       return true if suite == 'agent_only' and RUBY_PLATFORM == "java"
       return true if suite == 'active_record' and RUBY_VERSION >= '3.0.0'
       return true if ["grape"].include?(suite) and RUBY_VERSION >= '3.0'

--- a/test/multiverse/lib/multiverse/suite.rb
+++ b/test/multiverse/lib/multiverse/suite.rb
@@ -251,8 +251,6 @@ module Multiverse
     end
 
     def generate_gemfile(gemfile_text, env_index, local = true)
-      pin_rack_version_if_needed(gemfile_text)
-
       gemfile = File.join(Dir.pwd, "Gemfile.#{env_index}")
       File.open(gemfile, 'w') do |f|
         f.puts 'source "https://rubygems.org"'
@@ -305,16 +303,6 @@ module Multiverse
       require 'minitest'
     rescue LoadError
       require 'minitest/unit'
-    end
-
-    # Rack 2.0 works with Ruby > 2.2.2. Earlier rubies need to pin
-    # their Rack version prior to 2.0
-    def pin_rack_version_if_needed gemfile_text
-      return if suite == "rack"
-      rx = /^\s*?gem\s*?('|")rack('|")\s*?$/
-      if gemfile_text =~ rx && RUBY_VERSION < "2.2.2"
-        gemfile_text.gsub! rx, 'gem "rack", "< 2.0.0"'
-      end
     end
 
     def print_environment

--- a/test/multiverse/suites/active_record/Envfile
+++ b/test/multiverse/suites/active_record/Envfile
@@ -9,7 +9,7 @@ boilerplate_gems = <<-BOILERPLATE
   gem 'rack'
 BOILERPLATE
 
-if RUBY_VERSION >= '2.2.2' && RUBY_PLATFORM == 'java'
+if RUBY_PLATFORM == 'java'
   mysql_vsn = '~> 0.4.4'
 
   gemfile <<-RB
@@ -32,9 +32,7 @@ if RUBY_VERSION >= '2.2.2' && RUBY_PLATFORM == 'java'
     gem 'activerecord-jdbcmysql-adapter', '~>50.0'
     #{boilerplate_gems}
   RB
-end
-
-if RUBY_VERSION >= '2.2.2' && RUBY_PLATFORM != 'java'
+else
   mysql_vsn = '~> 0.4.4'
 
   gemfile <<-RB

--- a/test/multiverse/suites/agent_only/Envfile
+++ b/test/multiverse/suites/agent_only/Envfile
@@ -1,8 +1,6 @@
-rack_test_version = RUBY_VERSION < "2.2.0" ? "< 0.8.0" : ">= 0.8.0"
-
 gemfile <<-RB
   gem 'minitest', '4.7.5'
   gem 'rack', '< 2.1.0'
-  gem 'rack-test', '#{rack_test_version}'
+  gem 'rack-test', '>= 0.8.0'
   #{ruby3_gem_webrick}
 RB

--- a/test/multiverse/suites/bunny/Envfile
+++ b/test/multiverse/suites/bunny/Envfile
@@ -4,13 +4,11 @@ end
 
 instrumentation_methods :chain, :prepend
 
-amq_protocol_version_str = RUBY_VERSION < "2.2.0" ? ", '< 2.3.0'" : ''
-
 if RUBY_VERSION >= '2.3'
   gemfile <<-RB
     gem 'rack'
     gem 'bunny', '~>2.19.0'
-    gem 'amq-protocol'#{amq_protocol_version_str}
+    gem 'amq-protocol'
     #{ruby3_gem_webrick}
   RB
 end
@@ -18,6 +16,6 @@ end
 gemfile <<-RB
   gem 'rack'
   gem 'bunny', '~>2.9.1'
-  gem 'amq-protocol'#{amq_protocol_version_str}
+  gem 'amq-protocol'
   #{ruby3_gem_webrick}
 RB

--- a/test/multiverse/suites/capistrano/Envfile
+++ b/test/multiverse/suites/capistrano/Envfile
@@ -7,8 +7,6 @@ boilerplate = <<-BOILERPLATE
   #{ruby3_gem_webrick}
 BOILERPLATE
 
-boilerplate += "gem 'i18n', '< 1.3'\n" if RUBY_VERSION < "2.1.0"
-
 gemfile <<-RB
   gem 'sshkit', '1.16.0'
   gem 'capistrano', '~>3.11.1'

--- a/test/multiverse/suites/capistrano2/Envfile
+++ b/test/multiverse/suites/capistrano2/Envfile
@@ -2,16 +2,8 @@ suite_condition("Capistrano testing is flaky on JRuby") do
   RUBY_PLATFORM != 'java'
 end
 
-if RUBY_VERSION >= '2.2'
-  gemfile <<-RB
-    gem 'capistrano', '~> 2.15.5'
-    gem 'rack'
-    #{ruby3_gem_webrick}
-  RB
-else
-  gemfile <<-RB
-    gem 'capistrano', '2.15.5'
-    gem 'rack'
-    #{ruby3_gem_webrick}
-  RB
-end
+gemfile <<-RB
+  gem 'capistrano', '~> 2.15.5'
+  gem 'rack'
+  #{ruby3_gem_webrick}
+RB

--- a/test/multiverse/suites/curb/Envfile
+++ b/test/multiverse/suites/curb/Envfile
@@ -39,7 +39,6 @@ gemfile <<-RB
 
   # We try translating URIs through Addressable if it's there, so test with it.
   gem 'addressable', :require => 'addressable/uri'
-  gem 'public_suffix', '< 3.0.0' if RUBY_VERSION < "2.1.0"
   #{ruby3_gem_webrick}
 RB
 
@@ -49,16 +48,3 @@ gemfile <<-RB
   gem 'json', :platforms => [:rbx, :mri_18]
   #{ruby3_gem_webrick}
 RB
-
-# Older curbs require older libcurl binaries!
-# We'll use 0.8.1 since this is known to compile and work
-# w/o issue on older versions of Ruby whereas 0.8.6 was 
-# reported to have issues.
-# NOTE: instrumentation looks for CURB_MIN_VERSION = '0.8.1'
-if RUBY_VERSION < "2.2.0" && curl_version < 7.41
-gemfile <<-RB
-  gem 'curb', '0.8.1'
-  gem 'rack'
-  gem 'json', :platforms => [:rbx, :mri_18]
-RB
-end

--- a/test/multiverse/suites/datamapper/Envfile
+++ b/test/multiverse/suites/datamapper/Envfile
@@ -14,26 +14,7 @@ gemfile <<-RB
   gem 'datamapper', '~> 1.2.0', :require => 'data_mapper'
   gem 'dm-ar-finders', '~> 1.2.0'
   gem 'addressable', :require => 'addressable/uri'
-  gem 'public_suffix', '< 3.0.0' if RUBY_VERSION < "2.1.0"
   #{adapter_gems}
 RB
-
-if RUBY_VERSION < '2.0.0'
-gemfile <<-RB
-  gem 'datamapper', '~> 1.1.0'
-  gem 'dm-ar-finders', '~> 1.1.0'
-  gem 'addressable', :require => 'addressable/uri'
-  gem 'public_suffix', '< 3.0.0' if RUBY_VERSION < "2.1.0"
-  #{adapter_gems}
-RB
-
-gemfile <<-RB
-  gem 'datamapper', '~> 1.0.2'
-  gem 'dm-ar-finders', '~> 1.0.2'
-  gem 'addressable', :require => 'addressable/uri'
-  gem 'public_suffix', '< 3.0.0' if RUBY_VERSION < "2.1.0"
-  #{adapter_gems}
-RB
-end
 
 # vim: ft=ruby

--- a/test/multiverse/suites/deferred_instrumentation/Envfile
+++ b/test/multiverse/suites/deferred_instrumentation/Envfile
@@ -1,16 +1,15 @@
-rack_test_version = RUBY_VERSION < "2.2.2" ? "< 0.8.0" : ">= 0.8.0"
 instrumentation_methods :chain, :prepend
 
 gemfile <<-RB
   gem 'sinatra', '~> 1.4.8', :require => false
-  gem 'rack-test', '#{rack_test_version}', :require => 'rack/test'
+  gem 'rack-test', '>= 0.8.0', :require => 'rack/test'
   #{ruby3_gem_webrick}
 RB
 
 if RUBY_VERSION >= '2.3.0'
   gemfile <<-RB
     gem 'sinatra', '~> 2.1.0', :require => false
-    gem 'rack-test', '#{rack_test_version}', :require => 'rack/test'
+    gem 'rack-test', '>= 0.8.0', :require => 'rack/test'
     #{ruby3_gem_webrick}
   RB
 end

--- a/test/multiverse/suites/delayed_job/Envfile
+++ b/test/multiverse/suites/delayed_job/Envfile
@@ -30,7 +30,7 @@ if RUBY_VERSION < '2.4.0'
   RB
 end
 
-if RUBY_VERSION >= '2.2.2' && RUBY_VERSION < '2.5.0' && RUBY_PLATFORM != 'java'
+if RUBY_VERSION < '2.5.0' && RUBY_PLATFORM != 'java'
   # delayed_job_active_record 4.1.2 drops support for Rails 3
   gemfile <<-RB
     gem 'delayed_job', '~> 4.1.4'

--- a/test/multiverse/suites/grape/Envfile
+++ b/test/multiverse/suites/grape/Envfile
@@ -6,19 +6,17 @@ if RUBY_VERSION >= '2.4.0'
   grape_versions << '~> 1.4.0'
   grape_versions << '~> 1.3.1'
 end
-if RUBY_VERSION >= '2.2.0' && !RUBY_PLATFORM.eql?('java')
+unless RUBY_PLATFORM.eql?('java')
   grape_versions << '1.2.3'
   grape_versions << '1.1.0'
   grape_versions << '0.19.2'
 end
 
-rack_test_version = RUBY_VERSION < "2.2.0" ? "< 0.8.0" : ">= 0.8.0"
-
 # Tests latest Grape / Rack combo
 if RUBY_VERSION >= "2.5.0"
   gemfile <<-RB
     gem 'rack', '> 2.1.0'
-    gem 'rack-test', '#{rack_test_version}'
+    gem 'rack-test', '>= 0.8.0'
     gem 'grape'
     gem 'webrick'
     gem 'activesupport', '< 7.0'
@@ -28,7 +26,7 @@ end
 grape_versions.each do |version|
   gemfile <<-RB
     gem 'rack', '< 2.1.0' # rack >= 2.1.0 breaks grape <= 0.12.0
-    gem 'rack-test', '#{rack_test_version}'
+    gem 'rack-test', '>= 0.8.0'
     gem 'grape', '#{version}'
     gem 'webrick'
     gem 'activesupport', '< 7.0'

--- a/test/multiverse/suites/httprb/Envfile
+++ b/test/multiverse/suites/httprb/Envfile
@@ -1,13 +1,8 @@
-suite_condition("http.rb is only supported for versions >= 2.0.0") do
-  RUBY_VERSION >= '2.0.0'
-end
-
 instrumentation_methods :chain, :prepend
 
 unless RUBY_PLATFORM == 'java'
   gemfile <<-RB
     gem 'http' # latest version
-    gem 'public_suffix', '< 3.0.0' if RUBY_VERSION < "2.1.0"
     gem 'rack'
     #{ruby3_gem_webrick}
   RB
@@ -38,7 +33,6 @@ HTTPRB_VERSIONS.each do |httprb_version|
 
   gemfile <<-RB
     gem 'http', '~> #{httprb_version}'
-    gem 'public_suffix', '< 3.0.0' if RUBY_VERSION < "2.1.0"
     gem 'rack'
     #{ruby3_gem_webrick}
   RB

--- a/test/multiverse/suites/padrino/Envfile
+++ b/test/multiverse/suites/padrino/Envfile
@@ -1,4 +1,3 @@
-rack_test_version = RUBY_VERSION < "2.2.2" ? "< 0.8.0" : ">= 0.8.0"
 instrumentation_methods :chain, :prepend
 
 
@@ -8,13 +7,13 @@ if RUBY_VERSION < '2.7.0'
   gemfile <<-RB unless RUBY_PLATFORM.eql?('java')
     gem 'activesupport', '~> 3'
     gem 'padrino', '~> 0.14.0'
-    gem 'rack-test', '#{rack_test_version}', :require => 'rack/test'
+    gem 'rack-test', '>= 0.8.0', :require => 'rack/test'
   RB
 
   gemfile <<-RB
     gem 'activesupport', '~> 3'
     gem 'padrino', '~> 0.15.1'
-    gem 'rack-test', '#{rack_test_version}', :require => 'rack/test'
+    gem 'rack-test', '>= 0.8.0', :require => 'rack/test'
   RB
 end
 
@@ -22,14 +21,14 @@ if RUBY_VERSION >= '2.7.0'
   gemfile <<-RB
     gem 'activesupport', '~> 3'
     gem 'padrino', '~> 0.15.1'
-    gem 'rack-test', '#{rack_test_version}', :require => 'rack/test'
+    gem 'rack-test', '>= 0.8.0', :require => 'rack/test'
     gem 'webrick'
   RB
 
   gemfile <<-RB
     gem 'activesupport', '~> 3'
     gem 'padrino', '~> 0.15.1'
-    gem 'rack-test', '#{rack_test_version}', :require => 'rack/test'
+    gem 'rack-test', '>= 0.8.0', :require => 'rack/test'
     gem 'webrick'
   RB
 end

--- a/test/multiverse/suites/rack/Envfile
+++ b/test/multiverse/suites/rack/Envfile
@@ -1,6 +1,5 @@
 instrumentation_methods :chain, :prepend
 
-rack_test_version = RUBY_VERSION < "2.2.0" ? "< 0.8.0" : ">= 0.8.0"
 puma_versions = [nil, '~>3.12.0', '~>4.3.8', '~> 5.2.2', '~>5.3.2']
 ruby_rack_versions = { '2.3.0' => '~>2.2.3', '2.2.2' => '~>2.0.3'}
 
@@ -19,44 +18,44 @@ end
 
 gemfile <<-RB
   gem 'rack', '~>1.6.8'
-  gem 'rack-test', '#{rack_test_version}'
+  gem 'rack-test', '>= 0.8.0'
   #{ruby3_gem_webrick}
 RB
 
 gemfile <<-RB
   gem 'rack', '~>1.5.5'
-  gem 'rack-test', '#{rack_test_version}'
+  gem 'rack-test', '>= 0.8.0'
   #{ruby3_gem_webrick}
 RB
 
 gemfile <<-RB
   gem 'rack', '1.4.7'
-  gem 'rack-test', '#{rack_test_version}'
+  gem 'rack-test', '>= 0.8.0'
   #{ruby3_gem_webrick}
 RB
 
 gemfile <<-RB
   gem 'rack', '1.3.10'
-  gem 'rack-test', '#{rack_test_version}'
+  gem 'rack-test', '>= 0.8.0'
   #{ruby3_gem_webrick}
 RB
 
 gemfile <<-RB
   gem 'rack', '1.2.8'
-  gem 'rack-test', '#{rack_test_version}'
+  gem 'rack-test', '>= 0.8.0'
   #{ruby3_gem_webrick}
 RB
 
 gemfile <<-RB
   gem 'rack', '1.1.6'
-  gem 'rack-test', '#{rack_test_version}'
+  gem 'rack-test', '>= 0.8.0'
   #{ruby3_gem_webrick}
 RB
 
 # unsupported version
 gemfile <<-RB
   gem 'rack', '1.0.1'
-  gem 'rack-test', '#{rack_test_version}'
+  gem 'rack-test', '>= 0.8.0'
   #{ruby3_gem_webrick}
 RB
 

--- a/test/multiverse/suites/rails/Envfile
+++ b/test/multiverse/suites/rails/Envfile
@@ -38,7 +38,7 @@ if RUBY_VERSION >= '2.5.0' && RUBY_VERSION < '3.0.0'
   RB
 end
 
-if RUBY_VERSION >= '2.2.2' && RUBY_VERSION < '3.0.0'
+if RUBY_VERSION < '3.0.0'
   gemfile <<-RB
     gem 'rails', '~> 5.2.0'
     gem 'haml', '~> 5.1.2'
@@ -68,7 +68,6 @@ if RUBY_VERSION < '2.4.0'
     gem 'haml', '~> 5.1.2'
     gem 'haml-rails', '~> 1.0.0'
     gem 'minitest', '5.2.3'
-    gem 'nokogiri', '< 1.7' if RUBY_VERSION < '2.1.0' # nokogiri 1.7.0 only supports >= 2.1.0
   RB
 
   gemfile <<-RB
@@ -78,14 +77,12 @@ if RUBY_VERSION < '2.4.0'
     gem 'haml', '~> 5.1.2'
     gem 'haml-rails', '~> 1.0.0'
     gem 'minitest', '5.2.3'
-    gem 'nokogiri', '< 1.7' if RUBY_VERSION < '2.1.0' # nokogiri 1.7.0 only supports >= 2.1.0
   RB
 
   gemfile <<-RB
     gem 'rails', '~> 4.0.0'
     gem 'haml', '~> 5.1.2'
     gem 'haml-rails', '~> 1.0.0'
-    gem 'nokogiri', '< 1.7' if RUBY_VERSION < '2.1.0' # nokogiri 1.7.0 only supports >= 2.1.0
   RB
 
   gemfile <<-RB

--- a/test/multiverse/suites/rails_prepend/Envfile
+++ b/test/multiverse/suites/rails_prepend/Envfile
@@ -25,7 +25,7 @@ if RUBY_VERSION >= '2.5.0'
   RB
 end
 
-if RUBY_VERSION >= '2.2.2' && RUBY_VERSION < '3.0.0'
+if RUBY_VERSION < '3.0.0'
   gemfile <<-RB
     gem 'rails', '~> 5.2.0'
     gem 'haml', '~> 5.1.2'
@@ -55,7 +55,6 @@ if RUBY_VERSION < '2.4.0'
     gem 'haml', '~> 5.1.2'
     gem 'newrelic_prepender', path: File.expand_path('../newrelic_prepender', __FILE__)
     gem 'minitest', '5.2.3'
-    gem 'nokogiri', '< 1.7' if RUBY_VERSION < '2.1.0' # nokogiri 1.7.0 only supports >= 2.1.0
     # are these thor errors still present?
     gem 'thor', '< 0.20.1' if RUBY_PLATFORM == 'java' # unpredictable thor errors
   RB
@@ -67,7 +66,6 @@ if RUBY_VERSION < '2.4.0'
     gem 'haml', '~> 5.1.2'
     gem 'newrelic_prepender', path: File.expand_path('../newrelic_prepender', __FILE__)
     gem 'minitest', '5.2.3'
-    gem 'nokogiri', '< 1.7' if RUBY_VERSION < '2.1.0' # nokogiri 1.7.0 only supports >= 2.1.0
     gem 'thor', '< 0.20.1' if RUBY_PLATFORM == 'java' # unpredictable thor errors
   RB
 
@@ -75,7 +73,6 @@ if RUBY_VERSION < '2.4.0'
     gem 'rails', '~> 4.0.0'
     gem 'haml', '~> 5.1.2'
     gem 'newrelic_prepender', path: File.expand_path('../newrelic_prepender', __FILE__)
-    gem 'nokogiri', '< 1.7' if RUBY_VERSION < '2.1.0' # nokogiri 1.7.0 only supports >= 2.1.0
     gem 'thor', '< 0.20.1' if RUBY_PLATFORM == 'java' # unpredictable thor errors
   RB
 end

--- a/test/multiverse/suites/rake/Envfile
+++ b/test/multiverse/suites/rake/Envfile
@@ -24,13 +24,11 @@
 
 instrumentation_methods :chain, :prepend
 
-if RUBY_VERSION >= '2.2.0'
-  gemfile <<-RB
-    gem 'rack'
-    gem 'rake', '~> 13.0.0'
-    #{ruby3_gem_webrick}
-  RB
-end
+gemfile <<-RB
+  gem 'rack'
+  gem 'rake', '~> 13.0.0'
+  #{ruby3_gem_webrick}
+RB
 
 gemfile <<-RB
   gem 'rack'
@@ -45,7 +43,6 @@ if RUBY_VERSION < '2.4.0'
     gem 'rake', '~> 12.3.3'
     gem 'rails', '~> 4.2.1'
     gem 'minitest', '5.2.3'
-    gem 'nokogiri', '< 1.7' if RUBY_VERSION < '2.1.0' # nokogiri 1.7.0 only supports >= 2.1.0
   RB
 end
 

--- a/test/multiverse/suites/redis/Envfile
+++ b/test/multiverse/suites/redis/Envfile
@@ -1,33 +1,13 @@
 instrumentation_methods :chain, :prepend
 
-if RUBY_VERSION >= '2.2.2'
-  gemfile <<-RB
-    gem 'rack'
-    gem 'redis' # latest version published
-    #{ruby3_gem_webrick}
-  RB
+gemfile <<-RB
+  gem 'rack'
+  gem 'redis' # latest version published
+  #{ruby3_gem_webrick}
+RB
 
-  gemfile <<-RB
-    gem 'rack'
-    gem 'redis', '~>4.0.1'
-    #{ruby3_gem_webrick}
-  RB
-else
-  gemfile <<-RB
-    gem 'rack'
-    gem 'redis', '~>3.2.2'
-    #{ruby3_gem_webrick}
-  RB
-
-  gemfile <<-RB
-    gem 'rack'
-    gem 'redis', '~>3.1.0'
-    #{ruby3_gem_webrick}
-  RB
-
-  gemfile <<-RB
-    gem 'rack'
-    gem 'redis', '3.0.7' # oldest supported minor version
-    #{ruby3_gem_webrick}
-  RB
-end
+gemfile <<-RB
+  gem 'rack'
+  gem 'redis', '~>4.0.1'
+  #{ruby3_gem_webrick}
+RB

--- a/test/multiverse/suites/resque/Envfile
+++ b/test/multiverse/suites/resque/Envfile
@@ -1,7 +1,5 @@
 if RUBY_VERSION >= '2.3.0'
   gemfile <<-RB
-    gem 'redis', '< 4.0.0' if RUBY_VERSION < '2.2.0'
-    gem 'sinatra', '< 2.0' if RUBY_VERSION < '2.2.0'
     gem 'resque', '2.1.0'
     gem 'json'
     #{ruby3_gem_webrick}
@@ -9,9 +7,7 @@ if RUBY_VERSION >= '2.3.0'
 end
 
 gemfile <<-RB
-  gem 'redis', '< 4.0.0' if RUBY_VERSION < '2.2.0'
   gem 'resque', '~>1.27.4'
-  gem 'sinatra', '< 2.0' if RUBY_VERSION < '2.2.0'
   gem 'json'
   #{ruby3_gem_webrick}
 RB

--- a/test/multiverse/suites/sidekiq/Envfile
+++ b/test/multiverse/suites/sidekiq/Envfile
@@ -38,10 +38,9 @@ SIDEKIQ_VERSIONS.each do |sidekiq_version, timers_version|
   # must use older gems for older Rubies
   gem_redis = RUBY_VERSION <= "2.3.0" ? "gem 'redis', '<= 4.1.0'" : ""
   gem_connection_pool = RUBY_VERSION <= "2.3.0" ? "gem 'connection_pool', '<= 2.2.2'" : ""
-  gem_json = RUBY_VERSION >= "2.1.0" ? "gem 'json'" : "gem 'json', '< 2.0.0'"
   gemfile <<-RB
     gem 'rack'
-    #{gem_json}
+    gem 'json'
     #{gem_connection_pool}
     #{gem_timers}
     #{gem_redis}

--- a/test/multiverse/suites/sinatra/Envfile
+++ b/test/multiverse/suites/sinatra/Envfile
@@ -11,14 +11,12 @@ if RUBY_VERSION >= '2.3.0'
   RB
 end
 
-if RUBY_VERSION >= '2.2.0'
-  gemfile <<-RB
-    gem 'sinatra', '~> 2.0.0'
-    gem 'rack',    '~> 2.0.0'
-    gem 'rack-test', '#{rack_test_version}', :require => 'rack/test'
-    #{ruby3_gem_webrick}
-  RB
-end
+gemfile <<-RB
+  gem 'sinatra', '~> 2.0.0'
+  gem 'rack',    '~> 2.0.0'
+  gem 'rack-test', '#{rack_test_version}', :require => 'rack/test'
+  #{ruby3_gem_webrick}
+RB
 
 gemfile <<-RB
   gem 'sinatra', '~> 1.4.8'

--- a/test/multiverse/suites/sinatra_agent_disabled/Envfile
+++ b/test/multiverse/suites/sinatra_agent_disabled/Envfile
@@ -9,14 +9,12 @@ if RUBY_VERSION >= '2.3.0'
   RB
 end
 
-if RUBY_VERSION >= '2.2.0'
-  gemfile <<-RB
-    gem 'sinatra', '~> 2.0.0'
-    gem 'rack',    '~> 2.0.0'
-    gem 'rack-test', '#{rack_test_version}', :require => 'rack/test'
-    #{ruby3_gem_webrick}
-  RB
-end
+gemfile <<-RB
+  gem 'sinatra', '~> 2.0.0'
+  gem 'rack',    '~> 2.0.0'
+  gem 'rack-test', '#{rack_test_version}', :require => 'rack/test'
+  #{ruby3_gem_webrick}
+RB
 
 gemfile <<-RB
   gem 'sinatra', '~> 1.4.8'

--- a/test/new_relic/agent_test.rb
+++ b/test/new_relic/agent_test.rb
@@ -483,12 +483,7 @@ module NewRelic
       loop do
         visited << a = stack.pop
         if a.respond_to? :name
-          b = if RUBY_VERSION < '2.0.0'
-            a.name.split('::').reduce(nil) { |c, n| (c || Kernel).const_get n }
-          else
-            Kernel.const_get a.name
-          end
-          assert_equal a, b
+          assert_equal a, Kernel.const_get(a.name)
         end
 
         if a.respond_to? :constants


### PR DESCRIPTION
assume Ruby version 2.2.10 or higher is used for all tests and disable
or rework any checks that previous tested for older versions
