### PR TITLE
Add Array conversion for Environment Source values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,20 @@
 # New Relic Ruby Agent Release Notes #
 
+  ## v8.7.0
+
+  * **Enables Environment Varibles setting Array configurations to be converted to Arrays**
+
+    Prior to this change, when comma-separated lists were passed as environment variables, an error would be emitted to the newrelic_agent.log and a string would be set as the value. Now, Arrays will be accurately coerced.
+
   ## v8.6.0
 
-* **Telemetry-in-Context: Automatic Application Logs, a quick way to view logs no matter where you are in the platform**
+  * **Telemetry-in-Context: Automatic Application Logs, a quick way to view logs no matter where you are in the platform**
 
     - Adds support for forwarding application logs to New Relic. This automatically sends application logs that have been enriched to power Telemetry-in-Context. This is disabled by default in this release. This may be on by default in a future release.
     - Adds support for enriching application logs written to disk or standard out. This can be used with another log forwarder to power Telemetry-in-Context if in-agent log forwarding is not desired. We recommend enabling either log forwarding or local log decorating, but not both features. This is disabled by default in this release.
     - Improves speed and Resque support for logging metrics which shows the rate of log message by severity in the Logs chart in the APM Summary view. This is enabled by default in this release.
 
-    To learn more about Telemetry-in-Context and the configuration options please see the documentation [here](https://docs.newrelic.com/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration/).  
+    To learn more about Telemetry-in-Context and the configuration options please see the documentation [here](https://docs.newrelic.com/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration/).
 
   * **Improve the usage of the 'hostname' executable and other executables**
 
@@ -25,7 +31,7 @@
   * **Bugfix: Curb - satify method_with_tracing's verb argument requirement**
 
     When Curb instrumentation is used (either via prepend or chain), be sure to always pass the verb argument over to `method_with_tracing` which requires it. Thank you to @knarewski for bringing this issue to our attention, for providing a means of reproducing an error, and for providing a fix. That fix has been replicated by the agent team with permission. See [Issue 1033](https://github.com/newrelic/newrelic-ruby-agent/issues/1033) for more details.
-  
+
 
   ## v8.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
   ## v8.7.0
 
-  * **Enables Environment Varibles setting Array configurations to be converted to Arrays**
+  * **Enables Environment Variables setting Array configurations to be converted to Arrays**
 
     Prior to this change, when comma-separated lists were passed as environment variables, an error would be emitted to the newrelic_agent.log and a string would be set as the value. Now, Arrays will be accurately coerced.
 

--- a/lib/new_relic/agent/configuration/environment_source.rb
+++ b/lib/new_relic/agent/configuration/environment_source.rb
@@ -90,6 +90,8 @@ module NewRelic
             self[config_key] = value.to_f
           elsif type == Symbol
             self[config_key] = value.to_sym
+          elsif type == Array
+            self[config_key] = value.split(/\s*,\s*/)
           elsif type == NewRelic::Agent::Configuration::Boolean
             if value =~ /false|off|no/i
               self[config_key] = false

--- a/test/new_relic/agent/configuration/environment_source_test.rb
+++ b/test/new_relic/agent/configuration/environment_source_test.rb
@@ -130,6 +130,18 @@ module NewRelic::Agent::Configuration
       assert_equal true, @environment_source[:enabled]
     end
 
+    def test_set_key_by_type_converts_comma_lists_to_array
+      ENV['NEW_RELIC_ATTRIBUTES_INCLUDE'] = 'hi,bye'
+      @environment_source.set_key_by_type(:'attributes.include', 'NEW_RELIC_ATTRIBUTES_INCLUDE')
+      assert_equal ['hi', 'bye'], @environment_source[:'attributes.include']
+    end
+
+    def test_set_key_by_type_converts_comma_lists_with_spaces_to_array
+      ENV['NEW_RELIC_ATTRIBUTES_INCLUDE'] = 'hi, bye'
+      @environment_source.set_key_by_type(:'attributes.include', 'NEW_RELIC_ATTRIBUTES_INCLUDE')
+      assert_equal ['hi', 'bye'], @environment_source[:'attributes.include']
+    end
+
     def test_set_key_with_new_relic_prefix
       assert_applied_string('NEW_RELIC_LICENSE_KEY', :license_key)
     end


### PR DESCRIPTION
# Overview
Though Environment Source accepts configuration values with a type of Array, there was not an option to convert the received string into an array

# Related Github Issue
None

# Testing
Tests updated to include the case where comma-separated lists with and without spaces are accepted: 
ex: `NEW_RELIC_ATTRIBUTES_INCLUDE=hi,bye` and `NEW_RELIC_ATTRIBUTES_INCLUDE=hi, bye`