### PR TITLE
satisfy remaining MLT todos

### DIFF
--- a/lib/new_relic/agent.rb
+++ b/lib/new_relic/agent.rb
@@ -143,8 +143,7 @@ module NewRelic
     #
     def add_or_defer_method_tracer(receiver, method_name, metric_name, options)
       @tracer_lock.synchronize do
-        # TODO: MLT - need to pass this info downstream
-        # code_info = NewRelic::Agent::MethodTracerHelpers.code_information(receiver, method_name)
+        options[:code_information] = NewRelic::Agent::MethodTracerHelpers.code_information(receiver, method_name)
 
         if @agent
           receiver.send(:_nr_add_method_tracer_now, method_name, metric_name, options)

--- a/lib/new_relic/agent/method_tracer.rb
+++ b/lib/new_relic/agent/method_tracer.rb
@@ -84,8 +84,6 @@ module NewRelic
       # @api public
       #
       def trace_execution_unscoped(metric_names, options = NewRelic::EMPTY_HASH) # THREAD_LOCAL_ACCESS
-        # TODO: MLT - need to accept options[:code_information] and pass it forward down to segment creation
-
         NewRelic::Agent.record_api_supportability_metric :trace_execution_unscoped unless options[:internal]
         return yield unless NewRelic::Agent.tl_is_execution_traced?
         t0 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
@@ -337,16 +335,14 @@ module NewRelic
                       super(*args, &block)
                     else
                       ::NewRelic::Agent::MethodTracer.trace_execution_unscoped(unscoped_metrics_eval,
-                        internal: true,
-                        code_information: code_information) do
+                        internal: true) do
                         super(*args, &block)
                       end
                     end
                   end
                 elsif !unscoped_metrics_eval.empty?
                   ::NewRelic::Agent::MethodTracer.trace_execution_unscoped(unscoped_metrics_eval,
-                    internal: true,
-                    code_information: code_information) do
+                    internal: true) do
                     super(*args, &block)
                   end
                 end

--- a/lib/new_relic/agent/method_tracer_helpers.rb
+++ b/lib/new_relic/agent/method_tracer_helpers.rb
@@ -53,7 +53,9 @@ module NewRelic
           return NewRelic::EMTPY_HASH
         end
 
-        # TODO: MLT - maintain a cache for repeat lookups (object.object_id and method_name?)
+        @code_information ||= {}
+        cache_key = "#{object.object_id}#{method_name}"
+        return @code_information[cache_key] if @code_information.key?(cache_key)
 
         name = object.name if object.respond_to?(:name)
         if name
@@ -67,10 +69,10 @@ module NewRelic
 
         ::NewRelic::Agent.increment_metric(CODE_INFORMATION_SUCCESS_METRIC, 1)
 
-        {filepath: location.first,
-         lineno: location.last,
-         function: method_name,
-         namespace: name}
+        @code_information[cache_key] = {filepath: location.first,
+                                        lineno: location.last,
+                                        function: method_name,
+                                        namespace: name}
       rescue => e
         ::NewRelic::Agent.logger.error("Unable to determine source code info for '#{object}', " \
                                         "method '#{method_name}' - #{e.class}: #{e.message}")


### PR DESCRIPTION
* implement a caching system for MLT (not needed for manual tracing, but
  critical for Rails controller methods)
* stop passing MLT info downstream with unscoped metrics - these don't
  appear to have segments created for them