### PR TITLE
Logging: Turn log forwarding on by default

### DIFF
--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -1965,7 +1965,7 @@ A map of error classes to a list of messages. When an error of one of the classe
           :description => 'If `true`, enables log decoration and the collection of log events and metrics.'
         },
         :'application_logging.forwarding.enabled' => {
-          :default => false,
+          :default => true,
           :public => true,
           :type => Boolean,
           :allowed_from_server => false,

--- a/newrelic.yml
+++ b/newrelic.yml
@@ -31,7 +31,7 @@ common: &default_settings
 # application_logging.enabled: true
 
 # If `true`, the agent captures log records emitted by this application.
-# application_logging.forwarding.enabled: false
+# application_logging.forwarding.enabled: true
 
 # Defines the maximum number of log records to buffer in memory at a time.
 # application_logging.forwarding.max_samples_stored: 10000

--- a/newrelic_rpm.gemspec
+++ b/newrelic_rpm.gemspec
@@ -47,7 +47,10 @@ https://github.com/newrelic/newrelic-ruby-agent/
   s.require_paths = ["lib"]
   s.rubygems_version = Gem::VERSION
   s.summary = "New Relic Ruby Agent"
-
+  s.post_install_message = 'Thanks for installing the latest version of newrelic_rpm. '\
+    'This version turns on application log forwarding by default. If you want to turn ' \
+    'off this feature, set `application_logging.forwarding.enabled: false`. ' \
+    'For more information, visit: https://docs.newrelic.com/docs/logs/logs-context/configure-logs-context-ruby'
   s.add_development_dependency 'rake', '12.3.3'
   s.add_development_dependency 'rb-inotify', '0.9.10' # locked to support < Ruby 2.3 (and listen 3.0.8)
   s.add_development_dependency 'listen', '3.0.8' # locked to support < Ruby 2.3


### PR DESCRIPTION
# Overview
Sets the default for `application_logging.forwarding.enabled` to true.

# Related Github Issue
Closes #1022

# Testing
Updat[ing] tests to reflect the new default

# Todos
~~- [ ] Add CHANGELOG entry (once available)~~ - Moved to #1109 