### PR TITLE
Logging: Test agent response when connect reply is zero

### DIFF
--- a/test/new_relic/agent/configuration/event_harvest_config_test.rb
+++ b/test/new_relic/agent/configuration/event_harvest_config_test.rb
@@ -88,5 +88,23 @@ module NewRelic::Agent::Configuration
       }
       assert_equal expected, EventHarvestConfig.to_config_hash(connect_reply)
     end
+
+    def test_to_config_hash_with_zero_response_for_log_event_data
+      connect_reply = {
+        'event_harvest_config' => {
+          'report_period_ms' => 5000,
+          'harvest_limits' => {
+            'log_event_data' => 0
+          }
+        }
+      }
+
+      expected = {
+        :'application_logging.forwarding.max_samples_stored' => 0,
+        :'event_report_period.log_event_data' => 5,
+        :event_report_period => 5
+      }
+      assert_equal expected, EventHarvestConfig.to_config_hash(connect_reply)
+    end
   end
 end


### PR DESCRIPTION
# Overview
The "big red button" sets the harvest limits for log_event_data to zero for all applications in an account. This PR adds a test that uses a connect reply of 0 for `event_harvest_config.harvest_limits.log_event_data` to see how the agent responds.

# Related Github Issue
Relates to #1046 

# Testing
Adds unit test to evaluate response to a connect reply of zero.
