### PR TITLE
Deprecate gems and update tested versions

### DIFF
--- a/lib/new_relic/agent/agent.rb
+++ b/lib/new_relic/agent/agent.rb
@@ -459,6 +459,7 @@ module NewRelic
           # requests, we need to wait until the children are forked
           # before connecting, otherwise the parent process sends useless data
           def using_forking_dispatcher?
+            # TODO: MAJOR VERSION - remove :rainbows
             if [:puma, :passenger, :rainbows, :unicorn].include? Agent.config[:dispatcher]
               ::NewRelic::Agent.logger.info "Deferring startup of agent reporting thread because #{Agent.config[:dispatcher]} may fork."
               true

--- a/lib/new_relic/agent/instrumentation/active_merchant.rb
+++ b/lib/new_relic/agent/instrumentation/active_merchant.rb
@@ -16,7 +16,7 @@ DependencyDetection.defer do
   end
 
   executes do
-    if ActiveMerchant::Version < Gem::Version.new('1.65.0')
+    if ActiveMerchant::VERSION < Gem::Version.new('1.65.0')
       deprecation_msg = 'The Ruby Agent is dropping support for ActiveMerchant versions below 1.65.0 ' \
         'in version 9.0.0. Please upgrade your ActiveMerchant version to continue receiving full support. ' \
 

--- a/lib/new_relic/agent/instrumentation/active_merchant.rb
+++ b/lib/new_relic/agent/instrumentation/active_merchant.rb
@@ -16,8 +16,8 @@ DependencyDetection.defer do
   end
 
   executes do
-    if ActiveMerchant::Version < Gem::Version.new('0.65.0')
-      deprecation_msg = 'The Ruby Agent is dropping support for ActiveMerchant versions below 0.65.0 ' \
+    if ActiveMerchant::Version < Gem::Version.new('1.65.0')
+      deprecation_msg = 'The Ruby Agent is dropping support for ActiveMerchant versions below 1.65.0 ' \
         'in version 9.0.0. Please upgrade your ActiveMerchant version to continue receiving full support. ' \
 
       ::NewRelic::Agent.logger.log_once(

--- a/lib/new_relic/agent/instrumentation/active_merchant.rb
+++ b/lib/new_relic/agent/instrumentation/active_merchant.rb
@@ -16,6 +16,21 @@ DependencyDetection.defer do
   end
 
   executes do
+    if ActiveMerchant::Version < Gem::Version.new('0.65.0')
+      deprecation_msg = 'The Ruby Agent is dropping support for ActiveMerchant versions below 0.65.0 ' \
+        'in version 9.0.0. Please upgrade your ActiveMerchant version to continue receiving full support. ' \
+
+      ::NewRelic::Agent.logger.log_once(
+        :warn,
+        :deprecated_active_merchant_version,
+        deprecation_msg
+      )
+
+      ::NewRelic::Agent.record_metric("Supportability/Deprecated/ActiveMerchant", 1)
+    end
+  end
+
+  executes do
     class ActiveMerchant::Billing::Gateway
       include NewRelic::Agent::MethodTracer
     end

--- a/lib/new_relic/agent/instrumentation/acts_as_solr.rb
+++ b/lib/new_relic/agent/instrumentation/acts_as_solr.rb
@@ -44,6 +44,16 @@ DependencyDetection.defer do
 
   executes do
     ::NewRelic::Agent.logger.info 'Installing ActsAsSolr instrumentation'
+    deprecation_msg = 'The Ruby Agent is dropping support for ActsAsSolr ' \
+      'in version 9.0.0.' \
+
+    ::NewRelic::Agent.logger.log_once(
+      :warn,
+      :deprecated_acts_as_solr,
+      deprecation_msg
+    )
+
+    ::NewRelic::Agent.record_metric("Supportability/Deprecated/ActsAsSolr", 1)
   end
 
   executes do

--- a/lib/new_relic/agent/instrumentation/acts_as_solr.rb
+++ b/lib/new_relic/agent/instrumentation/acts_as_solr.rb
@@ -44,8 +44,8 @@ DependencyDetection.defer do
 
   executes do
     ::NewRelic::Agent.logger.info 'Installing ActsAsSolr instrumentation'
-    deprecation_msg = 'The Ruby Agent is dropping support for ActsAsSolr ' \
-      'in version 9.0.0.' \
+    deprecation_msg = 'The instrumentation for ActsAsSolr is deprecated. ' \
+      'It will be removed in version 9.0.0.' \
 
     ::NewRelic::Agent.logger.log_once(
       :warn,

--- a/lib/new_relic/agent/instrumentation/authlogic.rb
+++ b/lib/new_relic/agent/instrumentation/authlogic.rb
@@ -13,8 +13,8 @@ DependencyDetection.defer do
 
   executes do
     ::NewRelic::Agent.logger.info 'Installing Authlogic instrumentation'
-    deprecation_msg = 'The Ruby Agent is dropping support for Authlogic ' \
-      'in version 9.0.0.' \
+    deprecation_msg = 'The instrumentation for Authlogic is deprecated. ' \
+      'It will be removed in version 9.0.0.' \
 
     ::NewRelic::Agent.logger.log_once(
       :warn,

--- a/lib/new_relic/agent/instrumentation/authlogic.rb
+++ b/lib/new_relic/agent/instrumentation/authlogic.rb
@@ -13,6 +13,16 @@ DependencyDetection.defer do
 
   executes do
     ::NewRelic::Agent.logger.info 'Installing Authlogic instrumentation'
+    deprecation_msg = 'The Ruby Agent is dropping support for Authlogic ' \
+      'in version 9.0.0.' \
+
+    ::NewRelic::Agent.logger.log_once(
+      :warn,
+      :deprecated_authlogic,
+      deprecation_msg
+    )
+
+    ::NewRelic::Agent.record_metric("Supportability/Deprecated/Authlogic", 1)
   end
 
   executes do

--- a/lib/new_relic/agent/instrumentation/data_mapper.rb
+++ b/lib/new_relic/agent/instrumentation/data_mapper.rb
@@ -15,6 +15,18 @@ DependencyDetection.defer do
   executes do
     ::NewRelic::Agent.logger.info 'Installing DataMapper instrumentation'
     require 'new_relic/agent/datastores/metric_helper'
+
+    deprecation_msg = 'The instrumentation for DataMapper is deprecated. ' \
+     'It will be removed in version 9.0.0.' \
+     'Visit https://docs.newrelic.com/docs/apm/agents/ruby-agent/getting-started/ruby-agent-requirements-supported-frameworks ' \
+     'to learn about supported gems.'
+
+    ::NewRelic::Agent.logger.log_once(
+      :warn,
+      :deprecated_datamapper,
+      deprecation_msg
+    )
+    ::NewRelic::Agent.record_metric("Supportability/Deprecated/DataMapper", 1)
   end
 
   executes do

--- a/lib/new_relic/agent/instrumentation/delayed_job_instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/delayed_job_instrumentation.rb
@@ -87,7 +87,7 @@ DependencyDetection.defer do
   end
 
   executes do
-    if DelayedJob::Version < Gem::Version.new('4.1.0')
+    if delayed_job_version < Gem::Version.new('4.1.0')
       deprecation_msg = 'Instrumentation for DelayedJob versions below 4.1.0 is deprecated.' \
         'It will stop being monitored in version 9.0.0. ' \
         'Please upgrade your DelayedJob version to continue receiving full support. ' \
@@ -108,5 +108,9 @@ DependencyDetection.defer do
     else
       chain_instrument ::NewRelic::Agent::Instrumentation::DelayedJob::Chain
     end
+  end
+
+  def delayed_job_version
+    Gem.loaded_specs['delayed_job'].version if Gem.loaded_specs['delayed_job']
   end
 end

--- a/lib/new_relic/agent/instrumentation/delayed_job_instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/delayed_job_instrumentation.rb
@@ -87,6 +87,21 @@ DependencyDetection.defer do
   end
 
   executes do
+    if DelayedJob::Version < Gem::Version.new('4.1.0')
+      deprecation_msg = 'The Ruby Agent is dropping support for DelayedJob versions below 4.1.0 ' \
+        'in version 9.0.0. Please upgrade your DelayedJob version to continue receiving full compatibility. ' \
+
+      ::NewRelic::Agent.logger.log_once(
+        :warn,
+        :deprecated_delayed_job_version,
+        deprecation_msg
+      )
+
+      ::NewRelic::Agent.record_metric("Supportability/Deprecated/DelayedJob", 1)
+    end
+  end
+
+  executes do
     if use_prepend?
       prepend_instrument ::Delayed::Worker, ::NewRelic::Agent::Instrumentation::DelayedJob::Prepend
     else

--- a/lib/new_relic/agent/instrumentation/delayed_job_instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/delayed_job_instrumentation.rb
@@ -88,8 +88,9 @@ DependencyDetection.defer do
 
   executes do
     if DelayedJob::Version < Gem::Version.new('4.1.0')
-      deprecation_msg = 'The Ruby Agent is dropping support for DelayedJob versions below 4.1.0 ' \
-        'in version 9.0.0. Please upgrade your DelayedJob version to continue receiving full compatibility. ' \
+      deprecation_msg = 'Instrumentation for DelayedJob versions below 4.1.0 is deprecated.' \
+        'It will stop being monitored in version 9.0.0. ' \
+        'Please upgrade your DelayedJob version to continue receiving full support. ' \
 
       ::NewRelic::Agent.logger.log_once(
         :warn,

--- a/lib/new_relic/agent/instrumentation/rack/helpers.rb
+++ b/lib/new_relic/agent/instrumentation/rack/helpers.rb
@@ -20,6 +20,8 @@ module NewRelic::Agent::Instrumentation
       return false unless defined? ::Puma::Const::PUMA_VERSION
 
       version = Gem::Version.new(::Puma::Const::PUMA_VERSION)
+      # TODO: MAJOR RELEASE update min_version to 3.9.0
+      # min_version = Gem::Version.new('3.9.0')
       min_version = Gem::Version.new('2.12.0')
       version >= min_version
     end

--- a/lib/new_relic/agent/instrumentation/rainbows_instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/rainbows_instrumentation.rb
@@ -12,6 +12,17 @@ DependencyDetection.defer do
   executes do
     ::NewRelic::Agent.logger.info 'Installing Rainbows instrumentation'
     ::NewRelic::Agent.logger.info 'Detected Rainbows, please see additional documentation: https://newrelic.com/docs/troubleshooting/im-using-unicorn-and-i-dont-see-any-data'
+
+    deprecation_msg = 'The dispatcher rainbows is deprecated. It will be removed ' \
+     'in version 9.0.0. Please use a supported dispatcher instead. ' \
+     'Visit https://docs.newrelic.com/docs/apm/agents/ruby-agent/getting-started/ruby-agent-requirements-supported-frameworks for options.'
+
+    ::NewRelic::Agent.logger.log_once(
+      :warn,
+      :deprecated_rainbows_dispatcher,
+      deprecation_msg
+    )
+    ::NewRelic::Agent.record_metric("Supportability/Deprecated/Rainbows", 1)
   end
 
   executes do

--- a/lib/new_relic/agent/instrumentation/sidekiq.rb
+++ b/lib/new_relic/agent/instrumentation/sidekiq.rb
@@ -13,6 +13,21 @@ DependencyDetection.defer do
   end
 
   executes do
+    if Sidekiq::Version < Gem::Version.new('5.0.0')
+      deprecation_msg = 'The Ruby Agent is dropping support for Sidekiq versions below 5.0.0 ' \
+        'in version 9.0.0. Please upgrade your Sidekiq version to continue receiving full support. ' \
+
+      ::NewRelic::Agent.logger.log_once(
+        :warn,
+        :deprecated_sidekiq_version,
+        deprecation_msg
+      )
+
+      ::NewRelic::Agent.record_metric("Supportability/Deprecated/Sidekiq", 1)
+    end
+  end
+
+  executes do
     module NewRelic::SidekiqInstrumentation
       class Server
         include NewRelic::Agent::Instrumentation::ControllerInstrumentation

--- a/lib/new_relic/agent/instrumentation/sidekiq.rb
+++ b/lib/new_relic/agent/instrumentation/sidekiq.rb
@@ -14,8 +14,9 @@ DependencyDetection.defer do
 
   executes do
     if Sidekiq::Version < Gem::Version.new('5.0.0')
-      deprecation_msg = 'The Ruby Agent is dropping support for Sidekiq versions below 5.0.0 ' \
-        'in version 9.0.0. Please upgrade your Sidekiq version to continue receiving full support. ' \
+      deprecation_msg = 'Instrumentation for Sidekiq versions below 5.0.0 is deprecated.' \
+        'They will stop being monitored in version 9.0.0. ' \
+        'Please upgrade your Sidekiq version to continue receiving full support. '
 
       ::NewRelic::Agent.logger.log_once(
         :warn,

--- a/lib/new_relic/agent/instrumentation/sidekiq.rb
+++ b/lib/new_relic/agent/instrumentation/sidekiq.rb
@@ -13,7 +13,7 @@ DependencyDetection.defer do
   end
 
   executes do
-    if Sidekiq::Version < Gem::Version.new('5.0.0')
+    if Sidekiq::VERSION < Gem::Version.new('5.0.0')
       deprecation_msg = 'Instrumentation for Sidekiq versions below 5.0.0 is deprecated.' \
         'They will stop being monitored in version 9.0.0. ' \
         'Please upgrade your Sidekiq version to continue receiving full support. '

--- a/lib/new_relic/agent/instrumentation/sinatra.rb
+++ b/lib/new_relic/agent/instrumentation/sinatra.rb
@@ -32,18 +32,29 @@ DependencyDetection.defer do
   end
 
   executes do
-    if Sinatra::Base.respond_to?(:build)
-      # These requires are inside an executes block because they require rack, and
-      # we can't be sure that rack is available when this file is first required.
-      require 'new_relic/rack/agent_hooks'
-      require 'new_relic/rack/browser_monitoring'
-      if use_prepend?
-        prepend_instrument ::Sinatra::Base.singleton_class, NewRelic::Agent::Instrumentation::Sinatra::Build::Prepend
-      else
-        chain_instrument NewRelic::Agent::Instrumentation::Sinatra::Build::Chain
-      end
+    if Sinatra::Version < Gem::Version.new('2.0.0')
+      deprecation_msg = 'The Ruby Agent is dropping support for Sinatra versions below 2.0.0 ' \
+        'in version 9.0.0. Please upgrade your Sinatra version to continue receiving full compatibility. ' \
+
+      ::NewRelic::Agent.logger.log_once(
+        :warn,
+        :deprecated_sinatra_version,
+        deprecation_msg
+      )
+
+      ::NewRelic::Agent.record_metric("Supportability/Deprecated/Sinatra", 1)
+    end
+  end
+
+  executes do
+    # These requires are inside an executes block because they require rack, and
+    # we can't be sure that rack is available when this file is first required.
+    require 'new_relic/rack/agent_hooks'
+    require 'new_relic/rack/browser_monitoring'
+    if use_prepend?
+      prepend_instrument ::Sinatra::Base.singleton_class, NewRelic::Agent::Instrumentation::Sinatra::Build::Prepend
     else
-      ::NewRelic::Agent.logger.info("Skipping auto-injection of middleware for Sinatra - requires Sinatra 1.2.1+")
+      chain_instrument NewRelic::Agent::Instrumentation::Sinatra::Build::Chain
     end
   end
 end

--- a/lib/new_relic/agent/instrumentation/sinatra.rb
+++ b/lib/new_relic/agent/instrumentation/sinatra.rb
@@ -32,7 +32,7 @@ DependencyDetection.defer do
   end
 
   executes do
-    if Sinatra::Version < Gem::Version.new('2.0.0')
+    if Sinatra::VERSION < Gem::Version.new('2.0.0')
       deprecation_msg = 'Instrumentation for Sinatra versions below 2.0.0 is deprecated.' \
         'They will stop being monitored in version 9.0.0. ' \
         'Please upgrade your Sinatra version to continue receiving full support. '

--- a/lib/new_relic/agent/instrumentation/sunspot.rb
+++ b/lib/new_relic/agent/instrumentation/sunspot.rb
@@ -11,8 +11,8 @@ DependencyDetection.defer do
 
   executes do
     ::NewRelic::Agent.logger.info 'Installing Rails Sunspot instrumentation'
-    deprecation_msg = 'The Ruby Agent is dropping support for Sunspot ' \
-      'in version 9.0.0.' \
+    deprecation_msg = 'The instrumentation for Sunspot is deprecated.' \
+      ' It will be removed in version 9.0.0.' \
 
     ::NewRelic::Agent.logger.log_once(
       :warn,

--- a/lib/new_relic/agent/instrumentation/sunspot.rb
+++ b/lib/new_relic/agent/instrumentation/sunspot.rb
@@ -11,6 +11,16 @@ DependencyDetection.defer do
 
   executes do
     ::NewRelic::Agent.logger.info 'Installing Rails Sunspot instrumentation'
+    deprecation_msg = 'The Ruby Agent is dropping support for Sunspot ' \
+      'in version 9.0.0.' \
+
+    ::NewRelic::Agent.logger.log_once(
+      :warn,
+      :deprecated_sunspot,
+      deprecation_msg
+    )
+
+    ::NewRelic::Agent.record_metric("Supportability/Deprecated/Sunspot", 1)
   end
 
   executes do

--- a/lib/new_relic/local_environment.rb
+++ b/lib/new_relic/local_environment.rb
@@ -76,6 +76,7 @@ module NewRelic
         rainbows
         unicorn
       ]
+      # TODO: MAJOR VERSION - remove rainbows
       while dispatchers.any? && @discovered_dispatcher.nil?
         send 'check_for_' + (dispatchers.shift)
       end
@@ -127,6 +128,7 @@ module NewRelic
       end
     end
 
+    # TODO: Major version - remove this method
     def check_for_rainbows
       if (defined?(::Rainbows) && defined?(::Rainbows::HttpServer)) && NewRelic::LanguageSupport.object_space_usable?
         v = find_class_in_object_space(::Rainbows::HttpServer)

--- a/test/multiverse/lib/multiverse/runner.rb
+++ b/test/multiverse/lib/multiverse/runner.rb
@@ -110,14 +110,12 @@ module Multiverse
       # this suite uses mysql2 which has issues on ruby 3.0+
       # a new suite, active_record_pg, has been added to run active record tests on ruby 3.0+
       GROUPS['rails'].delete 'active_record'
-      GROUPS['frameworks'].delete 'grape'
     end
 
     def excluded?(suite)
       return true if suite == 'rake' and RUBY_VERSION < '2.3'
       return true if suite == 'agent_only' and RUBY_PLATFORM == "java"
       return true if suite == 'active_record' and RUBY_VERSION >= '3.0.0'
-      return true if ["grape"].include?(suite) and RUBY_VERSION >= '3.0'
     end
 
     def passes_filter?(dir, filter)

--- a/test/multiverse/suites/active_record/Envfile
+++ b/test/multiverse/suites/active_record/Envfile
@@ -13,30 +13,65 @@ if RUBY_PLATFORM == 'java'
   mysql_vsn = '~> 0.4.4'
 
   gemfile <<-RB
+    gem 'activerecord', '~> 6.1.0'
+    gem 'minitest', '~> 5.2.3'
+    gem 'activerecord-jdbcmysql-adapter', '~> 61.1'
+    #{boilerplate_gems}
+  RB
+
+  gemfile <<-RB
+    gem 'activerecord', '~> 6.0.0'
+    gem 'minitest', '~> 5.2.3'
+    gem 'activerecord-jdbcmysql-adapter', '~> 60.4'
+    #{boilerplate_gems}
+  RB
+
+  gemfile <<-RB
     gem 'activerecord', '5.2.2'
     gem 'minitest', '~> 5.2.3'
-    gem 'activerecord-jdbcmysql-adapter', '~>52.0'
+    gem 'activerecord-jdbcmysql-adapter', '~> 52.0'
     #{boilerplate_gems}
   RB
 
   gemfile <<-RB
     gem 'activerecord', '~> 5.1.6'
     gem 'minitest', '~> 5.2.3'
-    gem 'activerecord-jdbcmysql-adapter', '~>51.0'
+    gem 'activerecord-jdbcmysql-adapter', '~> 51.0'
     #{boilerplate_gems}
   RB
 
   gemfile <<-RB
     gem 'activerecord', '~> 5.0.0'
     gem 'minitest', '~> 5.2.3'
-    gem 'activerecord-jdbcmysql-adapter', '~>50.0'
+    gem 'activerecord-jdbcmysql-adapter', '~> 50.0'
     #{boilerplate_gems}
   RB
 else
   mysql_vsn = '~> 0.4.4'
 
   gemfile <<-RB
-    gem 'activerecord', '5.2.2'
+    gem 'activerecord', '~> 7.0.0'
+    gem 'minitest', '~> 5.2.3'
+    gem '#{mysql_gem}', '#{mysql_vsn}'
+    #{boilerplate_gems}
+  RB
+
+  gemfile <<-RB
+    gem 'activerecord', '~> 6.1.0'
+    gem 'minitest', '~> 5.2.3'
+    gem '#{mysql_gem}', '#{mysql_vsn}'
+    #{boilerplate_gems}
+  RB
+
+  gemfile <<-RB
+    gem 'activerecord', '~> 6.0.0'
+    gem 'minitest', '~> 5.2.3'
+    gem '#{mysql_gem}', '#{mysql_vsn}'
+    #{boilerplate_gems}
+  RB
+
+  gemfile <<-RB
+    gem 'activerecord', '~> 5.2.2'
     gem 'minitest', '~> 5.2.3'
     gem '#{mysql_gem}', '#{mysql_vsn}'
     #{boilerplate_gems}

--- a/test/multiverse/suites/activemerchant/Envfile
+++ b/test/multiverse/suites/activemerchant/Envfile
@@ -40,8 +40,6 @@ if RUBY_VERSION >= '2.3.0' && RUBY_VERSION < '3.0.0'
     # Need to load newrelic_rpm after ActiveMerchant Gateways are required
     gem 'newrelic_rpm', :require => false, :path => File.expand_path('../../../../')
   RB
-
-
 end
 
 if RUBY_VERSION < '2.4.0'

--- a/test/multiverse/suites/activemerchant/Envfile
+++ b/test/multiverse/suites/activemerchant/Envfile
@@ -1,6 +1,6 @@
 if RUBY_VERSION >= '3.0.0'
   gemfile <<-RB
-    gem 'activemerchant', '~>1.121.0'
+    gem 'activemerchant' # latest
     gem 'rack'
     gem 'rexml'
     gem 'webrick'
@@ -26,7 +26,7 @@ if RUBY_VERSION >= '2.5.0' && RUBY_VERSION < '3.0.0'
     # Need to load newrelic_rpm after ActiveMerchant Gateways are required
     gem 'newrelic_rpm', :require => false, :path => File.expand_path('../../../../')
   RB
-end 
+end
 
 if RUBY_VERSION >= '2.3.0' && RUBY_VERSION < '3.0.0'
   gemfile <<-RB
@@ -40,13 +40,13 @@ if RUBY_VERSION >= '2.3.0' && RUBY_VERSION < '3.0.0'
     # Need to load newrelic_rpm after ActiveMerchant Gateways are required
     gem 'newrelic_rpm', :require => false, :path => File.expand_path('../../../../')
   RB
-    
+
 
 end
 
 if RUBY_VERSION < '2.4.0'
   gemfile <<-RB
-    gem 'activemerchant', '~>1.62.0' # last supported version for ruby 2.0
+    gem 'activemerchant', '~>1.65.0'
     gem 'rack'
 
     gem 'activesupport', '~>4.0.4'

--- a/test/multiverse/suites/excon/Envfile
+++ b/test/multiverse/suites/excon/Envfile
@@ -5,7 +5,8 @@ gemfile <<-RB
   #{ruby3_gem_webrick}
 RB
 
-excon_versions = %w(0.64.0
+excon_versions = %w(0.56.0
+                    0.64.0
                     0.70.0
                     0.78.1
                     0.85.0

--- a/test/multiverse/suites/grape/Envfile
+++ b/test/multiverse/suites/grape/Envfile
@@ -1,8 +1,11 @@
 instrumentation_methods :chain, :prepend
 
 grape_versions = []
+if RUBY_VERSION >= '3.0.0'
+  grape_versions << '~> 1.6'
+end
 if RUBY_VERSION >= '2.4.0'
-  # grape_versions << '~> 1.5.1' # already covered by separate test covering latest (as of 2/18/2021)
+  grape_versions << '~> 1.5.3'
   grape_versions << '~> 1.4.0'
   grape_versions << '~> 1.3.1'
 end

--- a/test/multiverse/suites/grape/Envfile
+++ b/test/multiverse/suites/grape/Envfile
@@ -4,12 +4,12 @@ grape_versions = []
 if RUBY_VERSION >= '3.0.0'
   grape_versions << '~> 1.6'
 end
-if RUBY_VERSION >= '2.4.0'
+if RUBY_VERSION >= '2.4.0' && RUBY_VERSION < '3.0.0'
   grape_versions << '~> 1.5.3'
   grape_versions << '~> 1.4.0'
   grape_versions << '~> 1.3.1'
 end
-unless RUBY_PLATFORM.eql?('java')
+unless RUBY_PLATFORM.eql?('java') || RUBY_VERSION > '3.0.0'
   grape_versions << '1.2.3'
   grape_versions << '1.1.0'
   grape_versions << '0.19.2'

--- a/test/multiverse/suites/httpclient/Envfile
+++ b/test/multiverse/suites/httpclient/Envfile
@@ -1,33 +1,8 @@
+instrumentation_methods :chain, :prepend
+
 gemfile <<-RB
-  gem 'httpclient' # latest version
+  gem 'httpclient' # latest version, 2.8.3
   gem 'rack'
   gem 'json', :platforms => [:rbx, :mri_18]
   #{ruby3_gem_webrick}
 RB
-instrumentation_methods :chain, :prepend
-
-if RUBY_VERSION >= '3.1.0'
-  # versions below 2.8.3 use `timeout`, which does not exist in Ruby 3.1
-  gemfile <<-RB
-    gem 'httpclient', '~> 2.8.3'
-    gem 'rack'
-    gem 'json', :platforms => [:rbx, :mri_18]
-    #{ruby3_gem_webrick}
-  RB
-else
-  HTTPCLIENT_VERSIONS = %w(2.8.3
-                         2.6.0
-                         2.5.3
-                         2.4.0
-                         2.3.4
-                         2.2.0)
-
-  HTTPCLIENT_VERSIONS.each do |httpclient_version|
-    gemfile <<-RB
-      gem 'httpclient', '~> #{httpclient_version}'
-      gem 'rack'
-      gem 'json', :platforms => [:rbx, :mri_18]
-      #{ruby3_gem_webrick}
-    RB
-  end
-end

--- a/test/multiverse/suites/httpclient/Envfile
+++ b/test/multiverse/suites/httpclient/Envfile
@@ -1,8 +1,35 @@
 instrumentation_methods :chain, :prepend
 
 gemfile <<-RB
-  gem 'httpclient' # latest version, 2.8.3
+  gem 'httpclient' # latest version
   gem 'rack'
   gem 'json', :platforms => [:rbx, :mri_18]
   #{ruby3_gem_webrick}
 RB
+
+# TODO: Remove during major version 9.0
+if RUBY_VERSION >= '3.1.0'
+  # versions below 2.8.3 use `timeout`, which does not exist in Ruby 3.1
+  gemfile <<-RB
+    gem 'httpclient', '~> 2.8.3'
+    gem 'rack'
+    gem 'json', :platforms => [:rbx, :mri_18]
+    #{ruby3_gem_webrick}
+  RB
+else
+  HTTPCLIENT_VERSIONS = %w(2.8.3
+                         2.6.0
+                         2.5.3
+                         2.4.0
+                         2.3.4
+                         2.2.0)
+
+  HTTPCLIENT_VERSIONS.each do |httpclient_version|
+    gemfile <<-RB
+      gem 'httpclient', '~> #{httpclient_version}'
+      gem 'rack'
+      gem 'json', :platforms => [:rbx, :mri_18]
+      #{ruby3_gem_webrick}
+    RB
+  end
+end

--- a/test/multiverse/suites/memcache/Envfile
+++ b/test/multiverse/suites/memcache/Envfile
@@ -7,8 +7,9 @@ require File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "..", "he
 end
 
 if RUBY_VERSION >= '2.5.0'
+  %w(3.0.2 3.1.6 3.2.1).each do |version|
   gemfile <<-RB
-    gem 'dalli', '~> 3.0.2'
+    gem 'dalli', '~> #{version}'
   RB
 end
 

--- a/test/multiverse/suites/mongo/Envfile
+++ b/test/multiverse/suites/mongo/Envfile
@@ -16,14 +16,7 @@ MONGO_VERSIONS_RUBY25 = ['2.15.1',
 MONGO_VERSIONS_OLDER_RUBIES = ['2.9.0',
                                '2.7.0',
                                '2.5.0',
-                               '2.4.0',
-                               '2.1.0',
-                               '2.0.0',
-                               '1.9.2',
-                               '1.8.6']
-
-# The highest Mongo server version to test 1.x gems against
-MAX_SERVER_VERSION_FOR_1X_GEMS = 2.6
+                               '2.4.0']
 
 # * JRuby uses Mongo gem versions for v2.6.0+ Ruby only
 # * Newer CRubies use newer Mongo gem versions and older ones
@@ -50,8 +43,6 @@ def installed_mongo_server_version
 end
 
 mongo_versions.each do |mongo_version|
-  next if mongo_version.start_with?('1.') && installed_mongo_server_version > MAX_SERVER_VERSION_FOR_1X_GEMS
-
   if Gem::Version.new(mongo_version) >= Gem::Version.new("2.12.0")
     gemfile <<-RB
       gem 'mongo', '~> #{mongo_version}'

--- a/test/multiverse/suites/mongo/Envfile
+++ b/test/multiverse/suites/mongo/Envfile
@@ -16,7 +16,14 @@ MONGO_VERSIONS_RUBY25 = ['2.15.1',
 MONGO_VERSIONS_OLDER_RUBIES = ['2.9.0',
                                '2.7.0',
                                '2.5.0',
-                               '2.4.0']
+                               '2.4.0',
+                               '2.1.0',
+                               '2.0.0',
+                               '1.9.2',
+                               '1.8.6']
+
+# The highest Mongo server version to test 1.x gems against
+MAX_SERVER_VERSION_FOR_1X_GEMS = 2.6
 
 # * JRuby uses Mongo gem versions for v2.6.0+ Ruby only
 # * Newer CRubies use newer Mongo gem versions and older ones
@@ -43,6 +50,8 @@ def installed_mongo_server_version
 end
 
 mongo_versions.each do |mongo_version|
+  next if mongo_version.start_with?('1.') && installed_mongo_server_version > MAX_SERVER_VERSION_FOR_1X_GEMS
+
   if Gem::Version.new(mongo_version) >= Gem::Version.new("2.12.0")
     gemfile <<-RB
       gem 'mongo', '~> #{mongo_version}'

--- a/test/multiverse/suites/padrino/Envfile
+++ b/test/multiverse/suites/padrino/Envfile
@@ -1,10 +1,20 @@
 instrumentation_methods :chain, :prepend
 
-gemfile <<-RB
+# NOTE: this config (padrino = 0.14.0) will break if you have a local bundler version other than 1.17.3.
+# The github CI handles the bundler version correctly, so tests should pass on github CI.
+# TODO: Remove in major version 9.0.0
+gemfile <<-RB unless RUBY_PLATFORM.eql?('java')
+  gem 'activesupport', '~> 3'
+  gem 'padrino', '~> 0.14.0'
+  gem 'rack-test', '>= 0.8.0', :require => 'rack/test'
+  #{ruby3_gem_webrick}
+RB
+
+  gemfile <<-RB
   gem 'activesupport', '~> 3'
   gem 'padrino', '~> 0.15.1'
   gem 'rack-test', '>= 0.8.0', :require => 'rack/test'
-  gem 'webrick' if RUBY_VERSION >= '2.7.0'
+  #{ruby3_gem_webrick}
 RB
 
 # vim: ft=ruby

--- a/test/multiverse/suites/padrino/Envfile
+++ b/test/multiverse/suites/padrino/Envfile
@@ -1,35 +1,10 @@
 instrumentation_methods :chain, :prepend
 
+gemfile <<-RB
+  gem 'activesupport', '~> 3'
+  gem 'padrino', '~> 0.15.1'
+  gem 'rack-test', '>= 0.8.0', :require => 'rack/test'
+  gem 'webrick' if RUBY_VERSION >= '2.7.0'
+RB
 
-if RUBY_VERSION < '2.7.0'
-  # NOTE: this config (padrino = 0.14.0) will break if you have a local bundler version other than 1.17.3.
-  # The github CI handles the bundler version correctly, so tests should pass on github CI.
-  gemfile <<-RB unless RUBY_PLATFORM.eql?('java')
-    gem 'activesupport', '~> 3'
-    gem 'padrino', '~> 0.14.0'
-    gem 'rack-test', '>= 0.8.0', :require => 'rack/test'
-  RB
-
-  gemfile <<-RB
-    gem 'activesupport', '~> 3'
-    gem 'padrino', '~> 0.15.1'
-    gem 'rack-test', '>= 0.8.0', :require => 'rack/test'
-  RB
-end
-
-if RUBY_VERSION >= '2.7.0'
-  gemfile <<-RB
-    gem 'activesupport', '~> 3'
-    gem 'padrino', '~> 0.15.1'
-    gem 'rack-test', '>= 0.8.0', :require => 'rack/test'
-    gem 'webrick'
-  RB
-
-  gemfile <<-RB
-    gem 'activesupport', '~> 3'
-    gem 'padrino', '~> 0.15.1'
-    gem 'rack-test', '>= 0.8.0', :require => 'rack/test'
-    gem 'webrick'
-  RB
-end
 # vim: ft=ruby

--- a/test/multiverse/suites/rack/Envfile
+++ b/test/multiverse/suites/rack/Envfile
@@ -22,4 +22,42 @@ gemfile <<-RB
   #{ruby3_gem_webrick}
 RB
 
+# TODO: Remove everything below this line in major version 9.0.0
+gemfile <<-RB
+  gem 'rack', '~>1.5.5'
+  gem 'rack-test', '>= 0.8.0'
+  #{ruby3_gem_webrick}
+RB
+
+gemfile <<-RB
+  gem 'rack', '1.4.7'
+  gem 'rack-test', '>= 0.8.0'
+  #{ruby3_gem_webrick}
+RB
+
+gemfile <<-RB
+  gem 'rack', '1.3.10'
+  gem 'rack-test', '>= 0.8.0'
+  #{ruby3_gem_webrick}
+RB
+
+gemfile <<-RB
+  gem 'rack', '1.2.8'
+  gem 'rack-test', '>= 0.8.0'
+  #{ruby3_gem_webrick}
+RB
+
+gemfile <<-RB
+  gem 'rack', '1.1.6'
+  gem 'rack-test', '>= 0.8.0'
+  #{ruby3_gem_webrick}
+RB
+
+# unsupported version
+gemfile <<-RB
+  gem 'rack', '1.0.1'
+  gem 'rack-test', '>= 0.8.0'
+  #{ruby3_gem_webrick}
+RB
+
 # vim: ft=ruby

--- a/test/multiverse/suites/rack/Envfile
+++ b/test/multiverse/suites/rack/Envfile
@@ -17,7 +17,7 @@ ruby_rack_versions.each do |ruby_version, rack_version|
 end
 
 gemfile <<-RB
-  gem 'rack', '~>1.6'
+  gem 'rack', '~>1.6.8'
   gem 'rack-test', '>= 0.8.0'
   #{ruby3_gem_webrick}
 RB

--- a/test/multiverse/suites/rack/Envfile
+++ b/test/multiverse/suites/rack/Envfile
@@ -17,44 +17,7 @@ ruby_rack_versions.each do |ruby_version, rack_version|
 end
 
 gemfile <<-RB
-  gem 'rack', '~>1.6.8'
-  gem 'rack-test', '>= 0.8.0'
-  #{ruby3_gem_webrick}
-RB
-
-gemfile <<-RB
-  gem 'rack', '~>1.5.5'
-  gem 'rack-test', '>= 0.8.0'
-  #{ruby3_gem_webrick}
-RB
-
-gemfile <<-RB
-  gem 'rack', '1.4.7'
-  gem 'rack-test', '>= 0.8.0'
-  #{ruby3_gem_webrick}
-RB
-
-gemfile <<-RB
-  gem 'rack', '1.3.10'
-  gem 'rack-test', '>= 0.8.0'
-  #{ruby3_gem_webrick}
-RB
-
-gemfile <<-RB
-  gem 'rack', '1.2.8'
-  gem 'rack-test', '>= 0.8.0'
-  #{ruby3_gem_webrick}
-RB
-
-gemfile <<-RB
-  gem 'rack', '1.1.6'
-  gem 'rack-test', '>= 0.8.0'
-  #{ruby3_gem_webrick}
-RB
-
-# unsupported version
-gemfile <<-RB
-  gem 'rack', '1.0.1'
+  gem 'rack', '~>1.6'
   gem 'rack-test', '>= 0.8.0'
   #{ruby3_gem_webrick}
 RB

--- a/test/multiverse/suites/resque/Envfile
+++ b/test/multiverse/suites/resque/Envfile
@@ -1,6 +1,11 @@
 if RUBY_VERSION >= '2.3.0'
   gemfile <<-RB
-    gem 'resque', '2.1.0'
+    gem 'resque', '~> 2.2.0'
+    gem 'json'
+    #{ruby3_gem_webrick}
+  RB
+  gemfile <<-RB
+    gem 'resque', '~> 2.1.0'
     gem 'json'
     #{ruby3_gem_webrick}
   RB

--- a/test/multiverse/suites/sidekiq/Envfile
+++ b/test/multiverse/suites/sidekiq/Envfile
@@ -5,8 +5,7 @@ SIDEKIQ_VERSIONS = [
   ["~> 6.1.3"],
   ["~> 6.1.0"],
   ["~> 6.0.0"],
-  ["~> 5.0.3"],
-  ["~> 4.2.10"]
+  ["~> 5.0.3"]
 ]
 
 # 5.x series requires >= Ruby 2.3
@@ -22,15 +21,10 @@ def ruby2_compatible? sidekiq_version
   end
 end
 
-# older connection pool gems do not work with Ruby 3.0
-# Sidekiq 4.2.10 does not support Ruby 3.0.3/3.1+ YAML parsing
-def ruby3_compatible? sidekiq_version
-  sidekiq_version.split(" ")[-1].to_i > 4
-end
 
 SIDEKIQ_VERSIONS.each do |sidekiq_version, timers_version|
   next if RUBY_VERSION < "3.0.0" && !ruby2_compatible?(sidekiq_version)
-  next if (RUBY_VERSION >= "3.0.0" || RUBY_PLATFORM == "java") && !ruby3_compatible?(sidekiq_version)
+  next if RUBY_PLATFORM == "java"
 
   # use specified version when declared
   gem_timers = timers_version ? "gem 'timers', '#{timers_version}'" : ""

--- a/test/multiverse/suites/sidekiq/Envfile
+++ b/test/multiverse/suites/sidekiq/Envfile
@@ -5,9 +5,10 @@ SIDEKIQ_VERSIONS = [
   ["~> 6.1.3"],
   ["~> 6.1.0"],
   ["~> 6.0.0"],
-  ["~> 5.0.3"]
+  ["~> 5.0.3"],
+  ["~> 4.2.10"]
 ]
-
+# TODO: Remove 4.2.10 in major version 9.0.0
 # 5.x series requires >= Ruby 2.3
 # 6.x series requires >= Ruby 2.5
 def ruby2_compatible? sidekiq_version
@@ -21,10 +22,16 @@ def ruby2_compatible? sidekiq_version
   end
 end
 
+# TODO: Remove this method in major version 9.0.0
+# older connection pool gems do not work with Ruby 3.0
+# Sidekiq 4.2.10 does not support Ruby 3.0.3/3.1+ YAML parsing
+def ruby3_compatible? sidekiq_version
+  sidekiq_version.split(" ")[-1].to_i > 4
+end
 
 SIDEKIQ_VERSIONS.each do |sidekiq_version, timers_version|
   next if RUBY_VERSION < "3.0.0" && !ruby2_compatible?(sidekiq_version)
-  next if RUBY_PLATFORM == "java"
+  next if (RUBY_VERSION >= "3.0.0" || RUBY_PLATFORM == "java") && !ruby3_compatible?(sidekiq_version)
 
   # use specified version when declared
   gem_timers = timers_version ? "gem 'timers', '#{timers_version}'" : ""

--- a/test/multiverse/suites/sidekiq/sidekiq_instrumentation_test.rb
+++ b/test/multiverse/suites/sidekiq/sidekiq_instrumentation_test.rb
@@ -163,7 +163,6 @@ class SidekiqTest < Minitest::Test
     TestWorker.fail = false
   end
 
-
   def test_captures_sidekiq_internal_errors
     # When testing internal Sidekiq error capturing, we're looking to
     # ensure Sidekiq properly forwards errors to our custom error handler

--- a/test/multiverse/suites/sidekiq/sidekiq_instrumentation_test.rb
+++ b/test/multiverse/suites/sidekiq/sidekiq_instrumentation_test.rb
@@ -163,20 +163,15 @@ class SidekiqTest < Minitest::Test
     TestWorker.fail = false
   end
 
-  # In <= 2.x of Sidekiq, internal errors (or potentially errors further out
-  # the middleware stack) wouldn't get noticed, but there was no proper hook
-  # to catch it. 3.x+ gives us an error_handler, so only add our misbehaving
-  # middleware for those cases.
-  if Sidekiq::VERSION >= '3'
-    def test_captures_sidekiq_internal_errors
-      # When testing internal Sidekiq error capturing, we're looking to
-      # ensure Sidekiq properly forwards errors to our custom error handler
-      # in order for us to notice the error.
 
-      exception = StandardError.new('foo')
-      NewRelic::Agent.expects(:notice_error).with(exception)
-      Sidekiq::CLI.instance.handle_exception(exception)
-    end
+  def test_captures_sidekiq_internal_errors
+    # When testing internal Sidekiq error capturing, we're looking to
+    # ensure Sidekiq properly forwards errors to our custom error handler
+    # in order for us to notice the error.
+
+    exception = StandardError.new('foo')
+    NewRelic::Agent.expects(:notice_error).with(exception)
+    Sidekiq::CLI.instance.handle_exception(exception)
   end
 
   def assert_metric_and_call_count(name, expected_call_count)

--- a/test/multiverse/suites/sinatra/Envfile
+++ b/test/multiverse/suites/sinatra/Envfile
@@ -1,12 +1,16 @@
 instrumentation_methods :chain, :prepend
 
-rack_test_version = RUBY_VERSION < "2.2.2" ? "< 0.8.0" : ">= 0.8.0"
-
 if RUBY_VERSION >= '2.3.0'
+  gemfile <<-RB
+    gem 'sinatra', '~> 2.2.0'
+    gem 'rack',    '~> 2.2.0'
+    gem 'rack-test', '>= 0.8.0', :require => 'rack/test'
+    #{ruby3_gem_webrick}
+  RB
   gemfile <<-RB
     gem 'sinatra', '~> 2.1.0'
     gem 'rack',    '~> 2.2.0'
-    gem 'rack-test', '#{rack_test_version}', :require => 'rack/test'
+    gem 'rack-test', '>= 0.8.0', :require => 'rack/test'
     #{ruby3_gem_webrick}
   RB
 end
@@ -14,14 +18,7 @@ end
 gemfile <<-RB
   gem 'sinatra', '~> 2.0.0'
   gem 'rack',    '~> 2.0.0'
-  gem 'rack-test', '#{rack_test_version}', :require => 'rack/test'
-  #{ruby3_gem_webrick}
-RB
-
-gemfile <<-RB
-  gem 'sinatra', '~> 1.4.8'
-  gem 'rack',    '~> 1.5.0'
-  gem 'rack-test', '#{rack_test_version}', :require => 'rack/test'
+  gem 'rack-test', '>= 0.8.0', :require => 'rack/test'
   #{ruby3_gem_webrick}
 RB
 

--- a/test/multiverse/suites/sinatra/sinatra_test_cases.rb
+++ b/test/multiverse/suites/sinatra/sinatra_test_cases.rb
@@ -43,38 +43,7 @@ module SinatraTestCases
     end
   end
 
-  module NRRouteNaming
-    # get '/route/:name'
-    def route_name_segment
-      'GET route/([^/?#]+)'
-    end
-
-    # get '/route/no_match'
-    def route_no_match_segment
-      'GET route/no_match'
-    end
-
-    # get /\/regex.*/
-    def regex_segment
-      'GET regex.*'
-    end
-
-    # get '/precondition'
-    def precondition_segment
-      'GET precondition'
-    end
-
-    # get '/ignored'
-    def ignored_segment
-      'GET ignored'
-    end
-  end
-
-  if Sinatra::VERSION >= '1.4.3'
-    include SinatraRouteNaming
-  else
-    include NRRouteNaming
-  end
+  include SinatraRouteNaming
 
   def app
     raise "Must implement app on your test case"
@@ -147,17 +116,6 @@ module SinatraTestCases
     get '/regexes'
     assert_equal "Yeah, regex's!", last_response.body
     assert_metrics_recorded(["Controller/Sinatra/#{app_name}/#{regex_segment}"])
-  end
-
-  # this test is not applicable to environments that use sinatra.route for txn naming
-  if self.include? NRRouteNaming
-    def test_set_unknown_transaction_name_if_error_in_routing
-      ::NewRelic::Agent::Instrumentation::Sinatra::TransactionNamer \
-        .stubs(:http_verb).raises(StandardError.new('madness'))
-
-      get '/user/login'
-      assert_metrics_recorded(["Controller/Sinatra/#{app_name}/(unknown)"])
-    end
   end
 
   # https://support.newrelic.com/tickets/31061

--- a/test/multiverse/suites/sinatra/sinatra_test_cases.rb
+++ b/test/multiverse/suites/sinatra/sinatra_test_cases.rb
@@ -43,7 +43,38 @@ module SinatraTestCases
     end
   end
 
-  include SinatraRouteNaming
+  module NRRouteNaming
+    # get '/route/:name'
+    def route_name_segment
+      'GET route/([^/?#]+)'
+    end
+
+    # get '/route/no_match'
+    def route_no_match_segment
+      'GET route/no_match'
+    end
+
+    # get /\/regex.*/
+    def regex_segment
+      'GET regex.*'
+    end
+
+    # get '/precondition'
+    def precondition_segment
+      'GET precondition'
+    end
+
+    # get '/ignored'
+    def ignored_segment
+      'GET ignored'
+    end
+  end
+
+  if Sinatra::VERSION >= '1.4.3'
+    include SinatraRouteNaming
+  else
+    include NRRouteNaming
+  end
 
   def app
     raise "Must implement app on your test case"
@@ -116,6 +147,17 @@ module SinatraTestCases
     get '/regexes'
     assert_equal "Yeah, regex's!", last_response.body
     assert_metrics_recorded(["Controller/Sinatra/#{app_name}/#{regex_segment}"])
+  end
+
+  # this test is not applicable to environments that use sinatra.route for txn naming
+  if self.include? NRRouteNaming
+    def test_set_unknown_transaction_name_if_error_in_routing
+      ::NewRelic::Agent::Instrumentation::Sinatra::TransactionNamer \
+        .stubs(:http_verb).raises(StandardError.new('madness'))
+
+      get '/user/login'
+      assert_metrics_recorded(["Controller/Sinatra/#{app_name}/(unknown)"])
+    end
   end
 
   # https://support.newrelic.com/tickets/31061


### PR DESCRIPTION
# Overview
Deprecates older versions of gems and instrumented gems with low customer adoption. Raises the lowest tested version for some gems.

# Related Github Issue
Relates to #1100 

# Testing
Updates and removes tests as needed