### PR TITLE
MLT PR feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,80 @@
 # New Relic Ruby Agent Release Notes #
 
+  ## v8.7.0
+
+  * **APM logs-in-context log forwarding on by default**
+
+    Automatic application log forwarding is now enabled by default. This version of the agent will automatically send enriched application logs to New Relic. To learn more about about this feature see [here](https://docs.newrelic.com/docs/apm/new-relic-apm/getting-started/get-started-logs-context/), and additional configuration options are available [here](https://docs.newrelic.com/docs/logs/logs-context/configure-logs-context-ruby). To learn about how to toggle log ingestion on or off by account see [here](https://docs.newrelic.com/docs/logs/logs-context/disable-automatic-logging).
+
+  * **Improved async support and Thread instrumentation**
+
+    Previously, the agent was not able to record events and metrics inside Threads created inside of an already running transaction. This release includes 2 new configuration options to support multithreaded applications to automatically instrument threads. A new configuration option,`instrumentation.thread.tracing` (disabled by default), has been introduced that, when enabled, will allow the agent to insert New Relic tracing inside of all Threads created by an application. To support applications that only want some threads instrumented by New Relic, a new class is available, `NewRelic::TracedThread`, that will create a thread that includes New Relic instrumentation, see our [API documentation](https://www.rubydoc.info/gems/newrelic_rpm/NewRelic) for more details.
+
+    New configuration options included in this release:
+    | Configuration name | Default | Behavior |
+    | ----------- | ----------- |----------- |
+    | `instrumentation.thread`  | `auto` (enabled) | Allows the agent to correctly nest spans inside of an asyncronous transaction   |
+    | `instrumentation.thread.tracing` | `false` (disabled)   |  Automatically add tracing to all Threads created in the application. This may be enabled by default in a future release. |
+
+    We'd like to thank @mikeantonelli for sharing a gist with us that provided our team with an entry point for this feature.
+
+  *  **Deprecate instrumentation versions with low adoption and/or versions over five years old**
+
+    This release deprecates the following instrumentation:
+    | Deprecated | Replacement |
+    | ----------- | ----------- |
+    | ActiveMerchant < 1.65.0 | ActiveMerchant >= 1.65.0 |
+    | Acts As Solr (all versions) | none |
+    | Authlogic (all versions) | none |
+    | Bunny < 2.7.0 | bunny >= 2.7.0 |
+    | Dalli < 3.2.1 | Dalli >= 3.2.1 |
+    | DataMapper (all versions) | none |
+    | Delayed Job < 4.1.0 | Delayed Job >= 4.1.0 |
+    | Excon < 0.56.0 | Excon >= 0.56.0 |
+    | Grape < 0.19.2 | Grape >= 0.19.2 |
+    | HTTPClient < 2.8.3 | HTTPClient 2.8.3 |
+    | HTTP.rb < 2.2.2 | HTTP.rb >= 2.2.2 |
+    | Mongo < 2.4.1 | Mongo >= 2.4.1 |
+    | Padrino < 0.15.0 | Padrino >= 0.15.0 |
+    | Passenger < 5.1.3 | Passenger >= 5.1.3 |
+    | Puma < 3.9.0 | Puma >= 3.9.0 |
+    | Rack < 1.6.8 | Rack >= 1.6.8 |
+    | Rainbows (all versions) | none |
+    | Sequel < 4.45.0 | Sequel >= 4.45.0 |
+    | Sidekiq < 5.0.0 | Sidekiq >= 5.0.0 |
+    | Sinatra < 2.0.0 | Sinatra >= 2.0.0 |
+    | Sunspot (all versions) | none |
+    | Typhoeus < 1.3.0 | Typhoeus >= 1.3.0 |
+    | Unicorn < 5.3.0 | Unicorn >= 5.3.0 |
+
+    For the gems with deprecated versions, we will no longer test those versions in our multiverse suite. They may, however, still be compatible with the agent. We will no longer fix bug reports for issues related to these gem versions.
+
+  * **Clarify documentation for `rake.tasks` configuration**
+
+    The `rake.tasks` description in the default `newrelic.yml` file and the [New Relic Ruby Agent Configuration docs](https://docs.newrelic.com/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration#rake-tasks) have been updated to clarify its behavior and usage. The documentation now reads:
+
+    > Specify an array of Rake tasks to automatically instrument. This configuration option converts the Array to a RegEx list. If you'd like to allow all tasks by default, use `rake.tasks: [.+]`. Rake tasks will not be instrumented unless they're added to this list. For more information, visit the (New Relic Rake Instrumentation docs)[/docs/apm/agents/ruby-agent/background-jobs/rake-instrumentation].
+
+    We thank @robotfelix for suggesting these changes.
+
+  * **Enable Environment Variables setting Array configurations to be converted to Arrays**
+
+    Prior to this change, when comma-separated lists were passed as environment variables, an error would be emitted to the `newrelic_agent.log` and a String would be set as the value. Now, Arrays will be accurately coerced.
+
+  * **Bugfix: Allow TransactionEvents to be sampled at the expected rate**
+
+    The `transaction_events.max_samples_stored` capacity value within the TransactionEventAggregator did not match up with its expected harvest cycle interval, causing TransactionEvents to be over-sampled. This bugfix builds upon the updates made in [#952](https://github.com/newrelic/newrelic-ruby-agent/pull/952) so that the interval and capacity behave as expected for the renamed `transaction_events*` configuration options.
+
+
   ## v8.6.0
 
-* **Telemetry-in-Context: Automatic Application Logs, a quick way to view logs no matter where you are in the platform**
+  * **Telemetry-in-Context: Automatic Application Logs, a quick way to view logs no matter where you are in the platform**
 
     - Adds support for forwarding application logs to New Relic. This automatically sends application logs that have been enriched to power Telemetry-in-Context. This is disabled by default in this release. This may be on by default in a future release.
     - Adds support for enriching application logs written to disk or standard out. This can be used with another log forwarder to power Telemetry-in-Context if in-agent log forwarding is not desired. We recommend enabling either log forwarding or local log decorating, but not both features. This is disabled by default in this release.
     - Improves speed and Resque support for logging metrics which shows the rate of log message by severity in the Logs chart in the APM Summary view. This is enabled by default in this release.
 
-    To learn more about Telemetry-in-Context and the configuration options please see the documentation [here](https://docs.newrelic.com/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration/).  
+    To learn more about Telemetry-in-Context and the configuration options please see the documentation [here](https://docs.newrelic.com/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration/).
 
   * **Improve the usage of the 'hostname' executable and other executables**
 
@@ -25,7 +91,7 @@
   * **Bugfix: Curb - satify method_with_tracing's verb argument requirement**
 
     When Curb instrumentation is used (either via prepend or chain), be sure to always pass the verb argument over to `method_with_tracing` which requires it. Thank you to @knarewski for bringing this issue to our attention, for providing a means of reproducing an error, and for providing a fix. That fix has been replicated by the agent team with permission. See [Issue 1033](https://github.com/newrelic/newrelic-ruby-agent/issues/1033) for more details.
-  
+
 
   ## v8.5.0
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Community Plus header](https://github.com/newrelic/opensource-website/raw/master/src/images/categories/Community_Plus.png)](https://opensource.newrelic.com/oss-category/#community-plus)
+[![Blue banner - Community Plus: This code is currently maintained by New Relic engineering teams and delivered here in GitHub. See the README for troubleshooting and defect reporting instructions.](https://github.com/newrelic/opensource-website/raw/master/src/images/categories/Community_Plus.png)](https://opensource.newrelic.com/oss-category/#community-plus)
 
 # New Relic Ruby Agent
 

--- a/lib/new_relic/agent/agent.rb
+++ b/lib/new_relic/agent/agent.rb
@@ -9,6 +9,7 @@ require 'logger'
 require 'zlib'
 require 'stringio'
 require 'new_relic/constants'
+require 'new_relic/traced_thread'
 require 'new_relic/coerce'
 require 'new_relic/agent/autostart'
 require 'new_relic/agent/harvester'
@@ -459,6 +460,7 @@ module NewRelic
           # requests, we need to wait until the children are forked
           # before connecting, otherwise the parent process sends useless data
           def using_forking_dispatcher?
+            # TODO: MAJOR VERSION - remove :rainbows
             if [:puma, :passenger, :rainbows, :unicorn].include? Agent.config[:dispatcher]
               ::NewRelic::Agent.logger.info "Deferring startup of agent reporting thread because #{Agent.config[:dispatcher]} may fork."
               true
@@ -608,7 +610,7 @@ module NewRelic
             :"#{interval}_second_harvest"
           end
 
-          ANALYTIC_EVENT_DATA = "analytic_event_data".freeze
+          TRANSACTION_EVENT_DATA = "transaction_event_data".freeze
           CUSTOM_EVENT_DATA = "custom_event_data".freeze
           ERROR_EVENT_DATA = "error_event_data".freeze
           SPAN_EVENT_DATA = "span_event_data".freeze
@@ -623,7 +625,7 @@ module NewRelic
               transmit_data
             end
 
-            @event_loop.on(interval_for ANALYTIC_EVENT_DATA) do
+            @event_loop.on(interval_for TRANSACTION_EVENT_DATA) do
               transmit_analytic_event_data
             end
             @event_loop.on(interval_for CUSTOM_EVENT_DATA) do
@@ -638,6 +640,7 @@ module NewRelic
             @event_loop.on(interval_for LOG_EVENT_DATA) do
               transmit_log_event_data
             end
+
             @event_loop.on(:reset_log_once_keys) do
               ::NewRelic::Agent.logger.clear_already_logged
             end

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -1998,7 +1998,7 @@ A map of error classes to a list of messages. When an error of one of the classe
           :public => true,
           :type => Boolean,
           :allowed_from_server => true,
-          :description => 'If `true`, the agent will report source code level metrics for monitored methods.'
+          :description => 'If `true`, the agent will report source code level metrics for traced methods.'
         },
         :'instrumentation.active_support_logger' => {
           :default => instrumentation_value_from_boolean(:'application_logging.enabled'),

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -518,7 +518,11 @@ When `true`, the agent captures HTTP request parameters and attaches them to tra
           :type => Array,
           :allowed_from_server => false,
           :transform => DefaultSource.method(:convert_to_regexp_list),
-          :description => 'Specify an array of Rake tasks to automatically instrument.'
+          :description => 'Specify an Array of Rake tasks to automatically instrument. ' \
+          'This configuration option converts the Array to a RegEx list. If you\'d like '\
+          'to allow all tasks by default, use `rake.tasks: [.+]`. No rake tasks will be '\
+          'instrumented unless they\'re added to this list. For more information, '\
+          'visit the (New Relic Rake Instrumentation docs)[/docs/apm/agents/ruby-agent/background-jobs/rake-instrumentation].'
         },
         :'rake.connect_timeout' => {
           :default => 10,
@@ -921,6 +925,21 @@ If `true`, disables agent middleware for Sinatra. This middleware is responsible
           :allowed_from_server => false,
           :description => "Controls auto-instrumentation of resque at start up.  May be one of [auto|prepend|chain|disabled]."
         },
+        :'instrumentation.thread' => {
+          :default => 'auto',
+          :public => true,
+          :type => String,
+          :dynamic_name => true,
+          :allowed_from_server => false,
+          :description => "Controls auto-instrumentation of the Thread class at start up to allow the agent to correctly nest spans inside of an asyncronous transaction. This does not enable the agent to automatically trace all threads created (see `instrumentation.thread.tracing`). May be one of [auto|prepend|chain|disabled]."
+        },
+        :'instrumentation.thread.tracing' => {
+          :default => false,
+          :public => true,
+          :type => Boolean,
+          :allowed_from_server => false,
+          :description => "Controls auto-instrumentation of the Thread class at start up to automatically add tracing to all Threads created in the application."
+        },
         :'instrumentation.redis' => {
           :default => instrumentation_value_of(:disable_redis),
           :documentation_default => 'auto',
@@ -1005,7 +1024,7 @@ If `true`, disables agent middleware for Sinatra. This middleware is responsible
           :description => 'Controls auto-instrumentation of Rack::URLMap at start up.  May be one of [auto|prepend|chain|disabled].'
         },
         :'instrumentation.puma_rack' => {
-          :default => instrumentation_value_of(:disable_puma_rack), # TODO: change to value_of(:'instrumentation.rack') when we remove :disable_puma_rack in 8.0)
+          :default => instrumentation_value_of(:disable_puma_rack), # TODO: MAJOR VERSION - change to value_of(:'instrumentation.rack') when we remove :disable_puma_rack in 8.0)
           :documentation_default => 'auto',
           :public => true,
           :type => String,
@@ -1016,7 +1035,7 @@ If `true`, disables agent middleware for Sinatra. This middleware is responsible
                            "application startup.  May be one of [auto|prepend|chain|disabled]."
         },
         :'instrumentation.puma_rack_urlmap' => {
-          :default => instrumentation_value_of(:disable_puma_rack_urlmap), # TODO: change to value_of(:'instrumentation.rack_urlmap') when we remove :disable_puma_rack_urlmap in 8.0)
+          :default => instrumentation_value_of(:disable_puma_rack_urlmap), # TODO: MAJOR VERSION - change to value_of(:'instrumentation.rack_urlmap') when we remove :disable_puma_rack_urlmap in 8.0)
           :documentation_default => 'auto',
           :public => true,
           :type => String,
@@ -1965,7 +1984,7 @@ A map of error classes to a list of messages. When an error of one of the classe
           :description => 'If `true`, enables log decoration and the collection of log events and metrics.'
         },
         :'application_logging.forwarding.enabled' => {
-          :default => false,
+          :default => true,
           :public => true,
           :type => Boolean,
           :allowed_from_server => false,

--- a/lib/new_relic/agent/configuration/environment_source.rb
+++ b/lib/new_relic/agent/configuration/environment_source.rb
@@ -90,6 +90,8 @@ module NewRelic
             self[config_key] = value.to_f
           elsif type == Symbol
             self[config_key] = value.to_sym
+          elsif type == Array
+            self[config_key] = value.split(/\s*,\s*/)
           elsif type == NewRelic::Agent::Configuration::Boolean
             if value =~ /false|off|no/i
               self[config_key] = false

--- a/lib/new_relic/agent/instrumentation/action_controller_subscriber.rb
+++ b/lib/new_relic/agent/instrumentation/action_controller_subscriber.rb
@@ -47,32 +47,31 @@ module NewRelic
         end
 
         def start_transaction_or_segment(payload, request, controller_class)
-          code_info = NewRelic::Agent::MethodTracerHelpers.code_information(controller_class, payload[:action])
-
-          options = {
-            request: request,
-            filtered_params: NewRelic::Agent::ParameterFiltering.filter_using_rails(
-              payload[:params],
-              Rails.application.config.filter_parameters
-            ),
-            apdex_start_time: queue_start(request),
-            ignore_apdex: NewRelic::Agent::Instrumentation::IgnoreActions.is_filtered?(
-              ControllerInstrumentation::NR_IGNORE_APDEX_KEY,
-              controller_class,
-              payload[:action]
-            ),
-            ignore_enduser: NewRelic::Agent::Instrumentation::IgnoreActions.is_filtered?(
-              ControllerInstrumentation::NR_IGNORE_ENDUSER_KEY,
-              controller_class,
-              payload[:action]
-            )
-          }
-
           Tracer.start_transaction_or_segment(
             name: format_metric_name(payload[:action], controller_class),
             category: :controller,
-            options: options.merge(code_info)
+            options: tracer_options(payload, request, controller_class)
           )
+        end
+
+        def tracer_options(payload, request, controller_class)
+          {
+            request: request,
+            filtered_params: filtered_params(payload[:params]),
+            apdex_start_time: queue_start(request),
+            ignore_apdex: ignore?(payload[:action], ControllerInstrumentation::NR_IGNORE_APDEX_KEY, controller_class),
+            ignore_enduser: ignore?(payload[:action],
+              ControllerInstrumentation::NR_IGNORE_ENDUSER_KEY,
+              controller_class)
+          }.merge(NewRelic::Agent::MethodTracerHelpers.code_information(controller_class, payload[:action]))
+        end
+
+        def filtered_params(params)
+          NewRelic::Agent::ParameterFiltering.filter_using_rails(params, Rails.application.config.filter_parameters)
+        end
+
+        def ignore?(action, key, controller_class)
+          NewRelic::Agent::Instrumentation::IgnoreActions.is_filtered?(key, controller_class, action)
         end
 
         def format_metric_name(metric_action, controller_name)

--- a/lib/new_relic/agent/instrumentation/active_merchant.rb
+++ b/lib/new_relic/agent/instrumentation/active_merchant.rb
@@ -34,4 +34,18 @@ DependencyDetection.defer do
       end
     end
   end
+
+  executes do
+    next unless ActiveMerchant::VERSION < Gem::Version.new('1.65.0')
+    deprecation_msg = 'The Ruby Agent is dropping support for ActiveMerchant versions below 1.65.0 ' \
+      'in version 9.0.0. Please upgrade your ActiveMerchant version to continue receiving full support. ' \
+
+    ::NewRelic::Agent.logger.log_once(
+      :warn,
+      :deprecated_active_merchant_version,
+      deprecation_msg
+    )
+
+    ::NewRelic::Agent.record_metric("Supportability/Deprecated/ActiveMerchant", 1)
+  end
 end

--- a/lib/new_relic/agent/instrumentation/acts_as_solr.rb
+++ b/lib/new_relic/agent/instrumentation/acts_as_solr.rb
@@ -44,6 +44,16 @@ DependencyDetection.defer do
 
   executes do
     ::NewRelic::Agent.logger.info 'Installing ActsAsSolr instrumentation'
+    deprecation_msg = 'The instrumentation for ActsAsSolr is deprecated. ' \
+      'It will be removed in version 9.0.0.' \
+
+    ::NewRelic::Agent.logger.log_once(
+      :warn,
+      :deprecated_acts_as_solr,
+      deprecation_msg
+    )
+
+    ::NewRelic::Agent.record_metric("Supportability/Deprecated/ActsAsSolr", 1)
   end
 
   executes do

--- a/lib/new_relic/agent/instrumentation/authlogic.rb
+++ b/lib/new_relic/agent/instrumentation/authlogic.rb
@@ -13,6 +13,16 @@ DependencyDetection.defer do
 
   executes do
     ::NewRelic::Agent.logger.info 'Installing Authlogic instrumentation'
+    deprecation_msg = 'The instrumentation for Authlogic is deprecated. ' \
+      'It will be removed in version 9.0.0.' \
+
+    ::NewRelic::Agent.logger.log_once(
+      :warn,
+      :deprecated_authlogic,
+      deprecation_msg
+    )
+
+    ::NewRelic::Agent.record_metric("Supportability/Deprecated/Authlogic", 1)
   end
 
   executes do

--- a/lib/new_relic/agent/instrumentation/data_mapper.rb
+++ b/lib/new_relic/agent/instrumentation/data_mapper.rb
@@ -15,6 +15,18 @@ DependencyDetection.defer do
   executes do
     ::NewRelic::Agent.logger.info 'Installing DataMapper instrumentation'
     require 'new_relic/agent/datastores/metric_helper'
+
+    deprecation_msg = 'The instrumentation for DataMapper is deprecated. ' \
+     'It will be removed in version 9.0.0.' \
+     'Visit https://docs.newrelic.com/docs/apm/agents/ruby-agent/getting-started/ruby-agent-requirements-supported-frameworks ' \
+     'to learn about supported gems.'
+
+    ::NewRelic::Agent.logger.log_once(
+      :warn,
+      :deprecated_datamapper,
+      deprecation_msg
+    )
+    ::NewRelic::Agent.record_metric("Supportability/Deprecated/DataMapper", 1)
   end
 
   executes do

--- a/lib/new_relic/agent/instrumentation/delayed_job_instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/delayed_job_instrumentation.rb
@@ -93,4 +93,23 @@ DependencyDetection.defer do
       chain_instrument ::NewRelic::Agent::Instrumentation::DelayedJob::Chain
     end
   end
+
+  executes do
+    next unless delayed_job_version < Gem::Version.new('4.1.0')
+    deprecation_msg = 'Instrumentation for DelayedJob versions below 4.1.0 is deprecated.' \
+      'It will stop being monitored in version 9.0.0. ' \
+      'Please upgrade your DelayedJob version to continue receiving full support. ' \
+
+    ::NewRelic::Agent.logger.log_once(
+      :warn,
+      :deprecated_delayed_job_version,
+      deprecation_msg
+    )
+
+    ::NewRelic::Agent.record_metric("Supportability/Deprecated/DelayedJob", 1)
+  end
+
+  def delayed_job_version
+    Gem.loaded_specs['delayed_job'].version if Gem.loaded_specs['delayed_job']
+  end
 end

--- a/lib/new_relic/agent/instrumentation/rack/helpers.rb
+++ b/lib/new_relic/agent/instrumentation/rack/helpers.rb
@@ -20,6 +20,8 @@ module NewRelic::Agent::Instrumentation
       return false unless defined? ::Puma::Const::PUMA_VERSION
 
       version = Gem::Version.new(::Puma::Const::PUMA_VERSION)
+      # TODO: MAJOR VERSION - update min_version to 3.9.0
+      # min_version = Gem::Version.new('3.9.0')
       min_version = Gem::Version.new('2.12.0')
       version >= min_version
     end

--- a/lib/new_relic/agent/instrumentation/rainbows_instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/rainbows_instrumentation.rb
@@ -12,6 +12,17 @@ DependencyDetection.defer do
   executes do
     ::NewRelic::Agent.logger.info 'Installing Rainbows instrumentation'
     ::NewRelic::Agent.logger.info 'Detected Rainbows, please see additional documentation: https://newrelic.com/docs/troubleshooting/im-using-unicorn-and-i-dont-see-any-data'
+
+    deprecation_msg = 'The dispatcher rainbows is deprecated. It will be removed ' \
+     'in version 9.0.0. Please use a supported dispatcher instead. ' \
+     'Visit https://docs.newrelic.com/docs/apm/agents/ruby-agent/getting-started/ruby-agent-requirements-supported-frameworks for options.'
+
+    ::NewRelic::Agent.logger.log_once(
+      :warn,
+      :deprecated_rainbows_dispatcher,
+      deprecation_msg
+    )
+    ::NewRelic::Agent.record_metric("Supportability/Deprecated/Rainbows", 1)
   end
 
   executes do

--- a/lib/new_relic/agent/instrumentation/sidekiq.rb
+++ b/lib/new_relic/agent/instrumentation/sidekiq.rb
@@ -99,4 +99,19 @@ DependencyDetection.defer do
       end
     end
   end
+
+  executes do
+    next unless Sidekiq::VERSION < Gem::Version.new('5.0.0')
+    deprecation_msg = 'Instrumentation for Sidekiq versions below 5.0.0 is deprecated.' \
+      'They will stop being monitored in version 9.0.0. ' \
+      'Please upgrade your Sidekiq version to continue receiving full support. '
+
+    ::NewRelic::Agent.logger.log_once(
+      :warn,
+      :deprecated_sidekiq_version,
+      deprecation_msg
+    )
+
+    ::NewRelic::Agent.record_metric("Supportability/Deprecated/Sidekiq", 1)
+  end
 end

--- a/lib/new_relic/agent/instrumentation/sinatra.rb
+++ b/lib/new_relic/agent/instrumentation/sinatra.rb
@@ -32,18 +32,28 @@ DependencyDetection.defer do
   end
 
   executes do
-    if Sinatra::Base.respond_to?(:build)
-      # These requires are inside an executes block because they require rack, and
-      # we can't be sure that rack is available when this file is first required.
-      require 'new_relic/rack/agent_hooks'
-      require 'new_relic/rack/browser_monitoring'
-      if use_prepend?
-        prepend_instrument ::Sinatra::Base.singleton_class, NewRelic::Agent::Instrumentation::Sinatra::Build::Prepend
-      else
-        chain_instrument NewRelic::Agent::Instrumentation::Sinatra::Build::Chain
-      end
+    # These requires are inside an executes block because they require rack, and
+    # we can't be sure that rack is available when this file is first required.
+    require 'new_relic/rack/agent_hooks'
+    require 'new_relic/rack/browser_monitoring'
+    if use_prepend?
+      prepend_instrument ::Sinatra::Base.singleton_class, NewRelic::Agent::Instrumentation::Sinatra::Build::Prepend
     else
-      ::NewRelic::Agent.logger.info("Skipping auto-injection of middleware for Sinatra - requires Sinatra 1.2.1+")
+      chain_instrument NewRelic::Agent::Instrumentation::Sinatra::Build::Chain
     end
+  end
+
+  executes do
+    next unless Sinatra::VERSION < Gem::Version.new('2.0.0')
+    deprecation_msg = 'The Ruby Agent is dropping support for Sinatra versions below 2.0.0 ' \
+      'in version 9.0.0. Please upgrade your Sinatra version to continue receiving full compatibility. ' \
+
+    ::NewRelic::Agent.logger.log_once(
+      :warn,
+      :deprecated_sinatra_version,
+      deprecation_msg
+    )
+
+    ::NewRelic::Agent.record_metric("Supportability/Deprecated/Sinatra", 1)
   end
 end

--- a/lib/new_relic/agent/instrumentation/sunspot.rb
+++ b/lib/new_relic/agent/instrumentation/sunspot.rb
@@ -11,6 +11,16 @@ DependencyDetection.defer do
 
   executes do
     ::NewRelic::Agent.logger.info 'Installing Rails Sunspot instrumentation'
+    deprecation_msg = 'The instrumentation for Sunspot is deprecated.' \
+      ' It will be removed in version 9.0.0.' \
+
+    ::NewRelic::Agent.logger.log_once(
+      :warn,
+      :deprecated_sunspot,
+      deprecation_msg
+    )
+
+    ::NewRelic::Agent.record_metric("Supportability/Deprecated/Sunspot", 1)
   end
 
   executes do

--- a/lib/new_relic/agent/instrumentation/thread.rb
+++ b/lib/new_relic/agent/instrumentation/thread.rb
@@ -1,0 +1,20 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+
+require_relative 'thread/chain'
+require_relative 'thread/prepend'
+
+DependencyDetection.defer do
+  named :thread
+
+  executes do
+    ::NewRelic::Agent.logger.info 'Installing Thread Instrumentation'
+
+    if use_prepend?
+      prepend_instrument ::Thread, ::NewRelic::Agent::Instrumentation::MonitoredThread::Prepend
+    else
+      chain_instrument ::NewRelic::Agent::Instrumentation::MonitoredThread::Chain
+    end
+  end
+end

--- a/lib/new_relic/agent/instrumentation/thread/chain.rb
+++ b/lib/new_relic/agent/instrumentation/thread/chain.rb
@@ -1,0 +1,24 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+
+require_relative 'instrumentation'
+
+module NewRelic::Agent::Instrumentation
+  module MonitoredThread
+    module Chain
+      def self.instrument!
+        ::Thread.class_eval do
+          include NewRelic::Agent::Instrumentation::MonitoredThread
+
+          alias_method :initialize_without_new_relic, :initialize
+
+          def initialize(*args, &block)
+            traced_block = add_thread_tracing(*args, &block)
+            initialize_with_newrelic_tracing { initialize_without_new_relic(*args, &traced_block) }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/new_relic/agent/instrumentation/thread/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/thread/instrumentation.rb
@@ -1,0 +1,27 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+
+module NewRelic
+  module Agent
+    module Instrumentation
+      module MonitoredThread
+        attr_reader :nr_parent_thread_id
+
+        def initialize_with_newrelic_tracing
+          @nr_parent_thread_id = ::Thread.current.object_id
+          yield
+        end
+
+        def add_thread_tracing(*args, &block)
+          return block if skip_tracing?
+          NewRelic::Agent::Tracer.thread_block_with_current_transaction(*args, &block)
+        end
+
+        def skip_tracing?
+          !NewRelic::Agent.config[:'instrumentation.thread.tracing']
+        end
+      end
+    end
+  end
+end

--- a/lib/new_relic/agent/instrumentation/thread/prepend.rb
+++ b/lib/new_relic/agent/instrumentation/thread/prepend.rb
@@ -1,0 +1,22 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+
+require_relative 'instrumentation'
+
+module NewRelic
+  module Agent
+    module Instrumentation
+      module MonitoredThread
+        module Prepend
+          include NewRelic::Agent::Instrumentation::MonitoredThread
+
+          def initialize(*args, &block)
+            traced_block = add_thread_tracing(*args, &block)
+            initialize_with_newrelic_tracing { super(*args, &traced_block) }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/new_relic/agent/transaction.rb
+++ b/lib/new_relic/agent/transaction.rb
@@ -217,7 +217,8 @@ module NewRelic
 
       def initialize(category, options)
         @nesting_max_depth = 0
-        @current_segment = nil
+        @current_segment_by_thread = {}
+        @current_segment_lock = Mutex.new
         @segments = []
 
         self.default_name = options[:transaction_name]
@@ -259,6 +260,25 @@ module NewRelic
         else
           @request_attributes = nil
         end
+      end
+
+      def parent_thread_id
+        ::Thread.current.nr_parent_thread_id if ::Thread.current.respond_to?(:nr_parent_thread_id)
+      end
+
+      def current_segment
+        current_thread_id = ::Thread.current.object_id
+        return current_segment_by_thread[current_thread_id] if current_segment_by_thread[current_thread_id]
+        return current_segment_by_thread[parent_thread_id] if current_segment_by_thread[parent_thread_id]
+        current_segment_by_thread[@starting_thread_id]
+      end
+
+      def set_current_segment(new_segment)
+        @current_segment_lock.synchronize { current_segment_by_thread[::Thread.current.object_id] = new_segment }
+      end
+
+      def remove_current_segment_by_thread_id(id)
+        @current_segment_lock.synchronize { current_segment_by_thread.delete(id) }
       end
 
       def distributed_tracer
@@ -724,9 +744,9 @@ module NewRelic
       # Do not call this.  Invoke the class method instead.
       def notice_error(error, options = {}) # :nodoc:
         # Only the last error is kept
-        if @current_segment
-          @current_segment.notice_error error, expected: options[:expected]
-          options[:span_id] = @current_segment.guid
+        if current_segment
+          current_segment.notice_error(error, expected: options[:expected])
+          options[:span_id] = current_segment.guid
         end
 
         if @exceptions[error]

--- a/lib/new_relic/agent/transaction/abstract_segment.rb
+++ b/lib/new_relic/agent/transaction/abstract_segment.rb
@@ -20,13 +20,14 @@ module NewRelic
         # after its parent. We will use the optimized exclusive duration
         # calculation in all other cases.
         #
-        attr_reader :start_time, :end_time, :duration, :exclusive_duration, :guid
+        attr_reader :start_time, :end_time, :duration, :exclusive_duration, :guid, :starting_thread_id
         attr_accessor :name, :parent, :children_time, :transaction, :transaction_name
         attr_writer :record_metrics, :record_scoped_metric, :record_on_finish
         attr_reader :noticed_error
 
         def initialize name = nil, start_time = nil
           @name = name
+          @starting_thread_id = ::Thread.current.object_id
           @transaction_name = nil
           @transaction = nil
           @guid = NewRelic::Agent::GuidGenerator.generate_guid

--- a/lib/new_relic/agent/vm/mri_vm.rb
+++ b/lib/new_relic/agent/vm/mri_vm.rb
@@ -49,7 +49,19 @@ module NewRelic
           end
 
           if supports?(:constant_cache_invalidations)
-            snap.constant_cache_invalidations = RubyVM.stat[:global_constant_state]
+            snap.constant_cache_invalidations = gather_constant_cache_invalidations
+          end
+        end
+
+        def gather_constant_cache_invalidations
+          # Ruby >= 3.2 uses :constant_cache
+          # see: https://github.com/ruby/ruby/pull/5433 and https://bugs.ruby-lang.org/issues/18589
+          # TODO: now that 3.2+ provides more granual cache invalidation data, should we report it instead of summing?
+          if RUBY_VERSION >= '3.2.0'
+            RubyVM.stat[:constant_cache].values.sum
+          # Ruby < 3.2 uses :global_constant_state
+          else
+            RubyVM.stat[:global_constant_state]
           end
         end
 

--- a/lib/new_relic/dependency_detection.rb
+++ b/lib/new_relic/dependency_detection.rb
@@ -146,7 +146,7 @@ module DependencyDetection
       !(disabled_configured? || deprecated_disabled_configured?)
     end
 
-    # TODO: Remove in 8.0
+    # TODO: MAJOR VERSION
     # will only return true if a disabled key is found and is truthy
     def deprecated_disabled_configured?
       return false if self.name.nil?

--- a/lib/new_relic/local_environment.rb
+++ b/lib/new_relic/local_environment.rb
@@ -76,6 +76,7 @@ module NewRelic
         rainbows
         unicorn
       ]
+      # TODO: MAJOR VERSION - remove rainbows
       while dispatchers.any? && @discovered_dispatcher.nil?
         send 'check_for_' + (dispatchers.shift)
       end
@@ -127,6 +128,7 @@ module NewRelic
       end
     end
 
+    # TODO: MAJOR VERSION - remove this method
     def check_for_rainbows
       if (defined?(::Rainbows) && defined?(::Rainbows::HttpServer)) && NewRelic::LanguageSupport.object_space_usable?
         v = find_class_in_object_space(::Rainbows::HttpServer)

--- a/lib/new_relic/supportability_helper.rb
+++ b/lib/new_relic/supportability_helper.rb
@@ -50,6 +50,7 @@ module NewRelic
       :shutdown,
       :start_segment,
       :trace,
+      :traced_thread,
       :trace_execution_scoped,
       :trace_execution_unscoped,
       :wrap

--- a/lib/new_relic/traced_thread.rb
+++ b/lib/new_relic/traced_thread.rb
@@ -1,0 +1,36 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+module NewRelic
+  #
+  # This class allows the current transaction to be passed to a Thread so that nested segments can be created from the operations performed within the Thread's block.
+  # To have the New Relic Ruby agent automatically trace all of your applications threads,
+  # enable the `instrumentation.thread.tracing` configuration option in your newrelic.yml.
+  #
+  # Note: disabling the configuration option `instrumentation.thread` while using this class can cause incorrectly nested spans.
+  #
+  # @api public
+  class TracedThread < Thread
+    #
+    # Creates a new Thread whose work will be traced by New Relic.
+    # Use this class as a replacement for the native Thread class.
+    # Example: Instead of using `Thread.new`, use:
+    # ```ruby
+    #   NewRelic::TracedThread.new { execute_some_code }
+    # ```
+    #
+    # @api public
+    def initialize(*args, &block)
+      NewRelic::Agent.record_api_supportability_metric(:traced_thread)
+      traced_block = create_traced_block(*args, &block)
+      super(*args, &traced_block)
+    end
+
+    def create_traced_block(*args, &block)
+      return block if NewRelic::Agent.config[:'instrumentation.thread.tracing'] # if this is on, don't double trace
+      NewRelic::Agent::Tracer.thread_block_with_current_transaction(*args, &block)
+    end
+  end
+end

--- a/lib/new_relic/version.rb
+++ b/lib/new_relic/version.rb
@@ -6,7 +6,7 @@
 module NewRelic
   module VERSION # :nodoc:
     MAJOR = 8
-    MINOR = 6
+    MINOR = 7
     TINY = 0
 
     STRING = "#{MAJOR}.#{MINOR}.#{TINY}"

--- a/newrelic.yml
+++ b/newrelic.yml
@@ -31,7 +31,7 @@ common: &default_settings
 # application_logging.enabled: true
 
 # If `true`, the agent captures log records emitted by this application.
-# application_logging.forwarding.enabled: false
+# application_logging.forwarding.enabled: true
 
 # Defines the maximum number of log records to buffer in memory at a time.
 # application_logging.forwarding.max_samples_stored: 10000
@@ -398,6 +398,13 @@ common: &default_settings
 # May be one of [auto|prepend|chain|disabled].
 # instrumentation.typhoeus: auto
 
+# Controls auto-instrumentation of the Thread class at start up to allow the agent to correctly nest spans inside of an asyncronous transaction.
+# May be one of [auto|prepend|chain|disabled].
+# instrumentation.thread: auto
+
+# Controls auto-instrumentation of the Thread class at start up to automatically add tracing to all Threads created in the application.
+# instrumentation.thread.tracing: false
+
 # A dictionary of label names and values that will be applied to the data sent
 # from this agent. May also be expressed asa semicolon-delimited ; string of
 # colon-separated : pairs.
@@ -455,6 +462,10 @@ common: &default_settings
 # rake.connect_timeout: 10
 
 # Specify an array of Rake tasks to automatically instrument.
+# This configuration option converts the Array to a RegEx list.
+# If you'd like to allow all tasks by default, use `rake.tasks: [.+]`.
+# Rake tasks will not be instrumented unless they're added to this list.
+# For more information, visit the (New Relic Rake Instrumentation docs)[/docs/apm/agents/ruby-agent/background-jobs/rake-instrumentation].
 # rake.tasks: []
 
 # Define transactions you want the agent to ignore, by specifying a list of

--- a/newrelic.yml
+++ b/newrelic.yml
@@ -42,7 +42,7 @@ common: &default_settings
 # If `true`, the agent decorates logs with metadata to link to entities, hosts, traces, and spans.
 # application_logging.local_decorating.enabled: false
 
-# If `true`, the agent will report source code level metrics for monitored methods
+# If `true`, the agent will report source code level metrics for traced methods
 # code_level_metrics.enabled: true
 
 # If true, enables transaction event sampling.

--- a/newrelic_rpm.gemspec
+++ b/newrelic_rpm.gemspec
@@ -47,7 +47,10 @@ https://github.com/newrelic/newrelic-ruby-agent/
   s.require_paths = ["lib"]
   s.rubygems_version = Gem::VERSION
   s.summary = "New Relic Ruby Agent"
-
+  s.post_install_message = 'Thanks for installing the latest version of newrelic_rpm. '\
+    'This version turns on application log forwarding by default. If you want to turn ' \
+    'off this feature, set `application_logging.forwarding.enabled: false`. ' \
+    'For more information, visit: https://docs.newrelic.com/docs/logs/logs-context/configure-logs-context-ruby'
   s.add_development_dependency 'rake', '12.3.3'
   s.add_development_dependency 'rb-inotify', '0.9.10' # locked to support < Ruby 2.3 (and listen 3.0.8)
   s.add_development_dependency 'listen', '3.0.8' # locked to support < Ruby 2.3

--- a/test/multiverse/lib/multiverse/runner.rb
+++ b/test/multiverse/lib/multiverse/runner.rb
@@ -110,14 +110,12 @@ module Multiverse
       # this suite uses mysql2 which has issues on ruby 3.0+
       # a new suite, active_record_pg, has been added to run active record tests on ruby 3.0+
       GROUPS['rails'].delete 'active_record'
-      GROUPS['frameworks'].delete 'grape'
     end
 
     def excluded?(suite)
       return true if suite == 'rake' and RUBY_VERSION < '2.3'
       return true if suite == 'agent_only' and RUBY_PLATFORM == "java"
       return true if suite == 'active_record' and RUBY_VERSION >= '3.0.0'
-      return true if ["grape"].include?(suite) and RUBY_VERSION >= '3.0'
     end
 
     def passes_filter?(dir, filter)

--- a/test/multiverse/suites/activemerchant/Envfile
+++ b/test/multiverse/suites/activemerchant/Envfile
@@ -1,6 +1,6 @@
 if RUBY_VERSION >= '3.0.0'
   gemfile <<-RB
-    gem 'activemerchant', '~>1.121.0'
+    gem 'activemerchant'
     gem 'rack'
     gem 'rexml'
     gem 'webrick'
@@ -26,7 +26,7 @@ if RUBY_VERSION >= '2.5.0' && RUBY_VERSION < '3.0.0'
     # Need to load newrelic_rpm after ActiveMerchant Gateways are required
     gem 'newrelic_rpm', :require => false, :path => File.expand_path('../../../../')
   RB
-end 
+end
 
 if RUBY_VERSION >= '2.3.0' && RUBY_VERSION < '3.0.0'
   gemfile <<-RB
@@ -40,13 +40,13 @@ if RUBY_VERSION >= '2.3.0' && RUBY_VERSION < '3.0.0'
     # Need to load newrelic_rpm after ActiveMerchant Gateways are required
     gem 'newrelic_rpm', :require => false, :path => File.expand_path('../../../../')
   RB
-    
+
 
 end
 
 if RUBY_VERSION < '2.4.0'
   gemfile <<-RB
-    gem 'activemerchant', '~>1.62.0' # last supported version for ruby 2.0
+    gem 'activemerchant', '~>1.65.0'
     gem 'rack'
 
     gem 'activesupport', '~>4.0.4'

--- a/test/multiverse/suites/excon/Envfile
+++ b/test/multiverse/suites/excon/Envfile
@@ -5,10 +5,12 @@ gemfile <<-RB
   #{ruby3_gem_webrick}
 RB
 
-excon_versions = %w(0.64.0
-                    0.70.0
-                    0.78.1
-                    0.85.0
+excon_versions = %w(
+  0.56.0
+  0.64.0
+  0.70.0
+  0.78.1
+  0.85.0
 )
 
 excon_versions.each do |excon_version|

--- a/test/multiverse/suites/grape/Envfile
+++ b/test/multiverse/suites/grape/Envfile
@@ -1,12 +1,15 @@
 instrumentation_methods :chain, :prepend
 
 grape_versions = []
-if RUBY_VERSION >= '2.4.0'
-  # grape_versions << '~> 1.5.1' # already covered by separate test covering latest (as of 2/18/2021)
+if RUBY_VERSION >= '3.0.0'
+  grape_versions << '~> 1.6'
+end
+if RUBY_VERSION >= '2.4.0' && RUBY_VERSION < '3.0.0'
+  grape_versions << '~> 1.5.3'
   grape_versions << '~> 1.4.0'
   grape_versions << '~> 1.3.1'
 end
-unless RUBY_PLATFORM.eql?('java')
+unless RUBY_PLATFORM.eql?('java') || RUBY_VERSION > '3.0.0'
   grape_versions << '1.2.3'
   grape_versions << '1.1.0'
   grape_versions << '0.19.2'

--- a/test/multiverse/suites/httpclient/Envfile
+++ b/test/multiverse/suites/httpclient/Envfile
@@ -1,5 +1,5 @@
 gemfile <<-RB
-  gem 'httpclient' # latest version
+  gem 'httpclient'
   gem 'rack'
   gem 'json', :platforms => [:rbx, :mri_18]
   #{ruby3_gem_webrick}

--- a/test/multiverse/suites/httprb/Envfile
+++ b/test/multiverse/suites/httprb/Envfile
@@ -2,14 +2,14 @@ instrumentation_methods :chain, :prepend
 
 unless RUBY_PLATFORM == 'java'
   gemfile <<-RB
-    gem 'http' # latest version
+    gem 'http'
     gem 'rack'
     #{ruby3_gem_webrick}
   RB
 end
 
 # NOTE, some versions of HTTP gem implements body with
-# String.new("").force_encoding(@encoding) which won't work 
+# String.new("").force_encoding(@encoding) which won't work
 # with Ruby 2.7 and it's automatic freezing of string literals.
 # Those versions are capped at Ruby 2.6
 

--- a/test/multiverse/suites/memcache/Envfile
+++ b/test/multiverse/suites/memcache/Envfile
@@ -7,6 +7,7 @@ require File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "..", "he
 end
 
 if RUBY_VERSION >= '2.5.0'
+  # TODO: MAJOR VERSION - Bump lowest version to 3.2.1 in version 9.0.0
   gemfile <<-RB
     gem 'dalli', '~> 3.0.2'
   RB

--- a/test/multiverse/suites/mongo/Envfile
+++ b/test/multiverse/suites/mongo/Envfile
@@ -12,6 +12,7 @@ MONGO_VERSIONS_RUBY25 = ['2.15.1',
                          '2.14.0',
                          '2.12.0']
 
+# TODO: MAJOR VERSION - Stop testing mongo versions below 2.5.0
 # Mongo versions to test with CRubies below 2.5.0
 MONGO_VERSIONS_OLDER_RUBIES = ['2.9.0',
                                '2.7.0',

--- a/test/multiverse/suites/padrino/Envfile
+++ b/test/multiverse/suites/padrino/Envfile
@@ -1,35 +1,10 @@
 instrumentation_methods :chain, :prepend
 
+gemfile <<-RB
+  gem 'activesupport', '~> 3'
+  gem 'padrino', '~> 0.15.1'
+  gem 'rack-test', '>= 0.8.0', :require => 'rack/test'
+  gem 'webrick' if RUBY_VERSION >= '2.7.0'
+RB
 
-if RUBY_VERSION < '2.7.0'
-  # NOTE: this config (padrino = 0.14.0) will break if you have a local bundler version other than 1.17.3.
-  # The github CI handles the bundler version correctly, so tests should pass on github CI.
-  gemfile <<-RB unless RUBY_PLATFORM.eql?('java')
-    gem 'activesupport', '~> 3'
-    gem 'padrino', '~> 0.14.0'
-    gem 'rack-test', '>= 0.8.0', :require => 'rack/test'
-  RB
-
-  gemfile <<-RB
-    gem 'activesupport', '~> 3'
-    gem 'padrino', '~> 0.15.1'
-    gem 'rack-test', '>= 0.8.0', :require => 'rack/test'
-  RB
-end
-
-if RUBY_VERSION >= '2.7.0'
-  gemfile <<-RB
-    gem 'activesupport', '~> 3'
-    gem 'padrino', '~> 0.15.1'
-    gem 'rack-test', '>= 0.8.0', :require => 'rack/test'
-    gem 'webrick'
-  RB
-
-  gemfile <<-RB
-    gem 'activesupport', '~> 3'
-    gem 'padrino', '~> 0.15.1'
-    gem 'rack-test', '>= 0.8.0', :require => 'rack/test'
-    gem 'webrick'
-  RB
-end
 # vim: ft=ruby

--- a/test/multiverse/suites/rack/Envfile
+++ b/test/multiverse/suites/rack/Envfile
@@ -22,41 +22,4 @@ gemfile <<-RB
   #{ruby3_gem_webrick}
 RB
 
-gemfile <<-RB
-  gem 'rack', '~>1.5.5'
-  gem 'rack-test', '>= 0.8.0'
-  #{ruby3_gem_webrick}
-RB
-
-gemfile <<-RB
-  gem 'rack', '1.4.7'
-  gem 'rack-test', '>= 0.8.0'
-  #{ruby3_gem_webrick}
-RB
-
-gemfile <<-RB
-  gem 'rack', '1.3.10'
-  gem 'rack-test', '>= 0.8.0'
-  #{ruby3_gem_webrick}
-RB
-
-gemfile <<-RB
-  gem 'rack', '1.2.8'
-  gem 'rack-test', '>= 0.8.0'
-  #{ruby3_gem_webrick}
-RB
-
-gemfile <<-RB
-  gem 'rack', '1.1.6'
-  gem 'rack-test', '>= 0.8.0'
-  #{ruby3_gem_webrick}
-RB
-
-# unsupported version
-gemfile <<-RB
-  gem 'rack', '1.0.1'
-  gem 'rack-test', '>= 0.8.0'
-  #{ruby3_gem_webrick}
-RB
-
 # vim: ft=ruby

--- a/test/multiverse/suites/rails/Envfile
+++ b/test/multiverse/suites/rails/Envfile
@@ -40,7 +40,8 @@ end
 
 if RUBY_VERSION < '3.0.0'
   gemfile <<-RB
-    gem 'rails', '~> 5.2.0'
+    # Rails 5.2.7.1 uses a '~>>' style heredoc that breaks Ruby 2.2 compatibility
+    gem 'rails', '~> 5.2.0'#{", '<= 5.2.7'" if RUBY_VERSION < '2.3.0'}
     gem 'haml', '~> 5.1.2'
     gem 'haml-rails', '~> 1.0.0'
     gem 'minitest', '5.2.3'

--- a/test/multiverse/suites/rails_prepend/Envfile
+++ b/test/multiverse/suites/rails_prepend/Envfile
@@ -27,7 +27,8 @@ end
 
 if RUBY_VERSION < '3.0.0'
   gemfile <<-RB
-    gem 'rails', '~> 5.2.0'
+    # Rails 5.2.7.1 uses a '~>>' style heredoc that breaks Ruby 2.2 compatibility
+    gem 'rails', '~> 5.2.0'#{", '<= 5.2.7'" if RUBY_VERSION < '2.3.0'}
     gem 'haml', '~> 5.1.2'
     gem 'newrelic_prepender', path: File.expand_path('../newrelic_prepender', __FILE__)
     gem 'minitest', '5.2.3'

--- a/test/multiverse/suites/redis/Envfile
+++ b/test/multiverse/suites/redis/Envfile
@@ -2,7 +2,7 @@ instrumentation_methods :chain, :prepend
 
 gemfile <<-RB
   gem 'rack'
-  gem 'redis' # latest version published
+  gem 'redis'
   #{ruby3_gem_webrick}
 RB
 

--- a/test/multiverse/suites/resque/Envfile
+++ b/test/multiverse/suites/resque/Envfile
@@ -1,6 +1,11 @@
 if RUBY_VERSION >= '2.3.0'
   gemfile <<-RB
-    gem 'resque', '2.1.0'
+    gem 'resque', '~> 2.2.0'
+    gem 'json'
+    #{ruby3_gem_webrick}
+  RB
+  gemfile <<-RB
+    gem 'resque', '~> 2.1.0'
     gem 'json'
     #{ruby3_gem_webrick}
   RB

--- a/test/multiverse/suites/sidekiq/Envfile
+++ b/test/multiverse/suites/sidekiq/Envfile
@@ -5,8 +5,7 @@ SIDEKIQ_VERSIONS = [
   ["~> 6.1.3"],
   ["~> 6.1.0"],
   ["~> 6.0.0"],
-  ["~> 5.0.3"],
-  ["~> 4.2.10"]
+  ["~> 5.0.3"]
 ]
 
 # 5.x series requires >= Ruby 2.3
@@ -22,15 +21,10 @@ def ruby2_compatible? sidekiq_version
   end
 end
 
-# older connection pool gems do not work with Ruby 3.0
-# Sidekiq 4.2.10 does not support Ruby 3.0.3/3.1+ YAML parsing
-def ruby3_compatible? sidekiq_version
-  sidekiq_version.split(" ")[-1].to_i > 4
-end
 
 SIDEKIQ_VERSIONS.each do |sidekiq_version, timers_version|
   next if RUBY_VERSION < "3.0.0" && !ruby2_compatible?(sidekiq_version)
-  next if (RUBY_VERSION >= "3.0.0" || RUBY_PLATFORM == "java") && !ruby3_compatible?(sidekiq_version)
+  next if RUBY_PLATFORM == "java"
 
   # use specified version when declared
   gem_timers = timers_version ? "gem 'timers', '#{timers_version}'" : ""

--- a/test/multiverse/suites/sidekiq/sidekiq_instrumentation_test.rb
+++ b/test/multiverse/suites/sidekiq/sidekiq_instrumentation_test.rb
@@ -163,20 +163,14 @@ class SidekiqTest < Minitest::Test
     TestWorker.fail = false
   end
 
-  # In <= 2.x of Sidekiq, internal errors (or potentially errors further out
-  # the middleware stack) wouldn't get noticed, but there was no proper hook
-  # to catch it. 3.x+ gives us an error_handler, so only add our misbehaving
-  # middleware for those cases.
-  if Sidekiq::VERSION >= '3'
-    def test_captures_sidekiq_internal_errors
-      # When testing internal Sidekiq error capturing, we're looking to
-      # ensure Sidekiq properly forwards errors to our custom error handler
-      # in order for us to notice the error.
+  def test_captures_sidekiq_internal_errors
+    # When testing internal Sidekiq error capturing, we're looking to
+    # ensure Sidekiq properly forwards errors to our custom error handler
+    # in order for us to notice the error.
 
-      exception = StandardError.new('foo')
-      NewRelic::Agent.expects(:notice_error).with(exception)
-      Sidekiq::CLI.instance.handle_exception(exception)
-    end
+    exception = StandardError.new('foo')
+    NewRelic::Agent.expects(:notice_error).with(exception)
+    Sidekiq::CLI.instance.handle_exception(exception)
   end
 
   def assert_metric_and_call_count(name, expected_call_count)

--- a/test/multiverse/suites/sinatra/Envfile
+++ b/test/multiverse/suites/sinatra/Envfile
@@ -1,12 +1,16 @@
 instrumentation_methods :chain, :prepend
 
-rack_test_version = RUBY_VERSION < "2.2.2" ? "< 0.8.0" : ">= 0.8.0"
-
 if RUBY_VERSION >= '2.3.0'
+  gemfile <<-RB
+    gem 'sinatra', '~> 2.2.0'
+    gem 'rack',    '~> 2.2.0'
+    gem 'rack-test', '>= 0.8.0', :require => 'rack/test'
+    #{ruby3_gem_webrick}
+  RB
   gemfile <<-RB
     gem 'sinatra', '~> 2.1.0'
     gem 'rack',    '~> 2.2.0'
-    gem 'rack-test', '#{rack_test_version}', :require => 'rack/test'
+    gem 'rack-test', '>= 0.8.0', :require => 'rack/test'
     #{ruby3_gem_webrick}
   RB
 end
@@ -14,14 +18,7 @@ end
 gemfile <<-RB
   gem 'sinatra', '~> 2.0.0'
   gem 'rack',    '~> 2.0.0'
-  gem 'rack-test', '#{rack_test_version}', :require => 'rack/test'
-  #{ruby3_gem_webrick}
-RB
-
-gemfile <<-RB
-  gem 'sinatra', '~> 1.4.8'
-  gem 'rack',    '~> 1.5.0'
-  gem 'rack-test', '#{rack_test_version}', :require => 'rack/test'
+  gem 'rack-test', '>= 0.8.0', :require => 'rack/test'
   #{ruby3_gem_webrick}
 RB
 

--- a/test/multiverse/suites/sinatra/sinatra_test_cases.rb
+++ b/test/multiverse/suites/sinatra/sinatra_test_cases.rb
@@ -43,38 +43,7 @@ module SinatraTestCases
     end
   end
 
-  module NRRouteNaming
-    # get '/route/:name'
-    def route_name_segment
-      'GET route/([^/?#]+)'
-    end
-
-    # get '/route/no_match'
-    def route_no_match_segment
-      'GET route/no_match'
-    end
-
-    # get /\/regex.*/
-    def regex_segment
-      'GET regex.*'
-    end
-
-    # get '/precondition'
-    def precondition_segment
-      'GET precondition'
-    end
-
-    # get '/ignored'
-    def ignored_segment
-      'GET ignored'
-    end
-  end
-
-  if Sinatra::VERSION >= '1.4.3'
-    include SinatraRouteNaming
-  else
-    include NRRouteNaming
-  end
+  include SinatraRouteNaming
 
   def app
     raise "Must implement app on your test case"
@@ -147,17 +116,6 @@ module SinatraTestCases
     get '/regexes'
     assert_equal "Yeah, regex's!", last_response.body
     assert_metrics_recorded(["Controller/Sinatra/#{app_name}/#{regex_segment}"])
-  end
-
-  # this test is not applicable to environments that use sinatra.route for txn naming
-  if self.include? NRRouteNaming
-    def test_set_unknown_transaction_name_if_error_in_routing
-      ::NewRelic::Agent::Instrumentation::Sinatra::TransactionNamer \
-        .stubs(:http_verb).raises(StandardError.new('madness'))
-
-      get '/user/login'
-      assert_metrics_recorded(["Controller/Sinatra/#{app_name}/(unknown)"])
-    end
   end
 
   # https://support.newrelic.com/tickets/31061

--- a/test/multiverse/suites/typhoeus/Envfile
+++ b/test/multiverse/suites/typhoeus/Envfile
@@ -6,9 +6,9 @@ SUPPORTED_TYPHOEUS_VERSIONS = [
 instrumentation_methods :chain, :prepend
 
 gemfile <<-RB
-  gem 'typhoeus' # latest version
+  gem 'typhoeus'
   if RUBY_PLATFORM == 'java'
-    gem 'ethon', '0.14.0' 
+    gem 'ethon', '0.14.0'
   end
   gem 'rack'
   #{ruby3_gem_webrick}
@@ -18,7 +18,7 @@ SUPPORTED_TYPHOEUS_VERSIONS.each do |version|
   gemfile <<-RB
     gem 'typhoeus', '~> #{version}'
     if RUBY_PLATFORM == 'java'
-      gem 'ethon', '0.14.0' 
+      gem 'ethon', '0.14.0'
     end
     gem 'rack'
     #{ruby3_gem_webrick}

--- a/test/new_relic/agent/configuration/environment_source_test.rb
+++ b/test/new_relic/agent/configuration/environment_source_test.rb
@@ -130,6 +130,18 @@ module NewRelic::Agent::Configuration
       assert_equal true, @environment_source[:enabled]
     end
 
+    def test_set_key_by_type_converts_comma_lists_to_array
+      ENV['NEW_RELIC_ATTRIBUTES_INCLUDE'] = 'hi,bye'
+      @environment_source.set_key_by_type(:'attributes.include', 'NEW_RELIC_ATTRIBUTES_INCLUDE')
+      assert_equal ['hi', 'bye'], @environment_source[:'attributes.include']
+    end
+
+    def test_set_key_by_type_converts_comma_lists_with_spaces_to_array
+      ENV['NEW_RELIC_ATTRIBUTES_INCLUDE'] = 'hi, bye'
+      @environment_source.set_key_by_type(:'attributes.include', 'NEW_RELIC_ATTRIBUTES_INCLUDE')
+      assert_equal ['hi', 'bye'], @environment_source[:'attributes.include']
+    end
+
     def test_set_key_with_new_relic_prefix
       assert_applied_string('NEW_RELIC_LICENSE_KEY', :license_key)
     end

--- a/test/new_relic/agent/configuration/event_harvest_config_test.rb
+++ b/test/new_relic/agent/configuration/event_harvest_config_test.rb
@@ -88,5 +88,23 @@ module NewRelic::Agent::Configuration
       }
       assert_equal expected, EventHarvestConfig.to_config_hash(connect_reply)
     end
+
+    def test_to_config_hash_with_zero_response_for_log_event_data
+      connect_reply = {
+        'event_harvest_config' => {
+          'report_period_ms' => 5000,
+          'harvest_limits' => {
+            'log_event_data' => 0
+          }
+        }
+      }
+
+      expected = {
+        :'application_logging.forwarding.max_samples_stored' => 0,
+        :'event_report_period.log_event_data' => 5,
+        :event_report_period => 5
+      }
+      assert_equal expected, EventHarvestConfig.to_config_hash(connect_reply)
+    end
   end
 end

--- a/test/new_relic/agent/instrumentation/rails/active_storage_subscriber.rb
+++ b/test/new_relic/agent/instrumentation/rails/active_storage_subscriber.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 # This file is distributed under New Relic's license terms.
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+require File.expand_path '../../../../../test_helper', __FILE__
 
 module NewRelic
   module Agent

--- a/test/new_relic/agent/stats_engine_test.rb
+++ b/test/new_relic/agent/stats_engine_test.rb
@@ -178,22 +178,54 @@ class NewRelic::Agent::StatsEngineTest < Minitest::Test
     ])
   end
 
-  def test_record_scoped_and_unscoped_metrics_is_thread_safe
+  def test_record_scoped_and_unscoped_metrics_is_thread_safe_without_traced_threads
     threads = []
     nthreads = 25
     iterations = 100
 
-    nthreads.times do |tid|
-      threads << Thread.new do
-        iterations.times do
-          in_transaction('txn') do
-            @engine.tl_record_scoped_and_unscoped_metrics('m1', ['m3'], 1)
-            @engine.tl_record_scoped_and_unscoped_metrics('m2', ['m4'], 1)
+    with_config(:'instrumentation.thread.tracing' => false) do
+      nthreads.times do |tid|
+        threads << Thread.new do
+          iterations.times do
+            in_transaction('txn') do
+              @engine.tl_record_scoped_and_unscoped_metrics('m1', ['m3'], 1)
+              @engine.tl_record_scoped_and_unscoped_metrics('m2', ['m4'], 1)
+            end
           end
         end
+        threads.each { |t| t.join }
       end
     end
-    threads.each { |t| t.join }
+
+    expected = {:call_count => nthreads * iterations}
+    assert_metrics_recorded(
+      'm1' => expected,
+      'm2' => expected,
+      ['m1', 'txn'] => expected,
+      ['m2', 'txn'] => expected,
+      'm3' => expected,
+      'm4' => expected
+    )
+  end
+
+  def test_record_scoped_and_unscoped_metrics_is_thread_safe_with_traced_threads
+    threads = []
+    nthreads = 25
+    iterations = 100
+
+    with_config(:'instrumentation.thread.tracing' => true) do
+      in_transaction('txn') do
+        nthreads.times do |tid|
+          threads << Thread.new do
+            iterations.times do
+              @engine.tl_record_scoped_and_unscoped_metrics('m1', ['m3'], 1)
+              @engine.tl_record_scoped_and_unscoped_metrics('m2', ['m4'], 1)
+            end
+          end
+        end
+        threads.each { |t| t.join }
+      end
+    end
 
     expected = {:call_count => nthreads * iterations}
     assert_metrics_recorded(

--- a/test/new_relic/agent/tracer_test.rb
+++ b/test/new_relic/agent/tracer_test.rb
@@ -282,6 +282,64 @@ module NewRelic
         assert_nil Tracer.current_segment
       end
 
+      def test_current_segment_in_nested_threads_with_traced_thread
+        assert_nil Tracer.current_segment
+
+        txn = Tracer.start_transaction(name: "Controller/blogs/index", category: :controller)
+        assert_equal txn.initial_segment, Tracer.current_segment
+        threads = []
+
+        threads << ::NewRelic::TracedThread.new do
+          segment = Tracer.start_segment(name: "Custom/MyClass/myoperation")
+          assert_equal segment, Tracer.current_segment
+
+          threads << ::NewRelic::TracedThread.new do
+            segment2 = Tracer.start_segment(name: "Custom/MyClass/myoperation2")
+            assert_equal segment2, Tracer.current_segment
+            segment2.finish
+          end
+
+          # make sure current segment is still the outer segment
+          assert_equal segment, Tracer.current_segment
+          segment.finish # finish thread segment
+        end
+
+        assert_equal txn.initial_segment, Tracer.current_segment
+        threads.each(&:join)
+        txn.finish
+        assert_nil Tracer.current_segment
+      end
+
+      def test_current_segment_in_nested_threads_auto
+        with_config(:'instrumentation.thread.tracing' => true) do
+          assert_nil Tracer.current_segment
+
+          txn = Tracer.start_transaction(name: "Controller/blogs/index", category: :controller)
+          assert_equal txn.initial_segment, Tracer.current_segment
+          threads = []
+
+          threads << ::Thread.new do
+            segment = Tracer.start_segment(name: "Custom/MyClass/myoperation")
+            assert_equal segment, Tracer.current_segment
+
+            threads << Thread.new do
+              segment2 = Tracer.start_segment(name: "Custom/MyClass/myoperation2")
+              assert_equal segment2, Tracer.current_segment
+              segment2.finish
+            end
+
+            # make sure current segment is still the outer segment
+            assert_equal segment, Tracer.current_segment
+            segment.finish # finish thread segment
+          end
+
+          assert_equal txn.initial_segment, Tracer.current_segment
+          threads.each(&:join)
+          txn.finish
+          assert_nil Tracer.current_segment
+        end
+      end
+
       def test_start_segment
         name = "Custom/MyClass/myoperation"
         unscoped_metrics = [

--- a/test/new_relic/agent/transaction/external_request_segment_test.rb
+++ b/test/new_relic/agent/transaction/external_request_segment_test.rb
@@ -868,7 +868,7 @@ module NewRelic::Agent
         assert_empty last_span_events
       end
 
-      def test_non_sampled_segment_does_not_record_span_event
+      def test_ignored_segment_does_not_record_span_event
         in_transaction('wat') do |txn|
           txn.stubs(:ignore?).returns(true)
 

--- a/test/new_relic/dependency_detection_test.rb
+++ b/test/new_relic/dependency_detection_test.rb
@@ -158,7 +158,7 @@ class DependencyDetectionTest < Minitest::Test
       assert executed
     end
 
-    # TODO: Deprecated!  Remove in 8.0 Release
+    # TODO: MAJOR VERSION - Deprecated!
     with_config(:disable_testing => true) do
       executed = false
       DependencyDetection.detect!

--- a/test/performance/suites/external_segment.rb
+++ b/test/performance/suites/external_segment.rb
@@ -39,6 +39,17 @@ class ExternalSegment < Performance::TestCase
     stop_server io_server
   end
 
+  def test_external_request_in_thread
+    io_server = start_server
+    measure do
+      in_transaction do
+        thread = Thread.new { Net::HTTP.get(TEST_URI) }
+        thread.join
+      end
+    end
+    stop_server io_server
+  end
+
   def test_external_cat_request
     NewRelic::Agent.config.add_config_for_testing(CAT_CONFIG)
 
@@ -59,6 +70,19 @@ class ExternalSegment < Performance::TestCase
     measure do
       in_transaction do
         Net::HTTP.get(TEST_URI)
+      end
+    end
+    stop_server io_server
+  end
+
+  def test_external_trace_context_request_within_thread
+    NewRelic::Agent.config.add_config_for_testing(TRACE_CONTEXT_CONFIG)
+
+    io_server = start_server
+    measure do
+      in_transaction do
+        thread = Thread.new { Net::HTTP.get(TEST_URI) }
+        thread.join
       end
     end
     stop_server io_server


### PR DESCRIPTION
- We 'trace' methods in this context, we don't 'monitor' them
- Clean up `ActionControllerSubscriber#start_transaction_or_segment`'s
  awkwardly large options hash instantation
- Add comments to map the MLT attribute names to their Ruby counterparts
- Typo fix for `EMPTY_HASH`
- Rename `CODE_` constant to `SOURCE_CODE` for uniformity
- Fix bullet point indentation in source comment