### PR TITLE
Add alt-text to README banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Community Plus header](https://github.com/newrelic/opensource-website/raw/master/src/images/categories/Community_Plus.png)](https://opensource.newrelic.com/oss-category/#community-plus)
+[![Blue banner - Community Plus: This code is currently maintained by New Relic engineering teams and delivered here in GitHub. See the README for troubleshooting and defect reporting instructions.](https://github.com/newrelic/opensource-website/raw/master/src/images/categories/Community_Plus.png)](https://opensource.newrelic.com/oss-category/#community-plus)
 
 # New Relic Ruby Agent
 


### PR DESCRIPTION
# Overview
The Community Plus header on our README does not have alt text describing the image. This PR adds alt-text describing the banner and duplicating the text that appears so that it is more accessible.
