### PR TITLE
rails tests: keep Ruby 2.2 below Rails 5.2.7.1

### DIFF
--- a/test/multiverse/suites/rails/Envfile
+++ b/test/multiverse/suites/rails/Envfile
@@ -40,7 +40,8 @@ end
 
 if RUBY_VERSION < '3.0.0'
   gemfile <<-RB
-    gem 'rails', '~> 5.2.0'
+    # Rails 5.2.7.1 uses a '~>>' style heredoc that breaks Ruby 2.2 compatibility
+    gem 'rails', '~> 5.2.0'#{", '<= 5.2.7'" if RUBY_VERSION < '2.3.0'}
     gem 'haml', '~> 5.1.2'
     gem 'haml-rails', '~> 1.0.0'
     gem 'minitest', '5.2.3'

--- a/test/multiverse/suites/rails_prepend/Envfile
+++ b/test/multiverse/suites/rails_prepend/Envfile
@@ -27,7 +27,8 @@ end
 
 if RUBY_VERSION < '3.0.0'
   gemfile <<-RB
-    gem 'rails', '~> 5.2.0'
+    # Rails 5.2.7.1 uses a '~>>' style heredoc that breaks Ruby 2.2 compatibility
+    gem 'rails', '~> 5.2.0'#{", '<= 5.2.7'" if RUBY_VERSION >= 2.4.0}
     gem 'haml', '~> 5.1.2'
     gem 'newrelic_prepender', path: File.expand_path('../newrelic_prepender', __FILE__)
     gem 'minitest', '5.2.3'

--- a/test/multiverse/suites/rails_prepend/Envfile
+++ b/test/multiverse/suites/rails_prepend/Envfile
@@ -28,7 +28,7 @@ end
 if RUBY_VERSION < '3.0.0'
   gemfile <<-RB
     # Rails 5.2.7.1 uses a '~>>' style heredoc that breaks Ruby 2.2 compatibility
-    gem 'rails', '~> 5.2.0'#{", '<= 5.2.7'" if RUBY_VERSION >= 2.4.0}
+    gem 'rails', '~> 5.2.0'#{", '<= 5.2.7'" if RUBY_VERSION >= '2.4.0'}
     gem 'haml', '~> 5.1.2'
     gem 'newrelic_prepender', path: File.expand_path('../newrelic_prepender', __FILE__)
     gem 'minitest', '5.2.3'

--- a/test/multiverse/suites/rails_prepend/Envfile
+++ b/test/multiverse/suites/rails_prepend/Envfile
@@ -28,7 +28,7 @@ end
 if RUBY_VERSION < '3.0.0'
   gemfile <<-RB
     # Rails 5.2.7.1 uses a '~>>' style heredoc that breaks Ruby 2.2 compatibility
-    gem 'rails', '~> 5.2.0'#{", '<= 5.2.7'" if RUBY_VERSION >= '2.4.0'}
+    gem 'rails', '~> 5.2.0'#{", '<= 5.2.7'" if RUBY_VERSION < '2.3.0'}
     gem 'haml', '~> 5.1.2'
     gem 'newrelic_prepender', path: File.expand_path('../newrelic_prepender', __FILE__)
     gem 'minitest', '5.2.3'


### PR DESCRIPTION
Rails 5.2.7.1 inadvertently broke Ruby 2.2 compatibility by including a
'~>>` style heredoc. For Rubies below 2.4 that don't support that
heredoc syntax, stick with Rails 5.2.7 or below.