### PR TITLE
Fix comparison for string vs Gem::Version

### DIFF
--- a/lib/new_relic/agent/instrumentation/active_merchant.rb
+++ b/lib/new_relic/agent/instrumentation/active_merchant.rb
@@ -36,7 +36,7 @@ DependencyDetection.defer do
   end
 
   executes do
-    next unless ActiveMerchant::VERSION < Gem::Version.new('1.65.0')
+    next unless Gem::Version.new(ActiveMerchant::VERSION) < Gem::Version.new('1.65.0')
     deprecation_msg = 'The Ruby Agent is dropping support for ActiveMerchant versions below 1.65.0 ' \
       'in version 9.0.0. Please upgrade your ActiveMerchant version to continue receiving full support. ' \
 

--- a/lib/new_relic/agent/instrumentation/sidekiq.rb
+++ b/lib/new_relic/agent/instrumentation/sidekiq.rb
@@ -101,7 +101,7 @@ DependencyDetection.defer do
   end
 
   executes do
-    next unless Sidekiq::VERSION < Gem::Version.new('5.0.0')
+    next unless Gem::Version.new(Sidekiq::VERSION) < Gem::Version.new('5.0.0')
     deprecation_msg = 'Instrumentation for Sidekiq versions below 5.0.0 is deprecated.' \
       'They will stop being monitored in version 9.0.0. ' \
       'Please upgrade your Sidekiq version to continue receiving full support. '

--- a/lib/new_relic/agent/instrumentation/sinatra.rb
+++ b/lib/new_relic/agent/instrumentation/sinatra.rb
@@ -44,7 +44,7 @@ DependencyDetection.defer do
   end
 
   executes do
-    next unless Sinatra::VERSION < Gem::Version.new('2.0.0')
+    next unless Gem::Version.new(Sinatra::VERSION) < Gem::Version.new('2.0.0')
     deprecation_msg = 'The Ruby Agent is dropping support for Sinatra versions below 2.0.0 ' \
       'in version 9.0.0. Please upgrade your Sinatra version to continue receiving full compatibility. ' \
 


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
While I was looking into an unrelated issue, I discovered that there were errors in the agent log for these lines, since it doesn't like the string VS Gem::Version comparison. This pr converts the strings to version objects to avoid that issue.


