### PR TITLE
rework constantize calls

### DIFF
--- a/lib/new_relic/agent/autostart.rb
+++ b/lib/new_relic/agent/autostart.rb
@@ -40,7 +40,7 @@ module NewRelic
             # Example:
             #  irb> class MyClass; end; module MyModule; end
             #  irb> Object.const_defined?('MyModule::MyClass') # => true
-            !!::NewRelic::LanguageSupport.constantize(const_name)
+            !!::NewRelic::LanguageSupport.constantize(name)
           else
             Object.const_defined?(name)
           end

--- a/lib/new_relic/agent/autostart.rb
+++ b/lib/new_relic/agent/autostart.rb
@@ -31,23 +31,13 @@ module NewRelic
       COMMA = ",".freeze
 
       def denylisted_constants?
-        constants = NewRelic::Agent.config[:'autostart.denylisted_constants']
-
-        denylisted?(constants) do |name|
-          constant_is_defined?(name)
-        end
+        denylisted?(NewRelic::Agent.config[:'autostart.denylisted_constants']) { |name| Object.const_defined?(name) }
       end
 
       def denylisted_executables?
         denylisted?(NewRelic::Agent.config[:'autostart.denylisted_executables']) do |bin|
           File.basename($0) == bin
         end
-      end
-
-      # Lookup whether namespaced constants (e.g. ::Foo::Bar::Baz) are in the
-      # environment.
-      def constant_is_defined?(const_name)
-        !!::NewRelic::LanguageSupport.constantize(const_name)
       end
 
       def denylisted?(value, &block)

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -247,7 +247,7 @@ module NewRelic
         end
 
         def self.convert_to_constant_list(raw_value)
-          return [] if raw_value.nil? || raw_value.empty?
+          return NewRelic::EMPTY_ARRAY if raw_value.nil? || raw_value.empty?
 
           constants = convert_to_list(raw_value).map! do |class_name|
             const = ::NewRelic::LanguageSupport.constantize(class_name)

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -247,17 +247,15 @@ module NewRelic
         end
 
         def self.convert_to_constant_list(raw_value)
-          const_names = convert_to_list(raw_value)
-          const_names.map! do |class_name|
+          return [] if raw_value.nil? || raw_value.empty?
+
+          constants = convert_to_list(raw_value).map! do |class_name|
             const = ::NewRelic::LanguageSupport.constantize(class_name)
-
-            unless const
-              NewRelic::Agent.logger.warn("Ignoring unrecognized constant '#{class_name}' in #{raw_value}")
-            end
-
+            NewRelic::Agent.logger.warn("Ignoring invalid constant '#{class_name}' in #{raw_value}") unless const
             const
           end
-          const_names.compact
+          constants.compact!
+          constants
         end
 
         def self.enforce_fallback(allowed_values: nil, fallback: nil)

--- a/lib/new_relic/agent/instrumentation/action_controller_subscriber.rb
+++ b/lib/new_relic/agent/instrumentation/action_controller_subscriber.rb
@@ -72,7 +72,7 @@ module NewRelic
         end
 
         def format_metric_name(metric_action, controller_name)
-          controller_class = ::NewRelic::LanguageSupport.constantize(controller_name)
+          controller_class = Object.const_get(controller_name)
           "Controller/#{controller_class.controller_path}/#{metric_action}"
         end
 

--- a/lib/new_relic/agent/instrumentation/action_controller_subscriber.rb
+++ b/lib/new_relic/agent/instrumentation/action_controller_subscriber.rb
@@ -71,8 +71,8 @@ module NewRelic
           )
         end
 
-        def format_metric_name(metric_action, controller_name)
-          controller_class = Object.const_get(controller_name)
+        def format_metric_name(metric_action, controller)
+          controller_class = controller.is_a?(Class) ? controller : Object.const_get(controller)
           "Controller/#{controller_class.controller_path}/#{metric_action}"
         end
 

--- a/lib/new_relic/language_support.rb
+++ b/lib/new_relic/language_support.rb
@@ -34,6 +34,23 @@ module NewRelic
       RUBY_ENGINE == 'jruby'
     end
 
+    # TODO: OLD RUBIES - RUBY_VERSION < 2.6
+    #
+    # Ruby 2.6 introduced an improved version of `Object.const_get` that
+    # respects the full namespace of the input and doesn't just grab the first
+    # constant matching the string to the right of the last '::'.
+    # Once we drop support for Ruby 2.5 and below, the only value this custom
+    # method will provide beyond `Object.const_get` itself is to automatically
+    # catch NameError.
+    #
+    # see: https://github.com/rails/rails/commit/7057ccf6565c1cb5354c1906880119276a9d15c0
+    #
+    # With Ruby 2.6+, this method can be defined like so:
+    # def constantize(constant_as_string_or_symbol)
+    #   Object.const_get(constant_as_string_or_symbol)
+    # rescue NameError
+    # end
+    #
     def constantize(const_name)
       const_name.to_s.sub(/\A::/, '').split('::').inject(Object) do |namespace, name|
         begin


### PR DESCRIPTION
`NewRelic::LanguageSupport.constantize`, which returns a Ruby constant
corresponding to the given string, is very similar to
`ActiveSupport::Inflector#constantize`.

With
https://github.com/rails/rails/commit/7057ccf6565c1cb5354c1906880119276a9d15c0
the Rails team has updated `#constantize` to simply call
`Object.const_get` on the given input string and reaped performance
benefits from doing so. We're unable to update the agent's
`constantize` method until we drop support for Ruby 2.5, given that
`Object.const_get` does not provide the same functionality we desire
until Ruby 2.6.

Before Ruby 2.6 `Object.const_get('Namespace1::MyClass')` will return
`MyClass` if `Namespace2::MyClass` exists, even though
`Namespace1::MyClass` (the desired constant) does not.

But, we can still make some performance gains by eliminating 2 of the 3
calls being made to our `constantize` method:

- The processing of user input for
  `strip_execution_messages.allowed_classes`: must continue to use
  `constantize`
- The agent's autostart logic: can stop using `constantize`
- The Rails controller subscriber: can stop using `constantize`

The following changes have been introduced:

- The agent's autostart logic will now use `Object.const_defined?`
  instead of `constantize`
- When processing the `strip_execution_messages.allowed_classes`
  configuration parameter, return early if there aren't any string
  values to be constantized, and use `compact!` to cut down on object
  allocation
- When processing Rails controller class names in the subscriber, trust
  Rails to have given us a value that will work fine with
  `Object.const_get`
- Add a TODO to the `constantize` method for when we drop Ruby 2.5 in
  the future.