### PR TITLE
docker-compose.yml: supply a default Ruby version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,7 @@ services:
     build:
       context: .
       args:
-        - ruby_version=${RUBY_VERSION}
+        - ruby_version=${RUBY_VERSION:-3.1}
     image: newrelic_rpm
     tty: true
     stdin_open: true


### PR DESCRIPTION
`docker-compose.yml` was inadvertently made to require a 'RUBY_VERSION'
environment variable because passing an empty value to `Dockerfile`
caused the `Dockerfile` build argument default value to be overridden.

Now when the `RUBY_VERSION` environment variable is not set, a default
version will be defined by `docker-compose.yml`.
