### PR TITLE
Bugfix: Error events missing priority when created outside of a transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,11 @@
 
     The `transaction_events.max_samples_stored` capacity value within the TransactionEventAggregator did not match up with its expected harvest cycle interval, causing TransactionEvents to be over-sampled. This bugfix builds upon the updates made in [#952](https://github.com/newrelic/newrelic-ruby-agent/pull/952) so that the interval and capacity behave as expected for the renamed `transaction_events*` configuration options.
 
+  * **Bugfix: Error events missing attributes when created outside of a transaction**
+
+    Previously the agent was not assigning a priority to error events that were created by calling notice_error outside the scope of a transaction. This caused issues with sampling when the error event buffer was full, resulting in a `NoMethodError: undefined method '<' for nil:NilClass` in the newrelic_agent.log. This bugfix ensures that a priority is always assigned on error events so that the agent will be able to sample these error events correctly. Thank you to @olleolleolle for bringing this issue to our attention.
+    
+
 
   ## v8.6.0
 

--- a/lib/new_relic/agent/transaction_error_primitive.rb
+++ b/lib/new_relic/agent/transaction_error_primitive.rb
@@ -63,6 +63,8 @@ module NewRelic
           append_cat payload, attrs
           DistributedTraceAttributes.copy_to_hash payload, attrs
           PayloadMetricMapping.append_mapped_metrics payload[:metrics], attrs
+        else
+          attrs[PRIORITY_KEY] = rand.round(NewRelic::PRIORITY_PRECISION)
         end
 
         attrs

--- a/test/multiverse/suites/agent_only/error_events_test.rb
+++ b/test/multiverse/suites/agent_only/error_events_test.rb
@@ -101,6 +101,7 @@ class ErrorEventsTest < Minitest::Test
     assert_in_delta Process.clock_gettime(Process::CLOCK_REALTIME), intrinsics["timestamp"], 0.001
     assert_equal "RuntimeError", intrinsics["error.class"]
     assert_equal "No Txn", intrinsics["error.message"]
+    assert intrinsics["priority"], "Priority is nil"
   end
 
   def test_error_events_during_txn_abide_by_custom_attributes_config


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
This fixes a bug in how we're creating error events when not in a transaction.
Currently, when notice_error is called while not in a transaction, the priority is not set on the event because we are only taking it from the transaction payload passed in, which does not exist in this situation. This only begins to cause errors once the error event aggregator is full and we begin sampling.

I did check other event types to make sure this situation isn't possible for any other events.
- Span events are not created outside of a transaction
- Transaction events don't have this issue because they are the transaction
- Custom Events don't appear to have this issue since they are constructed differently and the priority is set directly in the custom even aggregator. 


# Related Github Issue
closes #817 


# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
