### PR TITLE
rework cross agent pull/push rake tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -116,8 +116,8 @@ task :update_ca_bundle do |t|
 end
 
 namespace :cross_agent_tests do
-  CROSS_AGENT_TESTS_UPSTREAM_PATH = File.expand_path(File.join('..', 'cross_agent_tests'), __FILE__).freeze
-  CROSS_AGENT_TESTS_LOCAL_PATH = File.expand_path(File.join('test', 'fixtures', 'cross_agent_tests'), __FILE__).freeze
+  CROSS_AGENT_TESTS_UPSTREAM_PATH = File.expand_path(File.join('..', 'cross_agent_tests')).freeze
+  CROSS_AGENT_TESTS_LOCAL_PATH = File.expand_path(File.join('test', 'fixtures', 'cross_agent_tests')).freeze
 
   def prompt_to_continue(command, destination = 'local')
     puts "The following rsync command will be executed to update the #{destination} copy of the specs:"

--- a/Rakefile
+++ b/Rakefile
@@ -116,24 +116,38 @@ task :update_ca_bundle do |t|
 end
 
 namespace :cross_agent_tests do
-  cross_agent_tests_upstream_path = File.expand_path(File.join(File.dirname(__FILE__), '..', 'cross_agent_tests'))
-  cross_agent_tests_local_path = File.expand_path(File.join(File.dirname(__FILE__), 'test', 'fixtures', 'cross_agent_tests'))
+  CROSS_AGENT_TESTS_UPSTREAM_PATH = File.expand_path(File.join('..', 'cross_agent_tests'), __FILE__).freeze
+  CROSS_AGENT_TESTS_LOCAL_PATH = File.expand_path(File.join('test', 'fixtures', 'cross_agent_tests'), __FILE__).freeze
 
-  # Note: before you pull, make sure your local repo is on the correct, synced branch!
+  def prompt_to_continue(command, destination = 'local')
+    puts "The following rsync command will be executed to update the #{destination} copy of the specs:"
+    puts
+    puts command
+    puts
+    puts "CAUTION: Any unsaved changes that exist within the #{destination} content will be OVERWRITTEN!"
+    if destination.eql?('local')
+      puts 'CAUTION 2: Before continuing, make sure your local repo is on the correct, synced branch!'
+    end
+    puts
+    print "Do you wish to continue? ('y' to continue, return to cancel) [n] "
+    continue = STDIN.gets.chomp
+    if continue.downcase.eql?('y')
+      system(command)
+    else
+      puts 'Cancelled'
+    end
+  end
+
   desc 'Pull latest changes from cross_agent_tests repo'
   task :pull do
-    puts "Updating embedded cross_agent_tests from #{cross_agent_tests_upstream_path}..."
-    cmd = "rsync -avu --exclude .git #{cross_agent_tests_upstream_path}/ #{cross_agent_tests_local_path}/"
-    puts cmd
-    system(cmd)
+    command = "  rsync -av --exclude .git #{CROSS_AGENT_TESTS_UPSTREAM_PATH}/ #{CROSS_AGENT_TESTS_LOCAL_PATH}/"
+    prompt_to_continue(command)
   end
 
   desc 'Copy changes from embedded cross_agent_tests to official repo working copy'
   task :push do
-    puts "Copying changes from embedded cross_agent_tests to #{cross_agent_tests_upstream_path}..."
-    cmd = "rsync -avu #{cross_agent_tests_local_path}/ #{cross_agent_tests_upstream_path}/"
-    puts cmd
-    system(cmd)
+    command = "rsync -av #{CROSS_AGENT_TESTS_LOCAL_PATH}/ #{CROSS_AGENT_TESTS_UPSTREAM_PATH}/"
+    prompt_to_continue(command, 'remote (agent spec repo)')
   end
 end
 


### PR DESCRIPTION
The previous passing of `-u` to `rsync` (don't overwrite the destination
content if it has a newer timestamp than the source content) was
problematic because it assumed that a developer would have both the Ruby
agent and the cross agent specs cloned, then have new specs authored and
pulled down, and then perform the sync. If the cross agent specs haven't
been updated in a while, then the clone order of the repos becomes a
factor in the timestamp comparison.

Now, the pull and push rake targets will always overwrite the
destination content with the source content. To compensate for this, the
user is now prompted to continue or cancel with a warning that any
unsaved changes will be overwritten, and the previous source code
comment based warning is now presented to stdout as well.

resolves #924

