### PR TITLE
default to Code Level Metrics support disabled

### DIFF
--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2013,7 +2013,7 @@ A map of error classes to a list of messages. When an error of one of the classe
           :description => 'If `true`, the agent decorates logs with metadata to link to entities, hosts, traces, and spans.'
         },
         :'code_level_metrics.enabled' => {
-          :default => true,
+          :default => false,
           :public => true,
           :type => Boolean,
           :allowed_from_server => true,

--- a/newrelic.yml
+++ b/newrelic.yml
@@ -43,7 +43,7 @@ common: &default_settings
 # application_logging.local_decorating.enabled: false
 
 # If `true`, the agent will report source code level metrics for traced methods
-# code_level_metrics.enabled: true
+# code_level_metrics.enabled: false
 
 # If true, enables transaction event sampling.
 # transaction_events.enabled: true

--- a/test/new_relic/agent/instrumentation/rails/action_controller_subscriber.rb
+++ b/test/new_relic/agent/instrumentation/rails/action_controller_subscriber.rb
@@ -324,15 +324,17 @@ class NewRelic::Agent::Instrumentation::ActionControllerSubscriberTest < Minites
   end
 
   def test_records_code_level_metrics
-    @subscriber.start('process_action.action_controller', :id, @entry_payload)
-    txn = NewRelic::Agent::Transaction.tl_current
-    @subscriber.finish('process_action.action_controller', :id, @entry_payload)
-    attributes = txn.segments.first.code_attributes
+    with_config(:'code_level_metrics.enabled' => true) do
+      @subscriber.start('process_action.action_controller', :id, @entry_payload)
+      txn = NewRelic::Agent::Transaction.tl_current
+      @subscriber.finish('process_action.action_controller', :id, @entry_payload)
+      attributes = txn.segments.first.code_attributes
 
-    assert_equal __FILE__, attributes['code.filepath']
-    assert_equal 'index', attributes['code.function']
-    assert_equal TestController.instance_method(:index).source_location.last, attributes['code.lineno']
-    assert_equal "NewRelic::Agent::Instrumentation::ActionControllerSubscriberTest::TestController",
-      attributes['code.namespace']
+      assert_equal __FILE__, attributes['code.filepath']
+      assert_equal 'index', attributes['code.function']
+      assert_equal TestController.instance_method(:index).source_location.last, attributes['code.lineno']
+      assert_equal "NewRelic::Agent::Instrumentation::ActionControllerSubscriberTest::TestController",
+        attributes['code.namespace']
+    end
   end
 end

--- a/test/new_relic/agent/method_tracer_helpers_test.rb
+++ b/test/new_relic/agent/method_tracer_helpers_test.rb
@@ -15,19 +15,25 @@ class NewRelic::Agent::MethodTracerHelpersTest < Minitest::Test
   # TODO: trace_execution_scoped should have test coverage
 
   def test_obtains_a_class_name_from_a_singleton_class_string
-    name = NewRelic::Agent::MethodTracerHelpers.send(:klass_name, The::Example.singleton_class.to_s)
-    assert_equal 'The::Example', name
+    with_config(:'code_level_metrics.enabled' => true) do
+      name = NewRelic::Agent::MethodTracerHelpers.send(:klass_name, The::Example.singleton_class.to_s)
+      assert_equal 'The::Example', name
+    end
   end
 
   def test_returns_nil_if_a_name_cannot_be_determined
-    assert_raises RuntimeError do
-      NewRelic::Agent::MethodTracerHelpers.send(:klass_name, 'StrawberriesAndSashimi')
+    with_config(:'code_level_metrics.enabled' => true) do
+      assert_raises RuntimeError do
+        NewRelic::Agent::MethodTracerHelpers.send(:klass_name, 'StrawberriesAndSashimi')
+      end
     end
   end
 
   def test_gets_at_an_underlying_class_from_a_singleton_class
-    klass = NewRelic::Agent::MethodTracerHelpers.send(:klassify_singleton, The::Example.singleton_class)
-    assert The::Example, klass
+    with_config(:'code_level_metrics.enabled' => true) do
+      klass = NewRelic::Agent::MethodTracerHelpers.send(:klassify_singleton, The::Example.singleton_class)
+      assert The::Example, klass
+    end
   end
 
   def test_do_not_gather_code_info_when_disabled_by_configuration
@@ -38,54 +44,64 @@ class NewRelic::Agent::MethodTracerHelpersTest < Minitest::Test
   end
 
   def test_uses_cache_if_an_object_and_method_combo_have_already_been_seen
-    object = The::Example.new
-    method_name = :instance_method
-    cached_info = 'Badger'
-    cache = {"#{object.object_id}#{method_name}" => cached_info}
-    NewRelic::Agent::MethodTracerHelpers.instance_variable_set(:@code_information, cache)
-    info = NewRelic::Agent::MethodTracerHelpers.code_information(object, method_name)
-    assert_equal cached_info, info
+    with_config(:'code_level_metrics.enabled' => true) do
+      object = The::Example.new
+      method_name = :instance_method
+      cached_info = 'Badger'
+      cache = {"#{object.object_id}#{method_name}" => cached_info}
+      NewRelic::Agent::MethodTracerHelpers.instance_variable_set(:@code_information, cache)
+      info = NewRelic::Agent::MethodTracerHelpers.code_information(object, method_name)
+      assert_equal cached_info, info
+    end
   end
 
   def test_provides_accurate_info_for_a_class_method
-    info = NewRelic::Agent::MethodTracerHelpers.code_information(The::Example.singleton_class, :class_method)
-    assert_equal({filepath: __FILE__,
-      lineno: The::Example.method(:class_method).source_location.last,
-      function: :class_method,
-      namespace: 'The::Example'},
-      info)
+    with_config(:'code_level_metrics.enabled' => true) do
+      info = NewRelic::Agent::MethodTracerHelpers.code_information(The::Example.singleton_class, :class_method)
+      assert_equal({filepath: __FILE__,
+        lineno: The::Example.method(:class_method).source_location.last,
+        function: :class_method,
+        namespace: 'The::Example'},
+        info)
+    end
   end
 
   def test_provides_accurate_info_for_an_instance_method
-    info = NewRelic::Agent::MethodTracerHelpers.code_information(::The::Example, :instance_method)
-    assert_equal({filepath: __FILE__,
-      lineno: The::Example.instance_method(:instance_method).source_location.last,
-      function: :instance_method,
-      namespace: 'The::Example'},
-      info)
+    with_config(:'code_level_metrics.enabled' => true) do
+      info = NewRelic::Agent::MethodTracerHelpers.code_information(::The::Example, :instance_method)
+      assert_equal({filepath: __FILE__,
+        lineno: The::Example.instance_method(:instance_method).source_location.last,
+        function: :instance_method,
+        namespace: 'The::Example'},
+        info)
+    end
   end
 
   def test_provides_accurate_info_for_an_anonymous_instance_method
-    klass = Class.new do
-      def an_instance_method; end
+    with_config(:'code_level_metrics.enabled' => true) do
+      klass = Class.new do
+        def an_instance_method; end
+      end
+      info = NewRelic::Agent::MethodTracerHelpers.code_information(klass, :an_instance_method)
+      assert_equal({filepath: __FILE__,
+        lineno: klass.instance_method(:an_instance_method).source_location.last,
+        function: :an_instance_method,
+        namespace: '(Anonymous)'},
+        info)
     end
-    info = NewRelic::Agent::MethodTracerHelpers.code_information(klass, :an_instance_method)
-    assert_equal({filepath: __FILE__,
-      lineno: klass.instance_method(:an_instance_method).source_location.last,
-      function: :an_instance_method,
-      namespace: '(Anonymous)'},
-      info)
   end
 
   def test_provides_accurate_info_for_an_anonymous_class_method
-    klass = Class.new do
-      def self.a_class_method; end
+    with_config(:'code_level_metrics.enabled' => true) do
+      klass = Class.new do
+        def self.a_class_method; end
+      end
+      info = NewRelic::Agent::MethodTracerHelpers.code_information(klass, :a_class_method)
+      assert_equal({filepath: __FILE__,
+        lineno: klass.method(:a_class_method).source_location.last,
+        function: :a_class_method,
+        namespace: '(Anonymous)'},
+        info)
     end
-    info = NewRelic::Agent::MethodTracerHelpers.code_information(klass, :a_class_method)
-    assert_equal({filepath: __FILE__,
-      lineno: klass.method(:a_class_method).source_location.last,
-      function: :a_class_method,
-      namespace: '(Anonymous)'},
-      info)
   end
 end


### PR DESCRIPTION
The test results and value add for CLM are in favor of enabling the
functionality by default, but we will follow the same approach taken for
logging and default to having the option off for an initial opt-in
rollout.