### PR TITLE
CLM: prefix class functions with 'self.'

### DIFF
--- a/test/new_relic/agent/method_tracer_helpers_test.rb
+++ b/test/new_relic/agent/method_tracer_helpers_test.rb
@@ -60,7 +60,7 @@ class NewRelic::Agent::MethodTracerHelpersTest < Minitest::Test
       info = NewRelic::Agent::MethodTracerHelpers.code_information(The::Example.singleton_class, :class_method)
       assert_equal({filepath: __FILE__,
         lineno: The::Example.method(:class_method).source_location.last,
-        function: :class_method,
+        function: 'self.class_method',
         namespace: 'The::Example'},
         info)
     end
@@ -71,7 +71,7 @@ class NewRelic::Agent::MethodTracerHelpersTest < Minitest::Test
       info = NewRelic::Agent::MethodTracerHelpers.code_information(::The::Example, :instance_method)
       assert_equal({filepath: __FILE__,
         lineno: The::Example.instance_method(:instance_method).source_location.last,
-        function: :instance_method,
+        function: 'instance_method',
         namespace: 'The::Example'},
         info)
     end
@@ -85,7 +85,7 @@ class NewRelic::Agent::MethodTracerHelpersTest < Minitest::Test
       info = NewRelic::Agent::MethodTracerHelpers.code_information(klass, :an_instance_method)
       assert_equal({filepath: __FILE__,
         lineno: klass.instance_method(:an_instance_method).source_location.last,
-        function: :an_instance_method,
+        function: 'an_instance_method',
         namespace: '(Anonymous)'},
         info)
     end
@@ -99,7 +99,7 @@ class NewRelic::Agent::MethodTracerHelpersTest < Minitest::Test
       info = NewRelic::Agent::MethodTracerHelpers.code_information(klass, :a_class_method)
       assert_equal({filepath: __FILE__,
         lineno: klass.method(:a_class_method).source_location.last,
-        function: :a_class_method,
+        function: 'self.a_class_method',
         namespace: '(Anonymous)'},
         info)
     end

--- a/test/new_relic/agent/method_tracer_test.rb
+++ b/test/new_relic/agent/method_tracer_test.rb
@@ -187,7 +187,7 @@ class NewRelic::Agent::MethodTracerTest < Minitest::Test
 
       attributes = txn.segments.last.code_attributes
       assert_equal __FILE__, attributes['code.filepath']
-      assert_equal :class_method, attributes['code.function']
+      assert_equal 'self.class_method', attributes['code.function']
       assert_equal 57, attributes['code.lineno']
       assert_equal 'MyClass', attributes['code.namespace']
     end
@@ -208,7 +208,7 @@ class NewRelic::Agent::MethodTracerTest < Minitest::Test
 
       attributes = txn.segments.last.code_attributes
       assert_equal __FILE__, attributes['code.filepath']
-      assert_equal :module_method, attributes['code.function']
+      assert_equal 'self.module_method', attributes['code.function']
       assert_equal 67, attributes['code.lineno']
       assert_equal 'MyModule', attributes['code.namespace']
     end
@@ -243,7 +243,7 @@ class NewRelic::Agent::MethodTracerTest < Minitest::Test
 
       attributes = txn.segments.last.code_attributes
       assert_equal __FILE__, attributes['code.filepath']
-      assert_equal :instance_method, attributes['code.function']
+      assert_equal 'instance_method', attributes['code.function']
       assert_equal 220, attributes['code.lineno']
       assert_equal '(Anonymous)', attributes['code.namespace']
     end


### PR DESCRIPTION
Especially to disambiguate them from instance methods with the same
names, prefix class method names with 'self.' in the 'code.function'
attribute.