### PR TITLE
code level metrics for ActiveJob

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -819,9 +819,6 @@ Lint/UselessAccessModifier:
 Lint/UselessAssignment:
   Enabled: false
 
-Lint/UselessElseWithoutRescue:
-  Enabled: true
-
 Lint/UselessMethodDefinition:
   Enabled: false
 

--- a/lib/new_relic/agent/instrumentation/active_job.rb
+++ b/lib/new_relic/agent/instrumentation/active_job.rb
@@ -58,14 +58,19 @@ module NewRelic
         end
 
         def self.run_in_trace(job, block, event)
-          trace_execution_scoped("MessageBroker/#{adapter}/Queue/#{event}/Named/#{job.queue_name}") do
+          trace_execution_scoped("MessageBroker/#{adapter}/Queue/#{event}/Named/#{job.queue_name}",
+            code_information: code_information_for_job(job)) do
             block.call
           end
         end
 
         def self.run_in_transaction(job, block)
           ::NewRelic::Agent::Tracer.in_transaction(name: transaction_name_for_job(job),
-            category: :other, &block)
+            category: :other, options: {code_information: code_information_for_job(job)}, &block)
+        end
+
+        def self.code_information_for_job(job)
+          NewRelic::Agent::MethodTracerHelpers.code_information(job.class, :perform)
         end
 
         def self.transaction_category


### PR DESCRIPTION
fetch and then pass code level metrics related attributes downstream to
segment creation when ActiveJob `perform` calls are traced