### PR TITLE
ActiveJob: record CLM for new transactions

### DIFF
--- a/lib/new_relic/agent/instrumentation/active_job.rb
+++ b/lib/new_relic/agent/instrumentation/active_job.rb
@@ -66,7 +66,7 @@ module NewRelic
 
         def self.run_in_transaction(job, block)
           ::NewRelic::Agent::Tracer.in_transaction(name: transaction_name_for_job(job),
-            category: :other, options: {code_information: code_information_for_job(job)}, &block)
+            category: :other, options: code_information_for_job(job), &block)
         end
 
         def self.code_information_for_job(job)


### PR DESCRIPTION
Fix the passing of code level metrics to the instantiation of new
segments when an ActiveJob execution generates a new transaction.

Previously the 4 CLM key/value pairs were being passed within an inner
`:code_information` hash. These value are now correctly present in the
top level hash that the ActiveJob instrumentation class sends downstream
to transactions and segments.