### PR TITLE
Fix TracedThread yard documentation

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,6 +1,7 @@
 --non-transitive-tag api
 --api public
 lib/new_relic/agent.rb
+lib/new_relic/traced_thread.rb
 lib/new_relic/agent/method_tracer.rb
 lib/new_relic/agent/distributed_tracing.rb
 lib/new_relic/agent/distributed_trace_payload.rb

--- a/lib/new_relic/traced_thread.rb
+++ b/lib/new_relic/traced_thread.rb
@@ -7,19 +7,18 @@ module NewRelic
   #
   # This class allows the current transaction to be passed to a Thread so that nested segments can be created from the operations performed within the Thread's block.
   # To have the New Relic Ruby agent automatically trace all of your applications threads,
-  # enable the `instrumentation.thread.tracing` configuration option in your newrelic.yml.
+  # enable the +instrumentation.thread.tracing+ configuration option in your newrelic.yml.
   #
-  # Note: disabling the configuration option `instrumentation.thread` while using this class can cause incorrectly nested spans.
+  # Note: disabling the configuration option +instrumentation.thread+ while using this class can cause incorrectly nested spans.
   #
   # @api public
   class TracedThread < Thread
     #
     # Creates a new Thread whose work will be traced by New Relic.
     # Use this class as a replacement for the native Thread class.
-    # Example: Instead of using `Thread.new`, use:
-    # ```ruby
-    #   NewRelic::TracedThread.new { execute_some_code }
-    # ```
+    # Example: Instead of using +Thread.new+, use:
+    #
+    #     NewRelic::TracedThread.new { execute_some_code }
     #
     # @api public
     def initialize(*args, &block)


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
I noticed that our rubydocs was [missing](https://www.rubydoc.info/gems/newrelic_rpm/NewRelic/TracedThread) the new TracedThread class we added in the last version. I figured out how to generate it locally and I was able to get it updated it to make it show up and also fixed some syntax since markdown is not what it uses.


# Related Github Issue
Include a link to the related GitHub issue, if applicable

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
Github Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
