### PR TITLE
lower min compression threshold to 2048 bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
   ## v8.8.0
 
-  * **Lowered the minimum payload size to apply compression at**
+  * **Lowered the minimum payload size to compress**
 
     Previously the Ruby agent used a particularly large payload size threshold of 64KiB that would need to be met before the agent would compress data en route to New Relic's collector. The original value stems from segfault issues that very old Rubies (< 2.2) used to encounter when compressing smaller payloads. This value has been lowered to 2KiB (2048 bytes), which should provide a more optimal balance between the CPU cycles spent on compression and the bandwidth savings gained from it.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
   ## v8.8.0
 
+  * **Lowered the minimum payload size to apply compression at**
+
+    Previously the Ruby agent used a particularly large payload size threshold of 64KiB that would need to be met before the agent would compress data en route to New Relic's collector. The original value stems from segfault issues that very old Rubies (< 2.2) used to encounter when compressing smaller payloads. This value has been lowered to 2KiB (2048 bytes), which should provide a more optimal balance between the CPU cycles spent on compression and the bandwidth savings gained from it.
+
   * **Supportability Metrics will always report uncompressed payload size**
 
     New Relic's agent specifications call for Supportability Metrics to always reference the uncompressed payload byte size. Previously, the Ruby agent was calculating the byte size after compression. Furthermore, compression is only performed on payloads of a certain size. This means that sometimes the value could have represented a compressed size and sometimes an uncompressed one. Now the uncompressed value is always used, bringing consistency for comparing two instances of the same metric and alignment with the New Relic agent specifications.

--- a/test/new_relic/license_test.rb
+++ b/test/new_relic/license_test.rb
@@ -37,6 +37,7 @@ class LicenseTest < Minitest::Test
     ['/infinite_tracing/LICENSE', 'Apache'] => 6,
     ['/infinite_tracing/newrelic-infinite_tracing.gemspec', 'Apache'] => 1,
     ['/CHANGELOG.md', 'BSD'] => 3, # reference to BSD the operating system, not BSD the license
+    ['/lib/new_relic/agent/new_relic_service.rb', 'Apache'] => 1, # reference to Apache Tomcat in comments
     ['/lib/new_relic/agent/system_info.rb', 'BSD'] => 4, # reference to the operating system, not the license
     ['/test/new_relic/agent/system_info_test.rb', 'BSD'] => 2 # reference to the operating system, not the license
   }


### PR DESCRIPTION
lower the compression byte threshold:
`> 64 KiB`  ->  `>= 2 KiB`

previously the agent had a minimum byte size threshold of 64KiB. for any
payload equal to or below that size, compression would not be applied.
this relatively high threshold was originally established to prevent
segfaults from taking place in older versions of Ruby trying trying to
wrap C zlib/gzip libraries to compress small payloads.

with the currently supported Rubies (2.2 - 3.1), segfaults aren't a
problem for even the tiniest of payloads, so we are free to come up with
a value that balances cpu usage and bandwidth savings.

resolves #1136 