### PR TITLE
railsedge: explicitly target 'main' branch

### DIFF
--- a/test/environments/railsedge/Gemfile
+++ b/test/environments/railsedge/Gemfile
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 source 'https://rubygems.org'
 
-gem 'rails', git: 'https://github.com/rails/rails.git'
+gem 'rails', git: 'https://github.com/rails/rails.git', branch: 'main'
 gem "bootsnap", ">= 1.4.4", require: false
 
 gem 'minitest', '5.2.3'


### PR DESCRIPTION
help older Bundlers realize that the primary rails/rails branch is
`main`