### PR TITLE
Change log.level to level

### DIFF
--- a/lib/new_relic/agent/log_event_aggregator.rb
+++ b/lib/new_relic/agent/log_event_aggregator.rb
@@ -9,7 +9,7 @@ module NewRelic
   module Agent
     class LogEventAggregator < EventAggregator
       # Per-message keys
-      LEVEL_KEY = "log.level".freeze
+      LEVEL_KEY = "level".freeze
       MESSAGE_KEY = "message".freeze
       TIMESTAMP_KEY = "timestamp".freeze
       PRIORITY_KEY = "priority".freeze

--- a/test/multiverse/suites/agent_only/log_events_test.rb
+++ b/test/multiverse/suites/agent_only/log_events_test.rb
@@ -23,7 +23,7 @@ class LogEventsTest < Minitest::Test
 
     last_log = last_log_event
     assert_equal "Deadly", last_log["message"]
-    assert_equal "FATAL", last_log["log.level"]
+    assert_equal "FATAL", last_log["level"]
     assert_equal trace_id, last_log["trace.id"]
     assert_equal span_id, last_log["span.id"]
 
@@ -41,7 +41,7 @@ class LogEventsTest < Minitest::Test
 
     last_log = last_log_event
     assert_equal "Deadly", last_log["message"]
-    assert_equal "FATAL", last_log["log.level"]
+    assert_equal "FATAL", last_log["level"]
     assert_equal nil, last_log["trace.id"]
     assert_equal nil, last_log["span.id"]
 

--- a/test/multiverse/suites/logger/logger_instrumentation_test.rb
+++ b/test/multiverse/suites/logger/logger_instrumentation_test.rb
@@ -175,7 +175,7 @@ class LoggerInstrumentationTest < Minitest::Test
     # We count on Logger calls but actually write metrics on harvest to
     # minimize impact in the hot path
     _, logs = NewRelic::Agent.agent.log_event_aggregator.harvest!
-    logs_at_level = logs.select { |log| log.last["log.level"] == level }
+    logs_at_level = logs.select { |log| log.last["level"] == level }
     assert_equal count, logs_at_level.count
 
     assert_metrics_recorded_exclusive({

--- a/test/new_relic/agent/log_event_aggregator_test.rb
+++ b/test/new_relic/agent/log_event_aggregator_test.rb
@@ -129,7 +129,7 @@ module NewRelic::Agent
       @aggregator.record('Chocolate chips are great', nil)
       _, events = @aggregator.harvest!
 
-      assert_equal 'UNKNOWN', events[0][1]["log.level"]
+      assert_equal 'UNKNOWN', events[0][1]["level"]
       assert_metrics_recorded([
         "Logging/lines/UNKNOWN"
       ])
@@ -139,7 +139,7 @@ module NewRelic::Agent
       @aggregator.record('Chocolate chips are great', '')
       _, events = @aggregator.harvest!
 
-      assert_equal 'UNKNOWN', events[0][1]["log.level"]
+      assert_equal 'UNKNOWN', events[0][1]["level"]
       assert_metrics_recorded([
         "Logging/lines/UNKNOWN"
       ])
@@ -286,7 +286,7 @@ module NewRelic::Agent
       event = events.first
 
       assert_equal({
-        'log.level' => "INFO",
+        'level' => "INFO",
         'message' => message,
         'timestamp' => t0
       },

--- a/test/new_relic/agent/logging_test.rb
+++ b/test/new_relic/agent/logging_test.rb
@@ -26,7 +26,7 @@ module NewRelic
           # Should include the keys:
           #  entity.name, entity.type, hostname, timestamp, message, level
           assert_equal 'this is a test', message['message']
-          assert_equal 'INFO', message['level']
+          assert_equal 'INFO', message['log.level']
 
           assert_includes message, 'entity.name'
           refute_nil message['entity.name']

--- a/test/new_relic/agent/logging_test.rb
+++ b/test/new_relic/agent/logging_test.rb
@@ -24,9 +24,9 @@ module NewRelic
 
           message = last_message
           # Should include the keys:
-          #  entity.name, entity.type, hostname, timestamp, message, log.level
+          #  entity.name, entity.type, hostname, timestamp, message, level
           assert_equal 'this is a test', message['message']
-          assert_equal 'INFO', message['log.level']
+          assert_equal 'INFO', message['level']
 
           assert_includes message, 'entity.name'
           refute_nil message['entity.name']

--- a/test/new_relic/marshalling_test_cases.rb
+++ b/test/new_relic/marshalling_test_cases.rb
@@ -179,7 +179,7 @@ module MarshallingTestCases
     logs = result.first.logs
     refute_empty logs
 
-    log = logs.find { |l| l["message"] == message && l["log.level"] == severity }
+    log = logs.find { |l| l["message"] == message && l["level"] == severity }
 
     refute_nil log
     assert_equal t0, log["timestamp"]


### PR DESCRIPTION
# Overview
The agent spec changed the log severity key (ex. DEBUG) from `log.level` to `level`. The code has been updated to use this new reference.

# Testing
Existing tests with the old value have been updated.