### PR TITLE
Fix jruby failures on ci_cron runs

### DIFF
--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - dev
-      - update_ci_jruby_failures
   schedule:
     - cron:  '0 9 * * *'
 

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -92,7 +92,7 @@ jobs:
                 "rails": "norails,rails61,rails70,railsedge"
               },
               "jruby-9.3.4.0": {
-                "rails": "norails,rails61,rails60,rails52,rails51,rails50,rails42,railsedge"
+                "rails": "norails,rails61,rails60,rails52,rails51,rails50,rails42"
               }
             }
 

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -225,7 +225,7 @@ jobs:
 
   jruby_multiverse:
     needs: build-ruby
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
     services:
       mysql:
         image: mysql:5.7

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - dev
+      - update_ci_jruby_failures
   schedule:
     - cron:  '0 9 * * *'
 


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
I noticed that our scheduled nightly runs were having some odd failures I was unable to reproduce locally, and the PR ci runs were passing. Looks like just our jruby multiverse tests are still running on ubuntu 18.04 in our ci.yml, unlike in ci_cron.yml. I've updated ci_cron to use 18.04 and I've created a [ticket](https://github.com/newrelic/newrelic-ruby-agent/issues/1173) for us to address updating jruby test runs to 20.04
I also removed rails edge from running on jruby because rails edge requires ruby 2.7+, and jruby 9.3.4.0 is still 2.6, so it was giving errors for that as well.

# Related Github Issue
Include a link to the related GitHub issue, if applicable

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
Github Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
