### PR TITLE
Use read_nonblock instead of read in PipeChannelManager

### DIFF
--- a/lib/new_relic/agent/pipe_channel_manager.rb
+++ b/lib/new_relic/agent/pipe_channel_manager.rb
@@ -185,7 +185,12 @@ module NewRelic
                   merge_data_from_pipe(pipe) unless pipe == wake.out
                 end
 
-                wake.out.read(1) if ready_pipes.include?(wake.out)
+                begin
+                  wake.out.read_nonblock(1) if ready_pipes.include?(wake.out)
+                rescue IO::WaitReadable
+                  NewRelic::Agent.logger.error 'Issue while reading from the ready pipe'
+                  NewRelic::Agent.logger.error "Ready pipes: #{ready_pipes.map(&:to_s)}, wake.out pipe: #{wake.out}"
+                end
               end
 
               break unless should_keep_listening?

--- a/test/new_relic/agent/pipe_channel_manager_test.rb
+++ b/test/new_relic/agent/pipe_channel_manager_test.rb
@@ -303,6 +303,16 @@ class NewRelic::Agent::PipeChannelManagerTest < Minitest::Test
     end
   end
 
+  def test_blocking_error_rescued
+    listener = NewRelic::Agent::PipeChannelManager::Listener.new
+    error = -> { raise Errno::EWOULDBLOCK }
+    listener.stub(:start, error) do
+      NewRelic::Agent.logger.expects(:error).with do |messages|
+        messages.first.include? 'Issue while reading from the ready pipe'
+      end
+    end
+  end
+
   def assert_lifetime_counts container, value
     buffer = container.instance_variable_get :@buffer
     assert_equal value, buffer.captured_lifetime


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
Describe the changes present in the pull request

# Related Github Issue
Include a link to the related GitHub issue, if applicable

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
Github Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
