### PR TITLE
add support for makara database adapters

### DIFF
--- a/lib/new_relic/agent/instrumentation/active_record_helper.rb
+++ b/lib/new_relic/agent/instrumentation/active_record_helper.rb
@@ -153,16 +153,20 @@ module NewRelic
         PRODUCT_NAMES = {
           "mysql" => "MySQL",
           "mysql2" => "MySQL",
+          "mysql2_makara" => "MySQL",
 
           "postgresql" => "Postgres",
+          "postgresql_makara" => "Postgres",
 
           "sqlite3" => "SQLite",
 
           # https://rubygems.org/gems/activerecord-jdbcpostgresql-adapter
           "jdbcmysql" => "MySQL",
+          "jdbcmysql_makara" => "MySQL",
 
           # https://rubygems.org/gems/activerecord-jdbcpostgresql-adapter
           "jdbcpostgresql" => "Postgres",
+          "jdbcpostgresql_makara" => "Postgres",
 
           # https://rubygems.org/gems/activerecord-postgis-adapter
           "postgis" => "Postgres",
@@ -204,10 +208,14 @@ module NewRelic
           PRODUCT_SYMBOLS = {
             "mysql" => :mysql,
             "mysql2" => :mysql,
+            "mysql2_makara" => :mysql,
             "jdbcmysql" => :mysql,
+            "jdbcmysql_makara" => :mysql,
 
             "postgresql" => :postgres,
+            "postgresql_makara" => :postgres,
             "jdbcpostgresql" => :postgres,
+            "jdbcpostgresql_makara" => :postgres,
             "postgis" => :postgres
           }.freeze
 


### PR DESCRIPTION
# Overview
This PR adds support for [makara](https://github.com/instacart/makara) database adapters so that proper SQL query obfuscation can be done for the underlying database type. Makara defines its own database adapters for the following databases: mysql2, postgresql, jdbcmysql and jdbcpostgresql. Makara customizes the way ActiveRecord handles it connection pools. Previously, when a makara database connection was being traced by the newrelic gem, it would view it as `ActiveRecord` and not pick up on the underlying database type. This prevented the ability to utilize the proper SQL query obfuscation rules for any makara adapter database connections.

# Related Github Issue
https://github.com/newrelic/newrelic-ruby-agent/issues/507

# Testing
I've manually confirmed in a local environment that this works for the postgresql_makara adapter.

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
