### PR TITLE
Rubocop Performance

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -962,7 +962,7 @@ Performance/CollectionLiteralInLoop:
   Enabled: false
 
 Performance/CompareWithBlock:
-  Enabled: false
+  Enabled: true
 
 Performance/ConcurrentMonotonicTime:
   Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -962,6 +962,9 @@ Performance/CollectionLiteralInLoop:
   Enabled: false
 
 Performance/CompareWithBlock:
+  Enabled: false
+
+Performance/ConcurrentMonotonicTime:
   Enabled: true
 
 # Disabling for now
@@ -1068,6 +1071,9 @@ Performance/Squeeze:
 # Disabling for now
 Performance/StartWith:
   Enabled: false
+
+Performance/StringIdentifierArgument:
+  Enabled: true
 
 Performance/StringInclude:
   Enabled: false

--- a/test/multiverse/suites/agent_only/service_timeout_test.rb
+++ b/test/multiverse/suites/agent_only/service_timeout_test.rb
@@ -29,7 +29,7 @@ class ServiceTimeoutTest < Minitest::Test
     service = NewRelic::Agent::NewRelicService.new('deadbeef', server)
 
     assert_raises NewRelic::Agent::ServerConnectionException do
-      service.send('send_request',
+      service.send(:send_request,
         :uri => '/agent_listener/8/bd0e1d52adade840f7ca727d29a86249e89a6f1c/preconnect',
         :encoding => 'UTF-8', :collector => server, :data => 'blah')
     end

--- a/test/new_relic/agent/rpm_agent_test.rb
+++ b/test/new_relic/agent/rpm_agent_test.rb
@@ -46,7 +46,7 @@ class NewRelic::Agent::RpmAgentTest < Minitest::Test
   def test_manual_start
     NewRelic::Agent.instance.expects(:connect).once
     NewRelic::Agent.instance.expects(:start_worker_thread).once
-    NewRelic::Agent.instance.instance_variable_set '@started', nil
+    NewRelic::Agent.instance.instance_variable_set :@started, nil
     NewRelic::Agent.manual_start :monitor_mode => true, :license_key => ('x' * 40)
     NewRelic::Agent.shutdown
   end

--- a/test/new_relic/agent/sampler_test.rb
+++ b/test/new_relic/agent/sampler_test.rb
@@ -25,7 +25,7 @@ class NewRelic::Agent::SamplerTest < Minitest::Test
   end
 
   def test_sampler_classes_should_be_an_array
-    sampler_classes = NewRelic::Agent::Sampler.instance_variable_get('@sampler_classes')
+    sampler_classes = NewRelic::Agent::Sampler.instance_variable_get(:@sampler_classes)
     assert(sampler_classes.is_a?(Array), 'Sampler classes should be saved as an array')
     assert(sampler_classes.include?(NewRelic::Agent::Samplers::CpuSampler), 'Sampler classes should include the CPU sampler')
   end

--- a/test/new_relic/agent/samplers/cpu_sampler_test.rb
+++ b/test/new_relic/agent/samplers/cpu_sampler_test.rb
@@ -45,7 +45,7 @@ class NewRelic::Agent::Samplers::CpuSamplerTest < Minitest::Test
 
   def set_jruby_version_constant(string)
     Object.send(:remove_const, 'JRUBY_VERSION') if defined?(JRUBY_VERSION)
-    Object.const_set('JRUBY_VERSION', string)
+    Object.const_set(:JRUBY_VERSION, string)
   end
 
   def test_cpu_sampler_records_user_and_system_time

--- a/test/new_relic/agent/transaction_sampler_test.rb
+++ b/test/new_relic/agent/transaction_sampler_test.rb
@@ -112,7 +112,7 @@ module NewRelic::Agent
       assert_equal([], @sampler.harvest!)
 
       # make sure the samples have been cleared
-      assert_nil(@sampler.instance_variable_get('@last_sample'))
+      assert_nil(@sampler.instance_variable_get(:@last_sample))
     end
 
     def test_harvest_no_data

--- a/test/new_relic/metric_data_test.rb
+++ b/test/new_relic/metric_data_test.rb
@@ -47,7 +47,7 @@ class NewRelic::MetricDataTest < Minitest::Test
     spec = mock('metric_spec')
     stats = mock('stats')
     md1 = NewRelic::MetricData.new(spec, stats)
-    original_spec = md1.instance_variable_get('@original_spec')
+    original_spec = md1.instance_variable_get(:@original_spec)
     assert_nil(original_spec, "should start with a nil original spec, but was #{original_spec.inspect}")
     assert_equal(spec, md1.metric_spec, "should return the metric spec for original spec when original spec is nil, but was #{md1.original_spec}")
   end
@@ -55,13 +55,13 @@ class NewRelic::MetricDataTest < Minitest::Test
   def test_metric_spec_equal_should_not_set_original_spec_with_no_metric_spec
     stats = mock('stats')
     md1 = NewRelic::MetricData.new(nil, stats)
-    original_spec = md1.instance_variable_get('@original_spec')
+    original_spec = md1.instance_variable_get(:@original_spec)
     assert_nil(original_spec, "should start with a nil original spec, but was #{original_spec.inspect}")
 
     new_spec = mock('new metric_spec')
     assert_equal(new_spec, md1.metric_spec = (new_spec), "should return the new spec")
 
-    new_original_spec = md1.instance_variable_get('@original_spec')
+    new_original_spec = md1.instance_variable_get(:@original_spec)
     assert_nil(new_original_spec, "should not set @original_spec, but was #{new_original_spec.inspect}")
   end
 
@@ -69,13 +69,13 @@ class NewRelic::MetricDataTest < Minitest::Test
     spec = mock('metric_spec')
     stats = mock('stats')
     md1 = NewRelic::MetricData.new(spec, stats)
-    original_spec = md1.instance_variable_get('@original_spec')
+    original_spec = md1.instance_variable_get(:@original_spec)
     assert_nil(original_spec, "should start with a nil original spec, but was #{original_spec.inspect}")
 
     new_spec = mock('new metric_spec')
     assert_equal(new_spec, md1.metric_spec = (new_spec), "should return the new spec")
 
-    new_original_spec = md1.instance_variable_get('@original_spec')
+    new_original_spec = md1.instance_variable_get(:@original_spec)
     assert_equal(spec, new_original_spec, "should set @original_spec to the existing metric_spec  but was #{new_original_spec.inspect}")
   end
 


### PR DESCRIPTION
# Overview
Added two new Rubocop Performance updates to rubocop.yml: [concurrent_monotonic_time](https://github.com/rubocop/rubocop-performance/blob/master/lib/rubocop/cop/performance/concurrent_monotonic_time.rb) and [string_identifier_argument](https://github.com/rubocop/rubocop-performance/blob/master/lib/rubocop/cop/performance/string_identifier_argument.rb). 

Edited files where Rubocop was upset about string_identifier_argument. Codebase was already looking good for concurrent_monotonic_time.