### PR TITLE
support db adapter suffixes, such as '_makara'

### DIFF
--- a/lib/new_relic/agent/instrumentation/active_record_helper.rb
+++ b/lib/new_relic/agent/instrumentation/active_record_helper.rb
@@ -93,9 +93,21 @@ module NewRelic
 
         ACTIVE_RECORD = "ActiveRecord".freeze
         OTHER = "other".freeze
+        MAKARA_SUFFIX = "_makara".freeze
+
+        # convert vendor (makara, etc.) wrapper names to their bare names
+        # ex: postgresql_makara -> postgresql
+        def bare_adapter_name(adapter_name)
+          # TODO: OLD RUBIES - RUBY_VERSION < 2.5
+          # With Ruby 2.5+ we could use #delete_suffix instead of #chomp for a
+          # potential speed boost
+          return adapter_name.chomp(MAKARA_SUFFIX) if adapter_name && adapter_name.end_with?(MAKARA_SUFFIX)
+
+          adapter_name
+        end
 
         def product_operation_collection_for name, sql, adapter_name
-          product = map_product(adapter_name)
+          product = map_product(bare_adapter_name(adapter_name))
           splits = split_name(name)
           model = model_from_splits(splits)
           operation = operation_from_splits(splits, sql)
@@ -194,8 +206,7 @@ module NewRelic
         ACTIVE_RECORD_DEFAULT_PRODUCT_NAME = "ActiveRecord".freeze
 
         def map_product(adapter_name)
-          PRODUCT_NAMES.fetch(adapter_name,
-            ACTIVE_RECORD_DEFAULT_PRODUCT_NAME)
+          PRODUCT_NAMES.fetch(adapter_name, ACTIVE_RECORD_DEFAULT_PRODUCT_NAME)
         end
 
         module InstanceIdentification
@@ -221,11 +232,16 @@ module NewRelic
           SLASH = "/".freeze
           LOCALHOST = "localhost".freeze
 
+          def adapter_from_config(config)
+            bare_name = NewRelic::Agent::Instrumentation::ActiveRecordHelper.bare_adapter_name(config[:adapter])
+            PRODUCT_SYMBOLS[bare_name]
+          end
+
           def host(config)
             return UNKNOWN unless config
 
             configured_value = config[:host]
-            adapter = PRODUCT_SYMBOLS[config[:adapter]]
+            adapter = adapter_from_config(config)
             if configured_value.nil? ||
                 postgres_unix_domain_socket_case?(configured_value, adapter)
 
@@ -243,7 +259,7 @@ module NewRelic
           def port_path_or_id(config)
             return UNKNOWN unless config
 
-            adapter = PRODUCT_SYMBOLS[config[:adapter]]
+            adapter = adapter_from_config(config)
             if config[:socket]
               config[:socket].empty? ? UNKNOWN : config[:socket]
             elsif postgres_unix_domain_socket_case?(config[:host], adapter) || mysql_default_case?(config, adapter)
@@ -263,7 +279,7 @@ module NewRelic
           SUPPORTED_ADAPTERS = [:mysql, :postgres].freeze
 
           def supported_adapter? config
-            config && SUPPORTED_ADAPTERS.include?(PRODUCT_SYMBOLS[config[:adapter]])
+            config && SUPPORTED_ADAPTERS.include?(adapter_from_config(config))
           end
 
           private

--- a/lib/new_relic/agent/instrumentation/active_record_subscriber.rb
+++ b/lib/new_relic/agent/instrumentation/active_record_subscriber.rb
@@ -91,17 +91,24 @@ module NewRelic
           end
 
           return unless connection_id = payload[:connection_id]
-          connection = nil
 
           ::ActiveRecord::Base.connection_handler.connection_pool_list.each do |handler|
-            connection = handler.connections.detect do |conn|
-              conn.object_id == connection_id
-            end
+            connection = handler.connections.detect { |conn| conn.object_id == connection_id }
 
-            break if connection
+            return connection.instance_variable_get(:@config) if connection
+
+            # when using makara, handler.connections will be empty, so use the
+            # spec config instead.
+            # https://github.com/newrelic/newrelic-ruby-agent/issues/507
+            # thank you @lucasklaassen
+            return handler.spec.config if use_spec_config?(handler)
           end
 
-          connection.instance_variable_get(:@config) if connection
+          nil
+        end
+
+        def use_spec_config?(handler)
+          handler.spec && handler.spec.config && handler.spec.config[:adapter].end_with?('makara')
         end
 
         def start_segment(config, payload)

--- a/test/new_relic/agent/instrumentation/active_record_helper_test.rb
+++ b/test/new_relic/agent/instrumentation/active_record_helper_test.rb
@@ -62,5 +62,23 @@ module NewRelic::Agent::Instrumentation
       assert_equal "other", operation
       assert_nil collection
     end
+
+    def test_suffixes_are_stripped_away_from_the_adapter_name
+      assert_equal 'postgresql', ActiveRecordHelper.bare_adapter_name('postgresql_makara')
+    end
+
+    def test_product_operation_collection_for_handles_suffixes
+      mock = MiniTest::Mock.new
+      mock.expect('postgresql', [])
+      NewRelic::Agent::Instrumentation::ActiveRecordHelper.stub :map_product, mock do
+        product, operation, collection = ActiveRecordHelper.product_operation_collection_for(1, '', 'postgres_makara')
+      end
+    end
+
+    def test_suffixes_on_configuration_based_adapter_names_are_stripped_away
+      config = {adapter: 'postgresql_makara'}
+      adapter = NewRelic::Agent::Instrumentation::ActiveRecordHelper::InstanceIdentification.adapter_from_config(config)
+      assert_equal :postgres, adapter
+    end
   end
 end


### PR DESCRIPTION
* route ActiveRecord database adapter names through a filter to perform
  vendor specific transformations. for now, only makara based adapters
  are supported, and the '_makara' suffix is stripped away. thus
  'postgresql_makara' will be converted to 'postgresql' so that SQL
  obfuscation will work with makara
* for Rails <= 5, seek the database info needed for New Relic agent
  segment creation from the first known connection pool's spec config

Many thanks to @lucasklaassen for the original implementation of these
concepts, which will take makara off of our unsupported gem list and
also potentially help with other similar database related gems in
future.