### PR TITLE
Remove verbose = true from Rake::TestTask

### DIFF
--- a/lib/tasks/tests.rake
+++ b/lib/tasks/tests.rake
@@ -31,7 +31,6 @@ if defined? Rake::TestTask
       t.libs << "#{agent_home}/test"
       t.libs << "#{agent_home}/lib"
       t.pattern = Array(file_pattern)
-      t.verbose = true
     end
   end
 end


### PR DESCRIPTION
I've had a hard time reading test output since I started working on this repository. One culprit seems to be the inclusion of all files being tested in each run's output. Removing `verbose = true` from `Rake::TestTask(:newrelic)` seems to remove the file list output.