### PR TITLE
Label community on pull_resquest_target

### DIFF
--- a/.github/workflows/label_community_cards.yml
+++ b/.github/workflows/label_community_cards.yml
@@ -3,7 +3,7 @@ name: Label community issues and pr
 on:
   issues:
     types: [opened]
-  pull_request:
+  pull_request_target:
     types: [opened]
 
 jobs:


### PR DESCRIPTION
Previously, CI runs triggered by pull requests opened by community members would fail automatically due to a permissions issue. Based on some guidance from https://github.community/t/github-actions-are-severely-limited-on-prs/18179#M9249, we want to see if this change resolves the problem.

Closes #971 

To test this, we'll need to merge the PR and attempt to open a PR using a non-allowlisted username. I'm willing to use @kreopelle 🌻 