### PR TITLE
update Puma multiverse tests

### DIFF
--- a/test/multiverse/suites/rack/Envfile
+++ b/test/multiverse/suites/rack/Envfile
@@ -1,25 +1,16 @@
 instrumentation_methods :chain, :prepend
 
-puma_versions = [nil, '~>3.12.0', '~>4.3.8', '~> 5.2.2', '~>5.3.2']
-ruby_rack_versions = {'2.3.0' => '~>2.2.3', '2.2.2' => '~>2.0.3'}
+puma_versions = [nil, '~> 3.12.6', '~> 4.3.12', '~> 5.6.4']
+ruby_rack_versions = {'2.3.0' => '~> 2.2.3', '2.2.2' => '~> 2.0.3'}
 
-ruby_rack_versions.each do |ruby_version, rack_version|
-  if RUBY_VERSION >= ruby_version
-    puma_versions.each do |puma_version|
-      gemfile <<-RB
-        #{puma_version ? "gem 'puma', '#{puma_version}'" : ''}
-        gem 'rack', '#{rack_version}'
-        gem 'rack-test'
-        #{ruby3_gem_webrick}
-      RB
-    end
-  end
+# TODO: OLD RUBIES - stop checking once Ruby 2.2 is no longer supported
+rack_version = RUBY_VERSION >= '2.3.0' ? '~> 2.2.3' : '~> 2.1.4'
+
+puma_versions.each do |puma_version|
+  gemfile <<-RB
+    #{"gem 'puma', '#{puma_version}'" if puma_version}
+    gem 'rack', '#{rack_version}'
+    gem 'rack-test'
+    #{ruby3_gem_webrick}
+  RB
 end
-
-gemfile <<-RB
-  gem 'rack', '~>1.6.8'
-  gem 'rack-test', '>= 0.8.0'
-  #{ruby3_gem_webrick}
-RB
-
-# vim: ft=ruby

--- a/test/multiverse/suites/rack/puma_rack_urlmap_test.rb
+++ b/test/multiverse/suites/rack/puma_rack_urlmap_test.rb
@@ -1,0 +1,28 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+
+if NewRelic::Agent::Instrumentation::RackHelpers.puma_rack_version_supported?
+
+  require 'puma/rack/urlmap'
+
+  class PumaRackURLMapTest < Minitest::Test
+    include MultiverseHelpers
+
+    def test_url_map_generation_is_enhanced_with_tracing
+      pairs = {'/' => 'one',
+               '/another' => 'another'}
+      mapping = pairs.each_with_object({}) { |(k, v), h| h[k] = Proc.new { v } }
+      map = Puma::Rack::URLMap.new(mapping)
+      pairs.each do |k, v|
+        env = {'PATH_INFO' => k, 'SCRIPT_NAME' => 'Eagle Fang'}
+        result = map.call(env)
+        # confirm basic mapping functionality still works as expected
+        assert_equal v, result
+        # confirm that we've enhanced the mapping experience
+        assert_equal true, env['newrelic.transaction_started']
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
update the testing of our Puma instrumentation:

- point to the latest package of each of the 3 most recently released
  major Puma versions
- stop having newer Rubies test multiple versions of Rack. Now simply
  test with the latest Rack for those Rubies that can (Ruby 2.3+) and
  the latest Ruby 2.2 compatible Rack for Ruby 2.2
- add a test for Puma URLMap handling which was previously instrumented
  but not covered by multiverse testing

Pumas are less than half as fast as cheetahs and over 1.5 times as
heavy.

But Pumas can live 19 years as opposed to 11 for cheetahs. If the Ruby
Puma project had been named Cheetah when it began in 2011, it might have
been on its last legs now in 2022.

resolves #1189