### PR TITLE
Add initial structure for gem slack notifications

### DIFF
--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -338,7 +338,7 @@ jobs:
       - uses: actions/checkout@v2
       - run: gem install httparty
       - name: Check for outdated gems 
-        run: ruby ./.github/workflows/scripts/slack_gem_notifications/notifications_script.rb ${{ env.gems }}
+        run: ruby .github/workflows/scripts/slack_gem_notifications/notifications_script.rb ${{ env.gems }}
         env:
           SLACK_GEM_NOTIFICATIONS_WEBHOOK: ${{ secrets.SLACK_GEM_NOTIFICATIONS_WEBHOOK }}
           gems:

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -328,3 +328,35 @@ jobs:
       - name: Annotate errors
         if: ${{ failure() }}
         uses: ./.github/actions/annotate
+
+  gem_notifications:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: ruby/setup-ruby@v1.90.0
+        with:
+          ruby-version: 2.7
+      - uses: actions/checkout@v2
+      - run: gem install httparty
+      - name: Check for outdated gems 
+        run: ruby ./.github/workflows/scripts/slack_gem_notifications/notifications_script.rb ${{ env.gems }}
+        env:
+          SLACK_GEM_NOTIFICATIONS_WEBHOOK: ${{ secrets.SLACK_GEM_NOTIFICATIONS_WEBHOOK }}
+          gems:
+            "activerecord 
+            bunny
+            dalli
+            delayed_job
+            excon
+            http
+            httpclient
+            mongo
+            puma
+            sidekiq
+            sinatra
+            tilt
+            rack
+            rails
+            rake 
+            redis
+            resque
+            unicorn"

--- a/.github/workflows/scripts/slack_gem_notifications/notifications_methods.rb
+++ b/.github/workflows/scripts/slack_gem_notifications/notifications_methods.rb
@@ -1,0 +1,48 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+require 'time'
+require 'httparty'
+
+def check_for_updates(watched_gems)
+  return if gem_list_empty(watched_gems)
+  watched_gems.each do |gem_name|
+    verify_gem(gem_name) ? gem_info = verify_gem(gem_name) : return
+    versions = gem_versions(gem_info)
+    send_bot(gem_name, versions) if gem_updated?(versions)
+  end
+end
+
+def gem_list_empty(watched_gems)
+  if watched_gems.empty?
+    abort "Nothing to see here! The 'watched_gems' array cannot be empty"
+  end
+end
+
+def verify_gem(gem_name)
+  gem_info = HTTParty.get("https://rubygems.org/api/v1/versions/#{gem_name}.json")
+
+  gem_info if gem_info.success?
+end
+
+# Gem entries are ordered by release date. The break limits versions to two versions: newest and previous.
+def gem_versions(gem_info)
+  versions = gem_info.each_with_object([]) do |gem, arr|
+    arr << gem if gem['platform'] == 'ruby'
+    break arr if arr.size == 2
+  end
+end
+
+def gem_updated?(versions)
+  Time.now.utc - Time.parse(versions[0]['created_at']) < 24 * 60 * 60
+end
+
+def send_bot(gem_name, versions)
+  abort "Expected exactly 2 version numbers in the 'versions' array" unless versions.size == 2
+  newest, previous = versions[0]['number'], versions[1]['number']
+  HTTParty.post(ENV['SLACK_GEM_NOTIFICATIONS_WEBHOOK'],
+    headers: {'Content-Type' => 'application/json'},
+    body: {text: "A new gem version is out! Gem: #{gem_name}, #{previous} -> #{newest}."}.to_json)
+end

--- a/.github/workflows/scripts/slack_gem_notifications/notifications_script.rb
+++ b/.github/workflows/scripts/slack_gem_notifications/notifications_script.rb
@@ -1,0 +1,10 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+# This script runs on a 24 hour cycle via ci_cron.yml and sends slack updates for new gem version releases.
+
+require_relative 'notifications_methods'
+
+check_for_updates(ARGV)

--- a/newrelic_rpm.gemspec
+++ b/newrelic_rpm.gemspec
@@ -64,4 +64,5 @@ https://github.com/newrelic/newrelic-ruby-agent/
     s.add_development_dependency 'simplecov'
     s.add_development_dependency 'simplecov_json_formatter'
   end
+  s.add_development_dependency 'httparty'
 end

--- a/test/new_relic/gem_notifications_tests.rb
+++ b/test/new_relic/gem_notifications_tests.rb
@@ -1,0 +1,63 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+# require_relative '../test_helper'
+require 'minitest/autorun'
+require_relative '../../.github/workflows/scripts/slack_gem_notifications/notifications_methods'
+
+class GemNotifications < Minitest::Test
+  def invalid_gem_response
+    response = MiniTest::Mock.new
+    response.expect :success?, false
+  end
+
+  def valid_gem_response
+    response = MiniTest::Mock.new
+    response.expect :success?, true
+  end
+
+  def http_get_response
+    [{"created_at" => "2001-07-18T16:15:29.083Z", "platform" => "ruby", "number" => "3.0.0"},
+      {"created_at" => "1997-05-23T16:15:29.083Z", "platform" => "java", "number" => "2.0.0"},
+      {"created_at" => "1993-06-11T16:15:29.083Z", "platform" => "ruby", "number" => "1.0.0"}]
+  end
+
+  def test_valid_gem_name
+    response = valid_gem_response()
+    HTTParty.stub :get, response do
+      assert verify_gem("puma!")
+    end
+  end
+
+  def test_invalid_gem_name
+    response = invalid_gem_response()
+    HTTParty.stub :get, response do
+      assert_nil verify_gem("TrexRawr!")
+    end
+  end
+
+  def test_get_gem_info_returns_array
+    versions = gem_versions(http_get_response())
+    assert_instance_of Array, versions
+  end
+
+  def test_get_gem_info_max_size
+    versions = gem_versions(http_get_response())
+    assert_equal true, versions.size == 2
+  end
+
+  def test_gem_updated
+    assert_equal true, gem_updated?([{"created_at" => "#{Time.now}"}])
+    assert_equal false, gem_updated?([{"created_at" => "1993-06-11T17:31:14.298Z"}])
+  end
+
+  def test_send_bot_input_size
+    assert_raises(ArgumentError) { send_bot() }
+    assert_raises(ArgumentError) { send_bot("tyrannosaurus") }
+    HTTParty.stub :post, nil do
+      assert_nil send_bot("tyrannosaurus", [{"number" => "83.6"}, {"number" => "66.0"}])
+    end
+  end
+end


### PR DESCRIPTION
# Overview

A ruby script that checks for and notifies the Ruby agent team slack channel of new gem version releases.
closes #1195 

Inside `ci_cron.yml`, a newly added`gem_notifications` job stores a list of gems the team has determined to be core technologies. When the nightly CI runs, this list of gems is passed to the script, `notifications_script`. 

Gem updates are determined by calling the Ruby Gems API and using the `created_at` timestamp. If the release is within the past 24 hours, we know a new version is our and send a POST request to an internal Slackbot.

Files Added:
- `.github/workflows/scripts/slack_gem_notifications/notifications_methods`
- `.github/workflows/scripts/slack_gem_notifications/notifications_script`
- `test/gem_notifications_tests`

Files Edited:
- `ci_cron.yml`

_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

Submitter Checklist:
- [x] Include a link to the related GitHub issue, if applicable
- [x] Include a security review link, if applicable

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
Github Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 
