### PR TITLE
MiniTest: optionally fail fast

### DIFF
--- a/test/helpers/minitest.rb
+++ b/test/helpers/minitest.rb
@@ -25,3 +25,22 @@ class Minitest::Test
     super
   end
 end
+
+class MiniTest::Unit
+  def puke klass, meth, e
+    if fail_fast? && !e.is_a?(MiniTest::Skip)
+      puke_fast klass, meth, e
+    else
+      super klass, meth, e
+    end
+  end
+
+  def puke_fast klass, meth, e
+    warn %Q(\n\nFailing fast.\n\n#{klass}:#{meth}\n\n#{e.message}\n\n#{e.backtrace.join("\n")}\n\n)
+    raise Interrupt # other exceptions will be caught by MiniTest
+  end
+
+  def fail_fast?
+    ENV['MT_FAIL_FAST']
+  end
+end


### PR DESCRIPTION
To have MiniTest "fail fast" and halt after encountering the first
failed test, set the "MT_FAIL_FAST" environment variable and then
proceed to run the tests as normal.