### PR TITLE
gRPC: define all individual method args

### DIFF
--- a/lib/new_relic/agent/instrumentation/grpc/client/chain.rb
+++ b/lib/new_relic/agent/instrumentation/grpc/client/chain.rb
@@ -19,33 +19,83 @@ module NewRelic::Agent::Instrumentation
             alias initialize_without_newrelic_trace initialize
             alias initialize initialize_with_newrelic_trace
 
-            def bidi_streamer_with_newrelic_trace(*args)
-              issue_request_with_tracing(*args)
+            def bidi_streamer_with_new_relic_trace(method, requests, marshal, unmarshal,
+              deadline: nil,
+              return_op: false,
+              parent: nil,
+              credentials: nil,
+              metadata: {},
+              &blk)
+
+              issue_request_with_tracing(method, requests, marshal, unmarshal,
+                deadline: deadline,
+                return_op: return_op,
+                parent: parent,
+                credentials: credentials,
+                metadata: metadata)
+
+              # TODO: gRPC - confirm that &blk is being invoked correctly
             end
 
             alias bidi_streamer_without_newrelic_trace bidi_streamer
-            alias bidi_streamer bidi_streamer_with_newrelic_tracer
+            alias bidi_streamer bidi_streamer_with_newrelic_trace
 
-            def client_streamer_with_newrelic_trace(*args)
-              issue_request_with_tracing(*args)
+            def client_streamer_with_newrelic_trace(method, requests, marshal, unmarshal,
+              deadline: nil,
+              return_op: false,
+              parent: nil,
+              credentials: nil,
+              metadata: {})
+
+              issue_request_with_tracing(method, requests, marshal, unmarshal,
+                deadline: deadline,
+                return_op: return_op,
+                parent: parent,
+                credentials: credentials,
+                metadata: metadata)
             end
 
             alias client_streamer_without_newrelic_trace client_streamer
-            alias client_streamer client_streamer_with_newrelic_tracer
+            alias client_streamer client_streamer_with_newrelic_trace
 
-            def request_response_with_newrelic_trace(*args)
-              issue_request_with_tracing(*args)
+            def request_response_with_newrelic_trace(method, req, marshal, unmarshal,
+              deadline: nil,
+              return_op: false,
+              parent: nil,
+              credentials: nil,
+              metadata: {})
+
+              issue_request_with_tracing(method, req, marshal, unmarshal,
+                deadline: deadline,
+                return_op: return_op,
+                parent: parent,
+                credentials: credentials,
+                metadata: metadata)
             end
 
             alias request_response_without_newrelic_trace request_response
-            alias request_response request_response_with_newrelic_tracer
+            alias request_response request_response_with_newrelic_trace
 
-            def server_streamer_with_newrelic_trace(*args)
-              issue_request_with_tracing(*args)
+            def server_streamer_with_newrelic_trace(method, req, marshal, unmarshal,
+              deadline: nil,
+              return_op: false,
+              parent: nil,
+              credentials: nil,
+              metadata: {},
+              &blk)
+
+              issue_request_with_tracing(method, req, marshal, unmarshal,
+                deadline: deadline,
+                return_op: return_op,
+                parent: parent,
+                credentials: credentials,
+                metadata: metadata)
+
+              # TODO: gRPC - confirm that &blk is being invoked correctly
             end
 
             alias server_streamer_without_newrelic_trace server_streamer
-            alias server_streamer server_streamer_with_newrelic_tracer
+            alias server_streamer server_streamer_with_newrelic_trace
           end
         end
       end

--- a/lib/new_relic/agent/instrumentation/grpc/client/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/grpc/client/instrumentation.rb
@@ -19,13 +19,15 @@ module NewRelic
             instance
           end
 
-          def issue_request_with_tracing(*args, metadata: {})
+          def issue_request_with_tracing(method, requests, marshal, unmarshal,
+            deadline:, return_op:, parent:, credentials:, metadata:)
             return yield unless trace_with_newrelic?
 
             response = nil
-            segment = request_segment(args.first) # args.first is the method
+            segment = request_segment(method)
             request_wrapper = NewRelic::Agent::Instrumentation::GRPC::Client::RequestWrapper.new(@host)
             segment.add_request_headers request_wrapper
+
             metadata.merge! metadata, request_wrapper.instance_variable_get(:@newrelic_metadata)
 
             NewRelic::Agent.disable_all_tracing do

--- a/lib/new_relic/agent/instrumentation/grpc/client/prepend.rb
+++ b/lib/new_relic/agent/instrumentation/grpc/client/prepend.rb
@@ -16,20 +16,96 @@ module NewRelic
               initialize_with_tracing(*args) { super }
             end
 
-            def bidi_streamer(*args)
-              issue_request_with_tracing(*args) { super }
+            def bidi_streamer(method, requests, marshal, unmarshal,
+              deadline: nil,
+              return_op: false,
+              parent: nil,
+              credentials: nil,
+              metadata: {},
+              &blk)
+
+              issue_request_with_tracing(method, requests, marshal, unmarshal,
+                deadline: deadline,
+                return_op: return_op,
+                parent: parent,
+                credentials: credentials,
+                metadata: metadata) do
+                  super(method, requests, marshal, unmarshal,
+                        deadline: deadline,
+                        return_op: return_op,
+                        parent: parent,
+                        credentials: credentials,
+                        metadata: metadata,
+                        &blk)
+                end
             end
 
-            def client_streamer(*args)
-              issue_request_with_tracing(*args) { super }
+            def client_streamer(method, requests, marshal, unmarshal,
+              deadline: nil,
+              return_op: false,
+              parent: nil,
+              credentials: nil,
+              metadata: {})
+
+              issue_request_with_tracing(method, requests, marshal, unmarshal,
+                deadline: deadline,
+                return_op: return_op,
+                parent: parent,
+                credentials: credentials,
+                metadata: metadata) do
+                  super(method, requests, marshal, unmarshal,
+                        deadline: deadline,
+                        return_op: return_op,
+                        parent: parent,
+                        credentials: credentials,
+                        metadata: metadata)
+                end
             end
 
-            def request_response(*args)
-              issue_request_with_tracing(*args) { super }
+            def request_response(method, req, marshal, unmarshal,
+              deadline: nil,
+              return_op: false,
+              parent: nil,
+              credentials: nil,
+              metadata: {})
+
+              issue_request_with_tracing(method, req, marshal, unmarshal,
+                deadline: deadline,
+                return_op: return_op,
+                parent: parent,
+                credentials: credentials,
+                metadata: metadata) do
+                  super(method, req, marshal, unmarshal,
+                        deadline: deadline,
+                        return_op: return_op,
+                        parent: parent,
+                        credentials: credentials,
+                        metadata: metadata)
+                end
             end
 
-            def server_streamer(*args)
-              issue_request_with_tracing(*args) { super }
+            def server_streamer(method, req, marshal, unmarshal,
+              deadline: nil,
+              return_op: false,
+              parent: nil,
+              credentials: nil,
+              metadata: {},
+              &blk)
+
+              issue_request_with_tracing(method, req, marshal, unmarshal,
+                deadline: deadline,
+                return_op: return_op,
+                parent: parent,
+                credentials: credentials,
+                metadata: metadata) do
+                  super(method, req, marshal, unmarshal,
+                        deadline: deadline,
+                        return_op: return_op,
+                        parent: parent,
+                        credentials: credentials,
+                        metadata: metadata,
+                        &blk)
+                end
             end
           end
         end


### PR DESCRIPTION
the gRPC client methods for sending data all accept an optional
`metadata` keyword argument. Because this argument is optional, the
traditional approach of prepending a method that accepts `*args` as
input is problematic given that the arguments aren't guaranteed to
contain the `metadata` keyword. We need to add additional key/val pairs
to the metadata hash, at all times - both when the caller supplied
metadata, and when it is missing and defaults to an empty hash. Given
our instrumentation's approach of calling `super` within a block, we
need to ensure that modified metadata always reaches `super` as input.
Switching away from the `*args` approach to explicitly defining all
input params allows us to accomplish this.

Many thanks to @tannalynn for her help in discussing this approach.

Resolves #1239