### PR TITLE
Add configuration for grpc blocklist

### DIFF
--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -1095,7 +1095,7 @@ If `true`, disables agent middleware for Sinatra. This middleware is responsible
           :description => 'Controls auto-instrumentation of gRPC clients at start up.  May be one of [auto|prepend|chain|disabled].'
         },
         :'instrumentation.grpc.host_denylist' => {
-          :default => ['tracing\.(staging-)?edge\.nr-data'],
+          :default => ['tracing\.(?:staging-)?edge\.nr-data'],
           :public => true,
           :type => Array,
           :allowed_from_server => false,

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -1094,6 +1094,14 @@ If `true`, disables agent middleware for Sinatra. This middleware is responsible
           :allowed_from_server => false,
           :description => 'Controls auto-instrumentation of gRPC clients at start up.  May be one of [auto|prepend|chain|disabled].'
         },
+        :'instrumentation.grpc.host_denylist' => {
+          :default => ['tracing\.(staging-)?edge\.nr-data'],
+          :public => true,
+          :type => Array,
+          :allowed_from_server => false,
+          :transform => DefaultSource.method(:convert_to_regexp_list),
+          :description => 'Define grpc connections you want the agent to ignore by specifying a list of patterns matching the URI of the hosts to be ignored'
+        },
         :'instrumentation.grpc_server' => {
           :default => instrumentation_value_of(:disable_grpc_server),
           :documentation_default => 'auto',

--- a/lib/new_relic/agent/instrumentation/grpc/client/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/grpc/client/instrumentation.rb
@@ -70,14 +70,14 @@ module NewRelic
             return do_trace unless do_trace.nil?
 
             host ||= @host
-            return false unless host && !host_denylisted(host)
+            return false unless host && !host_denylisted?(host)
 
             true
           end
 
-          def host_denylisted(host)
+          def host_denylisted?(host)
             NewRelic::Agent.config[:'instrumentation.grpc.host_denylist'].any? do |regex|
-              host.match(regex)
+              host.match?(regex)
             end
           end
         end

--- a/lib/new_relic/agent/instrumentation/grpc/client/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/grpc/client/instrumentation.rb
@@ -10,9 +10,6 @@ module NewRelic
     module Instrumentation
       module GRPC
         module Client
-          # TODO: allow the blocklist to be set via config
-          HOST_BLOCKLIST_PATTERN = %r{\.newrelic\.com/}.freeze
-
           def initialize_with_tracing(*args)
             instance = yield
             instance.instance_variable_set(:@trace_with_newrelic, trace_with_newrelic?(args.first))
@@ -73,9 +70,15 @@ module NewRelic
             return do_trace unless do_trace.nil?
 
             host ||= @host
-            return false unless host && !host.match?(HOST_BLOCKLIST_PATTERN)
+            return false unless host && !host_denylisted(host)
 
             true
+          end
+
+          def host_denylisted(host)
+            NewRelic::Agent.config[:'instrumentation.grpc.host_denylist'].any? do |regex|
+              host.match(regex)
+            end
           end
         end
       end


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
Adds the configuration option `instrumentation.grpc.host_denylist` as an array of regexes that the agent will use to ignore certain grpc connections. Currently is only set up for the grpc client. We have a few other configs that use `denylist`, so I opted to use that over blocklist for consistency. 
#1245

Submitter Checklist:
- [ ] Include a link to the related GitHub issue, if applicable
- [ ] Include a security review link, if applicable

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
Github Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
