### PR TITLE
Enforce MethodCallWithArgsParentheses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1468,9 +1468,18 @@ Style/MapToHash:
   Enabled: false
 
 Style/MethodCallWithArgsParentheses:
-  Enabled: false
+  Enabled: true
+  IgnoredMethods:
+    - puts
+    - require
+    - raise
+    - include
+    - fail
+    - print
+    - add_dependency
+    - add_development_dependency
+  AllowedPatterns: [^assert, ^refute]
 
-# Disabling for now
 Style/MethodCallWithoutArgsParentheses:
   Enabled: false
   IgnoredMethods: []

--- a/bin/mongrel_rpm
+++ b/bin/mongrel_rpm
@@ -13,9 +13,9 @@ OptionParser.new do |opts|
   opts.on("--[no-]logging", "turn off request logging") { |l| options[:logging] = l }
   opts.on("--license=license_key", "override license key") { |l| options[:license_key] = l }
   opts.on("--install", "install a newrelic.yml template") { |l| options[:install] = true }
-  opts.separator ""
-  opts.separator "app_name is the name of the application where the metrics will be stored"
-  opts.separator ""
+  opts.separator("")
+  opts.separator("app_name is the name of the application where the metrics will be stored")
+  opts.separator("")
   # The rackup file references this var
   appname = opts.parse!(ARGV.clone).first
 end
@@ -23,10 +23,10 @@ end
 options[:app_name] = appname if appname
 
 ru_file = File.expand_path(File.join(File.dirname(__FILE__), "..", "lib", "new_relic", "rack", "mongrel_rpm.ru"))
-rackup_code = File.read ru_file
-builder = Rack::Builder.new { eval rackup_code, binding, ru_file }
+rackup_code = File.read(ru_file)
+builder = Rack::Builder.new { eval(rackup_code, binding, ru_file) }
 
 options = {:Host => '127.0.0.1', :Port => port}
 Rack::Handler::Mongrel.run(builder.to_app, options) do |server|
-  NewRelic::Agent.logger.info "Started Mongrel listening for '#{NewRelic::Control.instance.app_names.join(" and ")}' data at #{server.host}:#{server.port}"
+  NewRelic::Agent.logger.info("Started Mongrel listening for '#{NewRelic::Control.instance.app_names.join(" and ")}' data at #{server.host}:#{server.port}")
 end

--- a/bin/newrelic
+++ b/bin/newrelic
@@ -9,5 +9,5 @@ begin
 rescue NewRelic::Cli::Command::CommandFailure => failure
   STDERR.puts failure.message
   STDERR.puts failure.options if failure.options
-  exit 1
+  exit(1)
 end

--- a/bin/nrdebug
+++ b/bin/nrdebug
@@ -179,10 +179,10 @@ class ProcessReport
   def open
     if @path
       File.open(@path, "w") do |f|
-        yield f
+        yield(f)
       end
     else
-      yield $stdout
+      yield($stdout)
     end
   end
 

--- a/infinite_tracing/Rakefile
+++ b/infinite_tracing/Rakefile
@@ -17,7 +17,7 @@ task :console do
 end
 
 Rake::TestTask.new do |t|
-  ROOT = File.join File.dirname(__FILE__)
+  ROOT = File.join(File.dirname(__FILE__))
   $LOAD_PATH << ROOT
 
   file_pattern = "#{ROOT}/**/*_test.rb"

--- a/infinite_tracing/lib/infinite_tracing.rb
+++ b/infinite_tracing/lib/infinite_tracing.rb
@@ -7,7 +7,7 @@ require 'uri'
 
 require 'newrelic_rpm'
 
-NewRelic::Agent.logger.debug "Detected New Relic Infinite Tracing Gem"
+NewRelic::Agent.logger.debug("Detected New Relic Infinite Tracing Gem")
 
 require 'infinite_tracing/version'
 require 'infinite_tracing/config'
@@ -20,7 +20,7 @@ DependencyDetection.defer do
   end
 
   executes do
-    NewRelic::Agent.logger.debug "Loading New Relic Infinite Tracing Library"
+    NewRelic::Agent.logger.debug("Loading New Relic Infinite Tracing Library")
 
     require 'infinite_tracing/proto'
 

--- a/infinite_tracing/lib/infinite_tracing/agent_integrations.rb
+++ b/infinite_tracing/lib/infinite_tracing/agent_integrations.rb
@@ -6,7 +6,7 @@
 module NewRelic::Agent
   module InfiniteTracing
     if Config.enabled? || Config.test_framework?
-      NewRelic::Agent.logger.debug "Integrating Infinite Tracer with Agent"
+      NewRelic::Agent.logger.debug("Integrating Infinite Tracer with Agent")
 
       require_relative 'agent_integrations/agent'
       require_relative 'agent_integrations/segment'
@@ -14,7 +14,7 @@ module NewRelic::Agent
       require_relative 'agent_integrations/external_request_segment'
 
     else
-      NewRelic::Agent.logger.debug "Skipped Integrating Infinite Tracer with Agent"
+      NewRelic::Agent.logger.debug("Skipped Integrating Infinite Tracer with Agent")
     end
   end
 end

--- a/infinite_tracing/lib/infinite_tracing/agent_integrations/agent.rb
+++ b/infinite_tracing/lib/infinite_tracing/agent_integrations/agent.rb
@@ -4,7 +4,7 @@
 # frozen_string_literal: true
 
 module NewRelic::Agent
-  NewRelic::Agent.logger.debug "Installing Infinite Tracer in Agent"
+  NewRelic::Agent.logger.debug("Installing Infinite Tracer in Agent")
 
   Agent.class_eval do
     def new_infinite_tracer
@@ -12,7 +12,7 @@ module NewRelic::Agent
       # entire start up process for the Agent.
       InfiniteTracing::Client.new.tap do |client|
         @infinite_tracer_thread = InfiniteTracing::Worker.new(:infinite_tracer) do
-          NewRelic::Agent.logger.debug "Opening Infinite Tracer Stream with gRPC server"
+          NewRelic::Agent.logger.debug("Opening Infinite Tracer Stream with gRPC server")
           client.start_streaming
         end
       end
@@ -22,17 +22,17 @@ module NewRelic::Agent
     # this clears the data, clears connection attempts, and
     # waits a while to reconnect.
     def handle_force_restart(error)
-      ::NewRelic::Agent.logger.debug error.message
+      ::NewRelic::Agent.logger.debug(error.message)
       drop_buffered_data
       @service.force_restart if @service
       @connect_state = :pending
       close_infinite_tracer
-      sleep 30
+      sleep(30)
     end
 
     # Whenever we reconnect, close and restart
     def close_infinite_tracer
-      NewRelic::Agent.logger.debug "Closing infinite tracer threads"
+      NewRelic::Agent.logger.debug("Closing infinite tracer threads")
       return unless @infinite_tracer_thread
       @infinite_tracer_thread.join
       @infinite_tracer_thread.stop

--- a/infinite_tracing/lib/infinite_tracing/agent_integrations/datastore_segment.rb
+++ b/infinite_tracing/lib/infinite_tracing/agent_integrations/datastore_segment.rb
@@ -12,7 +12,7 @@ module NewRelic
           return if transaction.ignore?
 
           tracer = ::NewRelic::Agent.agent.infinite_tracer
-          tracer << Proc.new { SpanEventPrimitive.for_datastore_segment self }
+          tracer << Proc.new { SpanEventPrimitive.for_datastore_segment(self) }
         end
       end
     end

--- a/infinite_tracing/lib/infinite_tracing/agent_integrations/external_request_segment.rb
+++ b/infinite_tracing/lib/infinite_tracing/agent_integrations/external_request_segment.rb
@@ -12,7 +12,7 @@ module NewRelic
           return if transaction.ignore?
 
           tracer = ::NewRelic::Agent.agent.infinite_tracer
-          tracer << Proc.new { SpanEventPrimitive.for_external_request_segment self }
+          tracer << Proc.new { SpanEventPrimitive.for_external_request_segment(self) }
         end
       end
     end

--- a/infinite_tracing/lib/infinite_tracing/agent_integrations/segment.rb
+++ b/infinite_tracing/lib/infinite_tracing/agent_integrations/segment.rb
@@ -16,7 +16,7 @@ module NewRelic
           return if transaction.ignore?
 
           tracer = ::NewRelic::Agent.agent.infinite_tracer
-          tracer << Proc.new { SpanEventPrimitive.for_segment self }
+          tracer << Proc.new { SpanEventPrimitive.for_segment(self) }
         end
       end
     end

--- a/infinite_tracing/lib/infinite_tracing/channel.rb
+++ b/infinite_tracing/lib/infinite_tracing/channel.rb
@@ -7,12 +7,13 @@ module NewRelic::Agent
   module InfiniteTracing
     class Channel
       def stub
-        NewRelic::Agent.logger.debug "Infinite Tracer Opening Channel to #{host_and_port}"
+        NewRelic::Agent.logger.debug("Infinite Tracer Opening Channel to #{host_and_port}")
 
-        Com::Newrelic::Trace::V1::IngestService::Stub.new \
+        Com::Newrelic::Trace::V1::IngestService::Stub.new( \
           host_and_port,
           credentials,
           channel_override: channel
+        )
       end
 
       def channel

--- a/infinite_tracing/lib/infinite_tracing/config.rb
+++ b/infinite_tracing/lib/infinite_tracing/config.rb
@@ -53,7 +53,7 @@ module NewRelic::Agent
       end
 
       def trace_observer_host
-        without_scheme_or_port NewRelic::Agent.config[:'infinite_tracing.trace_observer.host']
+        without_scheme_or_port(NewRelic::Agent.config[:'infinite_tracing.trace_observer.host'])
       end
 
       # If the port is declared on the host entry, it overrides the port entry because otherwise
@@ -85,7 +85,7 @@ module NewRelic::Agent
         if trace_observer_configured?
           URI("#{trace_observer_scheme}://#{trace_observer_host_and_port}")
         else
-          NewRelic::Agent.logger.error TRACE_OBSERVER_NOT_CONFIGURED_ERROR
+          NewRelic::Agent.logger.error(TRACE_OBSERVER_NOT_CONFIGURED_ERROR)
           raise TRACE_OBSERVER_NOT_CONFIGURED_ERROR
         end
       end

--- a/infinite_tracing/lib/infinite_tracing/connection.rb
+++ b/infinite_tracing/lib/infinite_tracing/connection.rb
@@ -25,9 +25,10 @@ module NewRelic::Agent
         begin
           Connection.instance.notify_agent_started
         rescue => error
-          NewRelic::Agent.logger.error \
+          NewRelic::Agent.logger.error( \
             "Error during notify :server_source_configuration_added event",
             error
+          )
         end
       end
 
@@ -44,14 +45,14 @@ module NewRelic::Agent
         # so we're able to signal the client to restart when connectivity to the
         # server is disrupted.
         def record_spans client, enumerator, exponential_backoff
-          instance.record_spans client, enumerator, exponential_backoff
+          instance.record_spans(client, enumerator, exponential_backoff)
         end
 
         # RPC calls will pass the calling client instance in.  We track this
         # so we're able to signal the client to restart when connectivity to the
         # server is disrupted.
         def record_span_batches client, enumerator, exponential_backoff
-          instance.record_span_batch client, enumerator, exponential_backoff
+          instance.record_span_batch(client, enumerator, exponential_backoff)
         end
 
         def metadata
@@ -63,7 +64,7 @@ module NewRelic::Agent
       # unavailable errors coming from the stub being created and record_span call
       def record_spans client, enumerator, exponential_backoff
         @active_clients[client] = client
-        with_reconnection_backoff(exponential_backoff) { rpc.record_span enumerator, metadata: metadata }
+        with_reconnection_backoff(exponential_backoff) { rpc.record_span(enumerator, metadata: metadata) }
       end
 
       # RPC calls will pass the calling client instance in.  We track this
@@ -71,7 +72,7 @@ module NewRelic::Agent
       # server is disrupted.
       def record_span_batches client, enumerator, exponential_backoff
         @active_clients[client] = client
-        with_reconnection_backoff(exponential_backoff) { rpc.record_span_batch enumerator, metadata: metadata }
+        with_reconnection_backoff(exponential_backoff) { rpc.record_span_batch(enumerator, metadata: metadata) }
       end
 
       # Acquires the new channel stub for the RPC calls.
@@ -153,9 +154,9 @@ module NewRelic::Agent
           yield
         rescue => exception
           retry_connection_period = retry_connection_period(exponential_backoff)
-          ::NewRelic::Agent.logger.error "Error establishing connection with infinite tracing service:", exception
-          ::NewRelic::Agent.logger.info "Will re-attempt infinte tracing connection in #{retry_connection_period} seconds"
-          sleep retry_connection_period
+          ::NewRelic::Agent.logger.error("Error establishing connection with infinite tracing service:", exception)
+          ::NewRelic::Agent.logger.info("Will re-attempt infinte tracing connection in #{retry_connection_period} seconds")
+          sleep(retry_connection_period)
           note_connect_failure
           retry
         end

--- a/infinite_tracing/lib/infinite_tracing/record_status_handler.rb
+++ b/infinite_tracing/lib/infinite_tracing/record_status_handler.rb
@@ -19,29 +19,29 @@ module NewRelic::Agent
       end
 
       def start_handler
-        Worker.new self.class.name do
+        Worker.new(self.class.name) do
           begin
             @enumerator.each do |response|
               break if response.nil? || response.is_a?(Exception)
               @lock.synchronize do
                 @messages_seen = response
-                NewRelic::Agent.logger.debug "gRPC Infinite Tracer Observer saw #{messages_seen} messages"
+                NewRelic::Agent.logger.debug("gRPC Infinite Tracer Observer saw #{messages_seen} messages")
               end
             end
-            NewRelic::Agent.logger.debug "gRPC Infinite Tracer Observer closed the stream"
+            NewRelic::Agent.logger.debug("gRPC Infinite Tracer Observer closed the stream")
             @client.handle_close
           rescue => error
-            @client.handle_error error
+            @client.handle_error(error)
           end
         end
       rescue => error
-        NewRelic::Agent.logger.error "gRPC Worker Error", error
+        NewRelic::Agent.logger.error("gRPC Worker Error", error)
       end
 
       def stop
         return if @worker.nil?
         @lock.synchronize do
-          NewRelic::Agent.logger.debug "gRPC Stopping Response Handler"
+          NewRelic::Agent.logger.debug("gRPC Stopping Response Handler")
           @worker.stop
           @worker = nil
         end

--- a/infinite_tracing/lib/infinite_tracing/suspended_streaming_buffer.rb
+++ b/infinite_tracing/lib/infinite_tracing/suspended_streaming_buffer.rb
@@ -19,7 +19,7 @@ module NewRelic::Agent
 
       # updates the seen metric and discards the segment
       def << segment
-        NewRelic::Agent.increment_metric SPANS_SEEN_METRIC
+        NewRelic::Agent.increment_metric(SPANS_SEEN_METRIC)
       end
 
       def transfer new_buffer

--- a/infinite_tracing/lib/infinite_tracing/worker.rb
+++ b/infinite_tracing/lib/infinite_tracing/worker.rb
@@ -35,14 +35,14 @@ module NewRelic::Agent
 
       def join timeout = nil
         return unless @worker_thread
-        NewRelic::Agent.logger.debug "joining worker #{@name} thread..."
-        @worker_thread.join timeout
+        NewRelic::Agent.logger.debug("joining worker #{@name} thread...")
+        @worker_thread.join(timeout)
       end
 
       def stop
         @lock.synchronize do
           return unless @worker_thread
-          NewRelic::Agent.logger.debug "stopping worker #{@name} thread..."
+          NewRelic::Agent.logger.debug("stopping worker #{@name} thread...")
           @worker_thread.kill
           @worker_thread = nil
         end
@@ -51,7 +51,7 @@ module NewRelic::Agent
       private
 
       def start_thread
-        NewRelic::Agent.logger.debug "starting worker #{@name} thread..."
+        NewRelic::Agent.logger.debug("starting worker #{@name} thread...")
         @worker_thread = Thread.new do
           catch(:exit) do
             begin
@@ -63,7 +63,7 @@ module NewRelic::Agent
           end
         end
         @worker_thread.abort_on_exception = true
-        if @worker_thread.respond_to? :report_on_exception
+        if @worker_thread.respond_to?(:report_on_exception)
           @worker_thread.report_on_exception = NewRelic::Agent.config[:log_level] == "debug"
         end
       end

--- a/infinite_tracing/lib/new_relic/infinite_tracing.rb
+++ b/infinite_tracing/lib/new_relic/infinite_tracing.rb
@@ -7,7 +7,7 @@ require 'uri'
 
 require 'newrelic_rpm'
 
-NewRelic::Agent.logger.debug "Detected New Relic Infinite Tracing Gem"
+NewRelic::Agent.logger.debug("Detected New Relic Infinite Tracing Gem")
 
 require 'new_relic/infinite_tracing/version'
 require 'new_relic/infinite_tracing/config'
@@ -20,7 +20,7 @@ DependencyDetection.defer do
   end
 
   executes do
-    NewRelic::Agent.logger.debug "Loading New Relic Infinite Tracing Library"
+    NewRelic::Agent.logger.debug("Loading New Relic Infinite Tracing Library")
 
     require 'new_relic/infinite_tracing/proto'
 

--- a/infinite_tracing/newrelic-infinite_tracing.gemspec
+++ b/infinite_tracing/newrelic-infinite_tracing.gemspec
@@ -13,12 +13,12 @@ require 'new_relic/version'
 
 Gem::Specification.new do |s|
   def self.copy_files filelist
-    subfolder = File.expand_path File.dirname(__FILE__)
+    subfolder = File.expand_path(File.dirname(__FILE__))
 
     filelist.each do |filename|
       source_full_filename = File.expand_path(filename)
       dest_full_filename = File.join(subfolder, File.basename(filename))
-      FileUtils.cp source_full_filename, dest_full_filename
+      FileUtils.cp(source_full_filename, dest_full_filename)
     end
   end
 
@@ -27,12 +27,12 @@ Gem::Specification.new do |s|
     "../CONTRIBUTING.md"
   ]
 
-  self.copy_files shared_files
+  self.copy_files(shared_files)
 
   s.name = "newrelic-infinite_tracing"
   s.version = NewRelic::VERSION::STRING
   s.required_ruby_version = '>= 2.5.0'
-  s.required_rubygems_version = Gem::Requirement.new("> 1.3.1") if s.respond_to? :required_rubygems_version=
+  s.required_rubygems_version = Gem::Requirement.new("> 1.3.1") if s.respond_to?(:required_rubygems_version=)
   s.authors = ["Tanna McClure", "Kayla Reopelle", "James Bunch", "Hannah Ramadan"]
   s.licenses = ['Apache-2.0']
   s.description = <<-EOS

--- a/infinite_tracing/tasks/proto.rake
+++ b/infinite_tracing/tasks/proto.rake
@@ -18,9 +18,9 @@ namespace :proto do
     # Removes require lines since these are replicated in the proto.rb file.
     def add_license_preamble_and_remove_requires output_path
       gemspec_path = File.expand_path(File.join(output_path, '..', '..', '..', '..', '..'))
-      license_terms = extract_license_terms File.readlines(File.join(gemspec_path, "Gemfile"))
-      Dir.glob(File.join output_path, "*.rb") do |filename|
-        contents = File.readlines filename
+      license_terms = extract_license_terms(File.readlines(File.join(gemspec_path, "Gemfile")))
+      Dir.glob(File.join(output_path, "*.rb")) do |filename|
+        contents = File.readlines(filename)
         contents.reject! { |r| r =~ /^\s*require\s.*$/ }
         File.open(filename, 'w') do |output|
           output.puts license_terms
@@ -29,11 +29,11 @@ namespace :proto do
       end
     end
 
-    gem_folder = File.expand_path File.join(File.dirname(__FILE__), "..")
-    proto_filename = File.join gem_folder, "lib", "new_relic", "proto", "infinite_tracing.proto"
-    output_path = File.join gem_folder, "lib", "new_relic", "infinite_tracing", "proto"
+    gem_folder = File.expand_path(File.join(File.dirname(__FILE__), ".."))
+    proto_filename = File.join(gem_folder, "lib", "new_relic", "proto", "infinite_tracing.proto")
+    output_path = File.join(gem_folder, "lib", "new_relic", "infinite_tracing", "proto")
 
-    FileUtils.mkdir_p output_path
+    FileUtils.mkdir_p(output_path)
     cmd = [
       "grpc_tools_ruby_protoc",
       "-I#{gem_folder}/lib/new_relic/proto",
@@ -41,7 +41,7 @@ namespace :proto do
       "--grpc_out=#{output_path} #{proto_filename}"
     ].join(" ")
 
-    if system cmd
+    if system(cmd)
       puts "Proto file generated!"
       add_license_preamble_and_remove_requires output_path
     else

--- a/infinite_tracing/test/infinite_tracing/agent_integrations/agent_test.rb
+++ b/infinite_tracing/test/infinite_tracing/agent_integrations/agent_test.rb
@@ -21,8 +21,8 @@ module NewRelic
           total_spans = 5
 
           spans = create_grpc_mock
-          with_config fake_server_config do
-            simulate_connect_to_collector fake_server_config do |simulator|
+          with_config(fake_server_config) do
+            simulate_connect_to_collector(fake_server_config) do |simulator|
               simulator.join
 
               # starts client and streams count segments
@@ -57,7 +57,7 @@ module NewRelic
           inf_tracer = NewRelic::Agent.agent.infinite_tracer
 
           assert NewRelic::Agent.agent.instance_variable_get(:@infinite_tracer_thread), 'Expected infinite tracer thread to not be nil'
-          NewRelic::Agent.agent.handle_force_restart(StandardError.new 'test')
+          NewRelic::Agent.agent.handle_force_restart(StandardError.new('test'))
         end
       end
     end

--- a/infinite_tracing/test/infinite_tracing/agent_integrations/datastore_segment_test.rb
+++ b/infinite_tracing/test/infinite_tracing/agent_integrations/datastore_segment_test.rb
@@ -32,7 +32,7 @@ module NewRelic
                 database_name: "calzone_zone"
               )
 
-              segment.notice_sql sql_statement
+              segment.notice_sql(sql_statement)
               advance_process_time(1)
               segment.finish
 

--- a/infinite_tracing/test/infinite_tracing/agent_integrations/external_request_segment_test.rb
+++ b/infinite_tracing/test/infinite_tracing/agent_integrations/external_request_segment_test.rb
@@ -23,12 +23,13 @@ module NewRelic
             in_transaction('wat') do |txn|
               txn.stubs(:sampled?).returns(true)
 
-              segment = Transaction::ExternalRequestSegment.new \
+              segment = Transaction::ExternalRequestSegment.new( \
                 "Typhoeus",
                 "http://remotehost.com/blogs/index",
                 "GET"
+              )
 
-              txn.add_segment segment
+              txn.add_segment(segment)
               segment.start
               advance_process_time(1.0)
               segment.finish
@@ -71,12 +72,13 @@ module NewRelic
             in_transaction('wat') do |txn|
               txn.stubs(:sampled?).returns(false)
 
-              segment = Transaction::ExternalRequestSegment.new \
+              segment = Transaction::ExternalRequestSegment.new( \
                 "Typhoeus",
                 "http://remotehost.com/blogs/index",
                 "GET"
+              )
 
-              txn.add_segment segment
+              txn.add_segment(segment)
               segment.start
               advance_process_time(1.0)
               segment.finish
@@ -91,12 +93,13 @@ module NewRelic
             in_transaction('wat') do |txn|
               txn.stubs(:ignore?).returns(true)
 
-              segment = Transaction::ExternalRequestSegment.new \
+              segment = Transaction::ExternalRequestSegment.new( \
                 "Typhoeus",
                 "http://remotehost.com/blogs/index",
                 "GET"
+              )
 
-              txn.add_segment segment
+              txn.add_segment(segment)
               segment.start
               advance_process_time(1.0)
               segment.finish

--- a/infinite_tracing/test/infinite_tracing/agent_integrations/segment_test.rb
+++ b/infinite_tracing/test/infinite_tracing/agent_integrations/segment_test.rb
@@ -22,8 +22,8 @@ module NewRelic
             in_transaction('wat') do |txn|
               txn.stubs(:sampled?).returns(true)
 
-              segment = Transaction::Segment.new 'Ummm'
-              txn.add_segment segment
+              segment = Transaction::Segment.new('Ummm')
+              txn.add_segment(segment)
               segment.start
               advance_process_time(1.0)
               segment.finish
@@ -61,8 +61,8 @@ module NewRelic
             in_transaction('wat') do |txn|
               txn.stubs(:sampled?).returns(false)
 
-              segment = Transaction::Segment.new 'Ummm'
-              txn.add_segment segment
+              segment = Transaction::Segment.new('Ummm')
+              txn.add_segment(segment)
               segment.start
               advance_process_time(1.0)
               segment.finish
@@ -77,8 +77,8 @@ module NewRelic
             in_transaction('wat') do |txn|
               txn.stubs(:ignore?).returns(true)
 
-              segment = Transaction::Segment.new 'Ummm'
-              txn.add_segment segment
+              segment = Transaction::Segment.new('Ummm')
+              txn.add_segment(segment)
               segment.start
               advance_process_time(1.0)
               segment.finish

--- a/infinite_tracing/test/infinite_tracing/channel_test.rb
+++ b/infinite_tracing/test/infinite_tracing/channel_test.rb
@@ -4,7 +4,7 @@
 # frozen_string_literal: true
 
 require_relative '../test_helper'
-SimpleCovHelper.command_name "test:multiverse[infinite_tracing]"
+SimpleCovHelper.command_name("test:multiverse[infinite_tracing]")
 
 module NewRelic
   module Agent
@@ -29,7 +29,7 @@ module NewRelic
         def test_channel_is_secure_for_remote_host
           Config.stubs(:test_framework?).returns(false)
 
-          with_config remote_config do
+          with_config(remote_config) do
             channel = Channel.new
             credentials = channel.send(:credentials)
 
@@ -47,7 +47,7 @@ module NewRelic
             :'infinite_tracing.trace_observer.host' => "http://example.com"
           })
 
-          with_config insecure_remote_config do
+          with_config(insecure_remote_config) do
             channel = Channel.new
             credentials = channel.send(:credentials)
 

--- a/infinite_tracing/test/infinite_tracing/client_test.rb
+++ b/infinite_tracing/test/infinite_tracing/client_test.rb
@@ -15,7 +15,7 @@ module NewRelic
           with_serial_lock do
             NewRelic::Agent::Transaction::Segment.any_instance.stubs('record_span_event')
             total_spans = 5
-            spans, segments = emulate_streaming_segments total_spans
+            spans, segments = emulate_streaming_segments(total_spans)
 
             assert_equal total_spans, spans.size
             assert_equal total_spans, segments.size
@@ -36,7 +36,7 @@ module NewRelic
           with_serial_lock do
             NewRelic::Agent::Transaction::Segment.any_instance.stubs('record_span_event')
             total_spans = 5
-            spans, segments = emulate_streaming_segments total_spans do |client, current_segments|
+            spans, segments = emulate_streaming_segments(total_spans) do |client, current_segments|
               if current_segments.size == 3
                 client.restart
               else
@@ -69,12 +69,12 @@ module NewRelic
             total_spans = 5
             leftover_spans = 2
 
-            spans, segments = emulate_streaming_segments total_spans do |client, current_segments|
+            spans, segments = emulate_streaming_segments(total_spans) do |client, current_segments|
               if current_segments.size == total_spans - leftover_spans
                 # we do this here instead of server_proc because we are testing that if
                 # the server restarts while the CLIENT is currently running, it
                 # behaves as expected (since we just testing the client behavior)
-                simulate_server_response GRPC::Ok.new
+                simulate_server_response(GRPC::Ok.new)
               else
                 # we need to do this so the client streaming helpers know when
                 # the mock server has done its thing
@@ -105,7 +105,7 @@ module NewRelic
             connection.stubs(:retry_connection_period).returns(0)
 
             total_spans = 2
-            emulate_streaming_with_initial_error total_spans
+            emulate_streaming_with_initial_error(total_spans)
 
             assert_metrics_recorded "Supportability/InfiniteTracing/Span/Sent"
             assert_metrics_recorded "Supportability/InfiniteTracing/Span/Response/Error"
@@ -123,9 +123,9 @@ module NewRelic
             connection.stubs(:retry_connection_period).returns(0)
 
             total_spans = 5
-            emulate_streaming_segments total_spans do |client, segments|
+            emulate_streaming_segments(total_spans) do |client, segments|
               if segments.size == 3
-                simulate_server_response_shutdown GRPC::Unimplemented.new("i dont exist")
+                simulate_server_response_shutdown(GRPC::Unimplemented.new("i dont exist"))
               else
                 simulate_server_response
               end

--- a/infinite_tracing/test/infinite_tracing/config_test.rb
+++ b/infinite_tracing/test/infinite_tracing/config_test.rb
@@ -20,7 +20,7 @@ module NewRelic
         end
 
         def test_all_infinite_tracing_config_keys_are_used
-          scan_and_remove_used_entries @default_keys, non_test_files
+          scan_and_remove_used_entries(@default_keys, non_test_files)
           assert_empty @default_keys
         end
 
@@ -98,7 +98,7 @@ module NewRelic
         end
 
         def test_unset_trace_observer_host_raises_error
-          NewRelic::Agent.config.remove_config_type :yaml
+          NewRelic::Agent.config.remove_config_type(:yaml)
           error = assert_raises RuntimeError do
             Config.trace_observer_uri
           end
@@ -108,7 +108,7 @@ module NewRelic
         private
 
         def non_test_files
-          all_rb_files.reject { |filename| filename.include? 'test.rb' }
+          all_rb_files.reject { |filename| filename.include?('test.rb') }
         end
       end
     end

--- a/infinite_tracing/test/infinite_tracing/connection_test.rb
+++ b/infinite_tracing/test/infinite_tracing/connection_test.rb
@@ -15,11 +15,11 @@ module NewRelic
         # begins it's connection handshake.
         def test_connection_initialized_before_connecting
           with_serial_lock do
-            with_config localhost_config do
+            with_config(localhost_config) do
               connection = Connection.instance # instantiate before simulation
-              simulate_connect_to_collector fiddlesticks_config, 0.01 do |simulator|
+              simulate_connect_to_collector(fiddlesticks_config, 0.01) do |simulator|
                 simulator.join # ensure our simulation happens!
-                metadata = connection.send :metadata
+                metadata = connection.send(:metadata)
 
                 assert_equal "swiss_cheese", metadata["license_key"]
                 assert_equal "fiddlesticks", metadata["agent_run_token"]
@@ -32,11 +32,11 @@ module NewRelic
         # is instantiated.
         def test_connection_initialized_after_connecting
           with_serial_lock do
-            with_config localhost_config do
-              simulate_connect_to_collector fiddlesticks_config, 0.0 do |simulator|
+            with_config(localhost_config) do
+              simulate_connect_to_collector(fiddlesticks_config, 0.0) do |simulator|
                 simulator.join # ensure our simulation happens!
                 connection = Connection.instance # instantiate after simulated connection
-                metadata = connection.send :metadata
+                metadata = connection.send(:metadata)
 
                 assert_equal "swiss_cheese", metadata["license_key"]
                 assert_equal "fiddlesticks", metadata["agent_run_token"]
@@ -49,11 +49,11 @@ module NewRelic
         # the client is instantiated (via sleep 0.01 w/o explicit join).
         def test_connection_initialized_after_connecting_and_waiting
           with_serial_lock do
-            with_config localhost_config do
-              simulate_connect_to_collector fiddlesticks_config, 0.01 do |simulator|
+            with_config(localhost_config) do
+              simulate_connect_to_collector(fiddlesticks_config, 0.01) do |simulator|
                 simulator.join # ensure our simulation happens!
                 connection = Connection.instance
-                metadata = connection.send :metadata
+                metadata = connection.send(:metadata)
 
                 assert_equal "swiss_cheese", metadata["license_key"]
                 assert_equal "fiddlesticks", metadata["agent_run_token"]
@@ -66,17 +66,17 @@ module NewRelic
         # The metadata is expected to change since agent run token changes.
         def test_connection_reconnects
           with_serial_lock do
-            with_config localhost_config do
+            with_config(localhost_config) do
               connection = Connection.instance
-              simulate_connect_to_collector fiddlesticks_config, 0.0 do |simulator|
+              simulate_connect_to_collector(fiddlesticks_config, 0.0) do |simulator|
                 simulator.join
-                metadata = connection.send :metadata
+                metadata = connection.send(:metadata)
                 assert_equal "swiss_cheese", metadata["license_key"]
                 assert_equal "fiddlesticks", metadata["agent_run_token"]
 
                 simulate_reconnect_to_collector(reconnect_config)
 
-                metadata = connection.send :metadata
+                metadata = connection.send(:metadata)
 
                 assert_equal "swiss_cheese", metadata["license_key"]
                 assert_equal "shazbat", metadata["agent_run_token"]
@@ -88,7 +88,7 @@ module NewRelic
         def test_sending_spans_to_server
           with_serial_lock do
             total_spans = 5
-            spans, segments = emulate_streaming_segments total_spans
+            spans, segments = emulate_streaming_segments(total_spans)
             assert_equal total_spans, segments.size
             assert_equal total_spans, spans.size
           end
@@ -164,7 +164,7 @@ module NewRelic
 
             attempts = 0
             begin
-              connection.send :with_reconnection_backoff do
+              connection.send(:with_reconnection_backoff) do
                 attempts += 1
                 raise NewRelic::TestHelpers::Exceptions::TestRuntimeError # simulate grpc raising connection error
               end
@@ -178,13 +178,13 @@ module NewRelic
 
         def test_metadata_includes_request_headers_map
           with_serial_lock do
-            with_config localhost_config do
+            with_config(localhost_config) do
               NewRelic::Agent.agent.service.instance_variable_set(:@request_headers_map, {"NR-UtilizationMetadata" => "test_metadata"})
 
               connection = Connection.instance # instantiate before simulation
-              simulate_connect_to_collector fiddlesticks_config, 0.01 do |simulator|
+              simulate_connect_to_collector(fiddlesticks_config, 0.01) do |simulator|
                 simulator.join # ensure our simulation happens!
-                metadata = connection.send :metadata
+                metadata = connection.send(:metadata)
 
                 assert_equal "test_metadata", metadata["nr-utilizationmetadata"]
               end

--- a/infinite_tracing/test/infinite_tracing/record_status_handler_test.rb
+++ b/infinite_tracing/test/infinite_tracing/record_status_handler_test.rb
@@ -17,8 +17,8 @@ module NewRelic::Agent::InfiniteTracing
     def test_processes_single_item_and_stops
       queue = EnumeratorQueue.new.preload(RecordStatus.new(messages_seen: 12))
 
-      handler = build_handler queue
-      process_queue handler, queue
+      handler = build_handler(queue)
+      process_queue(handler, queue)
 
       assert_equal 12, handler.messages_seen
     end
@@ -27,8 +27,8 @@ module NewRelic::Agent::InfiniteTracing
       items = 5.times.map { |i| RecordStatus.new(messages_seen: i + 1) }
       queue = EnumeratorQueue.new.preload(items)
 
-      handler = build_handler queue
-      process_queue handler, queue
+      handler = build_handler(queue)
+      process_queue(handler, queue)
 
       assert_equal 5, handler.messages_seen
     end
@@ -37,8 +37,8 @@ module NewRelic::Agent::InfiniteTracing
       error_object = RuntimeError.new("oops")
       queue = EnumeratorQueue.new.preload(error_object)
 
-      handler = build_handler queue
-      process_queue handler, queue, true
+      handler = build_handler(queue)
+      process_queue(handler, queue, true)
 
       assert_equal 0, handler.messages_seen
     end
@@ -46,8 +46,8 @@ module NewRelic::Agent::InfiniteTracing
     def test_processes_nil_on_queue
       queue = EnumeratorQueue.new
 
-      handler = build_handler queue
-      process_queue handler, queue, true
+      handler = build_handler(queue)
+      process_queue(handler, queue, true)
 
       assert_equal 0, handler.messages_seen
     end
@@ -56,12 +56,12 @@ module NewRelic::Agent::InfiniteTracing
 
     class TestClient
       def handle_error error
-        NewRelic::Agent.record_metric "Supportability/InfiniteTracing/Span/Response/Error", 0.0
+        NewRelic::Agent.record_metric("Supportability/InfiniteTracing/Span/Response/Error", 0.0)
       end
     end
 
     def build_handler queue
-      RecordStatusHandler.new TestClient.new, queue.each_item
+      RecordStatusHandler.new(TestClient.new, queue.each_item)
     end
   end
 end

--- a/infinite_tracing/test/infinite_tracing/streaming_buffer_test.rb
+++ b/infinite_tracing/test/infinite_tracing/streaming_buffer_test.rb
@@ -21,8 +21,8 @@ module NewRelic
         def test_streams_single_segment
           with_serial_lock do
             total_spans = 1
-            buffer, _segments = stream_segments total_spans
-            consume_spans buffer
+            buffer, _segments = stream_segments(total_spans)
+            consume_spans(buffer)
 
             refute_metrics_recorded(["Supportability/InfiniteTracing/Span/AgentQueueDumped"])
             assert_metrics_recorded({
@@ -35,10 +35,10 @@ module NewRelic
         def test_streams_single_segment_in_threads
           with_serial_lock do
             total_spans = 1
-            generator, buffer, _segments = prepare_to_stream_segments total_spans
+            generator, buffer, _segments = prepare_to_stream_segments(total_spans)
 
             # consumes the queue as it fills
-            _spans, consumer = prepare_to_consume_spans buffer
+            _spans, consumer = prepare_to_consume_spans(buffer)
 
             generator.join
             buffer.flush_queue
@@ -56,9 +56,9 @@ module NewRelic
         def test_streams_multiple_segments
           with_serial_lock do
             total_spans = 5
-            buffer, segments = stream_segments total_spans
+            buffer, segments = stream_segments(total_spans)
 
-            spans = consume_spans buffer
+            spans = consume_spans(buffer)
 
             assert_equal total_spans, spans.size
             spans.each_with_index do |span, index|
@@ -78,10 +78,10 @@ module NewRelic
         def test_streams_multiple_segments_in_threads
           with_serial_lock do
             total_spans = 5
-            generator, buffer, segments = prepare_to_stream_segments total_spans
+            generator, buffer, segments = prepare_to_stream_segments(total_spans)
 
             # consumes the queue as it fills
-            spans, consumer = prepare_to_consume_spans buffer
+            spans, consumer = prepare_to_consume_spans(buffer)
 
             generator.join
             buffer.flush_queue
@@ -108,10 +108,10 @@ module NewRelic
             max_queue_size = 4
 
             # generate all spans before we attempt to consume
-            buffer, segments = stream_segments total_spans, max_queue_size
+            buffer, segments = stream_segments(total_spans, max_queue_size)
 
             # consumes the queue after we've filled it
-            spans = consume_spans buffer
+            spans = consume_spans(buffer)
 
             assert_equal 1, spans.size
             assert_equal segments[-1].transaction.trace_id, spans[0]["trace_id"]
@@ -129,10 +129,10 @@ module NewRelic
         def test_can_close_an_empty_buffer
           with_serial_lock do
             total_spans = 10
-            generator, buffer, segments = prepare_to_stream_segments total_spans
+            generator, buffer, segments = prepare_to_stream_segments(total_spans)
 
             # consumes the queue as it fills
-            spans, consumer = prepare_to_consume_spans buffer
+            spans, consumer = prepare_to_consume_spans(buffer)
 
             # closes the streaming buffer after queue is emptied
             closed = false
@@ -195,7 +195,7 @@ module NewRelic
 
         # starts a watched thread that will generate segments asynchronously.
         def prepare_to_stream_segments count, max_buffer_size = 100_000
-          buffer = StreamingBuffer.new max_buffer_size
+          buffer = StreamingBuffer.new(max_buffer_size)
           segments = []
 
           # generates segments that are streamed as spans
@@ -218,7 +218,7 @@ module NewRelic
         # Returns the buffer with segments on the queue as well
         # as the segments that were generated separately.
         def stream_segments count, max_buffer_size = 100_000
-          buffer = StreamingBuffer.new max_buffer_size
+          buffer = StreamingBuffer.new(max_buffer_size)
           segments = []
 
           # generates segments that are streamed as spans

--- a/infinite_tracing/test/infinite_tracing/suspended_streaming_buffer_test.rb
+++ b/infinite_tracing/test/infinite_tracing/suspended_streaming_buffer_test.rb
@@ -20,9 +20,9 @@ module NewRelic
 
         def test_streams_multiple_segments
           total_spans = 5
-          buffer, segments = stream_segments total_spans
+          buffer, segments = stream_segments(total_spans)
 
-          spans = consume_spans buffer
+          spans = consume_spans(buffer)
 
           assert_equal 0, spans.size
           spans.each_with_index do |span, index|
@@ -42,10 +42,10 @@ module NewRelic
 
         def test_can_close_an_empty_buffer
           total_spans = 10
-          generator, buffer, segments = prepare_to_stream_segments total_spans
+          generator, buffer, segments = prepare_to_stream_segments(total_spans)
 
           # consumes the queue as it fills
-          spans, consumer = prepare_to_consume_spans buffer
+          spans, consumer = prepare_to_consume_spans(buffer)
 
           # closes the streaming buffer after queue is emptied
           closed = false
@@ -112,7 +112,7 @@ module NewRelic
 
         # starts a watched thread that will generate segments asynchronously.
         def prepare_to_stream_segments count, max_buffer_size = 100_000
-          buffer = SuspendedStreamingBuffer.new max_buffer_size
+          buffer = SuspendedStreamingBuffer.new(max_buffer_size)
           segments = []
 
           # generates segments that are streamed as spans
@@ -135,7 +135,7 @@ module NewRelic
         # Returns the buffer with segments on the queue as well
         # as the segments that were generated separately.
         def stream_segments count, max_buffer_size = 100_000
-          buffer = SuspendedStreamingBuffer.new max_buffer_size
+          buffer = SuspendedStreamingBuffer.new(max_buffer_size)
           segments = []
 
           # generates segments that are streamed as spans

--- a/infinite_tracing/test/infinite_tracing/transformer_test.rb
+++ b/infinite_tracing/test/infinite_tracing/transformer_test.rb
@@ -10,7 +10,7 @@ module NewRelic
     module InfiniteTracing
       class TransformerTest < Minitest::Test
         def test_transforms_single_span_event
-          span_event = Transformer.transform span_event_fixture :single
+          span_event = Transformer.transform(span_event_fixture(:single))
           assert_kind_of Hash, span_event
           assert_equal "cb4925eee573c1f9c786fdb2b296459b", span_event["trace_id"]
           span_event["intrinsics"].each do |key, value|
@@ -22,7 +22,7 @@ module NewRelic
         end
 
         def test_transforms_single_full_span_event
-          span_event = Transformer.transform span_event_fixture :single_full_attributes
+          span_event = Transformer.transform(span_event_fixture(:single_full_attributes))
           assert_kind_of Hash, span_event
           assert_equal "cb4925eee573c1f9c786fdb2b296459b", span_event["trace_id"]
 

--- a/infinite_tracing/test/infinite_tracing/worker_test.rb
+++ b/infinite_tracing/test/infinite_tracing/worker_test.rb
@@ -12,7 +12,7 @@ module NewRelic::Agent::InfiniteTracing
     end
 
     def test_processes_simple_task
-      worker = Worker.new "simple" do
+      worker = Worker.new("simple") do
         NewRelic::Agent.record_metric("Supportability/InfiniteTracing/Worker", 0.0)
       end
       assert_equal "run", worker.status
@@ -26,7 +26,7 @@ module NewRelic::Agent::InfiniteTracing
     end
 
     def test_worker_handles_errors
-      worker = Worker.new "error" do
+      worker = Worker.new("error") do
         NewRelic::Agent.record_metric("Supportability/InfiniteTracing/Worker", 0.0)
         raise "Oops!"
         NewRelic::Agent.record_metric("Supportability/InfiniteTracing/Error", 0.0)

--- a/infinite_tracing/test/infinite_tracing_test.rb
+++ b/infinite_tracing/test/infinite_tracing_test.rb
@@ -16,7 +16,7 @@ module NewRelic
         end
 
         def test_span_events_fixtures_load
-          span_event = span_event_fixture :single
+          span_event = span_event_fixture(:single)
           assert_kind_of Array, span_event
           assert_kind_of Hash, span_event[0]
           assert_kind_of Hash, span_event[1]

--- a/infinite_tracing/test/support/enumerator_queue.rb
+++ b/infinite_tracing/test/support/enumerator_queue.rb
@@ -13,7 +13,7 @@ class EnumeratorQueue
   end
 
   def preload items
-    Array(items).each { |item| @queue.push item }
+    Array(items).each { |item| @queue.push(item) }
     self
   end
 
@@ -22,8 +22,8 @@ class EnumeratorQueue
     loop do
       value = @queue.pop
       break if value.nil?
-      fail value if value.is_a? Exception
-      yield value
+      fail value if value.is_a?(Exception)
+      yield(value)
     end
   end
 end

--- a/infinite_tracing/test/support/fixtures.rb
+++ b/infinite_tracing/test/support/fixtures.rb
@@ -13,8 +13,8 @@ def span_event_fixture fixture_name
   fixture_filename = File.join(fixtures_path, "span_events", "#{fixture_name}.yml")
   assert File.exist?(fixture_filename), "Missing Span Event Fixture: #{fixture_name}. Looked for #{fixture_filename}"
   if YAML.respond_to?(:unsafe_load)
-    YAML::unsafe_load File.read(fixture_filename)
+    YAML::unsafe_load(File.read(fixture_filename))
   else
-    YAML::load File.read(fixture_filename)
+    YAML::load(File.read(fixture_filename))
   end
 end

--- a/infinite_tracing/test/support/server_response_simulator.rb
+++ b/infinite_tracing/test/support/server_response_simulator.rb
@@ -28,7 +28,7 @@ module NewRelic
               if return_value.is_a?(GRPC::BadStatus) && !return_value.is_a?(GRPC::Ok)
                 raise return_value
               end
-              yield return_value
+              yield(return_value)
             end
           end
         end

--- a/infinite_tracing/test/test_helper.rb
+++ b/infinite_tracing/test/test_helper.rb
@@ -76,8 +76,8 @@ def trace
       :start_streaming,
       :notice_span,
       :wait_for_notice
-    ].include? tp.method_id
-    p [tp.lineno, tp.defined_class, tp.method_id, tp.event]
+    ].include?(tp.method_id)
+    p([tp.lineno, tp.defined_class, tp.method_id, tp.event])
   end
 end
 

--- a/init.rb
+++ b/init.rb
@@ -25,7 +25,7 @@ begin
     Rails.configuration
   end
 
-  NewRelic::Control.instance.init_plugin :config => current_config
+  NewRelic::Control.instance.init_plugin(:config => current_config)
 rescue => e
-  ::NewRelic::Agent.logger.error "Error initializing New Relic plugin. Agent is disabled.", e
+  ::NewRelic::Agent.logger.error("Error initializing New Relic plugin. Agent is disabled.", e)
 end

--- a/lib/new_relic/agent.rb
+++ b/lib/new_relic/agent.rb
@@ -420,7 +420,7 @@ module NewRelic
     #
     def add_instrumentation(file_pattern)
       record_api_supportability_metric(:add_instrumentation)
-      NewRelic::Control.instance.add_instrumentation file_pattern
+      NewRelic::Control.instance.add_instrumentation(file_pattern)
     end
 
     # Require agent testing helper methods
@@ -516,8 +516,8 @@ module NewRelic
     # @api public
     #
     def disable_transaction_tracing
-      Deprecator.deprecate :disable_transaction_tracing,
-        'disable_all_tracing or ignore_transaction'
+      Deprecator.deprecate(:disable_transaction_tracing,
+        'disable_all_tracing or ignore_transaction')
       record_api_supportability_metric(:disable_transaction_tracing)
       yield
     end
@@ -580,7 +580,7 @@ module NewRelic
     def add_custom_attributes(params) # THREAD_LOCAL_ACCESS
       record_api_supportability_metric(:add_custom_attributes)
 
-      if params.is_a? Hash
+      if params.is_a?(Hash)
         txn = Transaction.tl_current
         txn.add_custom_attributes(params) if txn
 
@@ -609,14 +609,14 @@ module NewRelic
     # @see https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/glossary#span
     # @api public
     def add_custom_span_attributes params
-      record_api_supportability_metric :add_custom_span_attributes
+      record_api_supportability_metric(:add_custom_span_attributes)
 
-      if params.is_a? Hash
+      if params.is_a?(Hash)
         if segment = NewRelic::Agent::Tracer.current_segment
-          segment.add_custom_attributes params
+          segment.add_custom_attributes(params)
         end
       else
-        ::NewRelic::Agent.logger.warn "Bad argument passed to #add_custom_span_attributes. Expected Hash but got #{params.class}"
+        ::NewRelic::Agent.logger.warn("Bad argument passed to #add_custom_span_attributes. Expected Hash but got #{params.class}")
       end
     end
 
@@ -699,7 +699,7 @@ module NewRelic
     def notify(event_type, *args)
       agent.events.notify(event_type, *args)
     rescue
-      NewRelic::Agent.logger.debug "Ignoring exception during %p event notification" % [event_type]
+      NewRelic::Agent.logger.debug("Ignoring exception during %p event notification" % [event_type])
     end
 
     # @!group Trace and Entity metadata

--- a/lib/new_relic/agent/adaptive_sampler.rb
+++ b/lib/new_relic/agent/adaptive_sampler.rb
@@ -85,7 +85,7 @@ module NewRelic
             end
           end
           if target_changed
-            NewRelic::Agent.logger.debug "Sampling target set to: #{target}"
+            NewRelic::Agent.logger.debug("Sampling target set to: #{target}")
           end
         end
       end
@@ -100,7 +100,7 @@ module NewRelic
             end
           end
           if period_changed
-            NewRelic::Agent.logger.debug "Sampling period set to: #{period_duration}"
+            NewRelic::Agent.logger.debug("Sampling period set to: #{period_duration}")
           end
         end
       end

--- a/lib/new_relic/agent/agent/shutdown.rb
+++ b/lib/new_relic/agent/agent/shutdown.rb
@@ -10,7 +10,7 @@ module NewRelic
       # data.
       def shutdown
         return unless started?
-        ::NewRelic::Agent.logger.info "Starting Agent shutdown"
+        ::NewRelic::Agent.logger.info("Starting Agent shutdown")
 
         stop_event_loop
         trap_signals_for_litespeed
@@ -27,7 +27,7 @@ module NewRelic
             graceful_disconnect
           end
         rescue => e
-          ::NewRelic::Agent.logger.error e
+          ::NewRelic::Agent.logger.error(e)
         end
       end
     end

--- a/lib/new_relic/agent/agent/special_startup.rb
+++ b/lib/new_relic/agent/agent/special_startup.rb
@@ -11,8 +11,8 @@ module NewRelic
       # before connecting, otherwise the parent process sends useless data
       def using_forking_dispatcher?
         # TODO: MAJOR VERSION - remove :rainbows
-        if [:puma, :passenger, :rainbows, :unicorn].include? Agent.config[:dispatcher]
-          ::NewRelic::Agent.logger.info "Deferring startup of agent reporting thread because #{Agent.config[:dispatcher]} may fork."
+        if [:puma, :passenger, :rainbows, :unicorn].include?(Agent.config[:dispatcher])
+          ::NewRelic::Agent.logger.info("Deferring startup of agent reporting thread because #{Agent.config[:dispatcher]} may fork.")
           true
         else
           false

--- a/lib/new_relic/agent/agent/start_worker_thread.rb
+++ b/lib/new_relic/agent/agent/start_worker_thread.rb
@@ -19,11 +19,11 @@ module NewRelic
       # See #connect for a description of connection_options.
       def start_worker_thread(connection_options = {})
         if disable = NewRelic::Agent.config[:disable_harvest_thread]
-          NewRelic::Agent.logger.info "Not starting Ruby Agent worker thread because :disable_harvest_thread is #{disable}"
+          NewRelic::Agent.logger.info("Not starting Ruby Agent worker thread because :disable_harvest_thread is #{disable}")
           return
         end
 
-        ::NewRelic::Agent.logger.debug "Creating Ruby Agent worker thread."
+        ::NewRelic::Agent.logger.debug("Creating Ruby Agent worker thread.")
         @worker_thread = Threading::AgentThread.create('Worker Loop') do
           deferred_work!(connection_options)
         end
@@ -45,7 +45,7 @@ module NewRelic
         # Wait the end of the event loop thread.
         if @worker_thread
           unless @worker_thread.join(3)
-            ::NewRelic::Agent.logger.debug "Event loop thread did not stop within 3 seconds"
+            ::NewRelic::Agent.logger.debug("Event loop thread did not stop within 3 seconds")
           end
         end
       end
@@ -67,19 +67,19 @@ module NewRelic
           transmit_data
         end
 
-        @event_loop.on(interval_for TRANSACTION_EVENT_DATA) do
+        @event_loop.on(interval_for(TRANSACTION_EVENT_DATA)) do
           transmit_analytic_event_data
         end
-        @event_loop.on(interval_for CUSTOM_EVENT_DATA) do
+        @event_loop.on(interval_for(CUSTOM_EVENT_DATA)) do
           transmit_custom_event_data
         end
-        @event_loop.on(interval_for ERROR_EVENT_DATA) do
+        @event_loop.on(interval_for(ERROR_EVENT_DATA)) do
           transmit_error_event_data
         end
-        @event_loop.on(interval_for SPAN_EVENT_DATA) do
+        @event_loop.on(interval_for(SPAN_EVENT_DATA)) do
           transmit_span_event_data
         end
-        @event_loop.on(interval_for LOG_EVENT_DATA) do
+        @event_loop.on(interval_for(LOG_EVENT_DATA)) do
           transmit_log_event_data
         end
 
@@ -97,18 +97,18 @@ module NewRelic
       # this clears the data, clears connection attempts, and
       # waits a while to reconnect.
       def handle_force_restart(error)
-        ::NewRelic::Agent.logger.debug error.message
+        ::NewRelic::Agent.logger.debug(error.message)
         drop_buffered_data
         @service.force_restart if @service
         @connect_state = :pending
-        sleep 30
+        sleep(30)
       end
 
       # when a disconnect is requested, stop the current thread, which
       # is the worker thread that gathers data and talks to the
       # server.
       def handle_force_disconnect(error)
-        ::NewRelic::Agent.logger.warn "Agent received a ForceDisconnectException from the server, disconnecting. (#{error.message})"
+        ::NewRelic::Agent.logger.warn("Agent received a ForceDisconnectException from the server, disconnecting. (#{error.message})")
         disconnect
       end
 
@@ -116,7 +116,7 @@ module NewRelic
       # it and disconnecting the agent, since we are now in an
       # unknown state.
       def handle_other_error(error)
-        ::NewRelic::Agent.logger.error "Unhandled error in worker thread, disconnecting."
+        ::NewRelic::Agent.logger.error("Unhandled error in worker thread, disconnecting.")
         # These errors are fatal (that is, they will prevent the agent from
         # reporting entirely), so we really want backtraces when they happen
         ::NewRelic::Agent.logger.log_exception(:error, error)
@@ -154,7 +154,7 @@ module NewRelic
               # never reaches here unless there is a problem or
               # the agent is exiting
             else
-              ::NewRelic::Agent.logger.debug "No connection.  Worker thread ending."
+              ::NewRelic::Agent.logger.debug("No connection.  Worker thread ending.")
             end
           end
         end

--- a/lib/new_relic/agent/agent/startup.rb
+++ b/lib/new_relic/agent/agent/startup.rb
@@ -69,7 +69,7 @@ module NewRelic
       # Log the environment the app thinks it's running in.
       # Useful in debugging, as this is the key for config YAML lookups.
       def log_environment
-        ::NewRelic::Agent.logger.info "Environment: #{NewRelic::Control.instance.env}"
+        ::NewRelic::Agent.logger.info("Environment: #{NewRelic::Control.instance.env}")
       end
 
       # Logs the dispatcher to the log file to assist with
@@ -79,21 +79,21 @@ module NewRelic
         dispatcher_name = Agent.config[:dispatcher].to_s
 
         if dispatcher_name.empty?
-          ::NewRelic::Agent.logger.info 'No known dispatcher detected.'
+          ::NewRelic::Agent.logger.info('No known dispatcher detected.')
         else
-          ::NewRelic::Agent.logger.info "Dispatcher: #{dispatcher_name}"
+          ::NewRelic::Agent.logger.info("Dispatcher: #{dispatcher_name}")
         end
       end
 
       def log_app_name
-        ::NewRelic::Agent.logger.info "Application: #{Agent.config[:app_name].join(", ")}"
+        ::NewRelic::Agent.logger.info("Application: #{Agent.config[:app_name].join(", ")}")
       end
 
       def log_ignore_url_regexes
         regexes = NewRelic::Agent.config[:'rules.ignore_url_regexes']
 
         unless regexes.empty?
-          ::NewRelic::Agent.logger.info "Ignoring URLs that match the following regexes: #{regexes.map(&:inspect).join(", ")}."
+          ::NewRelic::Agent.logger.info("Ignoring URLs that match the following regexes: #{regexes.map(&:inspect).join(", ")}.")
         end
       end
 
@@ -101,7 +101,7 @@ module NewRelic
       # so we can disambiguate processes in the log file and make
       # sure they're running a reasonable version
       def log_version_and_pid
-        ::NewRelic::Agent.logger.debug "New Relic Ruby Agent #{NewRelic::VERSION::STRING} Initialized: pid = #{$$}"
+        ::NewRelic::Agent.logger.debug("New Relic Ruby Agent #{NewRelic::VERSION::STRING} Initialized: pid = #{$$}")
       end
 
       # Logs the configured application names
@@ -165,21 +165,21 @@ module NewRelic
         return false if already_started? || disabled?
 
         if defer_for_delayed_job?
-          ::NewRelic::Agent.logger.debug "Deferring startup for DelayedJob"
+          ::NewRelic::Agent.logger.debug("Deferring startup for DelayedJob")
           return false
         end
 
         if defer_for_resque?
-          ::NewRelic::Agent.logger.debug "Deferring startup for Resque in case it daemonizes"
+          ::NewRelic::Agent.logger.debug("Deferring startup for Resque in case it daemonizes")
           return false
         end
 
         unless app_name_configured?
-          NewRelic::Agent.logger.error "No application name configured.",
+          NewRelic::Agent.logger.error("No application name configured.",
             "The Agent cannot start without at least one. Please check your ",
             "newrelic.yml and ensure that it is valid and has at least one ",
             "value set for app_name in the #{NewRelic::Control.instance.env} ",
-            "environment."
+            "environment.")
           return false
         end
 

--- a/lib/new_relic/agent/attribute_processing.rb
+++ b/lib/new_relic/agent/attribute_processing.rb
@@ -12,9 +12,9 @@ module NewRelic
       EMPTY_ARRAY_STRING_LITERAL = "[]".freeze
 
       def flatten_and_coerce(object, prefix = nil, result = {}, &blk)
-        if object.is_a? Hash
+        if object.is_a?(Hash)
           flatten_and_coerce_hash(object, prefix, result, &blk)
-        elsif object.is_a? Array
+        elsif object.is_a?(Array)
           flatten_and_coerce_array(object, prefix, result, &blk)
         elsif prefix
           val = Coerce.scalar(object)
@@ -24,7 +24,7 @@ module NewRelic
             result[prefix] = val
           end
         else
-          NewRelic::Agent.logger.warn "Unexpected object: #{object.inspect} with nil prefix passed to NewRelic::Agent::AttributeProcessing.flatten_and_coerce"
+          NewRelic::Agent.logger.warn("Unexpected object: #{object.inspect} with nil prefix passed to NewRelic::Agent::AttributeProcessing.flatten_and_coerce")
         end
         result
       end

--- a/lib/new_relic/agent/attributes.rb
+++ b/lib/new_relic/agent/attributes.rb
@@ -35,7 +35,7 @@ module NewRelic
       end
 
       def add_agent_attribute_with_key_check(key, value, default_destinations)
-        if exceeds_bytesize_limit? key, KEY_LIMIT
+        if exceeds_bytesize_limit?(key, KEY_LIMIT)
           NewRelic::Agent.logger.debug("Agent attribute #{key} was dropped for exceeding key length limit #{KEY_LIMIT}")
           return
         end

--- a/lib/new_relic/agent/commands/agent_command_router.rb
+++ b/lib/new_relic/agent/commands/agent_command_router.rb
@@ -78,16 +78,16 @@ module NewRelic
 
         def log_profiles(profiles)
           if profiles.empty?
-            ::NewRelic::Agent.logger.debug "No thread profiles with data found to send."
+            ::NewRelic::Agent.logger.debug("No thread profiles with data found to send.")
           else
             profile_descriptions = profiles.map { |p| p.to_log_description }
-            ::NewRelic::Agent.logger.debug "Sending thread profiles [#{profile_descriptions.join(", ")}]"
+            ::NewRelic::Agent.logger.debug("Sending thread profiles [#{profile_descriptions.join(", ")}]")
           end
         end
 
         def get_agent_commands
           commands = new_relic_service.get_agent_commands
-          NewRelic::Agent.logger.debug "Received get_agent_commands = #{commands.inspect}"
+          NewRelic::Agent.logger.debug("Received get_agent_commands = #{commands.inspect}")
           commands.map { |collector_command| AgentCommand.new(collector_command) }
         end
 

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -118,7 +118,7 @@ module NewRelic
         def self.config_path
           Proc.new {
             found_path = NewRelic::Agent.config[:config_search_paths].detect do |file|
-              File.expand_path(file) if File.exist? file
+              File.expand_path(file) if File.exist?(file)
             end
             found_path || NewRelic::EMPTY_STR
           }
@@ -135,7 +135,7 @@ module NewRelic
               when 4..7
                 :rails_notifications
               else
-                ::NewRelic::Agent.logger.warn "Detected untested Rails version #{Rails::VERSION::STRING}"
+                ::NewRelic::Agent.logger.warn("Detected untested Rails version #{Rails::VERSION::STRING}")
                 :rails_notifications
               end
             when defined?(::Sinatra) && defined?(::Sinatra::Base) then :sinatra
@@ -212,7 +212,7 @@ module NewRelic
 
         def self.api_host
           Proc.new do
-            if String(NewRelic::Agent.config[:license_key]).start_with? 'eu'
+            if String(NewRelic::Agent.config[:license_key]).start_with?('eu')
               'rpm.eu.newrelic.com'
             else
               'rpm.newrelic.com'

--- a/lib/new_relic/agent/configuration/environment_source.rb
+++ b/lib/new_relic/agent/configuration/environment_source.rb
@@ -43,7 +43,7 @@ module NewRelic
         def set_dotted_alias(original_config_setting)
           config_setting = original_config_setting.to_s
 
-          if config_setting.include? '.'
+          if config_setting.include?('.')
             config_alias = config_setting.gsub(/\./, '_').to_sym
             self.alias_map[config_alias] = original_config_setting
           end

--- a/lib/new_relic/agent/configuration/manager.rb
+++ b/lib/new_relic/agent/configuration/manager.rb
@@ -23,7 +23,7 @@ module NewRelic
         end
 
         def has_key?(key)
-          @cache.has_key? key
+          @cache.has_key?(key)
         end
 
         def keys

--- a/lib/new_relic/agent/configuration/security_policy_source.rb
+++ b/lib/new_relic/agent/configuration/security_policy_source.rb
@@ -27,9 +27,10 @@ module NewRelic
           def change_setting(policies, option, new_value)
             current_value = Agent.config[option]
             unless current_value == new_value
-              NewRelic::Agent.logger.info \
+              NewRelic::Agent.logger.info( \
                 "Setting changed: {#{option}: from #{current_value} " \
                 "to #{new_value}}. Source: SecurityPolicySource"
+              )
             end
             policies[option] = new_value
           end
@@ -219,15 +220,17 @@ module NewRelic
                   end
                 else
                   config_source = Agent.config.source(policy[:option]).class.name.split(COLON_COLON).last
-                  NewRelic::Agent.logger.info \
+                  NewRelic::Agent.logger.info( \
                     "Setting applied: {#{policy[:option]}: #{policy[:disabled_value]}}. " \
                     "Source: #{config_source}"
+                  )
                 end
               else
                 settings[policy[:option]] = policy[:disabled_value]
-                NewRelic::Agent.logger.info \
+                NewRelic::Agent.logger.info( \
                   "Setting applied: {#{policy[:option]}: #{policy[:disabled_value]}}. " \
                   "Source: SecurityPolicySource"
+                )
               end
             end
             settings

--- a/lib/new_relic/agent/configuration/server_source.rb
+++ b/lib/new_relic/agent/configuration/server_source.rb
@@ -87,14 +87,14 @@ module NewRelic
         }
 
         def add_event_harvest_config(merged_settings, connect_reply)
-          return unless event_harvest_config_is_valid connect_reply
+          return unless event_harvest_config_is_valid(connect_reply)
 
           event_harvest_config = EventHarvestConfig.to_config_hash(connect_reply)
           EVENT_HARVEST_CONFIG_SUPPORTABILITY_METRIC_NAMES.each do |config_key, metric_name|
-            NewRelic::Agent.record_metric metric_name, event_harvest_config[config_key]
+            NewRelic::Agent.record_metric(metric_name, event_harvest_config[config_key])
           end
 
-          merged_settings.merge! event_harvest_config
+          merged_settings.merge!(event_harvest_config)
         end
 
         def event_harvest_config_is_valid connect_reply
@@ -103,8 +103,8 @@ module NewRelic
           if event_harvest_config.nil? \
               || event_harvest_config['harvest_limits'].values.min < 0 \
               || (event_harvest_config['report_period_ms'] / 1000) <= 0
-            NewRelic::Agent.logger.warn "Invalid event harvest config found " \
-                "in connect response; using default event report period."
+            NewRelic::Agent.logger.warn("Invalid event harvest config found " \
+                "in connect response; using default event report period.")
             false
           else
             true

--- a/lib/new_relic/agent/configuration/yaml_source.rb
+++ b/lib/new_relic/agent/configuration/yaml_source.rb
@@ -136,7 +136,7 @@ module NewRelic
             elsif !config[option].nil? && !is_boolean?(config[option])
               coerced_value = !!(config[option].to_s =~ /yes|on|true/i)
               if !coerced_value
-                log_failure "Unexpected value (#{config[option]}) for '#{option}' in #{@path}"
+                log_failure("Unexpected value (#{config[option]}) for '#{option}' in #{@path}")
               end
               config[option] = coerced_value
             end

--- a/lib/new_relic/agent/connect/response_handler.rb
+++ b/lib/new_relic/agent/connect/response_handler.rb
@@ -38,16 +38,16 @@ module NewRelic
 
         def add_server_side_config(config_data)
           if config_data['agent_config']
-            ::NewRelic::Agent.logger.debug "Using config from server"
+            ::NewRelic::Agent.logger.debug("Using config from server")
           end
 
-          ::NewRelic::Agent.logger.debug "Server provided config: #{config_data.inspect}"
+          ::NewRelic::Agent.logger.debug("Server provided config: #{config_data.inspect}")
           server_config = NewRelic::Agent::Configuration::ServerSource.new(config_data, @config)
           @config.replace_or_add_config(server_config)
         end
 
         def add_security_policy_config(security_policies)
-          ::NewRelic::Agent.logger.info 'Installing security policies'
+          ::NewRelic::Agent.logger.info('Installing security policies')
           security_policy_source = NewRelic::Agent::Configuration::SecurityPolicySource.new(security_policies)
           @config.replace_or_add_config(security_policy_source)
           # drop data collected before applying security policies

--- a/lib/new_relic/agent/custom_event_aggregator.rb
+++ b/lib/new_relic/agent/custom_event_aggregator.rb
@@ -21,7 +21,7 @@ module NewRelic
       enabled_key :'custom_insights_events.enabled'
 
       def record(type, attributes)
-        unless attributes.is_a? Hash
+        unless attributes.is_a?(Hash)
           raise ArgumentError, "Expected Hash but got #{attributes.class}"
         end
 

--- a/lib/new_relic/agent/database.rb
+++ b/lib/new_relic/agent/database.rb
@@ -259,7 +259,7 @@ module NewRelic
           # between usage of mysql and mysql2. Obfuscation is the same, though.
           elsif adapter == MYSQL2_PREFIX
             :mysql2
-          elsif adapter.start_with? SQLITE_PREFIX
+          elsif adapter.start_with?(SQLITE_PREFIX)
             :sqlite
           else
             adapter.to_sym

--- a/lib/new_relic/agent/database/obfuscator.rb
+++ b/lib/new_relic/agent/database/obfuscator.rb
@@ -51,7 +51,7 @@ module NewRelic
         def default_sql_obfuscator(sql)
           stmt = sql.kind_of?(Statement) ? sql : Statement.new(sql)
 
-          if stmt.sql.end_with? ELLIPSIS
+          if stmt.sql.end_with?(ELLIPSIS)
             return QUERY_TOO_LARGE_MESSAGE
           end
 

--- a/lib/new_relic/agent/datastores.rb
+++ b/lib/new_relic/agent/datastores.rb
@@ -44,7 +44,7 @@ module NewRelic
 
             visibility = NewRelic::Helper.instance_method_visibility(klass, method_name)
 
-            alias_method method_name_without_newrelic, method_name
+            alias_method(method_name_without_newrelic, method_name)
 
             define_method(method_name) do |*args, &blk|
               segment = NewRelic::Agent::Tracer.start_datastore_segment(
@@ -58,8 +58,8 @@ module NewRelic
               end
             end
 
-            send visibility, method_name
-            send visibility, method_name_without_newrelic
+            send(visibility, method_name)
+            send(visibility, method_name_without_newrelic)
           end
         end
       end

--- a/lib/new_relic/agent/datastores/metric_helper.rb
+++ b/lib/new_relic/agent/datastores/metric_helper.rb
@@ -51,9 +51,9 @@ module NewRelic
 
         def self.scoped_metric_for product, operation, collection = nil
           if collection
-            statement_metric_for product, collection, operation
+            statement_metric_for(product, collection, operation)
           else
-            operation_metric_for product, operation
+            operation_metric_for(product, operation)
           end
         end
 
@@ -68,9 +68,9 @@ module NewRelic
           ]
 
           if NewRelic::Agent.config[:'datastore_tracer.instance_reporting.enabled'] && host && port_path_or_id
-            metrics.unshift instance_metric_for(product, host, port_path_or_id)
+            metrics.unshift(instance_metric_for(product, host, port_path_or_id))
           end
-          metrics.unshift operation_metric_for(product, operation) if collection
+          metrics.unshift(operation_metric_for(product, operation)) if collection
 
           metrics
         end
@@ -91,7 +91,7 @@ module NewRelic
           # Order of these metrics matters--the first metric in the list will
           # be treated as the scoped metric in a bunch of different cases.
           metrics = unscoped_metrics_for(product, operation, collection, host, port_path_or_id)
-          metrics.unshift scoped_metric_for(product, operation, collection)
+          metrics.unshift(scoped_metric_for(product, operation, collection))
 
           metrics
         end

--- a/lib/new_relic/agent/datastores/mongo/obfuscator.rb
+++ b/lib/new_relic/agent/datastores/mongo/obfuscator.rb
@@ -11,7 +11,7 @@ module NewRelic
           ALLOWLIST = [:operation].freeze
 
           def self.obfuscate_statement(source, allowlist = ALLOWLIST)
-            if source.is_a? Hash
+            if source.is_a?(Hash)
               obfuscated = {}
               source.each do |key, value|
                 if allowlist.include?(key)

--- a/lib/new_relic/agent/distributed_tracing.rb
+++ b/lib/new_relic/agent/distributed_tracing.rb
@@ -46,18 +46,18 @@ module NewRelic
         record_api_supportability_metric(:insert_distributed_trace_headers)
 
         unless Agent.config[:'distributed_tracing.enabled']
-          NewRelic::Agent.logger.warn "Not configured to insert distributed trace headers"
+          NewRelic::Agent.logger.warn("Not configured to insert distributed trace headers")
           return nil
         end
 
-        return unless valid_api_argument_class? headers, "headers", Hash
+        return unless valid_api_argument_class?(headers, "headers", Hash)
 
         return unless transaction = Transaction.tl_current
 
-        transaction.distributed_tracer.insert_headers headers
+        transaction.distributed_tracer.insert_headers(headers)
         transaction
       rescue => e
-        NewRelic::Agent.logger.error 'error during insert_distributed_trace_headers', e
+        NewRelic::Agent.logger.error('error during insert_distributed_trace_headers', e)
         nil
       end
 
@@ -100,18 +100,18 @@ module NewRelic
         record_api_supportability_metric(:accept_distributed_trace_headers)
 
         unless Agent.config[:'distributed_tracing.enabled']
-          NewRelic::Agent.logger.warn "Not configured to accept distributed trace headers"
+          NewRelic::Agent.logger.warn("Not configured to accept distributed trace headers")
           return nil
         end
 
-        return unless valid_api_argument_class? headers, "headers", Hash
-        return unless valid_api_argument_class? transport_type, "transport_type", String
+        return unless valid_api_argument_class?(headers, "headers", Hash)
+        return unless valid_api_argument_class?(transport_type, "transport_type", String)
 
         return unless transaction = Transaction.tl_current
 
         # assume we have Rack conforming keys when transport_type is HTTP(S)
         # otherwise, fish for key/value pairs regardless of prefix and case-sensitivity.
-        hdr = if transport_type.start_with? NewRelic::HTTP
+        hdr = if transport_type.start_with?(NewRelic::HTTP)
           headers
         else
           # start with the most common case first
@@ -122,16 +122,16 @@ module NewRelic
           }
 
           # when not found, search for any casing for trace context headers, ignoring potential prefixes
-          hdr[NewRelic::HTTP_TRACEPARENT_KEY] ||= variant_key_value headers, NewRelic::TRACEPARENT_KEY
-          hdr[NewRelic::HTTP_TRACESTATE_KEY] ||= variant_key_value headers, NewRelic::TRACESTATE_KEY
-          hdr[NewRelic::HTTP_NEWRELIC_KEY] ||= variant_key_value headers, NewRelic::CANDIDATE_NEWRELIC_KEYS
+          hdr[NewRelic::HTTP_TRACEPARENT_KEY] ||= variant_key_value(headers, NewRelic::TRACEPARENT_KEY)
+          hdr[NewRelic::HTTP_TRACESTATE_KEY] ||= variant_key_value(headers, NewRelic::TRACESTATE_KEY)
+          hdr[NewRelic::HTTP_NEWRELIC_KEY] ||= variant_key_value(headers, NewRelic::CANDIDATE_NEWRELIC_KEYS)
           hdr
         end
 
-        transaction.distributed_tracer.accept_incoming_request hdr, transport_type
+        transaction.distributed_tracer.accept_incoming_request(hdr, transport_type)
         transaction
       rescue => e
-        NewRelic::Agent.logger.error 'error during accept_distributed_trace_headers', e
+        NewRelic::Agent.logger.error('error during accept_distributed_trace_headers', e)
         nil
       end
 

--- a/lib/new_relic/agent/distributed_tracing/cross_app_tracing.rb
+++ b/lib/new_relic/agent/distributed_tracing/cross_app_tracing.rb
@@ -60,17 +60,17 @@ module NewRelic
         trip_id = cat_trip_id
         path_hash = cat_path_hash
 
-        insert_request_headers headers, txn_guid, trip_id, path_hash
+        insert_request_headers(headers, txn_guid, trip_id, path_hash)
       end
 
       def add_message_cat_headers headers
         return unless CrossAppTracing.cross_app_enabled?
         @is_cross_app_caller = true
-        insert_message_headers headers,
+        insert_message_headers(headers,
           transaction.guid,
           cat_trip_id,
           cat_path_hash,
-          transaction.raw_synthetics_header
+          transaction.raw_synthetics_header)
       end
 
       def record_cross_app_metrics
@@ -148,7 +148,7 @@ module NewRelic
         if Agent.config[:cross_process_id] && Agent.config[:cross_process_id].length > 0
           true
         else
-          NewRelic::Agent.logger.debug "No cross_process_id configured"
+          NewRelic::Agent.logger.debug("No cross_process_id configured")
           false
         end
       end
@@ -157,7 +157,7 @@ module NewRelic
         if Agent.config[:encoding_key] && Agent.config[:encoding_key].length > 0
           true
         else
-          NewRelic::Agent.logger.debug "No encoding_key set"
+          NewRelic::Agent.logger.debug("No encoding_key set")
           false
         end
       end
@@ -184,7 +184,7 @@ module NewRelic
         if !!response[NR_APPDATA_HEADER]
           true
         else
-          NewRelic::Agent.logger.debug "No #{NR_APPDATA_HEADER} header"
+          NewRelic::Agent.logger.debug("No #{NR_APPDATA_HEADER} header")
           false
         end
       end
@@ -226,7 +226,7 @@ module NewRelic
         split_id = id.match(/(\d+)#\d+/)
         return false if split_id.nil?
 
-        NewRelic::Agent.config[:trusted_account_ids].include? split_id.captures.first.to_i
+        NewRelic::Agent.config[:trusted_account_ids].include?(split_id.captures.first.to_i)
       end
 
       def trusted_valid_cross_app_id? id

--- a/lib/new_relic/agent/distributed_tracing/distributed_trace_attributes.rb
+++ b/lib/new_relic/agent/distributed_tracing/distributed_trace_attributes.rb
@@ -37,8 +37,8 @@ module NewRelic
       def copy_to_attributes transaction_payload, destination
         return unless enabled?
         INTRINSIC_KEYS.each do |key|
-          next unless transaction_payload.key? key
-          destination.add_intrinsic_attribute key, transaction_payload[key]
+          next unless transaction_payload.key?(key)
+          destination.add_intrinsic_attribute(key, transaction_payload[key])
         end
       end
 
@@ -53,18 +53,18 @@ module NewRelic
           destination[PARENT_SPAN_ID_KEY] = transaction.parent_span_id
         end
 
-        copy_parent_attributes transaction, trace_payload, destination
+        copy_parent_attributes(transaction, trace_payload, destination)
       end
 
       def copy_parent_attributes transaction, trace_payload, destination
         transport_type = transaction.distributed_tracer.caller_transport_type
-        destination[PARENT_TRANSPORT_TYPE_KEY] = DistributedTraceTransportType.from transport_type
+        destination[PARENT_TRANSPORT_TYPE_KEY] = DistributedTraceTransportType.from(transport_type)
 
         if trace_payload
           destination[PARENT_TYPE_KEY] = trace_payload.parent_type
           destination[PARENT_APP_KEY] = trace_payload.parent_app_id
           destination[PARENT_ACCOUNT_ID_KEY] = trace_payload.parent_account_id
-          destination[PARENT_TRANSPORT_DURATION_KEY] = transaction.calculate_transport_duration trace_payload
+          destination[PARENT_TRANSPORT_DURATION_KEY] = transaction.calculate_transport_duration(trace_payload)
 
           if parent_transaction_id = transaction.distributed_tracer.parent_transaction_id
             destination[PARENT_TRANSACTION_ID_KEY] = parent_transaction_id

--- a/lib/new_relic/agent/distributed_tracing/distributed_trace_metrics.rb
+++ b/lib/new_relic/agent/distributed_tracing/distributed_trace_metrics.rb
@@ -27,9 +27,9 @@ module NewRelic
         dt = transaction.distributed_tracer
         payload = dt.distributed_trace_payload || dt.trace_state_payload
 
-        record_caller_by_duration_metrics transaction, payload
-        record_transport_duration_metrics transaction, payload
-        record_errors_by_caller_metrics transaction, payload
+        record_caller_by_duration_metrics(transaction, payload)
+        record_transport_duration_metrics(transaction, payload)
+        record_errors_by_caller_metrics(transaction, payload)
       end
 
       def prefix_for_metric name, transaction, payload
@@ -45,30 +45,30 @@ module NewRelic
       end
 
       def record_caller_by_duration_metrics transaction, payload
-        prefix = prefix_for_metric "DurationByCaller", transaction, payload
-        record_unscoped_metric transaction, prefix, transaction.duration
+        prefix = prefix_for_metric("DurationByCaller", transaction, payload)
+        record_unscoped_metric(transaction, prefix, transaction.duration)
       end
 
       def record_transport_duration_metrics transaction, payload
         return unless payload
 
-        prefix = prefix_for_metric "TransportDuration", transaction, payload
-        duration = transaction.calculate_transport_duration payload
-        record_unscoped_metric transaction, prefix, duration
+        prefix = prefix_for_metric("TransportDuration", transaction, payload)
+        duration = transaction.calculate_transport_duration(payload)
+        record_unscoped_metric(transaction, prefix, duration)
       end
 
       def record_errors_by_caller_metrics transaction, payload
         return unless transaction.exceptions.size > 0
 
-        prefix = prefix_for_metric "ErrorsByCaller", transaction, payload
-        record_unscoped_metric transaction, prefix, 1
+        prefix = prefix_for_metric("ErrorsByCaller", transaction, payload)
+        record_unscoped_metric(transaction, prefix, 1)
       end
 
       private
 
       def record_unscoped_metric transaction, prefix, duration
-        transaction.metrics.record_unscoped "#{prefix}/#{ALL_SUFFIX}", duration
-        transaction.metrics.record_unscoped "#{prefix}/#{transaction_type_suffix}", duration
+        transaction.metrics.record_unscoped("#{prefix}/#{ALL_SUFFIX}", duration)
+        transaction.metrics.record_unscoped("#{prefix}/#{transaction_type_suffix}", duration)
       end
     end
   end

--- a/lib/new_relic/agent/distributed_tracing/distributed_trace_payload.rb
+++ b/lib/new_relic/agent/distributed_tracing/distributed_trace_payload.rb
@@ -58,7 +58,7 @@ module NewRelic
         end
 
         def from_json serialized_payload
-          raw_payload = JSON.parse serialized_payload
+          raw_payload = JSON.parse(serialized_payload)
           return raw_payload if raw_payload.nil?
           payload_data = raw_payload[DATA_KEY]
 
@@ -79,8 +79,8 @@ module NewRelic
         end
 
         def from_http_safe http_safe_payload
-          decoded_payload = Base64.strict_decode64 http_safe_payload
-          from_json decoded_payload
+          decoded_payload = Base64.strict_decode64(http_safe_payload)
+          from_json(decoded_payload)
         end
 
         def major_version_matches?(payload)
@@ -157,7 +157,7 @@ module NewRelic
       #
       # @api public
       def http_safe
-        Base64.strict_encode64 text
+        Base64.strict_encode64(text)
       end
     end
   end

--- a/lib/new_relic/agent/distributed_tracing/trace_context_payload.rb
+++ b/lib/new_relic/agent/distributed_tracing/trace_context_payload.rb
@@ -29,8 +29,8 @@ module NewRelic
           priority: nil,
           timestamp: now_ms
 
-          new version, parent_type, parent_account_id, parent_app_id, id,
-            transaction_id, sampled, priority, timestamp
+          new(version, parent_type, parent_account_id, parent_app_id, id,
+            transaction_id, sampled, priority, timestamp)
         end
 
         include NewRelic::Coerce
@@ -38,7 +38,7 @@ module NewRelic
         def from_s payload_string
           attrs = payload_string.split(DELIMITER)
 
-          payload = create \
+          payload = create( \
             version: int!(attrs[0]),
             parent_type: int!(attrs[1]),
             parent_account_id: attrs[2],
@@ -48,10 +48,11 @@ module NewRelic
             sampled: value_or_nil(attrs[6]) ? boolean_int!(attrs[6]) == 1 : nil,
             priority: float!(attrs[7]),
             timestamp: int!(attrs[8])
-          handle_invalid_payload message: 'payload missing attributes' unless payload.valid?
+          )
+          handle_invalid_payload(message: 'payload missing attributes') unless payload.valid?
           payload
         rescue => e
-          handle_invalid_payload error: e
+          handle_invalid_payload(error: e)
           raise
         end
 
@@ -62,11 +63,11 @@ module NewRelic
         end
 
         def handle_invalid_payload error: nil, message: nil
-          NewRelic::Agent.increment_metric SUPPORTABILITY_PARSE_EXCEPTION
+          NewRelic::Agent.increment_metric(SUPPORTABILITY_PARSE_EXCEPTION)
           if error
-            NewRelic::Agent.logger.warn "Error parsing trace context payload", error
+            NewRelic::Agent.logger.warn("Error parsing trace context payload", error)
           elsif message
-            NewRelic::Agent.logger.warn "Error parsing trace context payload: #{message}"
+            NewRelic::Agent.logger.warn("Error parsing trace context payload: #{message}")
           end
         end
       end

--- a/lib/new_relic/agent/error_collector.rb
+++ b/lib/new_relic/agent/error_collector.rb
@@ -22,7 +22,7 @@ module NewRelic
       # Returns a new error collector
       def initialize events
         @error_trace_aggregator = ErrorTraceAggregator.new(MAX_ERROR_QUEUE_LENGTH)
-        @error_event_aggregator = ErrorEventAggregator.new events
+        @error_event_aggregator = ErrorEventAggregator.new(events)
 
         @error_filter = NewRelic::Agent::ErrorFilter.new
 
@@ -64,7 +64,7 @@ module NewRelic
         if block
           define_method(:ignore_filter_proc, &block)
         elsif method_defined?(:ignore_filter_proc)
-          remove_method :ignore_filter_proc
+          remove_method(:ignore_filter_proc)
         end
         @ignore_filter
       end
@@ -214,7 +214,7 @@ module NewRelic
       def notice_segment_error(segment, exception, options = {})
         return if skip_notice_error?(exception)
 
-        segment.set_noticed_error create_noticed_error(exception, options)
+        segment.set_noticed_error(create_noticed_error(exception, options))
         exception
       rescue => e
         ::NewRelic::Agent.logger.warn("Failure when capturing segment error '#{exception}':", e)

--- a/lib/new_relic/agent/error_event_aggregator.rb
+++ b/lib/new_relic/agent/error_event_aggregator.rb
@@ -35,7 +35,7 @@ module NewRelic
       private
 
       def create_event noticed_error, transaction_payload, span_id
-        TransactionErrorPrimitive.create noticed_error, transaction_payload, span_id
+        TransactionErrorPrimitive.create(noticed_error, transaction_payload, span_id)
       end
     end
   end

--- a/lib/new_relic/agent/error_trace_aggregator.rb
+++ b/lib/new_relic/agent/error_trace_aggregator.rb
@@ -93,7 +93,7 @@ module NewRelic
       def register_config_callbacks
         Agent.config.register_callback(:'error_collector.enabled') do |enabled|
           reset! if enabled == false
-          ::NewRelic::Agent.logger.debug "Error traces will #{enabled ? '' : 'not '}be sent to the New Relic service."
+          ::NewRelic::Agent.logger.debug("Error traces will #{enabled ? '' : 'not '}be sent to the New Relic service.")
         end
       end
     end

--- a/lib/new_relic/agent/event_loop.rb
+++ b/lib/new_relic/agent/event_loop.rb
@@ -95,7 +95,7 @@ module NewRelic
       end
 
       def run
-        ::NewRelic::Agent.logger.debug "Running event loop"
+        ::NewRelic::Agent.logger.debug("Running event loop")
         while !stopped?
           run_once
         end
@@ -155,7 +155,7 @@ module NewRelic
         end
 
         if !errors.empty?
-          ::NewRelic::Agent.logger.error "#{errors.size} error(s) running task for event '#{event}' in Agent Event Loop:", *errors
+          ::NewRelic::Agent.logger.error("#{errors.size} error(s) running task for event '#{event}' in Agent Event Loop:", *errors)
         end
       end
 
@@ -173,20 +173,20 @@ module NewRelic
       end
 
       def fire_every(interval, event)
-        ::NewRelic::Agent.logger.debug "Firing event #{event} every #{interval} seconds."
+        ::NewRelic::Agent.logger.debug("Firing event #{event} every #{interval} seconds.")
         fire(:__add_timer, Timer.new(interval, event, true))
       end
 
       def fire_after(interval, event)
-        ::NewRelic::Agent.logger.debug "Firing event #{event} after #{interval} seconds."
+        ::NewRelic::Agent.logger.debug("Firing event #{event} after #{interval} seconds.")
         fire(:__add_timer, Timer.new(interval, event, false))
       end
 
       def wakeup
         begin
-          @self_pipe_wr.write_nonblock '.'
+          @self_pipe_wr.write_nonblock('.')
         rescue Errno::EAGAIN
-          ::NewRelic::Agent.logger.debug "Failed to wakeup event loop"
+          ::NewRelic::Agent.logger.debug("Failed to wakeup event loop")
         end
       end
     end

--- a/lib/new_relic/agent/external.rb
+++ b/lib/new_relic/agent/external.rb
@@ -38,7 +38,7 @@ module NewRelic
 
         state = NewRelic::Agent::Tracer.state
         if transaction = state.current_transaction
-          rmd = ::JSON.parse obfuscator.deobfuscate(request_metadata)
+          rmd = ::JSON.parse(obfuscator.deobfuscate(request_metadata))
 
           # handle/check ID
           #
@@ -49,24 +49,24 @@ module NewRelic
               payload = CrossAppPayload.new(id, transaction, txn_info)
               transaction.distributed_tracer.cross_app_payload = payload
 
-              CrossAppTracing.assign_intrinsic_transaction_attributes state
+              CrossAppTracing.assign_intrinsic_transaction_attributes(state)
             end
 
             # handle synthetics
             #
             if synth = rmd[NON_HTTP_CAT_SYNTHETICS_HEADER]
               transaction.synthetics_payload = synth
-              transaction.raw_synthetics_header = obfuscator.obfuscate ::JSON.dump(synth)
+              transaction.raw_synthetics_header = obfuscator.obfuscate(::JSON.dump(synth))
             end
 
           else
-            NewRelic::Agent.logger.error "error processing request metadata: invalid/non-trusted ID: '#{id}'"
+            NewRelic::Agent.logger.error("error processing request metadata: invalid/non-trusted ID: '#{id}'")
           end
 
           nil
         end
       rescue => e
-        NewRelic::Agent.logger.error 'error during process_request_metadata', e
+        NewRelic::Agent.logger.error('error during process_request_metadata', e)
       end
 
       # Obtain an obfuscated +String+ suitable for delivery across public networks that carries transaction
@@ -95,10 +95,10 @@ module NewRelic
 
           # obfuscate the generated response metadata JSON
           #
-          obfuscator.obfuscate ::JSON.dump(rmd)
+          obfuscator.obfuscate(::JSON.dump(rmd))
         end
       rescue => e
-        NewRelic::Agent.logger.error "error during get_response_metadata", e
+        NewRelic::Agent.logger.error("error during get_response_metadata", e)
       end
 
       private

--- a/lib/new_relic/agent/http_clients/abstract.rb
+++ b/lib/new_relic/agent/http_clients/abstract.rb
@@ -72,7 +72,7 @@ module NewRelic
         # Override this method to memoize a non-zero Integer representation
         # of HTTP status code from the response object
         def get_status_code
-          get_status_code_using :code
+          get_status_code_using(:code)
         end
       end
     end

--- a/lib/new_relic/agent/http_clients/curb_wrappers.rb
+++ b/lib/new_relic/agent/http_clients/curb_wrappers.rb
@@ -48,7 +48,7 @@ module NewRelic
 
       class CurbResponse < AbstractResponse
         def initialize wrapped_response
-          super wrapped_response
+          super(wrapped_response)
           @headers = {}
         end
 
@@ -70,7 +70,7 @@ module NewRelic
         private
 
         def get_status_code
-          get_status_code_using :response_code
+          get_status_code_using(:response_code)
         end
       end
     end

--- a/lib/new_relic/agent/http_clients/excon_wrappers.rb
+++ b/lib/new_relic/agent/http_clients/excon_wrappers.rb
@@ -10,7 +10,7 @@ module NewRelic
     module HTTPClients
       class ExconHTTPResponse < AbstractResponse
         def initialize wrapped_response
-          super wrapped_response
+          super(wrapped_response)
 
           # Since HTTP headers are case-insensitive, we normalize all of them to
           # upper case here, and then also in our [](key) implementation.
@@ -87,7 +87,7 @@ module NewRelic
 
         def uri
           url = "#{@scheme}://#{host}:#{@port}#{@path}"
-          URIUtil.parse_and_normalize_url url
+          URIUtil.parse_and_normalize_url(url)
         end
       end
     end

--- a/lib/new_relic/agent/http_clients/uri_util.rb
+++ b/lib/new_relic/agent/http_clients/uri_util.rb
@@ -44,7 +44,7 @@ module NewRelic
         QUESTION_MARK = "?"
 
         def self.strip_query_string(fragment)
-          if fragment.include? QUESTION_MARK
+          if fragment.include?(QUESTION_MARK)
             fragment.split(QUESTION_MARK).first
           else
             fragment

--- a/lib/new_relic/agent/instrumentation/action_cable_subscriber.rb
+++ b/lib/new_relic/agent/instrumentation/action_cable_subscriber.rb
@@ -24,20 +24,20 @@ module NewRelic
           end
           push_segment(id, finishable)
         rescue => e
-          log_notification_error e, name, 'start'
+          log_notification_error(e, name, 'start')
         end
 
         def finish(name, id, payload) # THREAD_LOCAL_ACCESS
           return unless state.is_execution_traced?
 
           if exception = exception_object(payload)
-            NewRelic::Agent.notice_error exception
+            NewRelic::Agent.notice_error(exception)
           end
 
           finishable = pop_segment(id)
           finishable.finish if finishable
         rescue => e
-          log_notification_error e, name, 'finish'
+          log_notification_error(e, name, 'finish')
         end
 
         private
@@ -53,7 +53,7 @@ module NewRelic
         DOT_ACTION_CABLE = '.action_cable'.freeze
 
         def action_name(name)
-          name.gsub DOT_ACTION_CABLE, NewRelic::EMPTY_STR
+          name.gsub(DOT_ACTION_CABLE, NewRelic::EMPTY_STR)
         end
       end
     end

--- a/lib/new_relic/agent/instrumentation/action_view_subscriber.rb
+++ b/lib/new_relic/agent/instrumentation/action_view_subscriber.rb
@@ -19,7 +19,7 @@ module NewRelic
           if state.is_execution_traced? && recordable?(name, metric_name)
             event.finishable = Tracer.start_segment(name: metric_name)
           end
-          push_segment id, event
+          push_segment(id, event)
         rescue => e
           log_notification_error(e, name, 'start')
         end
@@ -27,7 +27,7 @@ module NewRelic
         def finish(name, id, payload)
           if segment = pop_segment(id)
             if exception = exception_object(payload)
-              segment.notice_error exception
+              segment.notice_error(exception)
             end
             segment.finish
           end
@@ -104,7 +104,7 @@ module NewRelic
         end
 
         def notice_error error
-          @finishable.notice_error error if @finishable
+          @finishable.notice_error(error) if @finishable
         end
       end
     end

--- a/lib/new_relic/agent/instrumentation/active_job.rb
+++ b/lib/new_relic/agent/instrumentation/active_job.rb
@@ -13,7 +13,7 @@ DependencyDetection.defer do
   end
 
   executes do
-    ::NewRelic::Agent.logger.info 'Installing ActiveJob instrumentation'
+    ::NewRelic::Agent.logger.info('Installing ActiveJob instrumentation')
 
     ActiveSupport.on_load(:active_job) do
       ::ActiveJob::Base.around_enqueue do |job, block|

--- a/lib/new_relic/agent/instrumentation/active_merchant.rb
+++ b/lib/new_relic/agent/instrumentation/active_merchant.rb
@@ -13,7 +13,7 @@ DependencyDetection.defer do
   end
 
   executes do
-    ::NewRelic::Agent.logger.info 'Installing ActiveMerchant instrumentation'
+    ::NewRelic::Agent.logger.info('Installing ActiveMerchant instrumentation')
   end
 
   executes do

--- a/lib/new_relic/agent/instrumentation/active_record.rb
+++ b/lib/new_relic/agent/instrumentation/active_record.rb
@@ -22,8 +22,8 @@ module NewRelic
         def self.insert_instrumentation
           if defined?(::ActiveRecord::VERSION::MAJOR) && ::ActiveRecord::VERSION::MAJOR.to_i >= 3
             if ::NewRelic::Agent.config[:prepend_active_record_instrumentation]
-              ::ActiveRecord::Base.prepend ::NewRelic::Agent::Instrumentation::ActiveRecordPrepend::BaseExtensions
-              ::ActiveRecord::Relation.prepend ::NewRelic::Agent::Instrumentation::ActiveRecordPrepend::RelationExtensions
+              ::ActiveRecord::Base.prepend(::NewRelic::Agent::Instrumentation::ActiveRecordPrepend::BaseExtensions)
+              ::ActiveRecord::Relation.prepend(::NewRelic::Agent::Instrumentation::ActiveRecordPrepend::RelationExtensions)
             else
               ::NewRelic::Agent::Instrumentation::ActiveRecordHelper.instrument_additional_methods
             end
@@ -37,9 +37,9 @@ module NewRelic
         def self.included(instrumented_class)
           instrumented_class.class_eval do
             unless instrumented_class.method_defined?(:log_without_newrelic_instrumentation)
-              alias_method :log_without_newrelic_instrumentation, :log
-              alias_method :log, :log_with_newrelic_instrumentation
-              protected :log
+              alias_method(:log_without_newrelic_instrumentation, :log)
+              alias_method(:log, :log_with_newrelic_instrumentation)
+              protected(:log)
             end
           end
         end
@@ -81,7 +81,7 @@ module NewRelic
             segment._notice_sql(sql, @config, EXPLAINER)
 
             begin
-              NewRelic::Agent::Tracer.capture_segment_error segment do
+              NewRelic::Agent::Tracer.capture_segment_error(segment) do
                 log_without_newrelic_instrumentation(*args, &block)
               end
             ensure
@@ -125,7 +125,7 @@ module NewRelic
             segment._notice_sql(sql, @config, EXPLAINER)
 
             begin
-              NewRelic::Agent::Tracer.capture_segment_error segment do
+              NewRelic::Agent::Tracer.capture_segment_error(segment) do
                 log_without_newrelic_instrumentation(*args, **kwargs, &block)
               end
             ensure
@@ -152,7 +152,7 @@ DependencyDetection.defer do
   end
 
   executes do
-    ::NewRelic::Agent.logger.info 'Installing ActiveRecord instrumentation'
+    ::NewRelic::Agent.logger.info('Installing ActiveRecord instrumentation')
   end
 
   executes do

--- a/lib/new_relic/agent/instrumentation/active_record_helper.rb
+++ b/lib/new_relic/agent/instrumentation/active_record_helper.rb
@@ -20,7 +20,7 @@ module NewRelic
 
         def instrument_save_methods
           ::ActiveRecord::Base.class_eval do
-            alias_method :save_without_newrelic, :save
+            alias_method(:save_without_newrelic, :save)
 
             def save(*args, &blk)
               ::NewRelic::Agent.with_database_metric_name(self.class.name, nil, ACTIVE_RECORD) do
@@ -28,7 +28,7 @@ module NewRelic
               end
             end
 
-            alias_method :save_without_newrelic!, :save!
+            alias_method(:save_without_newrelic!, :save!)
 
             def save!(*args, &blk)
               ::NewRelic::Agent.with_database_metric_name(self.class.name, nil, ACTIVE_RECORD) do
@@ -40,7 +40,7 @@ module NewRelic
 
         def instrument_relation_methods
           ::ActiveRecord::Relation.class_eval do
-            alias_method :update_all_without_newrelic, :update_all
+            alias_method(:update_all_without_newrelic, :update_all)
 
             def update_all(*args, &blk)
               ::NewRelic::Agent.with_database_metric_name(self.name, nil, ACTIVE_RECORD) do
@@ -48,7 +48,7 @@ module NewRelic
               end
             end
 
-            alias_method :delete_all_without_newrelic, :delete_all
+            alias_method(:delete_all_without_newrelic, :delete_all)
 
             if RUBY_VERSION < "2.7.0"
               def delete_all(*args, &blk)
@@ -64,7 +64,7 @@ module NewRelic
               end
             end
 
-            alias_method :destroy_all_without_newrelic, :destroy_all
+            alias_method(:destroy_all_without_newrelic, :destroy_all)
 
             def destroy_all(*args, &blk)
               ::NewRelic::Agent.with_database_metric_name(self.name, nil, ACTIVE_RECORD) do
@@ -72,7 +72,7 @@ module NewRelic
               end
             end
 
-            alias_method :calculate_without_newrelic, :calculate
+            alias_method(:calculate_without_newrelic, :calculate)
 
             def calculate(*args, &blk)
               ::NewRelic::Agent.with_database_metric_name(self.name, nil, ACTIVE_RECORD) do
@@ -81,7 +81,7 @@ module NewRelic
             end
 
             if method_defined?(:pluck)
-              alias_method :pluck_without_newrelic, :pluck
+              alias_method(:pluck_without_newrelic, :pluck)
 
               def pluck(*args, &blk)
                 ::NewRelic::Agent.with_database_metric_name(self.name, nil, ACTIVE_RECORD) do
@@ -113,7 +113,7 @@ module NewRelic
           splits = split_name(name)
           model = model_from_splits(splits)
           operation = operation_from_splits(splits, sql)
-          NewRelic::Agent::Datastores::MetricHelper.product_operation_collection_for product, operation, model, ACTIVE_RECORD
+          NewRelic::Agent::Datastores::MetricHelper.product_operation_collection_for(product, operation, model, ACTIVE_RECORD)
         end
 
         SPACE = ' '.freeze
@@ -254,7 +254,7 @@ module NewRelic
               configured_value
             end
           rescue => e
-            NewRelic::Agent.logger.debug "Failed to retrieve ActiveRecord host: #{e}"
+            NewRelic::Agent.logger.debug("Failed to retrieve ActiveRecord host: #{e}")
             UNKNOWN
           end
 
@@ -274,7 +274,7 @@ module NewRelic
               UNKNOWN
             end
           rescue => e
-            NewRelic::Agent.logger.debug "Failed to retrieve ActiveRecord port_path_or_id: #{e}"
+            NewRelic::Agent.logger.debug("Failed to retrieve ActiveRecord port_path_or_id: #{e}")
             UNKNOWN
           end
 

--- a/lib/new_relic/agent/instrumentation/active_record_notifications.rb
+++ b/lib/new_relic/agent/instrumentation/active_record_notifications.rb
@@ -96,7 +96,7 @@ DependencyDetection.defer do
   end
 
   executes do
-    ::NewRelic::Agent.logger.info 'Installing notifications based Active Record instrumentation'
+    ::NewRelic::Agent.logger.info('Installing notifications based Active Record instrumentation')
   end
 
   executes do
@@ -150,7 +150,7 @@ DependencyDetection.defer do
         && ::ActiveRecord::VERSION::MINOR.to_i == 1 \
         && ::ActiveRecord::VERSION::TINY.to_i >= 6
 
-      ::ActiveRecord::Base.prepend ::NewRelic::Agent::Instrumentation::ActiveRecordPrepend::BaseExtensions516
+      ::ActiveRecord::Base.prepend(::NewRelic::Agent::Instrumentation::ActiveRecordPrepend::BaseExtensions516)
     end
   end
 end

--- a/lib/new_relic/agent/instrumentation/active_record_subscriber.rb
+++ b/lib/new_relic/agent/instrumentation/active_record_subscriber.rb
@@ -81,7 +81,7 @@ module NewRelic
               statement.binds)
           end
         rescue => e
-          NewRelic::Agent.logger.debug "Couldn't fetch the explain plan for #{statement} due to #{e}"
+          NewRelic::Agent.logger.debug("Couldn't fetch the explain plan for #{statement} due to #{e}")
         end
 
         def active_record_config(payload)
@@ -116,7 +116,7 @@ module NewRelic
         end
 
         def start_segment(config, payload)
-          sql = Helper.correctly_encoded payload[:sql]
+          sql = Helper.correctly_encoded(payload[:sql])
           product, operation, collection = ActiveRecordHelper.product_operation_collection_for(
             payload[:name],
             sql,
@@ -140,7 +140,7 @@ module NewRelic
             port_path_or_id: port_path_or_id,
             database_name: database)
 
-          segment._notice_sql sql, config, @explainer, payload[:binds], payload[:name]
+          segment._notice_sql(sql, config, @explainer, payload[:binds], payload[:name])
           segment
         end
       end

--- a/lib/new_relic/agent/instrumentation/active_storage.rb
+++ b/lib/new_relic/agent/instrumentation/active_storage.rb
@@ -14,7 +14,7 @@ DependencyDetection.defer do
   end
 
   executes do
-    ::NewRelic::Agent.logger.info 'Installing ActiveStorage instrumentation'
+    ::NewRelic::Agent.logger.info('Installing ActiveStorage instrumentation')
   end
 
   executes do

--- a/lib/new_relic/agent/instrumentation/active_storage_subscriber.rb
+++ b/lib/new_relic/agent/instrumentation/active_storage_subscriber.rb
@@ -11,23 +11,23 @@ module NewRelic
       class ActiveStorageSubscriber < NotificationsSubscriber
         def start name, id, payload
           return unless state.is_execution_traced?
-          start_segment name, id, payload
+          start_segment(name, id, payload)
         rescue => e
-          log_notification_error e, name, 'start'
+          log_notification_error(e, name, 'start')
         end
 
         def finish name, id, payload
           return unless state.is_execution_traced?
-          finish_segment id, payload
+          finish_segment(id, payload)
         rescue => e
-          log_notification_error e, name, 'finish'
+          log_notification_error(e, name, 'finish')
         end
 
         def start_segment name, id, payload
-          segment = Tracer.start_segment name: metric_name(name, payload)
+          segment = Tracer.start_segment(name: metric_name(name, payload))
           segment.params[:key] = payload[:key]
-          segment.params[:exist] = payload[:exist] if payload.key? :exist
-          push_segment id, segment
+          segment.params[:exist] = payload[:exist] if payload.key?(:exist)
+          push_segment(id, segment)
         end
 
         def finish_segment id, payload
@@ -41,7 +41,7 @@ module NewRelic
 
         def metric_name name, payload
           service = payload[:service]
-          method = method_from_name name
+          method = method_from_name(name)
           "Ruby/ActiveStorage/#{service}Service/#{method}"
         end
 

--- a/lib/new_relic/agent/instrumentation/active_support_logger.rb
+++ b/lib/new_relic/agent/instrumentation/active_support_logger.rb
@@ -13,7 +13,7 @@ DependencyDetection.defer do
   depends_on { defined?(::ActiveSupport::Logger) }
 
   executes do
-    ::NewRelic::Agent.logger.info 'Installing ActiveSupport::Logger instrumentation'
+    ::NewRelic::Agent.logger.info('Installing ActiveSupport::Logger instrumentation')
 
     if use_prepend?
       # the only method currently instrumented is a class method

--- a/lib/new_relic/agent/instrumentation/acts_as_solr.rb
+++ b/lib/new_relic/agent/instrumentation/acts_as_solr.rb
@@ -44,7 +44,7 @@ DependencyDetection.defer do
   end
 
   executes do
-    ::NewRelic::Agent.logger.info 'Installing ActsAsSolr instrumentation'
+    ::NewRelic::Agent.logger.info('Installing ActsAsSolr instrumentation')
     deprecation_msg = 'The instrumentation for ActsAsSolr is deprecated. ' \
       'It will be removed in version 9.0.0.' \
 

--- a/lib/new_relic/agent/instrumentation/authlogic.rb
+++ b/lib/new_relic/agent/instrumentation/authlogic.rb
@@ -13,7 +13,7 @@ DependencyDetection.defer do
   end
 
   executes do
-    ::NewRelic::Agent.logger.info 'Installing Authlogic instrumentation'
+    ::NewRelic::Agent.logger.info('Installing Authlogic instrumentation')
     deprecation_msg = 'The instrumentation for Authlogic is deprecated. ' \
       'It will be removed in version 9.0.0.' \
 

--- a/lib/new_relic/agent/instrumentation/bunny.rb
+++ b/lib/new_relic/agent/instrumentation/bunny.rb
@@ -15,7 +15,7 @@ DependencyDetection.defer do
   end
 
   executes do
-    ::NewRelic::Agent.logger.info 'Installing Bunny instrumentation'
+    ::NewRelic::Agent.logger.info('Installing Bunny instrumentation')
     require 'new_relic/agent/distributed_tracing/cross_app_tracing'
     require 'new_relic/agent/messaging'
     require 'new_relic/agent/transaction/message_broker_segment'

--- a/lib/new_relic/agent/instrumentation/bunny/chain.rb
+++ b/lib/new_relic/agent/instrumentation/bunny/chain.rb
@@ -9,23 +9,23 @@ module NewRelic::Agent::Instrumentation
       ::Bunny::Exchange.class_eval do
         include NewRelic::Agent::Instrumentation::Bunny::Exchange
 
-        alias_method :publish_without_new_relic, :publish
+        alias_method(:publish_without_new_relic, :publish)
 
         def publish payload, opts = {}
-          publish_with_tracing(payload, opts) { publish_without_new_relic payload, opts }
+          publish_with_tracing(payload, opts) { publish_without_new_relic(payload, opts) }
         end
       end
 
       ::Bunny::Queue.class_eval do
         include NewRelic::Agent::Instrumentation::Bunny::Queue
 
-        alias_method :pop_without_new_relic, :pop
+        alias_method(:pop_without_new_relic, :pop)
 
         def pop(opts = {:manual_ack => false}, &block)
-          pop_with_tracing { pop_without_new_relic opts, &block }
+          pop_with_tracing { pop_without_new_relic(opts, &block) }
         end
 
-        alias_method :purge_without_new_relic, :purge
+        alias_method(:purge_without_new_relic, :purge)
 
         def purge *args
           purge_with_tracing { purge_without_new_relic(*args) }
@@ -35,7 +35,7 @@ module NewRelic::Agent::Instrumentation
       ::Bunny::Consumer.class_eval do
         include NewRelic::Agent::Instrumentation::Bunny::Consumer
 
-        alias_method :call_without_new_relic, :call
+        alias_method(:call_without_new_relic, :call)
 
         def call *args
           call_with_tracing(*args) { call_without_new_relic(*args) }

--- a/lib/new_relic/agent/instrumentation/bunny/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/bunny/instrumentation.rb
@@ -47,10 +47,10 @@ module NewRelic
                 exchange_type: type
               )
             rescue => e
-              NewRelic::Agent.logger.error "Error starting message broker segment in Bunny::Exchange#publish", e
+              NewRelic::Agent.logger.error("Error starting message broker segment in Bunny::Exchange#publish", e)
               yield
             else
-              NewRelic::Agent::Tracer.capture_segment_error segment do
+              NewRelic::Agent::Tracer.capture_segment_error(segment) do
                 yield
               end
             ensure
@@ -91,10 +91,10 @@ module NewRelic
                 start_time: t0
               )
             rescue => e
-              NewRelic::Agent.logger.error "Error starting message broker segment in Bunny::Queue#pop", e
+              NewRelic::Agent.logger.error("Error starting message broker segment in Bunny::Queue#pop", e)
             else
               if bunny_error
-                segment.notice_error bunny_error
+                segment.notice_error(bunny_error)
                 raise bunny_error
               end
             ensure
@@ -114,10 +114,10 @@ module NewRelic
                 destination_name: name
               )
             rescue => e
-              NewRelic::Agent.logger.error "Error starting message broker segment in Bunny::Queue#purge", e
+              NewRelic::Agent.logger.error("Error starting message broker segment in Bunny::Queue#purge", e)
               yield
             else
-              NewRelic::Agent::Tracer.capture_segment_error segment do
+              NewRelic::Agent::Tracer.capture_segment_error(segment) do
                 yield
               end
             ensure

--- a/lib/new_relic/agent/instrumentation/controller_instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/controller_instrumentation.rb
@@ -82,9 +82,9 @@ module NewRelic
 
           def newrelic_ignore_aspect(property, specifiers = {}) # :nodoc:
             if specifiers.empty?
-              self.newrelic_write_attr property, true
+              self.newrelic_write_attr(property, true)
             elsif !(Hash === specifiers)
-              ::NewRelic::Agent.logger.error "newrelic_#{property} takes an optional hash with :only and :except lists of actions (illegal argument type '#{specifiers.class}')"
+              ::NewRelic::Agent.logger.error("newrelic_#{property} takes an optional hash with :only and :except lists of actions (illegal argument type '#{specifiers.class}')")
             else
               # symbolize the incoming values
               specifiers = specifiers.inject({}) do |memo, (key, values)|
@@ -95,7 +95,7 @@ module NewRelic
                 end
                 memo
               end
-              self.newrelic_write_attr property, specifiers
+              self.newrelic_write_attr(property, specifiers)
             end
           end
 
@@ -180,7 +180,7 @@ module NewRelic
             code_info = NewRelic::Agent::MethodTracerHelpers.code_information(self, method)
             argument_list = generate_argument_list(options.merge(code_info))
 
-            class_eval <<-EOC
+            class_eval(<<-EOC)
               def #{with_method_name}(*args, &block)
                 perform_action_with_newrelic_trace(#{argument_list.join(',')}) do
                   #{without_method_name}(*args, &block)
@@ -189,12 +189,12 @@ module NewRelic
               ruby2_keywords(:#{with_method_name}) if respond_to?(:ruby2_keywords, true)
             EOC
 
-            visibility = NewRelic::Helper.instance_method_visibility self, method
+            visibility = NewRelic::Helper.instance_method_visibility(self, method)
 
-            alias_method without_method_name, method.to_s
-            alias_method method.to_s, with_method_name
-            send visibility, method
-            send visibility, with_method_name
+            alias_method(without_method_name, method.to_s)
+            alias_method(method.to_s, with_method_name)
+            send(visibility, method)
+            send(visibility, with_method_name)
             ::NewRelic::Agent.logger.debug("Traced transaction: class = #{self.name}, method = #{method.to_s}, options = #{options.inspect}")
           end
 

--- a/lib/new_relic/agent/instrumentation/curb.rb
+++ b/lib/new_relic/agent/instrumentation/curb.rb
@@ -17,7 +17,7 @@ DependencyDetection.defer do
   end
 
   executes do
-    ::NewRelic::Agent.logger.info 'Installing Curb instrumentation'
+    ::NewRelic::Agent.logger.info('Installing Curb instrumentation')
     require 'new_relic/agent/distributed_tracing/cross_app_tracing'
     require 'new_relic/agent/http_clients/curb_wrappers'
   end

--- a/lib/new_relic/agent/instrumentation/curb/chain.rb
+++ b/lib/new_relic/agent/instrumentation/curb/chain.rb
@@ -16,46 +16,46 @@ module NewRelic::Agent::Instrumentation
             http_head_with_tracing { http_head_without_newrelic(*args, &blk) }
           end
 
-          alias_method :http_head_without_newrelic, :http_head
-          alias_method :http_head, :http_head_with_newrelic
+          alias_method(:http_head_without_newrelic, :http_head)
+          alias_method(:http_head, :http_head_with_newrelic)
 
           def http_post_with_newrelic(*args, &blk)
             http_post_with_tracing { http_post_without_newrelic(*args, &blk) }
           end
 
-          alias_method :http_post_without_newrelic, :http_post
-          alias_method :http_post, :http_post_with_newrelic
+          alias_method(:http_post_without_newrelic, :http_post)
+          alias_method(:http_post, :http_post_with_newrelic)
 
           def http_put_with_newrelic(*args, &blk)
             http_put_with_tracing { http_put_without_newrelic(*args, &blk) }
           end
 
-          alias_method :http_put_without_newrelic, :http_put
-          alias_method :http_put, :http_put_with_newrelic
+          alias_method(:http_put_without_newrelic, :http_put)
+          alias_method(:http_put, :http_put_with_newrelic)
 
           # Hook the #http method to set the verb.
           def http_with_newrelic verb
             http_with_tracing(verb) { http_without_newrelic(verb) }
           end
 
-          alias_method :http_without_newrelic, :http
-          alias_method :http, :http_with_newrelic
+          alias_method(:http_without_newrelic, :http)
+          alias_method(:http, :http_with_newrelic)
 
           # Hook the #perform method to mark the request as non-parallel.
           def perform_with_newrelic
             perform_with_tracing { perform_without_newrelic }
           end
 
-          alias_method :perform_without_newrelic, :perform
-          alias_method :perform, :perform_with_newrelic
+          alias_method(:perform_without_newrelic, :perform)
+          alias_method(:perform, :perform_with_newrelic)
 
           # Record the HTTP verb for future #perform calls
           def method_with_newrelic verb
             method_with_tracing(verb) { method_without_newrelic(verb) }
           end
 
-          alias_method :method_without_newrelic, :method
-          alias_method :method, :method_with_newrelic
+          alias_method(:method_without_newrelic, :method)
+          alias_method(:method, :method_with_newrelic)
 
           # We override this method in order to ensure access to header_str even
           # though we use an on_header callback
@@ -63,8 +63,8 @@ module NewRelic::Agent::Instrumentation
             header_str_with_tracing { header_str_without_newrelic }
           end
 
-          alias_method :header_str_without_newrelic, :header_str
-          alias_method :header_str, :header_str_with_newrelic
+          alias_method(:header_str_without_newrelic, :header_str)
+          alias_method(:header_str, :header_str_with_newrelic)
         end
 
         Curl::Multi.class_eval do
@@ -72,19 +72,19 @@ module NewRelic::Agent::Instrumentation
 
           # Add CAT with callbacks if the request is serial
           def add_with_newrelic(curl)
-            add_with_tracing(curl) { add_without_newrelic curl }
+            add_with_tracing(curl) { add_without_newrelic(curl) }
           end
 
-          alias_method :add_without_newrelic, :add
-          alias_method :add, :add_with_newrelic
+          alias_method(:add_without_newrelic, :add)
+          alias_method(:add, :add_with_newrelic)
 
           # Trace as an External/Multiple call if the first request isn't serial.
           def perform_with_newrelic(&blk)
             perform_with_tracing { perform_without_newrelic(&blk) }
           end
 
-          alias_method :perform_without_newrelic, :perform
-          alias_method :perform, :perform_with_newrelic
+          alias_method(:perform_without_newrelic, :perform)
+          alias_method(:perform, :perform_with_newrelic)
         end
       end
     end

--- a/lib/new_relic/agent/instrumentation/curb/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/curb/instrumentation.rb
@@ -99,7 +99,7 @@ module NewRelic
               procedure: wrapped_request.method
             )
 
-            segment.add_request_headers wrapped_request
+            segment.add_request_headers(wrapped_request)
 
             # install all callbacks
             unless request._nr_instrumented
@@ -129,9 +129,9 @@ module NewRelic
             request._nr_header_str = nil
             request.on_header do |header_data|
               if original_callback
-                original_callback.call header_data
+                original_callback.call(header_data)
               else
-                wrapped_response.append_header_data header_data
+                wrapped_response.append_header_data(header_data)
                 header_data.length
               end
             end
@@ -143,7 +143,7 @@ module NewRelic
             request._nr_original_on_complete = original_callback
             request.on_complete do |finished_request|
               begin
-                segment.process_response_headers wrapped_response
+                segment.process_response_headers(wrapped_response)
               ensure
                 segment.finish if segment
                 # Make sure the existing completion callback is run, and restore the
@@ -167,8 +167,8 @@ module NewRelic
             request.on_failure do |failed_request, error|
               begin
                 if segment
-                  noticible_error = NewRelic::Agent::NoticibleError.new error[0].name, error[-1]
-                  segment.notice_error noticible_error
+                  noticible_error = NewRelic::Agent::NoticibleError.new(error[0].name, error[-1])
+                  segment.notice_error(noticible_error)
                 end
               ensure
                 original_callback.call(failed_request, error) if original_callback

--- a/lib/new_relic/agent/instrumentation/data_mapper.rb
+++ b/lib/new_relic/agent/instrumentation/data_mapper.rb
@@ -14,7 +14,7 @@ DependencyDetection.defer do
   end
 
   executes do
-    ::NewRelic::Agent.logger.info 'Installing DataMapper instrumentation'
+    ::NewRelic::Agent.logger.info('Installing DataMapper instrumentation')
     require 'new_relic/agent/datastores/metric_helper'
 
     deprecation_msg = 'The instrumentation for DataMapper is deprecated. ' \
@@ -31,69 +31,69 @@ DependencyDetection.defer do
   end
 
   executes do
-    NewRelic::Agent::DataMapperTracing.add_tracer ::DataMapper::Model, :get
-    NewRelic::Agent::DataMapperTracing.add_tracer ::DataMapper::Model, :first
-    NewRelic::Agent::DataMapperTracing.add_tracer ::DataMapper::Model, :last
-    NewRelic::Agent::DataMapperTracing.add_tracer ::DataMapper::Model, :all
+    NewRelic::Agent::DataMapperTracing.add_tracer(::DataMapper::Model, :get)
+    NewRelic::Agent::DataMapperTracing.add_tracer(::DataMapper::Model, :first)
+    NewRelic::Agent::DataMapperTracing.add_tracer(::DataMapper::Model, :last)
+    NewRelic::Agent::DataMapperTracing.add_tracer(::DataMapper::Model, :all)
 
-    NewRelic::Agent::DataMapperTracing.add_tracer ::DataMapper::Model, :create
-    NewRelic::Agent::DataMapperTracing.add_tracer ::DataMapper::Model, :create!
-    NewRelic::Agent::DataMapperTracing.add_tracer ::DataMapper::Model, :update
-    NewRelic::Agent::DataMapperTracing.add_tracer ::DataMapper::Model, :update!
-    NewRelic::Agent::DataMapperTracing.add_tracer ::DataMapper::Model, :destroy
-    NewRelic::Agent::DataMapperTracing.add_tracer ::DataMapper::Model, :destroy!
+    NewRelic::Agent::DataMapperTracing.add_tracer(::DataMapper::Model, :create)
+    NewRelic::Agent::DataMapperTracing.add_tracer(::DataMapper::Model, :create!)
+    NewRelic::Agent::DataMapperTracing.add_tracer(::DataMapper::Model, :update)
+    NewRelic::Agent::DataMapperTracing.add_tracer(::DataMapper::Model, :update!)
+    NewRelic::Agent::DataMapperTracing.add_tracer(::DataMapper::Model, :destroy)
+    NewRelic::Agent::DataMapperTracing.add_tracer(::DataMapper::Model, :destroy!)
 
-    NewRelic::Agent::DataMapperTracing.add_tracer ::DataMapper::Model, :aggregate
-    NewRelic::Agent::DataMapperTracing.add_tracer ::DataMapper::Model, :find
-    NewRelic::Agent::DataMapperTracing.add_tracer ::DataMapper::Model, :find_by_sql
+    NewRelic::Agent::DataMapperTracing.add_tracer(::DataMapper::Model, :aggregate)
+    NewRelic::Agent::DataMapperTracing.add_tracer(::DataMapper::Model, :find)
+    NewRelic::Agent::DataMapperTracing.add_tracer(::DataMapper::Model, :find_by_sql)
   end
 
   executes do
-    NewRelic::Agent::DataMapperTracing.add_tracer ::DataMapper::Resource, :update
-    NewRelic::Agent::DataMapperTracing.add_tracer ::DataMapper::Resource, :update!
-    NewRelic::Agent::DataMapperTracing.add_tracer ::DataMapper::Resource, :save
-    NewRelic::Agent::DataMapperTracing.add_tracer ::DataMapper::Resource, :save!
-    NewRelic::Agent::DataMapperTracing.add_tracer ::DataMapper::Resource, :destroy
-    NewRelic::Agent::DataMapperTracing.add_tracer ::DataMapper::Resource, :destroy!
+    NewRelic::Agent::DataMapperTracing.add_tracer(::DataMapper::Resource, :update)
+    NewRelic::Agent::DataMapperTracing.add_tracer(::DataMapper::Resource, :update!)
+    NewRelic::Agent::DataMapperTracing.add_tracer(::DataMapper::Resource, :save)
+    NewRelic::Agent::DataMapperTracing.add_tracer(::DataMapper::Resource, :save!)
+    NewRelic::Agent::DataMapperTracing.add_tracer(::DataMapper::Resource, :destroy)
+    NewRelic::Agent::DataMapperTracing.add_tracer(::DataMapper::Resource, :destroy!)
   end
 
   executes do
-    NewRelic::Agent::DataMapperTracing.add_tracer ::DataMapper::Collection, :get
-    NewRelic::Agent::DataMapperTracing.add_tracer ::DataMapper::Collection, :first
-    NewRelic::Agent::DataMapperTracing.add_tracer ::DataMapper::Collection, :last
-    NewRelic::Agent::DataMapperTracing.add_tracer ::DataMapper::Collection, :all
+    NewRelic::Agent::DataMapperTracing.add_tracer(::DataMapper::Collection, :get)
+    NewRelic::Agent::DataMapperTracing.add_tracer(::DataMapper::Collection, :first)
+    NewRelic::Agent::DataMapperTracing.add_tracer(::DataMapper::Collection, :last)
+    NewRelic::Agent::DataMapperTracing.add_tracer(::DataMapper::Collection, :all)
 
-    NewRelic::Agent::DataMapperTracing.add_tracer ::DataMapper::Collection, :lazy_load
+    NewRelic::Agent::DataMapperTracing.add_tracer(::DataMapper::Collection, :lazy_load)
 
-    NewRelic::Agent::DataMapperTracing.add_tracer ::DataMapper::Collection, :create
-    NewRelic::Agent::DataMapperTracing.add_tracer ::DataMapper::Collection, :create!
-    NewRelic::Agent::DataMapperTracing.add_tracer ::DataMapper::Collection, :update
-    NewRelic::Agent::DataMapperTracing.add_tracer ::DataMapper::Collection, :update!
-    NewRelic::Agent::DataMapperTracing.add_tracer ::DataMapper::Collection, :destroy
-    NewRelic::Agent::DataMapperTracing.add_tracer ::DataMapper::Collection, :destroy!
+    NewRelic::Agent::DataMapperTracing.add_tracer(::DataMapper::Collection, :create)
+    NewRelic::Agent::DataMapperTracing.add_tracer(::DataMapper::Collection, :create!)
+    NewRelic::Agent::DataMapperTracing.add_tracer(::DataMapper::Collection, :update)
+    NewRelic::Agent::DataMapperTracing.add_tracer(::DataMapper::Collection, :update!)
+    NewRelic::Agent::DataMapperTracing.add_tracer(::DataMapper::Collection, :destroy)
+    NewRelic::Agent::DataMapperTracing.add_tracer(::DataMapper::Collection, :destroy!)
 
-    NewRelic::Agent::DataMapperTracing.add_tracer ::DataMapper::Collection, :aggregate
+    NewRelic::Agent::DataMapperTracing.add_tracer(::DataMapper::Collection, :aggregate)
   end
 
   executes do
     # Catch direct SQL calls that bypass CRUD
     if defined?(::DataMapper::Adapters::DataObjectsAdapter)
-      NewRelic::Agent::DataMapperTracing.add_tracer ::DataMapper::Adapters::DataObjectsAdapter, :select, true
-      NewRelic::Agent::DataMapperTracing.add_tracer ::DataMapper::Adapters::DataObjectsAdapter, :execute, true
+      NewRelic::Agent::DataMapperTracing.add_tracer(::DataMapper::Adapters::DataObjectsAdapter, :select, true)
+      NewRelic::Agent::DataMapperTracing.add_tracer(::DataMapper::Adapters::DataObjectsAdapter, :execute, true)
     end
   end
 
   executes do
     # DM::Validations overrides Model#create, so we patch it here as well
     if defined?(::DataMapper::Validations::ClassMethods)
-      NewRelic::Agent::DataMapperTracing.add_tracer ::DataMapper::Validations::ClassMethods, :create
+      NewRelic::Agent::DataMapperTracing.add_tracer(::DataMapper::Validations::ClassMethods, :create)
     end
   end
 
   executes do
     # DM::Transaction calls commit() twice, so potentially shows up twice.
     if defined?(::DataMapper::Transaction)
-      NewRelic::Agent::DataMapperTracing.add_tracer ::DataMapper::Transaction, :commit, true
+      NewRelic::Agent::DataMapperTracing.add_tracer(::DataMapper::Transaction, :commit, true)
     end
   end
 
@@ -115,8 +115,8 @@ module NewRelic
             define_method("#{method_name}_with_newrelic",
               NewRelic::Agent::DataMapperTracing.method_body(clazz, method_name, operation_only))
 
-            alias_method "#{method_name}_without_newrelic", method_name
-            alias_method method_name, "#{method_name}_with_newrelic"
+            alias_method("#{method_name}_without_newrelic", method_name)
+            alias_method(method_name, "#{method_name}_with_newrelic")
           end
         end
       end
@@ -153,7 +153,7 @@ module NewRelic
             )
 
             begin
-              NewRelic::Agent::Tracer.capture_segment_error segment do
+              NewRelic::Agent::Tracer.capture_segment_error(segment) do
                 self.send("#{method_name}_without_newrelic", *args, &blk)
               end
             rescue ::DataObjects::ConnectionError => e
@@ -206,7 +206,7 @@ module NewRelic
           txn = state.current_transaction
 
           if txn && txn.current_segment.respond_to?(:notice_sql)
-            txn.current_segment.notice_sql msg.query
+            txn.current_segment.notice_sql(msg.query)
           end
         ensure
           super

--- a/lib/new_relic/agent/instrumentation/delayed_job/chain.rb
+++ b/lib/new_relic/agent/instrumentation/delayed_job/chain.rb
@@ -22,7 +22,7 @@ module NewRelic::Agent::Instrumentation
             Delayed::Job.class_eval do
               include NewRelic::Agent::Instrumentation::DelayedJobTracer
 
-              alias_method :invoke_job_without_new_relic, :invoke_job
+              alias_method(:invoke_job_without_new_relic, :invoke_job)
 
               def invoke_job(*args, &block)
                 invoke_job_with_tracing { invoke_job_without_new_relic(*args, &block) }

--- a/lib/new_relic/agent/instrumentation/delayed_job/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/delayed_job/instrumentation.rb
@@ -19,9 +19,9 @@ module NewRelic
           if defined?(::Delayed::Job) && ::Delayed::Job.method_defined?(:invoke_job) &&
               !(::Delayed::Job.method_defined?(:invoke_job_without_new_relic))
 
-            ::NewRelic::Agent.logger.info 'Installing DelayedJob instrumentation [part 2/2]'
+            ::NewRelic::Agent.logger.info('Installing DelayedJob instrumentation [part 2/2]')
             install_newrelic_job_tracer
-            NewRelic::Control.instance.init_plugin :dispatcher => :delayed_job
+            NewRelic::Control.instance.init_plugin(:dispatcher => :delayed_job)
           else
             NewRelic::Agent.logger.warn("Did not find a Delayed::Job class responding to invoke_job, aborting DJ instrumentation")
           end

--- a/lib/new_relic/agent/instrumentation/delayed_job/prepend.rb
+++ b/lib/new_relic/agent/instrumentation/delayed_job/prepend.rb
@@ -17,7 +17,7 @@ module NewRelic
           end
 
           def install_newrelic_job_tracer
-            Delayed::Job.send :prepend, ::NewRelic::Agent::Instrumentation::DelayedJobTracerPrepend
+            Delayed::Job.send(:prepend, ::NewRelic::Agent::Instrumentation::DelayedJobTracerPrepend)
           end
         end
       end

--- a/lib/new_relic/agent/instrumentation/delayed_job_instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/delayed_job_instrumentation.rb
@@ -22,7 +22,7 @@ module NewRelic
           LEGACY_DJ_DEFAULT_CLASS = '(unknown class)'.freeze
 
           def name_from_payload(payload_object)
-            if payload_object.is_a? ::Delayed::PerformableMethod
+            if payload_object.is_a?(::Delayed::PerformableMethod)
               # payload_object contains a reference to an object
               # that received an asynchronous method call via .delay or .handle_asynchronously
               "#{object_name(payload_object)}#{delimiter(payload_object)}#{method_name(payload_object)}"
@@ -84,7 +84,7 @@ DependencyDetection.defer do
   end
 
   executes do
-    ::NewRelic::Agent.logger.info 'Installing DelayedJob instrumentation [part 1/2]'
+    ::NewRelic::Agent.logger.info('Installing DelayedJob instrumentation [part 1/2]')
   end
 
   executes do

--- a/lib/new_relic/agent/instrumentation/excon.rb
+++ b/lib/new_relic/agent/instrumentation/excon.rb
@@ -41,7 +41,7 @@ DependencyDetection.defer do
   end
 
   def install_middleware_excon_instrumentation
-    ::NewRelic::Agent.logger.info 'Installing middleware-based Excon instrumentation'
+    ::NewRelic::Agent.logger.info('Installing middleware-based Excon instrumentation')
     require 'new_relic/agent/instrumentation/excon/middleware'
     defaults = Excon.defaults
 

--- a/lib/new_relic/agent/instrumentation/excon/middleware.rb
+++ b/lib/new_relic/agent/instrumentation/excon/middleware.rb
@@ -26,7 +26,7 @@ module ::Excon
               procedure: wrapped_request.method
             )
 
-            segment.add_request_headers wrapped_request
+            segment.add_request_headers(wrapped_request)
 
             datum[:connection].instance_variable_set(TRACE_DATA_IVAR, segment)
           end
@@ -55,7 +55,7 @@ module ::Excon
 
             if datum[:response]
               wrapped_response = ::NewRelic::Agent::HTTPClients::ExconHTTPResponse.new(datum[:response])
-              segment.process_response_headers wrapped_response
+              segment.process_response_headers(wrapped_response)
             end
           ensure
             segment.finish if segment

--- a/lib/new_relic/agent/instrumentation/grape/chain.rb
+++ b/lib/new_relic/agent/instrumentation/grape/chain.rb
@@ -10,14 +10,14 @@ module NewRelic::Agent::Instrumentation
         Grape::Instrumentation.instrumented_class.class_eval do
           def call_with_new_relic env
             begin
-              call_without_new_relic env
+              call_without_new_relic(env)
             ensure
-              Grape::Instrumentation.capture_transaction env, self
+              Grape::Instrumentation.capture_transaction(env, self)
             end
           end
 
-          alias_method :call_without_new_relic, :call
-          alias_method :call, :call_with_new_relic
+          alias_method(:call_without_new_relic, :call)
+          alias_method(:call, :call_with_new_relic)
         end
       end
     end

--- a/lib/new_relic/agent/instrumentation/grape/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/grape/instrumentation.rb
@@ -30,10 +30,10 @@ module NewRelic::Agent::Instrumentation
 
       def prepare!
         if defined?(::Grape::VERSION) && Gem::Version.new(::Grape::VERSION) >= Gem::Version.new("0.16.0")
-          send :remove_method, :name_for_transaction_deprecated
+          send(:remove_method, :name_for_transaction_deprecated)
         else
-          send :remove_method, :name_for_transaction
-          send :alias_method, :name_for_transaction, :name_for_transaction_deprecated
+          send(:remove_method, :name_for_transaction)
+          send(:alias_method, :name_for_transaction, :name_for_transaction_deprecated)
         end
       end
 

--- a/lib/new_relic/agent/instrumentation/grape/prepend.rb
+++ b/lib/new_relic/agent/instrumentation/grape/prepend.rb
@@ -8,9 +8,9 @@ module NewRelic::Agent::Instrumentation
     module Prepend
       def call env
         begin
-          super env
+          super(env)
         ensure
-          Grape::Instrumentation.capture_transaction env, self
+          Grape::Instrumentation.capture_transaction(env, self)
         end
       end
     end

--- a/lib/new_relic/agent/instrumentation/httpclient.rb
+++ b/lib/new_relic/agent/instrumentation/httpclient.rb
@@ -24,7 +24,7 @@ DependencyDetection.defer do
   end
 
   executes do
-    ::NewRelic::Agent.logger.info 'Installing HTTPClient instrumentation'
+    ::NewRelic::Agent.logger.info('Installing HTTPClient instrumentation')
     require 'new_relic/agent/distributed_tracing/cross_app_tracing'
     require 'new_relic/agent/http_clients/httpclient_wrappers'
   end

--- a/lib/new_relic/agent/instrumentation/httpclient/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/httpclient/instrumentation.rb
@@ -16,17 +16,17 @@ module NewRelic::Agent::Instrumentation
 
         begin
           response = nil
-          segment.add_request_headers wrapped_request
+          segment.add_request_headers(wrapped_request)
 
-          NewRelic::Agent::Tracer.capture_segment_error segment do
+          NewRelic::Agent::Tracer.capture_segment_error(segment) do
             yield
           end
 
           response = connection.pop
-          connection.push response
+          connection.push(response)
 
           wrapped_response = ::NewRelic::Agent::HTTPClients::HTTPClientResponse.new(response)
-          segment.process_response_headers wrapped_response
+          segment.process_response_headers(wrapped_response)
 
           response
         ensure

--- a/lib/new_relic/agent/instrumentation/httprb.rb
+++ b/lib/new_relic/agent/instrumentation/httprb.rb
@@ -15,7 +15,7 @@ DependencyDetection.defer do
   end
 
   executes do
-    ::NewRelic::Agent.logger.info "Installing http.rb Wrappers"
+    ::NewRelic::Agent.logger.info("Installing http.rb Wrappers")
     require 'new_relic/agent/distributed_tracing/cross_app_tracing'
     require 'new_relic/agent/http_clients/http_rb_wrappers'
   end

--- a/lib/new_relic/agent/instrumentation/httprb/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/httprb/instrumentation.rb
@@ -15,12 +15,12 @@ module NewRelic::Agent::Instrumentation
           procedure: wrapped_request.method
         )
 
-        segment.add_request_headers wrapped_request
+        segment.add_request_headers(wrapped_request)
 
         response = NewRelic::Agent::Tracer.capture_segment_error(segment) { yield }
 
-        wrapped_response = ::NewRelic::Agent::HTTPClients::HTTPResponse.new response
-        segment.process_response_headers wrapped_response
+        wrapped_response = ::NewRelic::Agent::HTTPClients::HTTPResponse.new(response)
+        segment.process_response_headers(wrapped_response)
 
         response
       ensure

--- a/lib/new_relic/agent/instrumentation/ignore_actions.rb
+++ b/lib/new_relic/agent/instrumentation/ignore_actions.rb
@@ -11,7 +11,7 @@ module NewRelic
           # We'll walk the superclass chain and see if
           # any class says 'yes, filter this one'.
 
-          while klass.respond_to? :newrelic_read_attr
+          while klass.respond_to?(:newrelic_read_attr)
             ignore_actions = klass.newrelic_read_attr(key)
 
             should_filter = case ignore_actions

--- a/lib/new_relic/agent/instrumentation/logger.rb
+++ b/lib/new_relic/agent/instrumentation/logger.rb
@@ -16,7 +16,7 @@ DependencyDetection.defer do
   end
 
   executes do
-    ::NewRelic::Agent.logger.info "Installing Logger instrumentation"
+    ::NewRelic::Agent.logger.info("Installing Logger instrumentation")
 
     if use_prepend?
       prepend_instrument ::Logger, NewRelic::Agent::Instrumentation::Logger::Prepend

--- a/lib/new_relic/agent/instrumentation/logger/chain.rb
+++ b/lib/new_relic/agent/instrumentation/logger/chain.rb
@@ -9,7 +9,7 @@ module NewRelic::Agent::Instrumentation
       ::Logger.class_eval do
         include NewRelic::Agent::Instrumentation::Logger
 
-        alias_method :format_message_without_new_relic, :format_message
+        alias_method(:format_message_without_new_relic, :format_message)
 
         def format_message(severity, datetime, progname, msg)
           format_message_with_tracing(severity, datetime, progname, msg) do

--- a/lib/new_relic/agent/instrumentation/memcache.rb
+++ b/lib/new_relic/agent/instrumentation/memcache.rb
@@ -75,7 +75,7 @@ DependencyDetection.defer do
   depends_on { ::NewRelic::Agent::Instrumentation::Memcache::DalliCAS.should_instrument? }
 
   executes do
-    ::NewRelic::Agent.logger.info 'Installing Dalli CAS Client Memcache instrumentation'
+    ::NewRelic::Agent.logger.info('Installing Dalli CAS Client Memcache instrumentation')
     if use_prepend?
       prepend_module = ::NewRelic::Agent::Instrumentation::Memcache::Prepend
       prepend_module.dalli_cas_prependers do |client_class, instrumenting_module|

--- a/lib/new_relic/agent/instrumentation/memcache/chain.rb
+++ b/lib/new_relic/agent/instrumentation/memcache/chain.rb
@@ -9,7 +9,7 @@ module NewRelic::Agent::Instrumentation
       extend Helper
 
       def self.instrument! target_class
-        instrument_methods target_class, client_methods
+        instrument_methods(target_class, client_methods)
       end
     end
   end

--- a/lib/new_relic/agent/instrumentation/memcache/dalli.rb
+++ b/lib/new_relic/agent/instrumentation/memcache/dalli.rb
@@ -15,7 +15,7 @@ module NewRelic
           def instrument!
             if supports_datastore_instances?
               instrument_methods(::Dalli::Client, dalli_methods)
-              instrument_multi_method :get_multi
+              instrument_multi_method(:get_multi)
               instrument_send_multiget
               instrument_server_for_key
             else
@@ -24,18 +24,18 @@ module NewRelic
           end
 
           def instrument_multi_method method_name
-            visibility = NewRelic::Helper.instance_method_visibility ::Dalli::Client, method_name
+            visibility = NewRelic::Helper.instance_method_visibility(::Dalli::Client, method_name)
             method_name_without = :"#{method_name}_without_newrelic_trace"
 
             ::Dalli::Client.class_eval do
-              alias_method method_name_without, method_name
+              alias_method(method_name_without, method_name)
 
-              define_method method_name do |*args, &block|
-                get_multi_with_newrelic_tracing(method_name) { __send__ method_name_without, *args, &block }
+              define_method(method_name) do |*args, &block|
+                get_multi_with_newrelic_tracing(method_name) { __send__(method_name_without, *args, &block) }
               end
 
-              __send__ visibility, method_name
-              __send__ visibility, method_name_without
+              __send__(visibility, method_name)
+              __send__(visibility, method_name_without)
             end
           end
 
@@ -43,10 +43,10 @@ module NewRelic
             ::Dalli::Ring.class_eval do
               include NewRelic::Agent::Instrumentation::Memcache::Tracer
 
-              alias_method :server_for_key_without_newrelic_trace, :server_for_key
+              alias_method(:server_for_key_without_newrelic_trace, :server_for_key)
 
               def server_for_key key
-                server_for_key_with_newrelic_tracing { server_for_key_without_newrelic_trace key }
+                server_for_key_with_newrelic_tracing { server_for_key_without_newrelic_trace(key) }
               end
             end
           end
@@ -61,14 +61,14 @@ module NewRelic
 
               # TODO: Dalli - 3.1.0 renamed send_multiget to piplined_get, but the method is otherwise the same
               if Gem::Version.new(::Dalli::VERSION) >= Gem::Version.new('3.1.0')
-                alias_method :pipelined_get_without_newrelic_trace, :pipelined_get
+                alias_method(:pipelined_get_without_newrelic_trace, :pipelined_get)
                 def pipelined_get keys
-                  send_multiget_with_newrelic_tracing(keys) { pipelined_get_without_newrelic_trace keys }
+                  send_multiget_with_newrelic_tracing(keys) { pipelined_get_without_newrelic_trace(keys) }
                 end
               else
-                alias_method :send_multiget_without_newrelic_trace, :send_multiget
+                alias_method(:send_multiget_without_newrelic_trace, :send_multiget)
                 def send_multiget keys
-                  send_multiget_with_newrelic_tracing(keys) { send_multiget_without_newrelic_trace keys }
+                  send_multiget_with_newrelic_tracing(keys) { send_multiget_without_newrelic_trace(keys) }
                 end
               end
             end
@@ -86,8 +86,8 @@ module NewRelic
           end
 
           def instrument!
-            instrument_methods ::Dalli::Client, dalli_cas_methods
-            instrument_multi_method :get_multi_cas
+            instrument_methods(::Dalli::Client, dalli_cas_methods)
+            instrument_multi_method(:get_multi_cas)
           end
         end
       end

--- a/lib/new_relic/agent/instrumentation/memcache/helper.rb
+++ b/lib/new_relic/agent/instrumentation/memcache/helper.rb
@@ -6,8 +6,8 @@
 module NewRelic::Agent::Instrumentation
   module Memcache
     module Helper
-      DATASTORE_INSTANCES_SUPPORTED_VERSION = Gem::Version.new '2.6.4'
-      BINARY_PROTOCOL_SUPPORTED_VERSION = Gem::Version.new '3.0.2'
+      DATASTORE_INSTANCES_SUPPORTED_VERSION = Gem::Version.new('2.6.4')
+      BINARY_PROTOCOL_SUPPORTED_VERSION = Gem::Version.new('3.0.2')
 
       def supports_datastore_instances?
         DATASTORE_INSTANCES_SUPPORTED_VERSION <= Gem::Version.new(::Dalli::VERSION)
@@ -38,20 +38,20 @@ module NewRelic::Agent::Instrumentation
 
       def instrument_methods(client_class, requested_methods = METHODS)
         supported_methods_for(client_class, requested_methods).each do |method_name|
-          visibility = NewRelic::Helper.instance_method_visibility client_class, method_name
+          visibility = NewRelic::Helper.instance_method_visibility(client_class, method_name)
           method_name_without = :"#{method_name}_without_newrelic_trace"
 
           client_class.class_eval do
             include NewRelic::Agent::Instrumentation::Memcache::Tracer
 
-            alias_method method_name_without, method_name
+            alias_method(method_name_without, method_name)
 
-            define_method method_name do |*args, &block|
-              with_newrelic_tracing(method_name, *args) { __send__ method_name_without, *args, &block }
+            define_method(method_name) do |*args, &block|
+              with_newrelic_tracing(method_name, *args) { __send__(method_name_without, *args, &block) }
             end
 
-            __send__ visibility, method_name
-            __send__ visibility, method_name_without
+            __send__(visibility, method_name)
+            __send__(visibility, method_name_without)
           end
         end
       end

--- a/lib/new_relic/agent/instrumentation/memcache/prepend.rb
+++ b/lib/new_relic/agent/instrumentation/memcache/prepend.rb
@@ -24,24 +24,24 @@ module NewRelic::Agent::Instrumentation
       end
 
       def dalli_cas_prependers
-        yield ::Dalli::Client, dalli_client_prepender(dalli_cas_methods)
-        yield ::Dalli::Client, dalli_get_multi_prepender(:get_multi_cas)
+        yield(::Dalli::Client, dalli_client_prepender(dalli_cas_methods))
+        yield(::Dalli::Client, dalli_get_multi_prepender(:get_multi_cas))
       end
 
       def dalli_prependers
         if supports_datastore_instances?
-          yield ::Dalli::Client, dalli_client_prepender(dalli_methods)
-          yield ::Dalli::Client, dalli_get_multi_prepender(:get_multi)
+          yield(::Dalli::Client, dalli_client_prepender(dalli_methods))
+          yield(::Dalli::Client, dalli_get_multi_prepender(:get_multi))
 
           if supports_binary_protocol?
-            yield ::Dalli::Protocol::Binary, dalli_server_prepender
+            yield(::Dalli::Protocol::Binary, dalli_server_prepender)
           else
-            yield ::Dalli::Server, dalli_server_prepender
+            yield(::Dalli::Server, dalli_server_prepender)
           end
 
-          yield ::Dalli::Ring, dalli_ring_prepender
+          yield(::Dalli::Ring, dalli_ring_prepender)
         else
-          yield ::Dalli::Client, dalli_client_prepender(client_methods)
+          yield(::Dalli::Client, dalli_client_prepender(client_methods))
         end
       end
 

--- a/lib/new_relic/agent/instrumentation/mongo.rb
+++ b/lib/new_relic/agent/instrumentation/mongo.rb
@@ -19,7 +19,7 @@ DependencyDetection.defer do
   end
 
   executes do
-    NewRelic::Agent.logger.info 'Installing Mongo instrumentation'
+    NewRelic::Agent.logger.info('Installing Mongo instrumentation')
     install_mongo_command_subscriber
   end
 

--- a/lib/new_relic/agent/instrumentation/mongodb_command_subscriber.rb
+++ b/lib/new_relic/agent/instrumentation/mongodb_command_subscriber.rb
@@ -15,7 +15,7 @@ module NewRelic
         def started(event)
           begin
             return unless NewRelic::Agent::Tracer.tracing_enabled?
-            segments[event.operation_id] = start_segment event
+            segments[event.operation_id] = start_segment(event)
           rescue Exception => e
             log_notification_error('started', e)
           end
@@ -42,12 +42,12 @@ module NewRelic
             if error_key = error_key_present?(event)
               # taking the last error as there can potentially be many
               attributes = event.reply[error_key][-1]
-              segment.notice_error Mongo::Error.new("%s (%s)" % [attributes["errmsg"], attributes["code"]])
+              segment.notice_error(Mongo::Error.new("%s (%s)" % [attributes["errmsg"], attributes["code"]]))
 
             # failing commands return a CommandFailed event with an error message
             # in the form of "% (%s)" for the message and code
-            elsif event.is_a? Mongo::Monitoring::Event::CommandFailed
-              segment.notice_error Mongo::Error.new(event.message)
+            elsif event.is_a?(Mongo::Monitoring::Event::CommandFailed)
+              segment.notice_error(Mongo::Error.new(event.message))
             end
             segment.finish
           rescue Exception => e
@@ -61,8 +61,8 @@ module NewRelic
         private
 
         def start_segment event
-          host = host_from_address event.address
-          port_path_or_id = port_path_or_id_from_address event.address
+          host = host_from_address(event.address)
+          port_path_or_id = port_path_or_id_from_address(event.address)
           segment = NewRelic::Agent::Tracer.start_datastore_segment(
             product: MONGODB,
             operation: operation(event.command_name),
@@ -109,31 +109,31 @@ module NewRelic
         LOCALHOST = "localhost".freeze
 
         def host_from_address(address)
-          if unix_domain_socket? address.host
+          if unix_domain_socket?(address.host)
             LOCALHOST
           else
             address.host
           end
         rescue => e
-          NewRelic::Agent.logger.debug "Failed to retrieve Mongo host: #{e}"
+          NewRelic::Agent.logger.debug("Failed to retrieve Mongo host: #{e}")
           UNKNOWN
         end
 
         def port_path_or_id_from_address(address)
-          if unix_domain_socket? address.host
+          if unix_domain_socket?(address.host)
             address.host
           else
             address.port
           end
         rescue => e
-          NewRelic::Agent.logger.debug "Failed to retrieve Mongo port_path_or_id: #{e}"
+          NewRelic::Agent.logger.debug("Failed to retrieve Mongo port_path_or_id: #{e}")
           UNKNOWN
         end
 
         SLASH = "/".freeze
 
         def unix_domain_socket?(host)
-          host.start_with? SLASH
+          host.start_with?(SLASH)
         end
       end
     end

--- a/lib/new_relic/agent/instrumentation/net_http.rb
+++ b/lib/new_relic/agent/instrumentation/net_http.rb
@@ -14,7 +14,7 @@ DependencyDetection.defer do
   end
 
   executes do
-    ::NewRelic::Agent.logger.info 'Installing Net:HTTP Wrappers'
+    ::NewRelic::Agent.logger.info('Installing Net:HTTP Wrappers')
     require 'new_relic/agent/http_clients/net_http_wrappers'
   end
 

--- a/lib/new_relic/agent/instrumentation/net_http/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/net_http/instrumentation.rb
@@ -18,18 +18,18 @@ module NewRelic
 
           begin
             response = nil
-            segment.add_request_headers wrapped_request
+            segment.add_request_headers(wrapped_request)
 
             # RUBY-1244 Disable further tracing in request to avoid double
             # counting if connection wasn't started (which calls request again).
             NewRelic::Agent.disable_all_tracing do
-              response = NewRelic::Agent::Tracer.capture_segment_error segment do
+              response = NewRelic::Agent::Tracer.capture_segment_error(segment) do
                 yield
               end
             end
 
-            wrapped_response = NewRelic::Agent::HTTPClients::NetHTTPResponse.new response
-            segment.process_response_headers wrapped_response
+            wrapped_response = NewRelic::Agent::HTTPClients::NetHTTPResponse.new(response)
+            segment.process_response_headers(wrapped_response)
             response
           ensure
             segment.finish

--- a/lib/new_relic/agent/instrumentation/notifications_subscriber.rb
+++ b/lib/new_relic/agent/instrumentation/notifications_subscriber.rb
@@ -27,11 +27,11 @@ module NewRelic
           instance_variable_names.each do |name|
             if notifier.instance_variable_defined?(name)
               subscribers = notifier.instance_variable_get(name)
-              if subscribers.is_a? Array
+              if subscribers.is_a?(Array)
                 # Rails 5 @subscribers, and Rails 6 @other_subscribers is a
                 # plain array of subscriber objects
                 all_subscribers += subscribers
-              elsif subscribers.is_a? Hash
+              elsif subscribers.is_a?(Hash)
                 # Rails 6 @string_subscribers is a Hash mapping the pattern
                 # string of a subscriber to an array of subscriber objects
                 subscribers.values.each { |array| all_subscribers += array }
@@ -56,7 +56,7 @@ module NewRelic
         end
 
         def push_segment(id, segment)
-          segment_stack[id].push segment
+          segment_stack[id].push(segment)
         end
 
         def pop_segment(id)
@@ -86,7 +86,7 @@ module NewRelic
             def exception_object(payload)
               exception_class, message = payload[:exception]
               return nil unless exception_class
-              NewRelic::Agent::NoticibleError.new exception_class, message
+              NewRelic::Agent::NoticibleError.new(exception_class, message)
             end
           else
             def exception_object(payload)

--- a/lib/new_relic/agent/instrumentation/padrino.rb
+++ b/lib/new_relic/agent/instrumentation/padrino.rb
@@ -23,7 +23,7 @@ DependencyDetection.defer do
   depends_on { defined?(::Padrino) && defined?(::Padrino::Routing::InstanceMethods) }
 
   executes do
-    ::NewRelic::Agent.logger.info 'Installing Padrino instrumentation'
+    ::NewRelic::Agent.logger.info('Installing Padrino instrumentation')
     if use_prepend?
       prepend_instrument ::Padrino::Application, NewRelic::Agent::Instrumentation::PadrinoTracer::Prepend
     else

--- a/lib/new_relic/agent/instrumentation/passenger_instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/passenger_instrumentation.rb
@@ -11,10 +11,10 @@ DependencyDetection.defer do
   end
 
   executes do
-    ::NewRelic::Agent.logger.debug "Installing Passenger event hooks."
+    ::NewRelic::Agent.logger.debug("Installing Passenger event hooks.")
 
     ::PhusionPassenger.on_event(:stopping_worker_process) do
-      ::NewRelic::Agent.logger.debug "Passenger stopping this process, shutdown the agent."
+      ::NewRelic::Agent.logger.debug("Passenger stopping this process, shutdown the agent.")
       NewRelic::Agent.instance.shutdown
     end
 

--- a/lib/new_relic/agent/instrumentation/rack/chain.rb
+++ b/lib/new_relic/agent/instrumentation/rack/chain.rb
@@ -7,7 +7,7 @@ module NewRelic::Agent::Instrumentation
   module Rack
     module Chain
       def self.instrument! builder_class
-        NewRelic::Agent::Instrumentation::RackBuilder.track_deferred_detection builder_class
+        NewRelic::Agent::Instrumentation::RackBuilder.track_deferred_detection(builder_class)
 
         builder_class.class_eval do
           include ::NewRelic::Agent::Instrumentation::RackBuilder
@@ -16,26 +16,26 @@ module NewRelic::Agent::Instrumentation
             with_deferred_dependency_detection { to_app_without_newrelic }
           end
 
-          alias_method :to_app_without_newrelic, :to_app
-          alias_method :to_app, :to_app_with_newrelic_deferred_dependency_detection
+          alias_method(:to_app_without_newrelic, :to_app)
+          alias_method(:to_app, :to_app_with_newrelic_deferred_dependency_detection)
 
           if ::NewRelic::Agent::Instrumentation::RackHelpers.middleware_instrumentation_enabled?
-            ::NewRelic::Agent.logger.info "Installing #{builder_class} middleware instrumentation"
+            ::NewRelic::Agent.logger.info("Installing #{builder_class} middleware instrumentation")
 
             def run_with_newrelic(app, *args)
               run_with_tracing(app) { |wrapped_app| run_without_newrelic(wrapped_app, *args) }
             end
 
-            alias_method :run_without_newrelic, :run
-            alias_method :run, :run_with_newrelic
+            alias_method(:run_without_newrelic, :run)
+            alias_method(:run, :run_with_newrelic)
 
             def use_with_newrelic(middleware_class, *args, &block)
               use_with_tracing(middleware_class) { |wrapped_class| use_without_newrelic(wrapped_class, *args, &block) }
             end
             ruby2_keywords(:use_with_newrelic) if respond_to?(:ruby2_keywords, true)
 
-            alias_method :use_without_newrelic, :use
-            alias_method :use, :use_with_newrelic
+            alias_method(:use_without_newrelic, :use)
+            alias_method(:use, :use_with_newrelic)
           end
         end
       end
@@ -45,7 +45,7 @@ module NewRelic::Agent::Instrumentation
       module Chain
         def self.instrument! url_map_class
           url_map_class.class_eval do
-            alias_method :initialize_without_newrelic, :initialize
+            alias_method(:initialize_without_newrelic, :initialize)
 
             def initialize(map = {})
               traced_map = ::NewRelic::Agent::Instrumentation::RackURLMap.generate_traced_map(map)

--- a/lib/new_relic/agent/instrumentation/rack/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/rack/instrumentation.rb
@@ -17,7 +17,7 @@ module NewRelic
         def deferred_dependency_check
           return if self.class._nr_deferred_detection_ran
 
-          NewRelic::Agent.logger.info "Doing deferred dependency-detection before Rack startup"
+          NewRelic::Agent.logger.info("Doing deferred dependency-detection before Rack startup")
           DependencyDetection.detect!
           self.class._nr_deferred_detection_ran = true
         end
@@ -50,13 +50,13 @@ module NewRelic
 
         def run_with_tracing app
           return yield(app) unless middleware_instrumentation_enabled?
-          yield ::NewRelic::Agent::Instrumentation::MiddlewareProxy.wrap(app, true)
+          yield(::NewRelic::Agent::Instrumentation::MiddlewareProxy.wrap(app, true))
         end
 
         def use_with_tracing middleware_class
           return if middleware_class.nil?
           return yield(middleware_class) unless middleware_instrumentation_enabled?
-          yield ::NewRelic::Agent::Instrumentation::MiddlewareProxy.for_class(middleware_class)
+          yield(::NewRelic::Agent::Instrumentation::MiddlewareProxy.for_class(middleware_class))
         end
       end
 

--- a/lib/new_relic/agent/instrumentation/rack/prepend.rb
+++ b/lib/new_relic/agent/instrumentation/rack/prepend.rb
@@ -8,7 +8,7 @@ module NewRelic::Agent::Instrumentation
     module URLMap
       module Prepend
         def initialize(map = {})
-          super ::NewRelic::Agent::Instrumentation::RackURLMap.generate_traced_map(map)
+          super(::NewRelic::Agent::Instrumentation::RackURLMap.generate_traced_map(map))
         end
       end
     end
@@ -17,7 +17,7 @@ module NewRelic::Agent::Instrumentation
       include ::NewRelic::Agent::Instrumentation::RackBuilder
 
       def self.prepended builder_class
-        NewRelic::Agent::Instrumentation::RackBuilder.track_deferred_detection builder_class
+        NewRelic::Agent::Instrumentation::RackBuilder.track_deferred_detection(builder_class)
       end
 
       def to_app

--- a/lib/new_relic/agent/instrumentation/rails3/action_controller.rb
+++ b/lib/new_relic/agent/instrumentation/rails3/action_controller.rb
@@ -41,7 +41,7 @@ module NewRelic
                 "file"
               elsif identifier.nil?
                 ::NewRelic::Agent::UNKNOWN_METRIC
-              elsif identifier.include? '/' # this is a filepath
+              elsif identifier.include?('/') # this is a filepath
                 identifier.split('/')[-2..-1].join('/')
               else
                 identifier
@@ -75,7 +75,7 @@ DependencyDetection.defer do
   end
 
   executes do
-    ::NewRelic::Agent.logger.info 'Installing Rails 3 Controller instrumentation'
+    ::NewRelic::Agent.logger.info('Installing Rails 3 Controller instrumentation')
   end
 
   executes do
@@ -102,7 +102,7 @@ DependencyDetection.defer do
   end
 
   executes do
-    ::NewRelic::Agent.logger.info 'Installing Rails 3.2 view instrumentation'
+    ::NewRelic::Agent.logger.info('Installing Rails 3.2 view instrumentation')
   end
 
   executes do
@@ -112,10 +112,10 @@ DependencyDetection.defer do
 
       def render_with_newrelic(context, options)
         # This is needed for rails 3.2 compatibility
-        @details = extract_details(options) if respond_to? :extract_details, true
+        @details = extract_details(options) if respond_to?(:extract_details, true)
         identifier = determine_template(options) ? determine_template(options).identifier : nil
         scope_name = "View/#{NewRelic::Agent::Instrumentation::Rails3::ActionView::NewRelic.template_metric(identifier, options)}/Rendering"
-        trace_execution_scoped scope_name do
+        trace_execution_scoped(scope_name) do
           render_without_newrelic(context, options)
         end
       end

--- a/lib/new_relic/agent/instrumentation/rails_notifications/action_cable.rb
+++ b/lib/new_relic/agent/instrumentation/rails_notifications/action_cable.rb
@@ -21,7 +21,7 @@ DependencyDetection.defer do
   end
 
   executes do
-    ::NewRelic::Agent.logger.info 'Installing notifications based Action Cable instrumentation'
+    ::NewRelic::Agent.logger.info('Installing notifications based Action Cable instrumentation')
   end
 
   executes do

--- a/lib/new_relic/agent/instrumentation/rails_notifications/action_controller.rb
+++ b/lib/new_relic/agent/instrumentation/rails_notifications/action_controller.rb
@@ -18,7 +18,7 @@ DependencyDetection.defer do
   end
 
   executes do
-    ::NewRelic::Agent.logger.info 'Installing notifications based Action Controller instrumentation'
+    ::NewRelic::Agent.logger.info('Installing notifications based Action Controller instrumentation')
   end
 
   executes do

--- a/lib/new_relic/agent/instrumentation/rails_notifications/action_view.rb
+++ b/lib/new_relic/agent/instrumentation/rails_notifications/action_view.rb
@@ -19,7 +19,7 @@ DependencyDetection.defer do
   end
 
   executes do
-    NewRelic::Agent.logger.info 'Installing notification based Action View instrumentation'
+    NewRelic::Agent.logger.info('Installing notification based Action View instrumentation')
   end
 
   executes do

--- a/lib/new_relic/agent/instrumentation/rainbows_instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/rainbows_instrumentation.rb
@@ -11,8 +11,8 @@ DependencyDetection.defer do
   end
 
   executes do
-    ::NewRelic::Agent.logger.info 'Installing Rainbows instrumentation'
-    ::NewRelic::Agent.logger.info 'Detected Rainbows, please see additional documentation: https://newrelic.com/docs/troubleshooting/im-using-unicorn-and-i-dont-see-any-data'
+    ::NewRelic::Agent.logger.info('Installing Rainbows instrumentation')
+    ::NewRelic::Agent.logger.info('Detected Rainbows, please see additional documentation: https://newrelic.com/docs/troubleshooting/im-using-unicorn-and-i-dont-see-any-data')
 
     deprecation_msg = 'The dispatcher rainbows is deprecated. It will be removed ' \
      'in version 9.0.0. Please use a supported dispatcher instead. ' \

--- a/lib/new_relic/agent/instrumentation/rake.rb
+++ b/lib/new_relic/agent/instrumentation/rake.rb
@@ -18,8 +18,8 @@ DependencyDetection.defer do
   depends_on { ::NewRelic::Agent::Instrumentation::Rake.safe_from_third_party_gem? }
 
   executes do
-    ::NewRelic::Agent.logger.info "Installing Rake instrumentation"
-    ::NewRelic::Agent.logger.debug "Instrumenting Rake tasks: #{::NewRelic::Agent.config[:'rake.tasks']}"
+    ::NewRelic::Agent.logger.info("Installing Rake instrumentation")
+    ::NewRelic::Agent.logger.debug("Instrumenting Rake tasks: #{::NewRelic::Agent.config[:'rake.tasks']}")
   end
 
   executes do

--- a/lib/new_relic/agent/instrumentation/rake/chain.rb
+++ b/lib/new_relic/agent/instrumentation/rake/chain.rb
@@ -9,7 +9,7 @@ module NewRelic::Agent::Instrumentation
       def self.instrument!
         ::Rake::Task.class_eval do
           include NewRelic::Agent::Instrumentation::Rake::Tracer
-          alias_method :invoke_without_newrelic, :invoke
+          alias_method(:invoke_without_newrelic, :invoke)
 
           def invoke(*args)
             invoke_with_newrelic_tracing(*args) { invoke_without_newrelic(*args) }

--- a/lib/new_relic/agent/instrumentation/rake/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/rake/instrumentation.rb
@@ -9,7 +9,7 @@ module NewRelic
       module Rake
         module Tracer
           def invoke_with_newrelic_tracing(*args)
-            unless NewRelic::Agent::Instrumentation::Rake.should_trace? name
+            unless NewRelic::Agent::Instrumentation::Rake.should_trace?(name)
               return yield
             end
 

--- a/lib/new_relic/agent/instrumentation/redis.rb
+++ b/lib/new_relic/agent/instrumentation/redis.rb
@@ -29,7 +29,7 @@ DependencyDetection.defer do
   end
 
   executes do
-    NewRelic::Agent.logger.info 'Installing Redis Instrumentation'
+    NewRelic::Agent.logger.info('Installing Redis Instrumentation')
     if use_prepend?
       prepend_instrument ::Redis::Client, NewRelic::Agent::Instrumentation::Redis::Prepend
     else

--- a/lib/new_relic/agent/instrumentation/redis/chain.rb
+++ b/lib/new_relic/agent/instrumentation/redis/chain.rb
@@ -10,19 +10,19 @@ module NewRelic::Agent::Instrumentation
         ::Redis::Client.class_eval do
           include NewRelic::Agent::Instrumentation::Redis
 
-          alias_method :call_without_new_relic, :call
+          alias_method(:call_without_new_relic, :call)
 
           def call(*args, &block)
             call_with_tracing(args[0]) { call_without_new_relic(*args, &block) }
           end
 
-          alias_method :call_pipeline_without_new_relic, :call_pipeline
+          alias_method(:call_pipeline_without_new_relic, :call_pipeline)
 
           def call_pipeline(*args, &block)
             call_pipeline_with_tracing(args[0]) { call_pipeline_without_new_relic(*args, &block) }
           end
 
-          alias_method :connect_without_new_relic, :connect
+          alias_method(:connect_without_new_relic, :connect)
 
           def connect(*args, &block)
             connect_with_tracing { connect_without_new_relic(*args, &block) }

--- a/lib/new_relic/agent/instrumentation/redis/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/redis/instrumentation.rb
@@ -51,14 +51,14 @@ module NewRelic::Agent::Instrumentation
     def _nr_hostname
       self.path ? LOCALHOST : self.host
     rescue => e
-      NewRelic::Agent.logger.debug "Failed to retrieve Redis host: #{e}"
+      NewRelic::Agent.logger.debug("Failed to retrieve Redis host: #{e}")
       UNKNOWN
     end
 
     def _nr_port_path_or_id
       self.path || self.port
     rescue => e
-      NewRelic::Agent.logger.debug "Failed to retrieve Redis port_path_or_id: #{e}"
+      NewRelic::Agent.logger.debug("Failed to retrieve Redis port_path_or_id: #{e}")
       UNKNOWN
     end
   end

--- a/lib/new_relic/agent/instrumentation/resque.rb
+++ b/lib/new_relic/agent/instrumentation/resque.rb
@@ -20,12 +20,12 @@ DependencyDetection.defer do
   end
 
   executes do
-    ::NewRelic::Agent.logger.info 'Installing Resque instrumentation'
+    ::NewRelic::Agent.logger.info('Installing Resque instrumentation')
   end
 
   executes do
     if NewRelic::Agent.config[:'resque.use_ruby_dns'] && NewRelic::Agent.config[:dispatcher] == :resque
-      ::NewRelic::Agent.logger.info 'Requiring resolv-replace'
+      ::NewRelic::Agent.logger.info('Requiring resolv-replace')
       require 'resolv'
       require 'resolv-replace'
     end

--- a/lib/new_relic/agent/instrumentation/resque/chain.rb
+++ b/lib/new_relic/agent/instrumentation/resque/chain.rb
@@ -10,7 +10,7 @@ module NewRelic::Agent::Instrumentation
         ::Resque::Job.class_eval do
           include NewRelic::Agent::Instrumentation::Resque
 
-          alias_method :perform_without_instrumentation, :perform
+          alias_method(:perform_without_instrumentation, :perform)
 
           def perform
             with_tracing { perform_without_instrumentation }

--- a/lib/new_relic/agent/instrumentation/sequel.rb
+++ b/lib/new_relic/agent/instrumentation/sequel.rb
@@ -25,24 +25,24 @@ DependencyDetection.defer do
   executes do
     if supported_sequel_version?
 
-      ::NewRelic::Agent.logger.info 'Installing Sequel instrumentation'
+      ::NewRelic::Agent.logger.info('Installing Sequel instrumentation')
 
       if Sequel::Database.respond_to?(:extension)
-        Sequel::Database.extension :newrelic_instrumentation
+        Sequel::Database.extension(:newrelic_instrumentation)
       else
-        NewRelic::Agent.logger.info "Detected Sequel version %s." % [Sequel::VERSION]
-        NewRelic::Agent.logger.info "Please see additional documentation: " +
-          "https://newrelic.com/docs/ruby/sequel-instrumentation"
+        NewRelic::Agent.logger.info("Detected Sequel version %s." % [Sequel::VERSION])
+        NewRelic::Agent.logger.info("Please see additional documentation: " +
+          "https://newrelic.com/docs/ruby/sequel-instrumentation")
       end
 
       Sequel.synchronize { Sequel::DATABASES.dup }.each do |db|
-        db.extension :newrelic_instrumentation
+        db.extension(:newrelic_instrumentation)
       end
 
       Sequel::Model.plugin(:newrelic_instrumentation) if defined?(Sequel::Model)
     else
 
-      NewRelic::Agent.logger.info "Sequel instrumentation requires at least version 3.37.0."
+      NewRelic::Agent.logger.info("Sequel instrumentation requires at least version 3.37.0.")
 
     end
   end

--- a/lib/new_relic/agent/instrumentation/sidekiq.rb
+++ b/lib/new_relic/agent/instrumentation/sidekiq.rb
@@ -11,7 +11,7 @@ DependencyDetection.defer do
   end
 
   executes do
-    ::NewRelic::Agent.logger.info 'Installing Sidekiq instrumentation'
+    ::NewRelic::Agent.logger.info('Installing Sidekiq instrumentation')
   end
 
   executes do
@@ -82,16 +82,16 @@ DependencyDetection.defer do
 
     Sidekiq.configure_client do |config|
       config.client_middleware do |chain|
-        chain.add NewRelic::SidekiqInstrumentation::Client
+        chain.add(NewRelic::SidekiqInstrumentation::Client)
       end
     end
 
     Sidekiq.configure_server do |config|
       config.client_middleware do |chain|
-        chain.add NewRelic::SidekiqInstrumentation::Client
+        chain.add(NewRelic::SidekiqInstrumentation::Client)
       end
       config.server_middleware do |chain|
-        chain.add NewRelic::SidekiqInstrumentation::Server
+        chain.add(NewRelic::SidekiqInstrumentation::Server)
       end
 
       if config.respond_to?(:error_handlers)

--- a/lib/new_relic/agent/instrumentation/sinatra.rb
+++ b/lib/new_relic/agent/instrumentation/sinatra.rb
@@ -18,7 +18,7 @@ DependencyDetection.defer do
   depends_on { Sinatra::Base.private_method_defined?(:route_eval) }
 
   executes do
-    ::NewRelic::Agent.logger.info 'Installing Sinatra instrumentation'
+    ::NewRelic::Agent.logger.info('Installing Sinatra instrumentation')
   end
 
   executes do

--- a/lib/new_relic/agent/instrumentation/sinatra/ignorer.rb
+++ b/lib/new_relic/agent/instrumentation/sinatra/ignorer.rb
@@ -31,7 +31,7 @@ module NewRelic::Agent::Instrumentation
       def set_newrelic_ignore(type, *routes)
         # Important to default this in the context of the actual app
         # If it's done at register time, ignores end up shared between apps.
-        set :newrelic_ignores, Hash.new([]) if !respond_to?(:newrelic_ignores)
+        set(:newrelic_ignores, Hash.new([])) if !respond_to?(:newrelic_ignores)
 
         # If we call an ignore without a route, it applies to the whole app
         routes = ["*"] if routes.empty?

--- a/lib/new_relic/agent/instrumentation/sinatra/transaction_namer.rb
+++ b/lib/new_relic/agent/instrumentation/sinatra/transaction_namer.rb
@@ -13,7 +13,7 @@ module NewRelic
           SINATRA_ROUTE = 'sinatra.route'
 
           def transaction_name_for_route(env, request)
-            if env.key? SINATRA_ROUTE
+            if env.key?(SINATRA_ROUTE)
               env[SINATRA_ROUTE]
             else
               name = route_for_sinatra(env)

--- a/lib/new_relic/agent/instrumentation/sunspot.rb
+++ b/lib/new_relic/agent/instrumentation/sunspot.rb
@@ -11,7 +11,7 @@ DependencyDetection.defer do
   end
 
   executes do
-    ::NewRelic::Agent.logger.info 'Installing Rails Sunspot instrumentation'
+    ::NewRelic::Agent.logger.info('Installing Rails Sunspot instrumentation')
     deprecation_msg = 'The instrumentation for Sunspot is deprecated. ' \
       'It will be removed in version 9.0.0.'
 

--- a/lib/new_relic/agent/instrumentation/thread.rb
+++ b/lib/new_relic/agent/instrumentation/thread.rb
@@ -10,7 +10,7 @@ DependencyDetection.defer do
   named :thread
 
   executes do
-    ::NewRelic::Agent.logger.info 'Installing Thread Instrumentation'
+    ::NewRelic::Agent.logger.info('Installing Thread Instrumentation')
 
     if use_prepend?
       prepend_instrument ::Thread, ::NewRelic::Agent::Instrumentation::MonitoredThread::Prepend

--- a/lib/new_relic/agent/instrumentation/thread/chain.rb
+++ b/lib/new_relic/agent/instrumentation/thread/chain.rb
@@ -12,7 +12,7 @@ module NewRelic::Agent::Instrumentation
         ::Thread.class_eval do
           include NewRelic::Agent::Instrumentation::MonitoredThread
 
-          alias_method :initialize_without_new_relic, :initialize
+          alias_method(:initialize_without_new_relic, :initialize)
 
           def initialize(*args, &block)
             traced_block = add_thread_tracing(*args, &block)

--- a/lib/new_relic/agent/instrumentation/typhoeus.rb
+++ b/lib/new_relic/agent/instrumentation/typhoeus.rb
@@ -19,7 +19,7 @@ DependencyDetection.defer do
   end
 
   executes do
-    ::NewRelic::Agent.logger.info 'Installing Typhoeus instrumentation'
+    ::NewRelic::Agent.logger.info('Installing Typhoeus instrumentation')
     require 'new_relic/agent/distributed_tracing/cross_app_tracing'
     require 'new_relic/agent/http_clients/typhoeus_wrappers'
   end

--- a/lib/new_relic/agent/instrumentation/typhoeus/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/typhoeus/instrumentation.rb
@@ -32,8 +32,8 @@ module NewRelic
         end
 
         def with_tracing
-          segment = NewRelic::Agent::Tracer.start_segment name: HYDRA_SEGMENT_NAME
-          instance_variable_set :@__newrelic_hydra_segment, segment
+          segment = NewRelic::Agent::Tracer.start_segment(name: HYDRA_SEGMENT_NAME)
+          instance_variable_set(:@__newrelic_hydra_segment, segment)
           begin
             yield
           ensure
@@ -58,15 +58,15 @@ module NewRelic
             parent: parent
           )
 
-          segment.add_request_headers wrapped_request
+          segment.add_request_headers(wrapped_request)
 
           callback = Proc.new do
             wrapped_response = HTTPClients::TyphoeusHTTPResponse.new(request.response)
 
-            segment.process_response_headers wrapped_response
+            segment.process_response_headers(wrapped_response)
 
             if request.response.code == 0
-              segment.notice_error NoticibleError.new NOTICIBLE_ERROR_CLASS, response_message(request.response)
+              segment.notice_error(NoticibleError.new(NOTICIBLE_ERROR_CLASS, response_message(request.response)))
             end
 
             segment.finish if segment

--- a/lib/new_relic/agent/javascript_instrumentor.rb
+++ b/lib/new_relic/agent/javascript_instrumentor.rb
@@ -57,25 +57,25 @@ module NewRelic
           true
         end
       rescue => e
-        ::NewRelic::Agent.logger.debug "Failure during 'js_enabled_and_ready?'", e
+        ::NewRelic::Agent.logger.debug("Failure during 'js_enabled_and_ready?'", e)
         false
       end
 
       def insert_js?(state)
         if !state.current_transaction
-          ::NewRelic::Agent.logger.debug "Not in transaction. Skipping browser instrumentation."
+          ::NewRelic::Agent.logger.debug("Not in transaction. Skipping browser instrumentation.")
           false
         elsif !state.is_execution_traced?
-          ::NewRelic::Agent.logger.debug "Execution is not traced. Skipping browser instrumentation."
+          ::NewRelic::Agent.logger.debug("Execution is not traced. Skipping browser instrumentation.")
           false
         elsif state.current_transaction.ignore_enduser?
-          ::NewRelic::Agent.logger.debug "Ignore end user for this transaction is set. Skipping browser instrumentation."
+          ::NewRelic::Agent.logger.debug("Ignore end user for this transaction is set. Skipping browser instrumentation.")
           false
         else
           true
         end
       rescue => e
-        ::NewRelic::Agent.logger.debug "Failure during insert_js", e
+        ::NewRelic::Agent.logger.debug("Failure during insert_js", e)
         false
       end
 
@@ -96,7 +96,7 @@ module NewRelic
 
         bt_config + browser_timing_loader(nonce)
       rescue => e
-        ::NewRelic::Agent.logger.debug "Failure during RUM browser_timing_header construction", e
+        ::NewRelic::Agent.logger.debug("Failure during RUM browser_timing_header construction", e)
         ''
       end
 

--- a/lib/new_relic/agent/logging.rb
+++ b/lib/new_relic/agent/logging.rb
@@ -36,7 +36,7 @@ module NewRelic
         REPLACEMENT_CHAR = '�'
 
         def initialize
-          Agent.config.register_callback :app_name do
+          Agent.config.register_callback(:app_name) do
             @app_name = nil
           end
         end
@@ -44,34 +44,34 @@ module NewRelic
         def call severity, time, progname, msg
           message = String.new('{')
           if app_name
-            add_key_value message, ENTITY_NAME_KEY, app_name
+            add_key_value(message, ENTITY_NAME_KEY, app_name)
             message << COMMA
           end
-          add_key_value message, ENTITY_TYPE_KEY, ENTITY_TYPE
+          add_key_value(message, ENTITY_TYPE_KEY, ENTITY_TYPE)
           message << COMMA
-          add_key_value message, HOSTNAME_KEY, Hostname.get
+          add_key_value(message, HOSTNAME_KEY, Hostname.get)
 
           if entity_guid = Agent.config[:entity_guid]
             message << COMMA
-            add_key_value message, ENTITY_GUID_KEY, entity_guid
+            add_key_value(message, ENTITY_GUID_KEY, entity_guid)
           end
 
           if trace_id = Tracer.trace_id
             message << COMMA
-            add_key_value message, TRACE_ID_KEY, trace_id
+            add_key_value(message, TRACE_ID_KEY, trace_id)
           end
           if span_id = Tracer.span_id
             message << COMMA
-            add_key_value message, SPAN_ID_KEY, span_id
+            add_key_value(message, SPAN_ID_KEY, span_id)
           end
 
           message << COMMA
           message << QUOTE << MESSAGE_KEY << QUOTE << COLON << escape(msg)
           message << COMMA
-          add_key_value message, LOG_LEVEL_KEY, severity
+          add_key_value(message, LOG_LEVEL_KEY, severity)
           if progname
             message << COMMA
-            add_key_value message, LOG_NAME_KEY, progname
+            add_key_value(message, LOG_NAME_KEY, progname)
           end
 
           message << COMMA

--- a/lib/new_relic/agent/messaging.rb
+++ b/lib/new_relic/agent/messaging.rb
@@ -125,24 +125,24 @@ module NewRelic
         txn = nil
 
         begin
-          txn_name = transaction_name library, destination_type, destination_name
+          txn_name = transaction_name(library, destination_type, destination_name)
 
-          txn = Tracer.start_transaction name: txn_name, category: :message
+          txn = Tracer.start_transaction(name: txn_name, category: :message)
 
           if headers
-            txn.distributed_tracer.consume_message_headers headers, state, RABBITMQ_TRANSPORT_TYPE
+            txn.distributed_tracer.consume_message_headers(headers, state, RABBITMQ_TRANSPORT_TYPE)
             CrossAppTracing.reject_messaging_cat_headers(headers).each do |k, v|
-              txn.add_agent_attribute :"message.headers.#{k}", v, AttributeFilter::DST_NONE unless v.nil?
+              txn.add_agent_attribute(:"message.headers.#{k}", v, AttributeFilter::DST_NONE) unless v.nil?
             end
           end
 
-          txn.add_agent_attribute :'message.routingKey', routing_key, ATTR_DESTINATION if routing_key
-          txn.add_agent_attribute :'message.exchangeType', exchange_type, AttributeFilter::DST_NONE if exchange_type
-          txn.add_agent_attribute :'message.correlationId', correlation_id, AttributeFilter::DST_NONE if correlation_id
-          txn.add_agent_attribute :'message.queueName', queue_name, ATTR_DESTINATION if queue_name
-          txn.add_agent_attribute :'message.replyTo', reply_to, AttributeFilter::DST_NONE if reply_to
+          txn.add_agent_attribute(:'message.routingKey', routing_key, ATTR_DESTINATION) if routing_key
+          txn.add_agent_attribute(:'message.exchangeType', exchange_type, AttributeFilter::DST_NONE) if exchange_type
+          txn.add_agent_attribute(:'message.correlationId', correlation_id, AttributeFilter::DST_NONE) if correlation_id
+          txn.add_agent_attribute(:'message.queueName', queue_name, ATTR_DESTINATION) if queue_name
+          txn.add_agent_attribute(:'message.replyTo', reply_to, AttributeFilter::DST_NONE) if reply_to
         rescue => e
-          NewRelic::Agent.logger.error "Error starting Message Broker consume transaction", e
+          NewRelic::Agent.logger.error("Error starting Message Broker consume transaction", e)
         end
 
         yield
@@ -150,7 +150,7 @@ module NewRelic
         begin
           txn.finish if txn
         rescue => e
-          NewRelic::Agent.logger.error "Error stopping Message Broker consume transaction", e
+          NewRelic::Agent.logger.error("Error stopping Message Broker consume transaction", e)
         end
       end
 
@@ -258,8 +258,8 @@ module NewRelic
 
         if segment_parameters_enabled?
           if message_properties[:headers] && !message_properties[:headers].empty?
-            non_cat_headers = CrossAppTracing.reject_messaging_cat_headers message_properties[:headers]
-            non_synth_headers = SyntheticsMonitor.reject_messaging_synthetics_header non_cat_headers
+            non_cat_headers = CrossAppTracing.reject_messaging_cat_headers(message_properties[:headers])
+            non_synth_headers = SyntheticsMonitor.reject_messaging_synthetics_header(non_cat_headers)
             segment.params[:headers] = non_synth_headers unless non_synth_headers.empty?
           end
 
@@ -308,7 +308,7 @@ module NewRelic
         queue_name: nil,
         &block
 
-        wrap_message_broker_consume_transaction library: library,
+        wrap_message_broker_consume_transaction(library: library,
           destination_type: :exchange,
           destination_name: Instrumentation::Bunny.exchange_name(destination_name),
           routing_key: delivery_info[:routing_key],
@@ -316,7 +316,7 @@ module NewRelic
           queue_name: queue_name,
           exchange_type: exchange_type,
           headers: message_properties[:headers],
-          correlation_id: message_properties[:correlation_id], &block
+          correlation_id: message_properties[:correlation_id], &block)
       end
 
       private

--- a/lib/new_relic/agent/method_tracer.rb
+++ b/lib/new_relic/agent/method_tracer.rb
@@ -69,7 +69,7 @@ module NewRelic
       # @api public
       #
       def trace_execution_scoped(metric_names, options = NewRelic::EMPTY_HASH) # THREAD_LOCAL_ACCESS
-        NewRelic::Agent.record_api_supportability_metric :trace_execution_scoped unless options[:internal]
+        NewRelic::Agent.record_api_supportability_metric(:trace_execution_scoped) unless options[:internal]
         NewRelic::Agent::MethodTracerHelpers.trace_execution_scoped(metric_names, options) do
           # Using an implicit block avoids object allocation for a &block param
           yield
@@ -85,7 +85,7 @@ module NewRelic
       # @api public
       #
       def trace_execution_unscoped(metric_names, options = NewRelic::EMPTY_HASH) # THREAD_LOCAL_ACCESS
-        NewRelic::Agent.record_api_supportability_metric :trace_execution_unscoped unless options[:internal]
+        NewRelic::Agent.record_api_supportability_metric(:trace_execution_unscoped) unless options[:internal]
         return yield unless NewRelic::Agent.tl_is_execution_traced?
         t0 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
         begin
@@ -164,7 +164,7 @@ module NewRelic
           # for testing only
           def _nr_clear_traced_methods!
             _nr_traced_method_module.module_eval do
-              self.instance_methods.each { |m| remove_method m }
+              self.instance_methods.each { |m| remove_method(m) }
             end
           end
 
@@ -269,7 +269,7 @@ module NewRelic
 
           options = _nr_validate_method_tracer_options(method_name, options)
 
-          visibility = NewRelic::Helper.instance_method_visibility self, method_name
+          visibility = NewRelic::Helper.instance_method_visibility(self, method_name)
 
           scoped_metric, unscoped_metrics = _nr_scoped_unscoped_metrics(metric_name, method_name, push_scope: options[:push_scope])
 
@@ -350,7 +350,7 @@ module NewRelic
               end
             end
 
-            send visibility, method_name
+            send(visibility, method_name)
             ruby2_keywords(method_name) if respond_to?(:ruby2_keywords, true)
           end
         end

--- a/lib/new_relic/agent/monitors.rb
+++ b/lib/new_relic/agent/monitors.rb
@@ -18,9 +18,9 @@ module NewRelic
       attr_reader :distributed_tracing_monitor
 
       def initialize events
-        @synthetics_monitor = NewRelic::Agent::SyntheticsMonitor.new events
-        @cross_app_monitor = NewRelic::Agent::DistributedTracing::CrossAppMonitor.new events
-        @distributed_tracing_monitor = NewRelic::Agent::DistributedTracing::Monitor.new events
+        @synthetics_monitor = NewRelic::Agent::SyntheticsMonitor.new(events)
+        @cross_app_monitor = NewRelic::Agent::DistributedTracing::CrossAppMonitor.new(events)
+        @distributed_tracing_monitor = NewRelic::Agent::DistributedTracing::Monitor.new(events)
       end
     end
   end

--- a/lib/new_relic/agent/monitors/cross_app_monitor.rb
+++ b/lib/new_relic/agent/monitors/cross_app_monitor.rb
@@ -59,7 +59,7 @@ module NewRelic
                 txn.distributed_tracer.cross_app_payload = payload
               end
 
-              CrossAppTracing.assign_intrinsic_transaction_attributes state
+              CrossAppTracing.assign_intrinsic_transaction_attributes(state)
             end
           end
 

--- a/lib/new_relic/agent/monitors/distributed_tracing_monitor.rb
+++ b/lib/new_relic/agent/monitors/distributed_tracing_monitor.rb
@@ -14,13 +14,13 @@ module NewRelic
 
         def on_before_call(request)
           unless NewRelic::Agent.config[:'distributed_tracing.enabled']
-            NewRelic::Agent.logger.warn "Not configured to accept distributed trace headers"
+            NewRelic::Agent.logger.warn("Not configured to accept distributed trace headers")
             return
           end
 
           return unless txn = Tracer.current_transaction
 
-          txn.distributed_tracer.accept_incoming_request request
+          txn.distributed_tracer.accept_incoming_request(request)
         end
       end
     end

--- a/lib/new_relic/agent/new_relic_service.rb
+++ b/lib/new_relic/agent/new_relic_service.rb
@@ -352,7 +352,7 @@ module NewRelic
         start_connection(conn)
         conn
       rescue Timeout::Error
-        ::NewRelic::Agent.logger.info ("Timeout while attempting to connect. You may need to install system-level CA Certificates, as the ruby agent no longer includes these.")
+        ::NewRelic::Agent.logger.info("Timeout while attempting to connect. You may need to install system-level CA Certificates, as the ruby agent no longer includes these.")
         raise
       end
 
@@ -360,7 +360,7 @@ module NewRelic
       # connection if verify_peer is enabled
       def cert_file_path
         if path_override = NewRelic::Agent.config[:ca_bundle_path]
-          NewRelic::Agent.logger.warn("Couldn't find CA bundle from configured ca_bundle_path: #{path_override}") unless File.exist? path_override
+          NewRelic::Agent.logger.warn("Couldn't find CA bundle from configured ca_bundle_path: #{path_override}") unless File.exist?(path_override)
           path_override
         end
       end
@@ -499,7 +499,7 @@ module NewRelic
       # than the limit configured in the control object
       def check_post_size(post_string, endpoint)
         return if post_string.size < Agent.config[:max_payload_size_in_bytes]
-        ::NewRelic::Agent.logger.debug "Tried to send too much data: #{post_string.size} bytes"
+        ::NewRelic::Agent.logger.debug("Tried to send too much data: #{post_string.size} bytes")
         NewRelic::Agent.increment_metric("Supportability/Agent/Collector/#{endpoint}/MaxPayloadSizeLimit")
         raise UnrecoverableServerException.new('413 Request Entity Too Large')
       end
@@ -539,7 +539,7 @@ module NewRelic
         begin
           attempts += 1
           conn = http_connection
-          ::NewRelic::Agent.logger.debug "Sending request to #{opts[:collector]}#{opts[:uri]} with #{request.method}"
+          ::NewRelic::Agent.logger.debug("Sending request to #{opts[:collector]}#{opts[:uri]} with #{request.method}")
           Timeout.timeout(@request_timeout) do
             response = conn.request(request)
           end
@@ -598,7 +598,7 @@ module NewRelic
       end
 
       def log_response(response)
-        ::NewRelic::Agent.logger.debug "Received response, status: #{response.code}, encoding: '#{response['content-encoding']}'"
+        ::NewRelic::Agent.logger.debug("Received response, status: #{response.code}, encoding: '#{response['content-encoding']}'")
       end
 
       # Per protocol 17, this metric should be recorded for all error response codes

--- a/lib/new_relic/agent/new_relic_service/encoders.rb
+++ b/lib/new_relic/agent/new_relic_service/encoders.rb
@@ -30,7 +30,7 @@ module NewRelic
 
             def self.encode(data, opts = nil)
               output = StringIO.new
-              output.set_encoding BINARY
+              output.set_encoding(BINARY)
               gz = Zlib::GzipWriter.new(output, Zlib::DEFAULT_COMPRESSION, Zlib::DEFAULT_STRATEGY)
               gz.write(data)
               gz.close

--- a/lib/new_relic/agent/new_relic_service/json_marshaller.rb
+++ b/lib/new_relic/agent/new_relic_service/json_marshaller.rb
@@ -21,11 +21,11 @@ module NewRelic
           if defined?(::Yajl)
             require 'yajl/version'
             if Gem::Version.new(::Yajl::VERSION) < OK_YAJL_VERSION
-              ::NewRelic::Agent.logger.warn "Detected yajl-ruby version #{::Yajl::VERSION} which can cause segfaults with newrelic_rpm's thread profiling features. We strongly recommend you upgrade to the latest yajl-ruby version available."
+              ::NewRelic::Agent.logger.warn("Detected yajl-ruby version #{::Yajl::VERSION} which can cause segfaults with newrelic_rpm's thread profiling features. We strongly recommend you upgrade to the latest yajl-ruby version available.")
             end
           end
         rescue => err
-          ::NewRelic::Agent.logger.warn "Failed trying to watch for problematic yajl-ruby version.", err
+          ::NewRelic::Agent.logger.warn("Failed trying to watch for problematic yajl-ruby version.", err)
         end
 
         def dump(ruby, opts = {})
@@ -45,7 +45,7 @@ module NewRelic
 
           return_value(::JSON.load(data))
         rescue => e
-          ::NewRelic::Agent.logger.debug "#{e.class.name} : #{e.message} encountered loading collector response: #{data}"
+          ::NewRelic::Agent.logger.debug("#{e.class.name} : #{e.message} encountered loading collector response: #{data}")
           raise
         end
 

--- a/lib/new_relic/agent/pipe_channel_manager.rb
+++ b/lib/new_relic/agent/pipe_channel_manager.rb
@@ -189,15 +189,15 @@ module NewRelic
                 begin
                   wake.out.read_nonblock(1) if ready_pipes.include?(wake.out)
                 rescue IO::WaitReadable
-                  NewRelic::Agent.logger.error 'Issue while reading from the ready pipe'
-                  NewRelic::Agent.logger.error "Ready pipes: #{ready_pipes.map(&:to_s)}, wake.out pipe: #{wake.out}"
+                  NewRelic::Agent.logger.error('Issue while reading from the ready pipe')
+                  NewRelic::Agent.logger.error("Ready pipes: #{ready_pipes.map(&:to_s)}, wake.out pipe: #{wake.out}")
                 end
               end
 
               break unless should_keep_listening?
             end
           end
-          sleep 0.001 # give time for the thread to spawn
+          sleep(0.001) # give time for the thread to spawn
         end
 
         def stop_listener_thread
@@ -254,8 +254,8 @@ module NewRelic
         def unmarshal(data)
           Marshal.load(data)
         rescue StandardError => e
-          ::NewRelic::Agent.logger.error "Failure unmarshalling message from Resque child process", e
-          ::NewRelic::Agent.logger.debug Base64.encode64(data)
+          ::NewRelic::Agent.logger.error("Failure unmarshalling message from Resque child process", e)
+          ::NewRelic::Agent.logger.debug(Base64.encode64(data))
           nil
         end
 

--- a/lib/new_relic/agent/range_extensions.rb
+++ b/lib/new_relic/agent/range_extensions.rb
@@ -13,7 +13,7 @@ module NewRelic
       end
 
       def merge r1, r2
-        return unless intersects? r1, r2
+        return unless intersects?(r1, r2)
         range_min = r1.begin < r2.begin ? r1.begin : r2.begin
         range_max = r1.end > r2.end ? r1.end : r2.end
         range_min..range_max
@@ -29,7 +29,7 @@ module NewRelic
             return ranges
           end
         end
-        ranges.push range
+        ranges.push(range)
       end
 
       # Computes the amount of overlap between range and an array of ranges.
@@ -37,7 +37,7 @@ module NewRelic
       # ranges in the ranges array.
       def compute_overlap range, ranges
         ranges.inject(0) do |memo, other|
-          next memo unless intersects? range, other
+          next memo unless intersects?(range, other)
           lower_bound = range.begin > other.begin ? range.begin : other.begin
           upper_bound = range.end < other.end ? range.end : other.end
           memo += upper_bound - lower_bound

--- a/lib/new_relic/agent/rules_engine.rb
+++ b/lib/new_relic/agent/rules_engine.rb
@@ -37,7 +37,7 @@ module NewRelic
             # Build segment_rules in reverse order from which they're provided,
             # so that when we eliminate duplicates with #uniq!, we retain the last
             # instances of repeated rules.
-            segment_rules.unshift SegmentTermsRule.new(spec)
+            segment_rules.unshift(SegmentTermsRule.new(spec))
           end
         end
 

--- a/lib/new_relic/agent/rules_engine/replacement_rule.rb
+++ b/lib/new_relic/agent/rules_engine/replacement_rule.rb
@@ -37,7 +37,7 @@ module NewRelic
               segment.match(@match_expression)
             end
           else
-            string.match @match_expression
+            string.match(@match_expression)
           end
         end
 

--- a/lib/new_relic/agent/samplers/memory_sampler.rb
+++ b/lib/new_relic/agent/samplers/memory_sampler.rb
@@ -23,10 +23,10 @@ module NewRelic
           elsif platform =~ /linux/
             @sampler = ProcStatus.new
             if !@sampler.can_run?
-              ::NewRelic::Agent.logger.debug "Error attempting to use /proc/#{$$}/status file for reading memory. Using ps command instead."
+              ::NewRelic::Agent.logger.debug("Error attempting to use /proc/#{$$}/status file for reading memory. Using ps command instead.")
               @sampler = ShellPS.new("ps -o rsz")
             else
-              ::NewRelic::Agent.logger.debug "Using /proc/#{$$}/status for reading process memory."
+              ::NewRelic::Agent.logger.debug("Using /proc/#{$$}/status for reading process memory.")
             end
           elsif platform =~ /darwin9/ # 10.5
             @sampler = ShellPS.new("ps -o rsz")
@@ -85,12 +85,12 @@ module NewRelic
             begin
               m = get_memory
               if m.nil?
-                ::NewRelic::Agent.logger.warn "Unable to get the resident memory for process #{$$}.  Disabling memory sampler."
+                ::NewRelic::Agent.logger.warn("Unable to get the resident memory for process #{$$}.  Disabling memory sampler.")
                 @broken = true
               end
               return m
             rescue => e
-              ::NewRelic::Agent.logger.warn "Unable to get the resident memory for process #{$$}. Disabling memory sampler.", e
+              ::NewRelic::Agent.logger.warn("Unable to get the resident memory for process #{$$}. Disabling memory sampler.", e)
               @broken = true
               return nil
             end

--- a/lib/new_relic/agent/span_event_aggregator.rb
+++ b/lib/new_relic/agent/span_event_aggregator.rb
@@ -25,7 +25,7 @@ module NewRelic
         return unless enabled?
 
         @lock.synchronize do
-          @buffer.append priority: priority, event: event, &blk
+          @buffer.append(priority: priority, event: event, &blk)
           notify_if_full
         end
       end

--- a/lib/new_relic/agent/sql_sampler.rb
+++ b/lib/new_relic/agent/sql_sampler.rb
@@ -75,8 +75,8 @@ module NewRelic
         data.set_transaction_name(name)
         if data.sql_data.size > 0
           @samples_lock.synchronize do
-            ::NewRelic::Agent.logger.debug "Examining #{data.sql_data.size} slow transaction sql statement(s)"
-            save_slow_sql data
+            ::NewRelic::Agent.logger.debug("Examining #{data.sql_data.size} slow transaction sql statement(s)")
+            save_slow_sql(data)
           end
         end
       end
@@ -163,7 +163,7 @@ module NewRelic
         if transaction && transaction.distributed_tracer.distributed_trace_payload
           params = {}
           payload = transaction.distributed_tracer.distributed_trace_payload
-          DistributedTraceAttributes.copy_from_transaction transaction, payload, params
+          DistributedTraceAttributes.copy_from_transaction(transaction, payload, params)
           params[PRIORITY] = transaction.priority
         end
         params
@@ -177,7 +177,7 @@ module NewRelic
         if state.is_sql_recorded?
           if duration > Agent.config[:'slow_sql.explain_threshold']
             backtrace = caller.join("\n")
-            params = distributed_trace_attributes state
+            params = distributed_trace_attributes(state)
             data.sql_data << SlowSql.new(statement, metric_name, duration, backtrace, params)
           end
         end
@@ -301,7 +301,7 @@ module NewRelic
         super()
         @params = slow_sql.base_params
         @sql_id = consistent_hash(normalized_query)
-        set_primary slow_sql, path, uri
+        set_primary(slow_sql, path, uri)
         record_data_point(float(slow_sql.duration))
       end
 
@@ -316,7 +316,7 @@ module NewRelic
 
       def aggregate(slow_sql, path, uri)
         if slow_sql.duration > max_call_time
-          set_primary slow_sql, path, uri
+          set_primary(slow_sql, path, uri)
         end
 
         record_data_point(float(slow_sql.duration))

--- a/lib/new_relic/agent/stats.rb
+++ b/lib/new_relic/agent/stats.rb
@@ -67,7 +67,7 @@ module NewRelic
 
       def record(value = nil, aux = nil, &blk)
         if blk
-          yield self
+          yield(self)
         else
           case value
           when Numeric

--- a/lib/new_relic/agent/stats_engine/stats_hash.rb
+++ b/lib/new_relic/agent/stats_engine/stats_hash.rb
@@ -77,11 +77,11 @@ module NewRelic
 
       def each
         @scoped.each do |k, v|
-          yield k, v
+          yield(k, v)
         end
         @unscoped.each do |k, v|
           spec = NewRelic::MetricSpec.new(k)
-          yield spec, v
+          yield(spec, v)
         end
       end
 

--- a/lib/new_relic/agent/synthetics_event_aggregator.rb
+++ b/lib/new_relic/agent/synthetics_event_aggregator.rb
@@ -21,14 +21,14 @@ module NewRelic
         return unless enabled?
 
         @lock.synchronize do
-          @buffer.append event: event, priority: -event[0][TIMESTAMP]
+          @buffer.append(event: event, priority: -event[0][TIMESTAMP])
         end
       end
 
       private
 
       def after_harvest metadata
-        record_dropped_synthetics metadata
+        record_dropped_synthetics(metadata)
       end
 
       def record_dropped_synthetics metadata

--- a/lib/new_relic/agent/system_info.rb
+++ b/lib/new_relic/agent/system_info.rb
@@ -203,7 +203,7 @@ module NewRelic
           return
         when /docker/
           ::NewRelic::Agent.logger.debug("Cgroup indicates docker but container_id unrecognized: '#{cpu_cgroup}'")
-          ::NewRelic::Agent.increment_metric "Supportability/utilization/docker/error"
+          ::NewRelic::Agent.increment_metric("Supportability/utilization/docker/error")
           return
         else
           ::NewRelic::Agent.logger.debug("Ignoring unrecognized cgroup ID format: '#{cpu_cgroup}'")
@@ -212,7 +212,7 @@ module NewRelic
 
         if container_id && container_id.size != 64
           ::NewRelic::Agent.logger.debug("Found docker container_id with invalid length: #{container_id}")
-          ::NewRelic::Agent.increment_metric "Supportability/utilization/docker/error"
+          ::NewRelic::Agent.increment_metric("Supportability/utilization/docker/error")
           nil
         else
           container_id
@@ -288,7 +288,7 @@ module NewRelic
           if bid.ascii_only?
             if bid.empty?
               ::NewRelic::Agent.logger.debug("boot_id not found in /proc/sys/kernel/random/boot_id")
-              ::NewRelic::Agent.increment_metric "Supportability/utilization/boot_id/error"
+              ::NewRelic::Agent.increment_metric("Supportability/utilization/boot_id/error")
               nil
 
             elsif bid.bytesize == 36
@@ -296,19 +296,19 @@ module NewRelic
 
             else
               ::NewRelic::Agent.logger.debug("Found boot_id with invalid length: #{bid}")
-              ::NewRelic::Agent.increment_metric "Supportability/utilization/boot_id/error"
+              ::NewRelic::Agent.increment_metric("Supportability/utilization/boot_id/error")
               bid[0, 128]
 
             end
           else
             ::NewRelic::Agent.logger.debug("Found boot_id with non-ASCII characters: #{bid}")
-            ::NewRelic::Agent.increment_metric "Supportability/utilization/boot_id/error"
+            ::NewRelic::Agent.increment_metric("Supportability/utilization/boot_id/error")
             nil
 
           end
         else
           ::NewRelic::Agent.logger.debug("boot_id not found in /proc/sys/kernel/random/boot_id")
-          ::NewRelic::Agent.increment_metric "Supportability/utilization/boot_id/error"
+          ::NewRelic::Agent.increment_metric("Supportability/utilization/boot_id/error")
           nil
 
         end

--- a/lib/new_relic/agent/threading/backtrace_node.rb
+++ b/lib/new_relic/agent/threading/backtrace_node.rb
@@ -19,7 +19,7 @@ module NewRelic
 
         def add_child_unless_present(child)
           child.depth = @depth + 1
-          @children << child unless @children.include? child
+          @children << child unless @children.include?(child)
         end
 
         def add_child(child)

--- a/lib/new_relic/agent/tracer.rb
+++ b/lib/new_relic/agent/tracer.rb
@@ -235,8 +235,8 @@ module NewRelic
           start_time: nil,
           parent: nil)
 
-          segment = Transaction::Segment.new name, unscoped_metrics, start_time
-          start_and_add_segment segment, parent
+          segment = Transaction::Segment.new(name, unscoped_metrics, start_time)
+          start_and_add_segment(segment, parent)
         rescue ArgumentError
           raise
         rescue => exception
@@ -293,8 +293,8 @@ module NewRelic
           product ||= UNKNOWN
           operation ||= OTHER
 
-          segment = Transaction::DatastoreSegment.new product, operation, collection, host, port_path_or_id, database_name
-          start_and_add_segment segment, parent
+          segment = Transaction::DatastoreSegment.new(product, operation, collection, host, port_path_or_id, database_name)
+          start_and_add_segment(segment, parent)
         rescue ArgumentError
           raise
         rescue => exception
@@ -334,8 +334,8 @@ module NewRelic
           start_time: nil,
           parent: nil)
 
-          segment = Transaction::ExternalRequestSegment.new library, uri, procedure, start_time
-          start_and_add_segment segment, parent
+          segment = Transaction::ExternalRequestSegment.new(library, uri, procedure, start_time)
+          start_and_add_segment(segment, parent)
         rescue ArgumentError
           raise
         rescue => exception
@@ -352,7 +352,7 @@ module NewRelic
           yield
         rescue => exception
           if segment && segment.is_a?(Transaction::AbstractSegment)
-            segment.notice_error exception
+            segment.notice_error(exception)
           end
           raise
         end
@@ -376,7 +376,7 @@ module NewRelic
             parameters: parameters,
             start_time: start_time
           )
-          start_and_add_segment segment, parent
+          start_and_add_segment(segment, parent)
         rescue ArgumentError
           raise
         rescue => exception
@@ -425,7 +425,7 @@ module NewRelic
           tracer_state = state
           if (txn = tracer_state.current_transaction) &&
               tracer_state.tracing_enabled?
-            txn.add_segment segment, parent
+            txn.add_segment(segment, parent)
           else
             segment.record_metrics = false
           end

--- a/lib/new_relic/agent/transaction.rb
+++ b/lib/new_relic/agent/transaction.rb
@@ -181,7 +181,7 @@ module NewRelic
         if txn = tl_current
           txn.add_agent_attribute(key, value, default_destinations)
         else
-          NewRelic::Agent.logger.debug "Attempted to add agent attribute: #{key} without transaction"
+          NewRelic::Agent.logger.debug("Attempted to add agent attribute: #{key} without transaction")
         end
       end
 
@@ -194,7 +194,7 @@ module NewRelic
         if txn = tl_current
           txn.merge_untrusted_agent_attributes(attributes, prefix, default_destinations)
         else
-          NewRelic::Agent.logger.debug "Attempted to merge untrusted attributes without transaction"
+          NewRelic::Agent.logger.debug("Attempted to merge untrusted attributes without transaction")
         end
       end
 
@@ -208,8 +208,8 @@ module NewRelic
       if defined? JRuby
         begin
           require 'java'
-          java_import 'java.lang.management.ManagementFactory'
-          java_import 'com.sun.management.OperatingSystemMXBean'
+          java_import('java.lang.management.ManagementFactory')
+          java_import('com.sun.management.OperatingSystemMXBean')
           @@java_classes_loaded = true
         rescue
         end
@@ -256,7 +256,7 @@ module NewRelic
         merge_request_parameters(@filtered_params)
 
         if request = options[:request]
-          @request_attributes = RequestAttributes.new request
+          @request_attributes = RequestAttributes.new(request)
         else
           @request_attributes = nil
         end
@@ -294,7 +294,7 @@ module NewRelic
       end
 
       def trace_id
-        @trace_id ||= NewRelic::Agent::GuidGenerator.generate_guid 32
+        @trace_id ||= NewRelic::Agent::GuidGenerator.generate_guid(32)
       end
 
       def trace_id=(value)
@@ -424,10 +424,11 @@ module NewRelic
         ignore! if user_defined_rules_ignore?
 
         create_initial_segment(options)
-        Segment.merge_untrusted_agent_attributes \
+        Segment.merge_untrusted_agent_attributes( \
           @filtered_params,
           :'request.parameters',
           AttributeFilter::DST_SPAN_EVENTS
+        )
       end
 
       def initial_segment
@@ -435,7 +436,7 @@ module NewRelic
       end
 
       def create_initial_segment(options = {})
-        segment = create_segment @default_name, options
+        segment = create_segment(@default_name, options)
         segment.record_scoped_metric = false
       end
 
@@ -466,19 +467,19 @@ module NewRelic
           merge_request_parameters(options[:filtered_params])
         end
 
-        @ignore_apdex = options[:ignore_apdex] if options.key? :ignore_apdex
-        @ignore_enduser = options[:ignore_enduser] if options.key? :ignore_enduser
+        @ignore_apdex = options[:ignore_apdex] if options.key?(:ignore_apdex)
+        @ignore_enduser = options[:ignore_enduser] if options.key?(:ignore_enduser)
 
         nest_initial_segment if segments.length == 1
-        nested_name = self.class.nested_transaction_name options[:transaction_name]
+        nested_name = self.class.nested_transaction_name(options[:transaction_name])
 
-        segment = create_segment nested_name, options
+        segment = create_segment(nested_name, options)
         set_default_transaction_name(options[:transaction_name], category)
         segment
       end
 
       def nest_initial_segment
-        self.initial_segment.name = self.class.nested_transaction_name initial_segment.name
+        self.initial_segment.name = self.class.nested_transaction_name(initial_segment.name)
         initial_segment.record_scoped_metric = true
       end
 
@@ -568,8 +569,8 @@ module NewRelic
       def assign_segment_dt_attributes
         dt_payload = distributed_tracer.trace_state_payload || distributed_tracer.distributed_trace_payload
         parent_attributes = {}
-        DistributedTraceAttributes.copy_parent_attributes self, dt_payload, parent_attributes
-        parent_attributes.each { |k, v| initial_segment.add_agent_attribute k, v }
+        DistributedTraceAttributes.copy_parent_attributes(self, dt_payload, parent_attributes)
+        parent_attributes.each { |k, v| initial_segment.add_agent_attribute(k, v) }
       end
 
       def assign_agent_attributes
@@ -590,7 +591,7 @@ module NewRelic
         end
 
         if @request_attributes
-          @request_attributes.assign_agent_attributes self
+          @request_attributes.assign_agent_attributes(self)
         end
 
         display_host = Agent.config[:'process_host.display_name']
@@ -735,7 +736,7 @@ module NewRelic
           options[:metric] = best_name
           options[:attributes] = @attributes
 
-          span_id = options.delete :span_id
+          span_id = options.delete(:span_id)
           error_recorded = !!agent.error_collector.notice_error(exception, options, span_id) || error_recorded
         end
         payload[:error] = error_recorded if payload
@@ -750,18 +751,18 @@ module NewRelic
         end
 
         if @exceptions[error]
-          @exceptions[error].merge! options
+          @exceptions[error].merge!(options)
         else
           @exceptions[error] = options
         end
       end
 
       def record_transaction_event
-        agent.transaction_event_recorder.record payload
+        agent.transaction_event_recorder.record(payload)
       end
 
       def record_log_events
-        agent.log_event_aggregator.record_batch self, @logs.to_a
+        agent.log_event_aggregator.record_batch(self, @logs.to_a)
       end
 
       def queue_time

--- a/lib/new_relic/agent/transaction/abstract_segment.rb
+++ b/lib/new_relic/agent/transaction/abstract_segment.rb
@@ -56,7 +56,7 @@ module NewRelic
         def start
           @start_time ||= Process.clock_gettime(Process::CLOCK_REALTIME)
           return unless transaction
-          parent.child_start self if parent
+          parent.child_start(self) if parent
         end
 
         def finish
@@ -67,7 +67,7 @@ module NewRelic
           run_complete_callbacks
           finalize if record_on_finish?
         rescue => e
-          NewRelic::Agent.logger.error "Exception finishing segment: #{name}", e
+          NewRelic::Agent.logger.error("Exception finishing segment: #{name}", e)
         end
 
         def finished?
@@ -153,20 +153,22 @@ module NewRelic
 
         def set_noticed_error noticed_error
           if @noticed_error
-            NewRelic::Agent.logger.debug \
+            NewRelic::Agent.logger.debug( \
               "Segment: #{name} overwriting previously noticed " \
               "error: #{@noticed_error.inspect} with: #{noticed_error.inspect}"
+            )
           end
           @noticed_error = noticed_error
         end
 
         def notice_error exception, options = {}
           if Agent.config[:high_security]
-            NewRelic::Agent.logger.debug \
+            NewRelic::Agent.logger.debug( \
               "Segment: #{name} ignores notice_error for " \
               "error: #{exception.inspect} because :high_security is enabled"
+            )
           else
-            NewRelic::Agent.instance.error_collector.notice_segment_error self, exception, options
+            NewRelic::Agent.instance.error_collector.notice_segment_error(self, exception, options)
           end
         end
 
@@ -192,7 +194,7 @@ module NewRelic
 
         def child_complete segment
           @active_children -= 1
-          record_child_time segment
+          record_child_time(segment)
 
           if finished?
             transaction.async = true
@@ -208,18 +210,18 @@ module NewRelic
         # make any corrections needed for exclusive time calculation.
 
         def descendant_complete child, descendant
-          RangeExtensions.merge_or_append descendant.time_range,
-            children_time_ranges
+          RangeExtensions.merge_or_append(descendant.time_range,
+            children_time_ranges)
           # If this child's time was previously added to this segment's
           # aggregate children time, we need to re-record it using a time range
           # for proper exclusive time calculation
           unless child.range_recorded?
             self.children_time -= child.duration
-            record_child_time_as_range child
+            record_child_time_as_range(child)
           end
 
           if parent && finished? && descendant.end_time >= end_time
-            parent.descendant_complete self, descendant
+            parent.descendant_complete(self, descendant)
           end
         end
 
@@ -227,15 +229,15 @@ module NewRelic
 
         def force_finish
           finish
-          NewRelic::Agent.logger.warn "Segment: #{name} was unfinished at " \
+          NewRelic::Agent.logger.warn("Segment: #{name} was unfinished at " \
             "the end of transaction. Timing information for this segment's" \
-            "parent #{parent.name} in #{transaction.best_name} may be inaccurate."
+            "parent #{parent.name} in #{transaction.best_name} may be inaccurate.")
         end
 
         def run_complete_callbacks
           segment_complete
-          parent.child_complete self if parent
-          transaction.segment_complete self
+          parent.child_complete(self) if parent
+          transaction.segment_complete(self)
         end
 
         def record_metrics
@@ -248,15 +250,15 @@ module NewRelic
 
         def record_child_time child
           if concurrent_children? || finished? && end_time < child.end_time
-            record_child_time_as_range child
+            record_child_time_as_range(child)
           else
-            record_child_time_as_number child
+            record_child_time_as_number(child)
           end
         end
 
         def record_child_time_as_range child
-          RangeExtensions.merge_or_append child.time_range,
-            children_time_ranges
+          RangeExtensions.merge_or_append(child.time_range,
+            children_time_ranges)
           child.range_recorded = true
         end
 
@@ -266,7 +268,7 @@ module NewRelic
 
         def record_exclusive_duration
           overlapping_duration = if children_time_ranges?
-            RangeExtensions.compute_overlap time_range, children_time_ranges
+            RangeExtensions.compute_overlap(time_range, children_time_ranges)
           else
             0.0
           end

--- a/lib/new_relic/agent/transaction/datastore_segment.rb
+++ b/lib/new_relic/agent/transaction/datastore_segment.rb
@@ -24,11 +24,11 @@ module NewRelic
           @sql_statement = nil
           @nosql_statement = nil
           @record_sql = true
-          set_instance_info host, port_path_or_id
+          set_instance_info(host, port_path_or_id)
           @database_name = database_name ? database_name.to_s : nil
-          super Datastores::MetricHelper.scoped_metric_for(product, operation, collection),
+          super(Datastores::MetricHelper.scoped_metric_for(product, operation, collection),
                 nil,
-                start_time
+                start_time)
         end
 
         def set_instance_info host = nil, port_path_or_id = nil
@@ -36,7 +36,7 @@ module NewRelic
           host_present = host && !host.empty?
           ppi_present = port_path_or_id && !port_path_or_id.empty?
 
-          host = NewRelic::Agent::Hostname.get_external host if host_present
+          host = NewRelic::Agent::Hostname.get_external(host) if host_present
 
           case
           when host_present && ppi_present
@@ -57,14 +57,14 @@ module NewRelic
         end
 
         def notice_sql sql
-          _notice_sql sql
+          _notice_sql(sql)
           nil
         end
 
         # @api private
         def _notice_sql sql, config = nil, explainer = nil, binds = nil, name = nil
           return unless record_sql?
-          @sql_statement = Database::Statement.new sql, config, explainer, binds, name, host, port_path_or_id, database_name
+          @sql_statement = Database::Statement.new(sql, config, explainer, binds, name, host, port_path_or_id, database_name)
         end
 
         # Method for simplifying attaching non-SQL data statements to a

--- a/lib/new_relic/agent/transaction/external_request_segment.rb
+++ b/lib/new_relic/agent/transaction/external_request_segment.rb
@@ -53,15 +53,15 @@ module NewRelic
         #
         # @api public
         def add_request_headers request
-          process_host_header request
+          process_host_header(request)
           synthetics_header = transaction && transaction.raw_synthetics_header
-          insert_synthetics_header request, synthetics_header if synthetics_header
+          insert_synthetics_header(request, synthetics_header) if synthetics_header
 
           return unless record_metrics?
 
-          transaction.distributed_tracer.insert_headers request
+          transaction.distributed_tracer.insert_headers(request)
         rescue => e
-          NewRelic::Agent.logger.error "Error in add_request_headers", e
+          NewRelic::Agent.logger.error("Error in add_request_headers", e)
         end
 
         # This method extracts app data from an external response if present. If
@@ -75,7 +75,7 @@ module NewRelic
           return unless record_metrics? && CrossAppTracing.cross_app_enabled?
           return unless CrossAppTracing.response_has_crossapp_header?(response)
           unless data = CrossAppTracing.extract_appdata(response)
-            NewRelic::Agent.logger.debug "Couldn't extract_appdata from external segment response"
+            NewRelic::Agent.logger.debug("Couldn't extract_appdata from external segment response")
             return
           end
 
@@ -83,10 +83,10 @@ module NewRelic
             @app_data = data
             update_segment_name
           else
-            NewRelic::Agent.logger.debug "External segment response has invalid cross_app_id"
+            NewRelic::Agent.logger.debug("External segment response has invalid cross_app_id")
           end
         rescue => e
-          NewRelic::Agent.logger.error "Error in read_response_headers", e
+          NewRelic::Agent.logger.error("Error in read_response_headers", e)
         end
 
         def cross_app_request? # :nodoc:
@@ -141,11 +141,11 @@ module NewRelic
 
             # obfuscate the generated request metadata JSON
             #
-            obfuscator.obfuscate ::JSON.dump(rmd)
+            obfuscator.obfuscate(::JSON.dump(rmd))
 
           end
         rescue => e
-          NewRelic::Agent.logger.error "error during get_request_metadata", e
+          NewRelic::Agent.logger.error("error during get_request_metadata", e)
         end
 
         # Process obfuscated +String+ sent from a called application that is also running a New Relic agent and
@@ -163,17 +163,17 @@ module NewRelic
 
             # validate cross app id
             #
-            if Array === app_data and CrossAppTracing.trusted_valid_cross_app_id? app_data[0]
+            if Array === app_data and CrossAppTracing.trusted_valid_cross_app_id?(app_data[0])
               @app_data = app_data
               update_segment_name
             else
-              NewRelic::Agent.logger.error "error processing response metadata: invalid/non-trusted ID"
+              NewRelic::Agent.logger.error("error processing response metadata: invalid/non-trusted ID")
             end
           end
 
           nil
         rescue => e
-          NewRelic::Agent.logger.error "error during process_response_metadata", e
+          NewRelic::Agent.logger.error("error during process_response_metadata", e)
         end
 
         def record_metrics
@@ -182,19 +182,19 @@ module NewRelic
         end
 
         def process_response_headers response # :nodoc:
-          set_http_status_code response
-          read_response_headers response
+          set_http_status_code(response)
+          read_response_headers(response)
         end
 
         private
 
         # Only sets the http_status_code if response.status_code is non-empty value
         def set_http_status_code response
-          if response.respond_to? :status_code
+          if response.respond_to?(:status_code)
             @http_status_code = response.status_code if response.has_status_code?
           else
-            NewRelic::Agent.logger.warn "Cannot extract HTTP Status Code from response #{response.class.to_s}"
-            NewRelic::Agent.record_metric "#{name}/#{MISSING_STATUS_CODE}", 1
+            NewRelic::Agent.logger.warn("Cannot extract HTTP Status Code from response #{response.class.to_s}")
+            NewRelic::Agent.record_metric("#{name}/#{MISSING_STATUS_CODE}", 1)
           end
         end
 

--- a/lib/new_relic/agent/transaction/message_broker_segment.rb
+++ b/lib/new_relic/agent/transaction/message_broker_segment.rb
@@ -67,7 +67,7 @@ module NewRelic
           @destination_name = destination_name
           @headers = headers
           super(nil, nil, start_time)
-          params.merge! parameters if parameters
+          params.merge!(parameters) if parameters
         end
 
         def name
@@ -86,12 +86,12 @@ module NewRelic
 
         def transaction_assigned
           if headers && transaction && action == :produce && record_metrics?
-            transaction.distributed_tracer.insert_distributed_trace_header headers
-            transaction.distributed_tracer.insert_cat_headers headers
-            transaction.distributed_tracer.log_request_headers headers
+            transaction.distributed_tracer.insert_distributed_trace_header(headers)
+            transaction.distributed_tracer.insert_cat_headers(headers)
+            transaction.distributed_tracer.log_request_headers(headers)
           end
         rescue => e
-          NewRelic::Agent.logger.error "Error during message header processing", e
+          NewRelic::Agent.logger.error("Error during message header processing", e)
         end
       end
     end

--- a/lib/new_relic/agent/transaction/request_attributes.rb
+++ b/lib/new_relic/agent/transaction/request_attributes.rb
@@ -15,15 +15,15 @@ module NewRelic
         HTTP_ACCEPT_HEADER_KEY = "HTTP_ACCEPT".freeze
 
         def initialize request
-          @request_path = path_from_request request
-          @referer = referer_from_request request
-          @accept = attribute_from_env request, HTTP_ACCEPT_HEADER_KEY
-          @content_length = content_length_from_request request
-          @content_type = attribute_from_request request, :content_type
-          @host = attribute_from_request request, :host
-          @port = port_from_request request
-          @user_agent = attribute_from_request request, :user_agent
-          @request_method = attribute_from_request request, :request_method
+          @request_path = path_from_request(request)
+          @referer = referer_from_request(request)
+          @accept = attribute_from_env(request, HTTP_ACCEPT_HEADER_KEY)
+          @content_length = content_length_from_request(request)
+          @content_type = attribute_from_request(request, :content_type)
+          @host = attribute_from_request(request, :host)
+          @port = port_from_request(request)
+          @user_agent = attribute_from_request(request, :user_agent)
+          @request_method = attribute_from_request(request, :request_method)
         end
 
         def assign_agent_attributes txn
@@ -32,38 +32,38 @@ module NewRelic
             AttributeFilter::DST_ERROR_COLLECTOR
 
           if referer
-            txn.add_agent_attribute :'request.headers.referer', referer, AttributeFilter::DST_ERROR_COLLECTOR
+            txn.add_agent_attribute(:'request.headers.referer', referer, AttributeFilter::DST_ERROR_COLLECTOR)
           end
 
           if request_path
-            txn.add_agent_attribute :'request.uri',
+            txn.add_agent_attribute(:'request.uri',
               request_path,
               AttributeFilter::DST_TRANSACTION_TRACER |
-                AttributeFilter::DST_ERROR_COLLECTOR
+                AttributeFilter::DST_ERROR_COLLECTOR)
           end
 
           if accept
-            txn.add_agent_attribute :'request.headers.accept', accept, default_destinations
+            txn.add_agent_attribute(:'request.headers.accept', accept, default_destinations)
           end
 
           if content_length
-            txn.add_agent_attribute :'request.headers.contentLength', content_length, default_destinations
+            txn.add_agent_attribute(:'request.headers.contentLength', content_length, default_destinations)
           end
 
           if content_type
-            txn.add_agent_attribute :'request.headers.contentType', content_type, default_destinations
+            txn.add_agent_attribute(:'request.headers.contentType', content_type, default_destinations)
           end
 
           if host
-            txn.add_agent_attribute :'request.headers.host', host, default_destinations
+            txn.add_agent_attribute(:'request.headers.host', host, default_destinations)
           end
 
           if user_agent
-            txn.add_agent_attribute :'request.headers.userAgent', user_agent, default_destinations
+            txn.add_agent_attribute(:'request.headers.userAgent', user_agent, default_destinations)
           end
 
           if request_method
-            txn.add_agent_attribute :'request.method', request_method, default_destinations
+            txn.add_agent_attribute(:'request.method', request_method, default_destinations)
           end
         end
 
@@ -74,7 +74,7 @@ module NewRelic
 
         def referer_from_request request
           if referer = attribute_from_request(request, :referer)
-            HTTPClients::URIUtil.strip_query_string referer.to_s
+            HTTPClients::URIUtil.strip_query_string(referer.to_s)
           end
         end
 
@@ -107,7 +107,7 @@ module NewRelic
         end
 
         def attribute_from_request request, attribute_method
-          if request.respond_to? attribute_method
+          if request.respond_to?(attribute_method)
             request.send(attribute_method)
           end
         end

--- a/lib/new_relic/agent/transaction/segment.rb
+++ b/lib/new_relic/agent/transaction/segment.rb
@@ -18,7 +18,7 @@ module NewRelic
 
         def initialize name = nil, unscoped_metrics = nil, start_time = nil
           @unscoped_metrics = unscoped_metrics
-          super name, start_time
+          super(name, start_time)
         end
 
         def attributes
@@ -33,7 +33,7 @@ module NewRelic
           if segment = NewRelic::Agent::Tracer.current_segment
             segment.merge_untrusted_agent_attributes(attributes, prefix, default_destinations)
           else
-            NewRelic::Agent.logger.debug "Attempted to merge untrusted attributes without segment"
+            NewRelic::Agent.logger.debug("Attempted to merge untrusted attributes without segment")
           end
         end
 
@@ -50,12 +50,12 @@ module NewRelic
 
         def record_metrics
           if record_scoped_metric?
-            metric_cache.record_scoped_and_unscoped name, duration, exclusive_duration
+            metric_cache.record_scoped_and_unscoped(name, duration, exclusive_duration)
           else
-            append_unscoped_metric name
+            append_unscoped_metric(name)
           end
           if unscoped_metrics
-            metric_cache.record_unscoped unscoped_metrics, duration, exclusive_duration
+            metric_cache.record_unscoped(unscoped_metrics, duration, exclusive_duration)
           end
         end
 

--- a/lib/new_relic/agent/transaction/trace.rb
+++ b/lib/new_relic/agent/transaction/trace.rb
@@ -51,7 +51,7 @@ module NewRelic
         end
 
         def create_node(time_since_start, metric_name = nil)
-          raise FinishedTraceError.new "Can't create additional node for finished trace." if self.finished
+          raise FinishedTraceError.new("Can't create additional node for finished trace.") if self.finished
           self.node_count += 1
           NewRelic::Agent::Transaction::TraceNode.new(metric_name, time_since_start)
         end

--- a/lib/new_relic/agent/transaction/trace_builder.rb
+++ b/lib/new_relic/agent/transaction/trace_builder.rb
@@ -14,9 +14,9 @@ module NewRelic
         extend self
 
         def build_trace transaction
-          trace = Trace.new transaction.start_time
+          trace = Trace.new(transaction.start_time)
           trace.root_node.exit_timestamp = transaction.end_time - transaction.start_time
-          copy_attributes transaction, trace
+          copy_attributes(transaction, trace)
           first, *rest = transaction.segments
           relationship_map = rest.group_by { |s| s.parent }
           trace.root_node.children << process_segments(transaction, first, trace.root_node, relationship_map)
@@ -27,11 +27,11 @@ module NewRelic
 
         # recursively builds a transaction trace from the flat list of segments
         def process_segments transaction, segment, parent, relationship_map
-          current = create_trace_node transaction, segment, parent
+          current = create_trace_node(transaction, segment, parent)
 
           if children = relationship_map[segment]
             current.children = children.map! do |child|
-              process_segments transaction, child, current, relationship_map
+              process_segments(transaction, child, current, relationship_map)
             end
           end
 
@@ -41,7 +41,7 @@ module NewRelic
         def create_trace_node transaction, segment, parent
           relative_start = segment.start_time - transaction.start_time
           relative_end = segment.end_time - transaction.start_time
-          TraceNode.new segment.name, relative_start, relative_end, segment.params, parent
+          TraceNode.new(segment.name, relative_start, relative_end, segment.params, parent)
         end
 
         def copy_attributes transaction, trace

--- a/lib/new_relic/agent/transaction/trace_node.rb
+++ b/lib/new_relic/agent/transaction/trace_node.rb
@@ -30,7 +30,7 @@ module NewRelic
         def select_allowed_params params
           return unless params
           params.select do |p|
-            NewRelic::Agent.instance.attribute_filter.allows_key? p, AttributeFilter::DST_TRANSACTION_SEGMENTS
+            NewRelic::Agent.instance.attribute_filter.allows_key?(p, AttributeFilter::DST_TRANSACTION_SEGMENTS)
           end
         end
 
@@ -134,7 +134,7 @@ module NewRelic
         # call the provided block for this node and each
         # of the called nodes
         def each_node(&block)
-          block.call self
+          block.call(self)
 
           if @children
             @children.each do |node|
@@ -146,7 +146,7 @@ module NewRelic
         # call the provided block for this node and each
         # of the called nodes while keeping track of nested nodes
         def each_node_with_nest_tracking(&block)
-          summary = block.call self
+          summary = block.call(self)
           summary.current_nest_count += 1 if summary
 
           if @children

--- a/lib/new_relic/agent/transaction/tracing.rb
+++ b/lib/new_relic/agent/transaction/tracing.rb
@@ -24,7 +24,7 @@ module NewRelic
         def add_segment segment, parent = nil
           segment.transaction = self
           segment.parent = parent || current_segment
-          set_current_segment segment
+          set_current_segment(segment)
           if @segments.length < segment_limit
             @segments << segment
           else
@@ -39,7 +39,7 @@ module NewRelic
           if segment.parent && segment.parent.starting_thread_id != ::Thread.current.object_id
             remove_current_segment_by_thread_id(::Thread.current.object_id)
           else
-            set_current_segment segment.parent
+            set_current_segment(segment.parent)
           end
         end
 
@@ -63,8 +63,8 @@ module NewRelic
             OTHER_TRANSACTION_TOTAL_TIME
           end
 
-          @metrics.record_unscoped total_time_metric, total_time
-          @metrics.record_unscoped "#{total_time_metric}/#{@frozen_name}", total_time
+          @metrics.record_unscoped(total_time_metric, total_time)
+          @metrics.record_unscoped("#{total_time_metric}/#{@frozen_name}", total_time)
         end
       end
     end

--- a/lib/new_relic/agent/transaction_error_primitive.rb
+++ b/lib/new_relic/agent/transaction_error_primitive.rb
@@ -60,10 +60,10 @@ module NewRelic
           attrs[DURATION_KEY] = payload[:duration]
           attrs[SAMPLED_KEY] = payload[:sampled] if payload.key?(:sampled)
           attrs[PRIORITY_KEY] = payload[:priority]
-          append_synthetics payload, attrs
-          append_cat payload, attrs
-          DistributedTraceAttributes.copy_to_hash payload, attrs
-          PayloadMetricMapping.append_mapped_metrics payload[:metrics], attrs
+          append_synthetics(payload, attrs)
+          append_cat(payload, attrs)
+          DistributedTraceAttributes.copy_to_hash(payload, attrs)
+          PayloadMetricMapping.append_mapped_metrics(payload[:metrics], attrs)
         else
           attrs[PRIORITY_KEY] = rand.round(NewRelic::PRIORITY_PRECISION)
         end

--- a/lib/new_relic/agent/transaction_event_aggregator.rb
+++ b/lib/new_relic/agent/transaction_event_aggregator.rb
@@ -25,7 +25,7 @@ module NewRelic
         return unless enabled?
 
         @lock.synchronize do
-          @buffer.append priority: priority, event: event, &blk
+          @buffer.append(priority: priority, event: event, &blk)
           notify_if_full
         end
       end
@@ -34,7 +34,7 @@ module NewRelic
 
       def after_harvest metadata
         return unless enabled?
-        record_sampling_rate metadata
+        record_sampling_rate(metadata)
       end
 
       def record_sampling_rate(metadata) # THREAD_LOCAL_ACCESS

--- a/lib/new_relic/agent/transaction_event_primitive.rb
+++ b/lib/new_relic/agent/transaction_event_primitive.rb
@@ -54,7 +54,7 @@ module NewRelic
 
         PayloadMetricMapping.append_mapped_metrics(payload[:metrics], intrinsics)
         append_optional_attributes(intrinsics, payload)
-        DistributedTraceAttributes.copy_to_hash payload, intrinsics
+        DistributedTraceAttributes.copy_to_hash(payload, intrinsics)
 
         attributes = payload[:attributes]
 

--- a/lib/new_relic/agent/transaction_event_recorder.rb
+++ b/lib/new_relic/agent/transaction_event_recorder.rb
@@ -17,28 +17,28 @@ module NewRelic
       attr_reader :synthetics_event_aggregator
 
       def initialize events
-        @transaction_event_aggregator = NewRelic::Agent::TransactionEventAggregator.new events
-        @synthetics_event_aggregator = NewRelic::Agent::SyntheticsEventAggregator.new events
+        @transaction_event_aggregator = NewRelic::Agent::TransactionEventAggregator.new(events)
+        @synthetics_event_aggregator = NewRelic::Agent::SyntheticsEventAggregator.new(events)
       end
 
       def record payload
         return unless NewRelic::Agent.config[:'transaction_events.enabled']
 
-        if synthetics_event? payload
-          event = create_event payload
-          result = synthetics_event_aggregator.record event
-          transaction_event_aggregator.record event: event if result.nil?
+        if synthetics_event?(payload)
+          event = create_event(payload)
+          result = synthetics_event_aggregator.record(event)
+          transaction_event_aggregator.record(event: event) if result.nil?
         else
           transaction_event_aggregator.record(priority: payload[:priority]) { create_event(payload) }
         end
       end
 
       def create_event payload
-        TransactionEventPrimitive.create payload
+        TransactionEventPrimitive.create(payload)
       end
 
       def synthetics_event? payload
-        payload.key? :synthetics_resource_id
+        payload.key?(:synthetics_resource_id)
       end
 
       def drop_buffered_data

--- a/lib/new_relic/agent/transaction_metrics.rb
+++ b/lib/new_relic/agent/transaction_metrics.rb
@@ -44,11 +44,11 @@ module NewRelic
       end
 
       def each_unscoped
-        @lock.synchronize { @unscoped.each { |name, stats| yield name, stats } }
+        @lock.synchronize { @unscoped.each { |name, stats| yield(name, stats) } }
       end
 
       def each_scoped
-        @lock.synchronize { @scoped.each { |name, stats| yield name, stats } }
+        @lock.synchronize { @scoped.each { |name, stats| yield(name, stats) } }
       end
 
       def _record_metrics(names, value, aux, target, &blk)

--- a/lib/new_relic/agent/transaction_sampler.rb
+++ b/lib/new_relic/agent/transaction_sampler.rb
@@ -33,9 +33,9 @@ module NewRelic
         Agent.config.register_callback(:'transaction_tracer.enabled') do |enabled|
           if enabled
             threshold = Agent.config[:'transaction_tracer.transaction_threshold']
-            ::NewRelic::Agent.logger.debug "Transaction tracing threshold is #{threshold} seconds."
+            ::NewRelic::Agent.logger.debug("Transaction tracing threshold is #{threshold} seconds.")
           else
-            ::NewRelic::Agent.logger.debug "Transaction traces will not be sent to the New Relic service."
+            ::NewRelic::Agent.logger.debug("Transaction traces will not be sent to the New Relic service.")
           end
         end
 
@@ -114,7 +114,7 @@ module NewRelic
         result.uniq!
         result.map! do |sample|
           if Transaction === sample
-            Transaction::TraceBuilder.build_trace sample
+            Transaction::TraceBuilder.build_trace(sample)
           else
             sample
           end

--- a/lib/new_relic/agent/transaction_time_aggregator.rb
+++ b/lib/new_relic/agent/transaction_time_aggregator.rb
@@ -13,13 +13,13 @@
 module NewRelic
   module Agent
     module TransactionTimeAggregator
-      TransactionStats = Struct.new :transaction_started_at, :elapsed_transaction_time
+      TransactionStats = Struct.new(:transaction_started_at, :elapsed_transaction_time)
 
       @lock = Mutex.new
       @harvest_cycle_started_at = Process.clock_gettime(Process::CLOCK_REALTIME)
 
       @stats = Hash.new do |h, k|
-        h[k] = TransactionStats.new nil, 0.0
+        h[k] = TransactionStats.new(nil, 0.0)
       end
 
       def reset!(timestamp = Process.clock_gettime(Process::CLOCK_REALTIME))
@@ -29,14 +29,14 @@ module NewRelic
 
       def transaction_start(timestamp = Process.clock_gettime(Process::CLOCK_REALTIME))
         @lock.synchronize do
-          set_transaction_start_time timestamp
+          set_transaction_start_time(timestamp)
         end
       end
 
       def transaction_stop(timestamp = Process.clock_gettime(Process::CLOCK_REALTIME), starting_thread_id = current_thread)
         @lock.synchronize do
-          record_elapsed_transaction_time_until timestamp, starting_thread_id
-          set_transaction_start_time nil, starting_thread_id
+          record_elapsed_transaction_time_until(timestamp, starting_thread_id)
+          set_transaction_start_time(nil, starting_thread_id)
         end
       end
 
@@ -101,7 +101,7 @@ module NewRelic
         end
 
         def thread_is_alive?(thread_id)
-          thread = thread_by_id thread_id
+          thread = thread_by_id(thread_id)
           thread && thread.alive?
         rescue StandardError
           false
@@ -133,13 +133,13 @@ module NewRelic
         end
 
         def transaction_time_in_thread timestamp, thread_id, entry
-          return entry.elapsed_transaction_time unless in_transaction? thread_id
+          return entry.elapsed_transaction_time unless in_transaction?(thread_id)
 
           # Count the portion of the transaction that's elapsed so far,...
-          elapsed = record_elapsed_transaction_time_until timestamp, thread_id
+          elapsed = record_elapsed_transaction_time_until(timestamp, thread_id)
 
           # ...then readjust the transaction start time to the next harvest
-          split_transaction_at_harvest timestamp, thread_id
+          split_transaction_at_harvest(timestamp, thread_id)
 
           elapsed
         end

--- a/lib/new_relic/agent/utilization/aws.rb
+++ b/lib/new_relic/agent/utilization/aws.rb
@@ -26,15 +26,15 @@ module NewRelic
               '',
               {'X-aws-ec2-metadata-token-ttl-seconds' => IMDS_TOKEN_TTL_SECS})
             unless response.code == Vendor::SUCCESS
-              NewRelic::Agent.logger.debug 'Failed to obtain an AWS token for use with IMDS - encountered ' \
+              NewRelic::Agent.logger.debug('Failed to obtain an AWS token for use with IMDS - encountered ' \
                                            "#{response.class} with HTTP response code #{response.code} - " \
-                                           'assuming non AWS'
+                                           'assuming non AWS')
               return
             end
 
             response.body
           rescue Net::OpenTimeout
-            NewRelic::Agent.logger.debug 'Timed out waiting for AWS IMDS - assuming non AWS'
+            NewRelic::Agent.logger.debug('Timed out waiting for AWS IMDS - assuming non AWS')
           end
         end
 

--- a/lib/new_relic/agent/utilization/gcp.rb
+++ b/lib/new_relic/agent/utilization/gcp.rb
@@ -19,9 +19,9 @@ module NewRelic
         ZONE = 'zone'.freeze
 
         def prepare_response response
-          body = JSON.parse response.body
-          body[MACH_TYPE] = trim_leading body[MACH_TYPE]
-          body[ZONE] = trim_leading body[ZONE]
+          body = JSON.parse(response.body)
+          body[MACH_TYPE] = trim_leading(body[MACH_TYPE])
+          body[ZONE] = trim_leading(body[ZONE])
           body
         end
 

--- a/lib/new_relic/agent/utilization/pcf.rb
+++ b/lib/new_relic/agent/utilization/pcf.rb
@@ -16,9 +16,9 @@ module NewRelic
         def detect
           begin
             return false unless pcf_keys_present?
-            process_response ENV
+            process_response(ENV)
           rescue
-            NewRelic::Agent.logger.error "Error occurred detecting: #{vendor_name}", e
+            NewRelic::Agent.logger.error("Error occurred detecting: #{vendor_name}", e)
             record_supportability_metric
             false
           end

--- a/lib/new_relic/agent/utilization/vendor.rb
+++ b/lib/new_relic/agent/utilization/vendor.rb
@@ -59,12 +59,12 @@ module NewRelic
 
           begin
             if response.code == SUCCESS
-              process_response prepare_response(response)
+              process_response(prepare_response(response))
             else
               false
             end
           rescue => e
-            NewRelic::Agent.logger.error "Error occurred detecting: #{vendor_name}", e
+            NewRelic::Agent.logger.error("Error occurred detecting: #{vendor_name}", e)
             record_supportability_metric
             false
           end
@@ -76,25 +76,25 @@ module NewRelic
           processed_headers = headers
           raise if processed_headers.values.include?(:error)
 
-          Timeout.timeout 1 do
+          Timeout.timeout(1) do
             response = nil
-            Net::HTTP.start endpoint.host, endpoint.port do |http|
-              req = Net::HTTP::Get.new endpoint, processed_headers
-              response = http.request req
+            Net::HTTP.start(endpoint.host, endpoint.port) do |http|
+              req = Net::HTTP::Get.new(endpoint, processed_headers)
+              response = http.request(req)
             end
             response
           end
         rescue
-          NewRelic::Agent.logger.debug "#{vendor_name} environment not detected"
+          NewRelic::Agent.logger.debug("#{vendor_name} environment not detected")
         end
 
         def prepare_response response
-          JSON.parse response.body
+          JSON.parse(response.body)
         end
 
         def process_response response
           keys.each do |key|
-            normalized = normalize response[key]
+            normalized = normalize(response[key])
             if normalized
               @metadata[transform_key(key)] = normalized
             else
@@ -112,11 +112,11 @@ module NewRelic
           value = value.to_s
           value = value.dup if value.frozen?
 
-          value.force_encoding Encoding::UTF_8
+          value.force_encoding(Encoding::UTF_8)
           value.strip!
 
-          return unless valid_length? value
-          return unless valid_chars? value
+          return unless valid_length?(value)
+          return unless valid_chars?(value)
 
           value
         end
@@ -125,7 +125,7 @@ module NewRelic
           if value.bytesize <= 255
             true
           else
-            NewRelic::Agent.logger.warn "Found invalid length value while detecting: #{vendor_name}"
+            NewRelic::Agent.logger.warn("Found invalid length value while detecting: #{vendor_name}")
             false
           end
         end
@@ -138,7 +138,7 @@ module NewRelic
             code_point = ch[0].ord # this works in Ruby 1.8.7 - 2.1.2
             next if code_point >= 0x80
 
-            NewRelic::Agent.logger.warn "Found invalid character while detecting: #{vendor_name}"
+            NewRelic::Agent.logger.warn("Found invalid character while detecting: #{vendor_name}")
             return false # it's in neither set of valid characters
           end
           true
@@ -150,7 +150,7 @@ module NewRelic
         end
 
         def record_supportability_metric
-          NewRelic::Agent.increment_metric "Supportability/utilization/#{vendor_name}/error"
+          NewRelic::Agent.increment_metric("Supportability/utilization/#{vendor_name}/error")
         end
       end
     end

--- a/lib/new_relic/agent/worker_loop.rb
+++ b/lib/new_relic/agent/worker_loop.rb
@@ -89,7 +89,7 @@ module NewRelic
             raise
           rescue => e
             # Don't blow out the stack for anything that hasn't already propagated
-            ::NewRelic::Agent.logger.error "Error running task in Agent Worker Loop:", e
+            ::NewRelic::Agent.logger.error("Error running task in Agent Worker Loop:", e)
           end
         end
       end

--- a/lib/new_relic/cli/command.rb
+++ b/lib/new_relic/cli/command.rb
@@ -17,7 +17,7 @@ module NewRelic
       class CommandFailure < StandardError
         attr_reader :options
         def initialize message, opt_parser = nil
-          super message
+          super(message)
           @options = opt_parser
         end
       end
@@ -34,7 +34,7 @@ module NewRelic
         if Hash === command_line_args
           # command line args is an options hash
           command_line_args.each do |key, value|
-            instance_variable_set "@#{key}", value.to_s if value
+            instance_variable_set("@#{key}", value.to_s) if value
           end
         else
           # parse command line args.  Throw an exception on a bad arg.
@@ -66,7 +66,7 @@ module NewRelic
             script_name = 'newrelic'
           end
           opts.banner = "Usage: #{script_name} [ #{@command_names.join(" | ")} ] [options]"
-          opts.separator "use '#{script_name} <command> -h' to see detailed command options"
+          opts.separator("use '#{script_name} <command> -h' to see detailed command options")
           opts
         end
         extra = options.order!

--- a/lib/new_relic/cli/commands/deployments.rb
+++ b/lib/new_relic/cli/commands/deployments.rb
@@ -90,8 +90,8 @@ class NewRelic::Cli::Deployments < NewRelic::Cli::Command
 
       response = http.request(request)
 
-      if response.is_a? Net::HTTPSuccess
-        info "Recorded deployment to '#{@appname}' (#{@description || Time.now})"
+      if response.is_a?(Net::HTTPSuccess)
+        info("Recorded deployment to '#{@appname}' (#{@description || Time.now})")
       else
         err_string = REXML::Document.new(response.body).elements['errors/error'].map(&:to_s).join("; ") rescue response.message
         raise NewRelic::Cli::Command::CommandFailure, "Deployment not recorded: #{err_string}"
@@ -103,8 +103,8 @@ class NewRelic::Cli::Deployments < NewRelic::Cli::Command
     rescue NewRelic::Cli::Command::CommandFailure
       raise
     rescue => e
-      err "Unexpected error attempting to connect to #{control.api_server}"
-      info "#{e}: #{e.backtrace.join("\n   ")}"
+      err("Unexpected error attempting to connect to #{control.api_server}")
+      info("#{e}: #{e.backtrace.join("\n   ")}")
       raise NewRelic::Cli::Command::CommandFailure.new(e.to_s)
     end
   end
@@ -112,8 +112,8 @@ class NewRelic::Cli::Deployments < NewRelic::Cli::Command
   private
 
   def options
-    OptionParser.new %Q(Usage: #{$0} #{self.class.command} [OPTIONS] ["description"] ), 40 do |o|
-      o.separator "OPTIONS:"
+    OptionParser.new(%Q(Usage: #{$0} #{self.class.command} [OPTIONS] ["description"] ), 40) do |o|
+      o.separator("OPTIONS:")
       o.on("-a", "--appname=NAME", String,
         "Set the application name.",
         "Default is app_name setting in newrelic.yml") { |e| @appname = e }
@@ -129,7 +129,7 @@ class NewRelic::Cli::Deployments < NewRelic::Cli::Command
         "Specify the license key of the account for the app being deployed") { |l| @license_key = l }
       o.on("-c", "--changes",
         "Read in a change log from the standard input") { @changelog = STDIN.read }
-      yield o if block_given?
+      yield(o) if block_given?
     end
   end
 end

--- a/lib/new_relic/cli/commands/install.rb
+++ b/lib/new_relic/cli/commands/install.rb
@@ -23,10 +23,10 @@ class NewRelic::Cli::Install < NewRelic::Cli::Command
   attr_reader :dest_dir, :license_key, :generated_for_user, :quiet, :src_file, :app_name
   def initialize command_line_args = {}
     @dest_dir = nil
-    super command_line_args
+    super(command_line_args)
     if @dest_dir.nil?
       # Install a newrelic.yml file into the local config directory.
-      if File.directory? "config"
+      if File.directory?("config")
         @dest_dir = "config"
       else
         @dest_dir = "."
@@ -71,13 +71,13 @@ Visit support.newrelic.com if you are experiencing installation issues.
   private
 
   def options
-    OptionParser.new "Usage: #{$0} #{self.class.command} [ OPTIONS] 'application name'", 40 do |o|
+    OptionParser.new("Usage: #{$0} #{self.class.command} [ OPTIONS] 'application name'", 40) do |o|
       o.on("-f", "--force", "Overwrite newrelic.yml if it exists") { |e| @force = true }
       o.on("-l", "--license_key=NAME", String,
         "Use the given license key") { |e| @license_key = e }
       o.on("-d", "--destdir=name", String,
         "Write the newrelic.yml to the given directory, default is '.'") { |e| @dest_dir = e }
-      yield o if block_given?
+      yield(o) if block_given?
     end
   end
 end

--- a/lib/new_relic/control/frameworks/rails.rb
+++ b/lib/new_relic/control/frameworks/rails.rb
@@ -74,7 +74,7 @@ module NewRelic
           begin
             require 'new_relic/rack/agent_hooks'
             return unless NewRelic::Rack::AgentHooks.needed?
-            config.middleware.use NewRelic::Rack::AgentHooks
+            config.middleware.use(NewRelic::Rack::AgentHooks)
             ::NewRelic::Agent.logger.debug("Installed New Relic Agent Hooks middleware")
           rescue => e
             ::NewRelic::Agent.logger.warn("Error installing New Relic Agent Hooks middleware", e)
@@ -88,7 +88,7 @@ module NewRelic
             return if config.nil? || !config.respond_to?(:middleware) || !Agent.config[:'browser_monitoring.auto_instrument']
             begin
               require 'new_relic/rack/browser_monitoring'
-              config.middleware.use NewRelic::Rack::BrowserMonitoring
+              config.middleware.use(NewRelic::Rack::BrowserMonitoring)
               ::NewRelic::Agent.logger.debug("Installed New Relic Browser Monitoring middleware")
             rescue => e
               ::NewRelic::Agent.logger.warn("Error installing New Relic Browser Monitoring middleware", e)

--- a/lib/new_relic/control/instance_methods.rb
+++ b/lib/new_relic/control/instance_methods.rb
@@ -64,8 +64,8 @@ module NewRelic
 
         # An artifact of earlier implementation, we put both #add_method_tracer and #trace_execution
         # methods in the module methods.
-        Module.send :include, NewRelic::Agent::MethodTracer::ClassMethods
-        Module.send :include, NewRelic::Agent::MethodTracer
+        Module.send(:include, NewRelic::Agent::MethodTracer::ClassMethods)
+        Module.send(:include, NewRelic::Agent::MethodTracer)
         init_config(options)
         NewRelic::Agent.agent = NewRelic::Agent::Agent.instance
 
@@ -121,11 +121,11 @@ module NewRelic
       end
 
       def handle_invalid_security_settings
-        NewRelic::Agent.logger.error "Security Policies and High Security " \
+        NewRelic::Agent.logger.error("Security Policies and High Security " \
           "Mode cannot both be present in the agent configuration. If " \
           "Security Policies have been set for your account, please " \
           "ensure the security_policies_token is set but high_security is " \
-          "disabled (default)."
+          "disabled (default).")
         install_shim
       end
 

--- a/lib/new_relic/control/instrumentation.rb
+++ b/lib/new_relic/control/instrumentation.rb
@@ -18,7 +18,7 @@ module NewRelic
           begin
             require file.to_s
           rescue => e
-            ::NewRelic::Agent.logger.warn "Error loading instrumentation file '#{file}':", e
+            ::NewRelic::Agent.logger.warn("Error loading instrumentation file '#{file}':", e)
           end
         end
       end
@@ -36,7 +36,7 @@ module NewRelic
       # are ready to be instrumented
       def add_instrumentation pattern
         if @instrumented
-          load_instrumentation_files pattern
+          load_instrumentation_files(pattern)
         else
           @instrumentation_files << pattern
         end
@@ -61,11 +61,11 @@ module NewRelic
         @instrumentation_files <<
           File.join(instrumentation_path, '*.rb') <<
           File.join(instrumentation_path, app.to_s, '*.rb')
-        @instrumentation_files.each { |pattern| load_instrumentation_files pattern }
+        @instrumentation_files.each { |pattern| load_instrumentation_files(pattern) }
         DependencyDetection.detect!
         ruby_22_deprecation
         rails_32_deprecation
-        ::NewRelic::Agent.logger.info "Finished instrumentation"
+        ::NewRelic::Agent.logger.info("Finished instrumentation")
       end
     end
 

--- a/lib/new_relic/control/server_methods.rb
+++ b/lib/new_relic/control/server_methods.rb
@@ -6,7 +6,7 @@
 module NewRelic
   class Control
     # Structs holding info for the remote server and proxy server
-    class Server < Struct.new :name, :port # :nodoc:
+    class Server < Struct.new(:name, :port) # :nodoc:
       def to_s; "#{name}:#{port}"; end
     end
 

--- a/lib/new_relic/dependency_detection.rb
+++ b/lib/new_relic/dependency_detection.rb
@@ -89,14 +89,14 @@ module DependencyDetection
 
     def log_and_instrument method, instrumenting_module, supportability_name
       supportability_name ||= extract_supportability_name(instrumenting_module)
-      NewRelic::Agent.logger.info "Installing New Relic supported #{supportability_name} instrumentation using #{method}"
+      NewRelic::Agent.logger.info("Installing New Relic supported #{supportability_name} instrumentation using #{method}")
       NewRelic::Agent.record_metric("Supportability/Instrumentation/#{supportability_name}/#{method}", 0.0)
       yield
     end
 
     def prepend_instrument target_class, instrumenting_module, supportability_name = nil
       log_and_instrument("Prepend", instrumenting_module, supportability_name) do
-        target_class.send :prepend, instrumenting_module
+        target_class.send(:prepend, instrumenting_module)
       end
     end
 
@@ -107,9 +107,9 @@ module DependencyDetection
     end
 
     def chain_instrument_target target, instrumenting_module, supportability_name = nil
-      NewRelic::Agent.logger.info "Installing deferred #{target} instrumentation"
+      NewRelic::Agent.logger.info("Installing deferred #{target} instrumentation")
       log_and_instrument("MethodChaining", instrumenting_module, supportability_name) do
-        instrumenting_module.instrument! target
+        instrumenting_module.instrument!(target)
       end
     end
 
@@ -118,7 +118,7 @@ module DependencyDetection
         begin
           x.call
         rescue => err
-          NewRelic::Agent.logger.error "Error while installing #{self.name} instrumentation:", err
+          NewRelic::Agent.logger.error("Error while installing #{self.name} instrumentation:", err)
           break
         end
       end
@@ -156,9 +156,10 @@ module DependencyDetection
       return false unless ::NewRelic::Agent.config[key] == true
 
       ::NewRelic::Agent.logger.debug("Not installing #{self.name} instrumentation because of configuration #{key}")
-      ::NewRelic::Agent.logger.debug \
+      ::NewRelic::Agent.logger.debug( \
         "[DEPRECATED] configuration #{key} for #{self.name} will be removed in the next major release. " \
         "Use `#{config_key}` with one of `#{VALID_CONFIG_VALUES.map(&:to_s).inspect}`"
+      )
 
       return true
     end

--- a/lib/new_relic/helper.rb
+++ b/lib/new_relic/helper.rb
@@ -17,16 +17,16 @@ module NewRelic
     # Confirm a string is correctly encoded,
     # If not force the encoding to ASCII-8BIT (binary)
     def correctly_encoded(string)
-      return string unless string.is_a? String
+      return string unless string.is_a?(String)
       # The .dup here is intentional, since force_encoding mutates the target,
       # and we don't know who is going to use this string downstream of us.
       string.valid_encoding? ? string : string.dup.force_encoding(Encoding::ASCII_8BIT)
     end
 
     def instance_method_visibility(klass, method_name)
-      if klass.private_instance_methods.map { |s| s.to_sym }.include? method_name.to_sym
+      if klass.private_instance_methods.map { |s| s.to_sym }.include?(method_name.to_sym)
         :private
-      elsif klass.protected_instance_methods.map { |s| s.to_sym }.include? method_name.to_sym
+      elsif klass.protected_instance_methods.map { |s| s.to_sym }.include?(method_name.to_sym)
         :protected
       else
         :public

--- a/lib/new_relic/local_environment.rb
+++ b/lib/new_relic/local_environment.rb
@@ -38,8 +38,8 @@ module NewRelic
       # Extend self with any any submodules of LocalEnvironment.  These can override
       # the discover methods to discover new framworks and dispatchers.
       NewRelic::LocalEnvironment.constants.each do |const|
-        mod = NewRelic::LocalEnvironment.const_get const
-        self.extend mod if mod.instance_of? Module
+        mod = NewRelic::LocalEnvironment.const_get(const)
+        self.extend(mod) if mod.instance_of?(Module)
       end
 
       @discovered_dispatcher = nil
@@ -79,7 +79,7 @@ module NewRelic
       ]
       # TODO: MAJOR VERSION - remove rainbows
       while dispatchers.any? && @discovered_dispatcher.nil?
-        send 'check_for_' + (dispatchers.shift)
+        send('check_for_' + (dispatchers.shift))
       end
     end
 

--- a/lib/new_relic/metric_data.rb
+++ b/lib/new_relic/metric_data.rb
@@ -19,7 +19,7 @@ module NewRelic
     end
 
     def eql?(o)
-      (metric_spec.eql? o.metric_spec) && (stats.eql? o.stats)
+      (metric_spec.eql?(o.metric_spec)) && (stats.eql?(o.stats))
     end
 
     def original_spec

--- a/lib/new_relic/noticed_error.rb
+++ b/lib/new_relic/noticed_error.rb
@@ -189,7 +189,7 @@ class NewRelic::NoticedError
     if exception.nil?
       @exception_class_name = UNKNOWN_ERROR_CLASS_NAME
       @message = NIL_ERROR_MESSAGE
-    elsif exception.is_a? NewRelic::Agent::NoticibleError
+    elsif exception.is_a?(NewRelic::Agent::NoticibleError)
       @exception_class_name = exception.class_name
       @message = exception.message
     else

--- a/lib/new_relic/rack/browser_monitoring.rb
+++ b/lib/new_relic/rack/browser_monitoring.rb
@@ -108,7 +108,7 @@ module NewRelic::Rack
             js_to_inject <<
             source[insertion_index..-1]
         else
-          NewRelic::Agent.logger.debug "Skipping RUM instrumentation. Could not properly determine location to inject script."
+          NewRelic::Agent.logger.debug("Skipping RUM instrumentation. Could not properly determine location to inject script.")
         end
       else
         msg = "Skipping RUM instrumentation. Unable to find <body> tag in first #{SCAN_LIMIT} bytes of document."
@@ -118,7 +118,7 @@ module NewRelic::Rack
 
       source
     rescue => e
-      NewRelic::Agent.logger.debug "Skipping RUM instrumentation on exception.", e
+      NewRelic::Agent.logger.debug("Skipping RUM instrumentation on exception.", e)
       nil
     end
 

--- a/lib/new_relic/recipes/capistrano3.rb
+++ b/lib/new_relic/recipes/capistrano3.rb
@@ -53,14 +53,14 @@ namespace :newrelic do
         :license_key => license_key
       }
 
-      debug "Uploading deployment to New Relic"
-      deployment = NewRelic::Cli::Deployments.new deploy_options
+      debug("Uploading deployment to New Relic")
+      deployment = NewRelic::Cli::Deployments.new(deploy_options)
       deployment.run
-      info "Uploaded deployment information to New Relic"
+      info("Uploaded deployment information to New Relic")
     rescue NewRelic::Cli::Command::CommandFailure => e
-      info e.message
+      info(e.message)
     rescue => e
-      info "Error creating New Relic deployment (#{e})\n#{e.backtrace.join("\n")}"
+      info("Error creating New Relic deployment (#{e})\n#{e.backtrace.join("\n")}")
     end
   end
 
@@ -69,7 +69,7 @@ namespace :newrelic do
     current_revision = fetch(:current_revision)
     return unless current_revision && previous_revision
 
-    debug "Retrieving changelog for New Relic Deployment details"
+    debug("Retrieving changelog for New Relic Deployment details")
 
     if Rake::Task.task_defined?("git:check")
       log_command = "git --no-pager log --no-color --pretty=format:'  * %an: %s' " +

--- a/lib/new_relic/recipes/capistrano_legacy.rb
+++ b/lib/new_relic/recipes/capistrano_legacy.rb
@@ -4,10 +4,10 @@
 # frozen_string_literal: true
 
 make_notify_task = Proc.new do
-  namespace :newrelic do
+  namespace(:newrelic) do
     # on all deployments, notify New Relic
-    desc "Record a deployment in New Relic (newrelic.com)"
-    task :notice_deployment, :roles => :app, :except => {:no_release => true} do
+    desc("Record a deployment in New Relic (newrelic.com)")
+    task(:notice_deployment, :roles => :app, :except => {:no_release => true}) do
       rails_env = fetch(:newrelic_rails_env, fetch(:rails_env, "production"))
 
       require 'new_relic/cli/command'
@@ -37,22 +37,22 @@ make_notify_task = Proc.new do
           :license_key => license_key
         }
 
-        logger.debug "Uploading deployment to New Relic"
-        deployment = NewRelic::Cli::Deployments.new deploy_options
+        logger.debug("Uploading deployment to New Relic")
+        deployment = NewRelic::Cli::Deployments.new(deploy_options)
         deployment.run
-        logger.info "Uploaded deployment information to New Relic"
+        logger.info("Uploaded deployment information to New Relic")
       rescue NewRelic::Cli::Command::CommandFailure => e
-        logger.info e.message
+        logger.info(e.message)
       rescue Capistrano::CommandError
-        logger.info "Unable to notify New Relic of the deployment... skipping"
+        logger.info("Unable to notify New Relic of the deployment... skipping")
       rescue => e
-        logger.info "Error creating New Relic deployment (#{e})\n#{e.backtrace.join("\n")}"
+        logger.info("Error creating New Relic deployment (#{e})\n#{e.backtrace.join("\n")}")
       end
     end
 
     def lookup_changelog(changelog)
       if !changelog
-        logger.debug "Getting log of changes for New Relic Deployment details"
+        logger.debug("Getting log of changes for New Relic Deployment details")
         from_revision = source.next_revision(current_revision)
 
         if scm == :git
@@ -70,7 +70,7 @@ make_notify_task = Proc.new do
     def lookup_rev(rev)
       if rev.nil?
         rev = source.query_revision(source.head()) do |cmd|
-          logger.debug "executing locally: '#{cmd}'"
+          logger.debug("executing locally: '#{cmd}'")
           `#{cmd}`
         end
 

--- a/lib/new_relic/supportability_helper.rb
+++ b/lib/new_relic/supportability_helper.rb
@@ -63,9 +63,9 @@ module NewRelic
     def record_api_supportability_metric(method_name)
       agent = NewRelic::Agent.agent or return
       if metric = API_SUPPORTABILITY_METRICS[method_name]
-        agent.stats_engine.tl_record_unscoped_metrics metric, &:increment_count
+        agent.stats_engine.tl_record_unscoped_metrics(metric, &:increment_count)
       else
-        NewRelic::Agent.logger.debug "API supportability metric not found for :#{method_name}"
+        NewRelic::Agent.logger.debug("API supportability metric not found for :#{method_name}")
       end
     end
 
@@ -77,7 +77,7 @@ module NewRelic
       message = "Bad argument passed to ##{caller_location}. " \
         "Expected #{klass} for `#{name}` but got #{arg.class}"
 
-      NewRelic::Agent.logger.warn message
+      NewRelic::Agent.logger.warn(message)
       nil
     end
   end

--- a/lib/sequel/extensions/newrelic_instrumentation.rb
+++ b/lib/sequel/extensions/newrelic_instrumentation.rb
@@ -72,9 +72,9 @@ module Sequel
       return unless current_segment.is_a?(NewRelic::Agent::Transaction::DatastoreSegment)
 
       if current_segment.sql_statement
-        current_segment.sql_statement.append_sql sql
+        current_segment.sql_statement.append_sql(sql)
       else
-        current_segment._notice_sql sql, self.opts, explainer_for(sql)
+        current_segment._notice_sql(sql, self.opts, explainer_for(sql))
       end
     end
 
@@ -94,6 +94,6 @@ module Sequel
     end
   end # module NewRelicInstrumentation
 
-  NewRelic::Agent.logger.debug "Registering the :newrelic_instrumentation extension."
+  NewRelic::Agent.logger.debug("Registering the :newrelic_instrumentation extension.")
   Database.register_extension(:newrelic_instrumentation, NewRelicInstrumentation)
 end # module Sequel

--- a/lib/tasks/config.rake
+++ b/lib/tasks/config.rake
@@ -123,7 +123,7 @@ namespace :newrelic do
     end
 
     def format_env_var(key)
-      return "None" if NON_ENV_CONFIGS.include? key
+      return "None" if NON_ENV_CONFIGS.include?(key)
       "NEW_RELIC_#{key.gsub(".", "_").upcase}"
     end
 

--- a/lib/tasks/coverage_report.rake
+++ b/lib/tasks/coverage_report.rake
@@ -11,7 +11,7 @@ namespace :coverage do
       puts 'This task is intended to be run only on the CI.'
       return
     end
-    SimpleCov.collate Dir["coverage*/.resultset.json"] do
+    SimpleCov.collate(Dir["coverage*/.resultset.json"]) do
       formatter SimpleCov::Formatter::MultiFormatter.new([
         SimpleCov::Formatter::JSONFormatter,
         SimpleCov::Formatter::HTMLFormatter

--- a/lib/tasks/multiverse.rb
+++ b/lib/tasks/multiverse.rb
@@ -56,18 +56,18 @@ namespace :test do
     end
 
     def remove_generated_gemfiles
-      file_path = File.expand_path "test/multiverse/suites"
-      Dir.glob(File.join file_path, "**", "Gemfile*").each do |fn|
+      file_path = File.expand_path("test/multiverse/suites")
+      Dir.glob(File.join(file_path, "**", "Gemfile*")).each do |fn|
         puts "Removing #{fn.gsub(file_path, '.../suites')}"
-        FileUtils.rm fn
+        FileUtils.rm(fn)
       end
     end
 
     def remove_generated_gemfile_lockfiles
-      file_path = File.expand_path "test/environments"
-      Dir.glob(File.join file_path, "**", "Gemfile.lock").each do |fn|
+      file_path = File.expand_path("test/environments")
+      Dir.glob(File.join(file_path, "**", "Gemfile.lock")).each do |fn|
         puts "Removing #{fn.gsub(file_path, '.../environments')}"
-        FileUtils.rm fn
+        FileUtils.rm(fn)
       end
     end
 
@@ -84,7 +84,7 @@ namespace :test do
 
     desc "Clean cached gemfiles from Bundler.bundle_path"
     task :clean_gemfile_cache do
-      glob = File.expand_path 'multiverse-cache/Gemfile.*.lock', Bundler.bundle_path
+      glob = File.expand_path('multiverse-cache/Gemfile.*.lock', Bundler.bundle_path)
       File.delete(*Dir[glob])
     end
 

--- a/newrelic_rpm.gemspec
+++ b/newrelic_rpm.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.name = "newrelic_rpm"
   s.version = NewRelic::VERSION::STRING
   s.required_ruby_version = '>= 2.2.0'
-  s.required_rubygems_version = Gem::Requirement.new("> 1.3.1") if s.respond_to? :required_rubygems_version=
+  s.required_rubygems_version = Gem::Requirement.new("> 1.3.1") if s.respond_to?(:required_rubygems_version=)
   s.authors = ["Tanna McClure", "Kayla Reopelle", "James Bunch", "Hannah Ramadan"]
   s.licenses = ['Apache-2.0']
   s.description = <<-EOS

--- a/test/config/test_control.rb
+++ b/test/config/test_control.rb
@@ -43,11 +43,11 @@ class NewRelic::Control::Frameworks::Test < parent_class
       return if defined? draw_without_test_route
       def draw_with_test_route
         draw_without_test_route do |map|
-          map.connect ':controller/:action/:id'
-          yield map
+          map.connect(':controller/:action/:id')
+          yield(map)
         end
       end
-      alias_method_chain :draw, :test_route
+      alias_method_chain(:draw, :test_route)
     end
     # Force the routes to be reloaded
     ActionController::Routing::Routes.reload!

--- a/test/environments/lib/environments/runner.rb
+++ b/test/environments/lib/environments/runner.rb
@@ -18,7 +18,7 @@ module Environments
     end
 
     def env_root
-      File.expand_path '../../..', __FILE__
+      File.expand_path('../../..', __FILE__)
     end
 
     def run_and_report
@@ -85,7 +85,7 @@ module Environments
       puts "Bundling in #{dir}..."
       bundler_version = explicit_bundler_version(dir)
       bundle_cmd = "bundle #{explicit_bundler_version(dir)}".strip
-      bundle_config dir, bundle_cmd
+      bundle_config(dir, bundle_cmd)
 
       command = "cd #{dir} && #{bundle_cmd} install"
       result = Multiverse::ShellUtils.try_command_n_times(command, 3)

--- a/test/environments/rails70/config/application.rb
+++ b/test/environments/rails70/config/application.rb
@@ -14,7 +14,7 @@ Bundler.require(*Rails.groups)
 module RpmTestApp
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 7.0
+    config.load_defaults(7.0)
     config.eager_load = false
     config.filter_parameters += [:password]
   end

--- a/test/environments/railsedge/config/application.rb
+++ b/test/environments/railsedge/config/application.rb
@@ -14,7 +14,7 @@ Bundler.require(*Rails.groups)
 module RpmTestApp
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 7.0 # TODO: keep this number up to date (and keep this TODO)
+    config.load_defaults(7.0) # TODO: keep this number up to date (and keep this TODO)
     config.eager_load = false
     config.filter_parameters += [:password]
   end

--- a/test/helpers/config_scanning.rb
+++ b/test/helpers/config_scanning.rb
@@ -27,7 +27,7 @@ module NewRelic
             captures << line.scan(NAMED_DEPENDENCY_PATTERN).map(&method(:disable_name))
 
             captures.flatten.compact.each do |key|
-              default_keys.delete key.gsub("'", "").to_sym
+              default_keys.delete(key.gsub("'", "").to_sym)
             end
             # Remove any config keys that are annotated with the 'dynamic_name' setting
             # This indicates that the names of these keys are constructed dynamically at

--- a/test/helpers/minitest.rb
+++ b/test/helpers/minitest.rb
@@ -30,16 +30,16 @@ end
 MiniTest::Unit.prepend(Module.new do
   def puke klass, meth, e
     if fail_fast? && !e.is_a?(MiniTest::Skip)
-      puke_fast klass, meth, e
+      puke_fast(klass, meth, e)
     else
-      super klass, meth, e
+      super(klass, meth, e)
     end
   end
 
   private
 
   def puke_fast klass, meth, e
-    warn %Q(\n\nFailing fast.\n\n#{klass}:#{meth}\n\n#{e.message}\n\n#{e.backtrace.join("\n")}\n\n)
+    warn(%Q(\n\nFailing fast.\n\n#{klass}:#{meth}\n\n#{e.message}\n\n#{e.backtrace.join("\n")}\n\n))
     raise Interrupt # other exceptions will be caught by MiniTest
   end
 

--- a/test/helpers/misc.rb
+++ b/test/helpers/misc.rb
@@ -42,7 +42,7 @@ def fixture_tcp_socket(response)
     stubs(:sysread) do |size, buf = ''|
       @data ||= response.to_s
       raise EOFError if @data.empty?
-      buf.replace @data.slice!(0, size)
+      buf.replace(@data.slice!(0, size))
       buf
     end
 
@@ -114,7 +114,7 @@ def wait_until_not_nil(give_up_after = 3, &block)
   total_tries = give_up_after * 10
   current_tries = 0
   while block.call.nil? and current_tries < total_tries
-    sleep 0.1
+    sleep(0.1)
     current_tries += 1
   end
 end

--- a/test/helpers/transaction_sample.rb
+++ b/test/helpers/transaction_sample.rb
@@ -15,7 +15,7 @@ module TransactionSampleTestHelper
       sampler.notice_push_frame(state, "a")
       explainer = NewRelic::Agent::Instrumentation::ActiveRecord::EXPLAINER
       sql.each { |sql_statement| sampler.notice_sql(sql_statement, {:adapter => "mysql"}, 0, state, explainer) }
-      sleep 0.02
+      sleep(0.02)
       yield if block_given?
       sampler.notice_pop_frame(state, "a")
     end

--- a/test/multiverse/lib/multiverse.rb
+++ b/test/multiverse/lib/multiverse.rb
@@ -9,7 +9,7 @@ require 'fileutils'
 module Multiverse
   # <ruby_agent>/test/multiverse
   #
-  ROOT = File.expand_path '../..', __FILE__
+  ROOT = File.expand_path('../..', __FILE__)
 
   # append <ruby_agent>/test/multiverse/lib to the load path
   #

--- a/test/multiverse/lib/multiverse/bundler_patch.rb
+++ b/test/multiverse/lib/multiverse/bundler_patch.rb
@@ -13,7 +13,7 @@ require 'bundler'
 unless Bundler.respond_to?(:with_unbundled_env)
   module Bundler
     def self.with_unbundled_env &block
-      Bundler.with_clean_env &block
+      Bundler.with_clean_env(&block)
     end
   end
 end

--- a/test/multiverse/lib/multiverse/envfile.rb
+++ b/test/multiverse/lib/multiverse/envfile.rb
@@ -16,9 +16,9 @@ module Multiverse
       @instrumentation_permutations = ["chain"]
       @gemfiles = []
       @mode = 'fork'
-      if File.exist? file_path
-        @text = File.read self.file_path
-        instance_eval @text
+      if File.exist?(file_path)
+        @text = File.read(self.file_path)
+        instance_eval(@text)
       end
       @gemfiles = [''] if @gemfiles.empty?
     end
@@ -63,7 +63,7 @@ module Multiverse
 
     def execute_mode(mode)
       valid_modes = %w[ fork spawn ]
-      unless valid_modes.member? mode
+      unless valid_modes.member?(mode)
         raise ArgumentError, "#{mode.inspect} is not a valid execute mode.  Valid modes: #{valid_modes.inspect}"
       end
       @mode = mode

--- a/test/multiverse/lib/multiverse/runner.rb
+++ b/test/multiverse/lib/multiverse/runner.rb
@@ -49,7 +49,7 @@ module Multiverse
     def run(filter = "", opts = {})
       execute_suites(filter, opts) do |suite|
         suite.each_instrumentation_method do |method|
-          suite.execute method
+          suite.execute(method)
         end
       end
     end
@@ -70,18 +70,18 @@ module Multiverse
 
         begin
           suite = Suite.new(full_path, opts)
-          yield suite
+          yield(suite)
         rescue => e
           puts red("Error when trying to run suite in #{full_path.inspect}")
           puts
           puts "#{e.class}: #{e}"
           puts(*e.backtrace)
-          notice_exit_status 1
+          notice_exit_status(1)
         end
       end
 
       OutputCollector.overall_report
-      exit exit_status
+      exit(exit_status)
     end
 
     GROUPS = {
@@ -100,17 +100,17 @@ module Multiverse
 
     # Would like to reinstate but requires investigation, see RUBY-1749
     if RUBY_VERSION < '2.3'
-      GROUPS['background_2'].delete 'rake'
+      GROUPS['background_2'].delete('rake')
     end
 
     if RUBY_PLATFORM == "java"
-      GROUPS['agent'].delete 'agent_only'
+      GROUPS['agent'].delete('agent_only')
     end
 
     if RUBY_VERSION >= '3.0'
       # this suite uses mysql2 which has issues on ruby 3.0+
       # a new suite, active_record_pg, has been added to run active record tests on ruby 3.0+
-      GROUPS['rails'].delete 'active_record'
+      GROUPS['rails'].delete('active_record')
     end
 
     def excluded?(suite)
@@ -136,7 +136,7 @@ module Multiverse
         # checks for malformed groups passed in
         if combined_groups.nil?
           puts red("Unrecognized groups in '#{filter}'. Stopping!")
-          exit 1
+          exit(1)
         end
 
         # This allows the "rest" group to be passed in as one of several groups that are ';' delimited

--- a/test/multiverse/lib/multiverse/shell_utils.rb
+++ b/test/multiverse/lib/multiverse/shell_utils.rb
@@ -15,7 +15,7 @@ module Multiverse
         if $?.success?
           return result
         elsif count < n
-          sleep wait_time
+          sleep(wait_time)
           redo
         else
           puts "System command: #{cmd} failed #{n} times. Giving up..."

--- a/test/multiverse/lib/multiverse/suite.rb
+++ b/test/multiverse/lib/multiverse/suite.rb
@@ -22,7 +22,7 @@ module Multiverse
     attr_accessor :directory, :opts
 
     def initialize(directory, opts = {})
-      self.directory = File.expand_path directory
+      self.directory = File.expand_path(directory)
       self.opts = opts
       ENV["VERBOSE"] = '1' if opts[:verbose]
     end
@@ -73,9 +73,9 @@ module Multiverse
     end
 
     def envfile_path
-      ep = File.expand_path 'Envfile'
+      ep = File.expand_path('Envfile')
       if !File.exist?(ep)
-        ep = File.expand_path 'Envfile', directory
+        ep = File.expand_path('Envfile', directory)
         raise "#{ep} not found" unless File.exist?(ep)
       end
       ep
@@ -83,7 +83,7 @@ module Multiverse
 
     def environments
       @environments ||= (
-        Dir.chdir directory
+        Dir.chdir(directory)
         Envfile.new(envfile_path)
       )
     end
@@ -160,14 +160,14 @@ module Multiverse
       puts "Bundling in #{dir}..."
       bundler_version = exact_version || explicit_bundler_version(dir)
       bundle_cmd = "bundle #{explicit_bundler_version(dir)}".strip
-      bundle_config dir, bundle_cmd
-      bundle_show_env bundle_cmd
+      bundle_config(dir, bundle_cmd)
+      bundle_show_env(bundle_cmd)
       full_bundle_cmd = "#{bundle_cmd} install"
-      result = ShellUtils.try_command_n_times full_bundle_cmd, 3
+      result = ShellUtils.try_command_n_times(full_bundle_cmd, 3)
       unless $?.success?
         puts "Failed local bundle, trying again without the version lock..."
         change_lock_version(dir, ENV["BUNDLE_GEMFILE"])
-        result = ShellUtils.try_command_n_times full_bundle_cmd, 3
+        result = ShellUtils.try_command_n_times(full_bundle_cmd, 3)
       end
 
       result = red(result) unless $?.success?
@@ -183,7 +183,7 @@ module Multiverse
         puts "ERROR: on lock_filename #{filepath.inspect} / #{gemfile.inspect}"
         raise
       end
-      return unless File.exist? lock_filename
+      return unless File.exist?(lock_filename)
 
       lock_contents = File.read(lock_filename).split("\n")
       old_version = lock_contents.pop.strip
@@ -315,7 +315,7 @@ module Multiverse
       gems = with_potentially_mismatched_bundler do
         Bundler.definition.specs.inject([]) do |m, s|
           next m if s.name == 'bundler'
-          m.push "#{s.name} (#{s.version})"
+          m.push("#{s.name} (#{s.version})")
           m
         end
       end.sort
@@ -351,7 +351,7 @@ module Multiverse
 
     def execute_child_environment(env_index, instrumentation_method)
       with_unbundled_env do
-        configure_instrumentation_method instrumentation_method
+        configure_instrumentation_method(instrumentation_method)
         optimize_jruby_startups
         ENV["MULTIVERSE_ENV"] = env_index.to_s
         ENV["MULTIVERSE_INSTRUMENTATION_METHOD"] = instrumentation_method
@@ -415,7 +415,7 @@ module Multiverse
     # loads a new JVM for the tests to run in.
     def execute instrumentation_method
       return unless check_environment_condition
-      configure_instrumentation_method instrumentation_method
+      configure_instrumentation_method(instrumentation_method)
 
       label = should_serialize? ? 'serial' : 'parallel'
       env_count = filter_env ? 1 : environments.size
@@ -423,9 +423,9 @@ module Multiverse
 
       environments.before.call if environments.before
       if should_serialize?
-        execute_serial instrumentation_method
+        execute_serial(instrumentation_method)
       else
-        execute_parallel instrumentation_method
+        execute_parallel(instrumentation_method)
       end
       environments.after.call if environments.after
     rescue => e
@@ -459,7 +459,7 @@ module Multiverse
     def with_each_environment
       environments.each_with_index do |gemfile_text, i|
         next unless should_run_environment?(i)
-        yield gemfile_text, i
+        yield(gemfile_text, i)
       end
     end
 
@@ -515,7 +515,7 @@ module Multiverse
         OutputCollector.write(suite, env, red("#{suite.inspect} for Envfile entry #{env} failed!"))
         OutputCollector.failed(suite, env)
       end
-      Multiverse::Runner.notice_exit_status $?
+      Multiverse::Runner.notice_exit_status($?)
     end
 
     def trigger_test_run
@@ -537,7 +537,7 @@ module Multiverse
         test_run = ::MiniTest::Unit.new.run(options)
       end
 
-      load @after_file if @after_file
+      load(@after_file) if @after_file
       begin
         ::MiniTest.class_variable_get(:@@after_run).reverse_each(&:call)
       rescue => e
@@ -622,7 +622,7 @@ module Multiverse
     end
 
     def execute_ruby_files
-      Dir.chdir directory
+      Dir.chdir(directory)
       ordered_ruby_files(directory).each do |file|
         puts yellow("Executing #{file.inspect}") if verbose?
         next if exclude?(file)

--- a/test/multiverse/script/runner
+++ b/test/multiverse/script/runner
@@ -2,4 +2,4 @@
 require 'fileutils'
 require_relative '../../multiverse/lib/multiverse/environment'
 
-Multiverse::Runner.run ARGV[0].to_s
+Multiverse::Runner.run(ARGV[0].to_s)

--- a/test/multiverse/suites/active_record/Rakefile
+++ b/test/multiverse/suites/active_record/Rakefile
@@ -9,6 +9,6 @@ desc "Setup for ActiveRecord"
 task :environment do
   if defined?(DatabaseTasks)
     ActiveRecord::Base.configurations = DatabaseTasks.database_configuration
-    ActiveRecord::Base.establish_connection DatabaseTasks.env.to_sym
+    ActiveRecord::Base.establish_connection(DatabaseTasks.env.to_sym)
   end
 end

--- a/test/multiverse/suites/active_record/active_record_test.rb
+++ b/test/multiverse/suites/active_record/active_record_test.rb
@@ -3,7 +3,7 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
-SimpleCovHelper.command_name "test:multiverse[active_record]"
+SimpleCovHelper.command_name("test:multiverse[active_record]")
 require_relative 'app/models/models'
 
 class ActiveRecordInstrumentationTest < Minitest::Test
@@ -140,11 +140,11 @@ class ActiveRecordInstrumentationTest < Minitest::Test
     minor_version = active_record_minor_version
     Order.class_eval do
       if major_version >= 4
-        scope :jeffs, lambda { where(:name => 'Jeff') }
+        scope(:jeffs, lambda { where(:name => 'Jeff') })
       elsif major_version == 3 && minor_version >= 1
-        scope :jeffs, :conditions => {:name => 'Jeff'}
+        scope(:jeffs, :conditions => {:name => 'Jeff'})
       else
-        named_scope :jeffs, :conditions => {:name => 'Jeff'}
+        named_scope(:jeffs, :conditions => {:name => 'Jeff'})
       end
     end
 
@@ -455,7 +455,7 @@ class ActiveRecordInstrumentationTest < Minitest::Test
     # Let's trigger an active record SQL StatemntInvalid error
     assert_raises ::ActiveRecord::StatementInvalid do
       in_web_transaction do
-        Order.connection.select_rows "select * from askdjfhkajsdhflkjh"
+        Order.connection.select_rows("select * from askdjfhkajsdhflkjh")
       end
     end
 

--- a/test/multiverse/suites/active_record/ar_method_aliasing.rb
+++ b/test/multiverse/suites/active_record/ar_method_aliasing.rb
@@ -16,7 +16,7 @@ class InstrumentActiveRecordMethods < Minitest::Test
   setup_and_teardown_agent
 
   def test_basic_creation
-    a_user = User.new :name => "Bob"
+    a_user = User.new(:name => "Bob")
     assert a_user.new_record?
     a_user.save!
 
@@ -25,13 +25,13 @@ class InstrumentActiveRecordMethods < Minitest::Test
   end
 
   def test_alias_collection_query_method
-    a_user = User.new :name => "Bob"
+    a_user = User.new(:name => "Bob")
     a_user.save!
 
     a_user = User.first
     assert User.connected?
 
-    an_alias = Alias.new :user_id => a_user.id, :aka => "the Blob"
+    an_alias = Alias.new(:user_id => a_user.id, :aka => "the Blob")
     assert an_alias.new_record?
     an_alias.save!
     assert an_alias.persisted? if a_user.respond_to?(:persisted?)

--- a/test/multiverse/suites/active_record/before_suite.rb
+++ b/test/multiverse/suites/active_record/before_suite.rb
@@ -4,7 +4,7 @@
 # frozen_string_literal: true
 
 def redefine_mysql_primary_key const_str
-  const = Object.const_get const_str rescue return
+  const = Object.const_get(const_str) rescue return
   const[:primary_key] = "int(11) auto_increment PRIMARY KEY"
 end
 
@@ -20,7 +20,7 @@ if defined? ::Mysql2
 end
 
 begin
-  load 'Rakefile'
+  load('Rakefile')
   Rake::Task['db:create'].invoke
   Rake::Task['db:migrate'].invoke
 rescue => e

--- a/test/multiverse/suites/active_record/config/database.rb
+++ b/test/multiverse/suites/active_record/config/database.rb
@@ -31,13 +31,13 @@ RAILS_ENV = "test"
 RAILS_ROOT = File.join(db_dir, "..")
 
 ActiveRecord::Base.configurations = config_yml
-ActiveRecord::Base.establish_connection :test
+ActiveRecord::Base.establish_connection(:test)
 ActiveRecord::Base.logger = Logger.new(ENV["VERBOSE"] ? STDOUT : StringIO.new)
 
 begin
-  load 'active_record/railties/databases.rake'
+  load('active_record/railties/databases.rake')
 rescue LoadError, StandardError
-  load 'tasks/databases.rake'
+  load('tasks/databases.rake')
 end
 
 if defined?(ActiveRecord::Tasks)
@@ -79,6 +79,6 @@ else
   end
 
   Rake::Task.define_task("db:environment")
-  Rake::Task["db:load_config"].clear if Rake::Task.task_defined? "db:load_config"
+  Rake::Task["db:load_config"].clear if Rake::Task.task_defined?("db:load_config")
   Rake::Task.define_task("db:rails_env")
 end

--- a/test/multiverse/suites/active_record/db/migrate/20141105131800_create_users_and_aliases.rb
+++ b/test/multiverse/suites/active_record/db/migrate/20141105131800_create_users_and_aliases.rb
@@ -5,19 +5,19 @@
 
 class CreateUsersAndAliases < ActiveRecord::VERSION::STRING >= "5.0.0" ? ActiveRecord::Migration[5.0] : ActiveRecord::Migration
   def self.up
-    create_table :users do |t|
-      t.string :name, null: false
+    create_table(:users) do |t|
+      t.string(:name, null: false)
     end
-    add_index :users, :name, unique: true
+    add_index(:users, :name, unique: true)
 
-    create_table :aliases do |t|
-      t.integer :user_id
-      t.string :aka
+    create_table(:aliases) do |t|
+      t.integer(:user_id)
+      t.string(:aka)
     end
   end
 
   def self.down
-    drop_table :users
-    drop_table :aliases
+    drop_table(:users)
+    drop_table(:aliases)
   end
 end

--- a/test/multiverse/suites/active_record/db/migrate/20141106082200_create_orders_and_shipments.rb
+++ b/test/multiverse/suites/active_record/db/migrate/20141106082200_create_orders_and_shipments.rb
@@ -5,22 +5,22 @@
 
 class CreateOrdersAndShipments < ActiveRecord::VERSION::STRING >= "5.0.0" ? ActiveRecord::Migration[5.0] : ActiveRecord::Migration
   def self.up
-    create_table :orders do |t|
-      t.string :name
+    create_table(:orders) do |t|
+      t.string(:name)
     end
 
-    create_table :shipments, :force => true do |t|
+    create_table(:shipments, :force => true) do |t|
     end
 
-    create_table :order_shipments, :force => true, :id => false do |t|
-      t.integer :order_id
-      t.integer :shipment_id, :integer
+    create_table(:order_shipments, :force => true, :id => false) do |t|
+      t.integer(:order_id)
+      t.integer(:shipment_id, :integer)
     end
   end
 
   def self.down
-    drop_table :orders
-    drop_table :shipments
-    drop_table :order_shipments
+    drop_table(:orders)
+    drop_table(:shipments)
+    drop_table(:order_shipments)
   end
 end

--- a/test/multiverse/suites/active_record/db/migrate/20150413011200_add_timestamps_to_orders.rb
+++ b/test/multiverse/suites/active_record/db/migrate/20150413011200_add_timestamps_to_orders.rb
@@ -11,7 +11,7 @@ class AddTimestampsToOrders < ActiveRecord::VERSION::STRING >= "5.0.0" ? ActiveR
   end
 
   def self.down
-    remove_column :orders, :updated_at
-    remove_column :orders, :created_at
+    remove_column(:orders, :updated_at)
+    remove_column(:orders, :created_at)
   end
 end

--- a/test/multiverse/suites/active_record/db/migrate/20150414084400_create_groups.rb
+++ b/test/multiverse/suites/active_record/db/migrate/20150414084400_create_groups.rb
@@ -5,18 +5,18 @@
 
 class CreateGroups < ActiveRecord::VERSION::STRING >= "5.0.0" ? ActiveRecord::Migration[5.0] : ActiveRecord::Migration
   def self.up
-    create_table :groups do |t|
-      t.string :name
+    create_table(:groups) do |t|
+      t.string(:name)
     end
 
-    create_table :groups_users, :id => false do |t|
-      t.integer :group_id, :integer
-      t.integer :user_id, :integer
+    create_table(:groups_users, :id => false) do |t|
+      t.integer(:group_id, :integer)
+      t.integer(:user_id, :integer)
     end
   end
 
   def self.down
-    drop_table :groups
-    drop_table :groups_users
+    drop_table(:groups)
+    drop_table(:groups_users)
   end
 end

--- a/test/multiverse/suites/active_record_pg/Rakefile
+++ b/test/multiverse/suites/active_record_pg/Rakefile
@@ -9,6 +9,6 @@ desc "Setup for ActiveRecord"
 task :environment do
   if defined?(DatabaseTasks)
     ActiveRecord::Base.configurations = DatabaseTasks.database_configuration
-    ActiveRecord::Base.establish_connection DatabaseTasks.env.to_sym
+    ActiveRecord::Base.establish_connection(DatabaseTasks.env.to_sym)
   end
 end

--- a/test/multiverse/suites/active_record_pg/active_record_test.rb
+++ b/test/multiverse/suites/active_record_pg/active_record_test.rb
@@ -3,7 +3,7 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
-SimpleCovHelper.command_name "test:multiverse[active_record_pg]"
+SimpleCovHelper.command_name("test:multiverse[active_record_pg]")
 require_relative 'app/models/models'
 
 class ActiveRecordInstrumentationTest < Minitest::Test
@@ -139,11 +139,11 @@ class ActiveRecordInstrumentationTest < Minitest::Test
     minor_version = active_record_minor_version
     Order.class_eval do
       if major_version >= 4
-        scope :jeffs, lambda { where(:name => 'Jeff') }
+        scope(:jeffs, lambda { where(:name => 'Jeff') })
       elsif major_version == 3 && minor_version >= 1
-        scope :jeffs, :conditions => {:name => 'Jeff'}
+        scope(:jeffs, :conditions => {:name => 'Jeff'})
       else
-        named_scope :jeffs, :conditions => {:name => 'Jeff'}
+        named_scope(:jeffs, :conditions => {:name => 'Jeff'})
       end
     end
 
@@ -439,7 +439,7 @@ class ActiveRecordInstrumentationTest < Minitest::Test
     # Let's trigger an active record SQL StatemntInvalid error
     assert_raises ::ActiveRecord::StatementInvalid do
       in_web_transaction do
-        Order.connection.select_rows "select * from askdjfhkajsdhflkjh"
+        Order.connection.select_rows("select * from askdjfhkajsdhflkjh")
       end
     end
 

--- a/test/multiverse/suites/active_record_pg/ar_method_aliasing.rb
+++ b/test/multiverse/suites/active_record_pg/ar_method_aliasing.rb
@@ -16,7 +16,7 @@ class InstrumentActiveRecordMethods < Minitest::Test
   setup_and_teardown_agent
 
   def test_basic_creation
-    a_user = User.new :name => "Bob"
+    a_user = User.new(:name => "Bob")
     assert a_user.new_record?
     a_user.save!
 
@@ -25,13 +25,13 @@ class InstrumentActiveRecordMethods < Minitest::Test
   end
 
   def test_alias_collection_query_method
-    a_user = User.new :name => "Bob"
+    a_user = User.new(:name => "Bob")
     a_user.save!
 
     a_user = User.first
     assert User.connected?
 
-    an_alias = Alias.new :user_id => a_user.id, :aka => "the Blob"
+    an_alias = Alias.new(:user_id => a_user.id, :aka => "the Blob")
     assert an_alias.new_record?
     an_alias.save!
     assert an_alias.persisted? if a_user.respond_to?(:persisted?)

--- a/test/multiverse/suites/active_record_pg/before_suite.rb
+++ b/test/multiverse/suites/active_record_pg/before_suite.rb
@@ -4,12 +4,12 @@
 # frozen_string_literal: true
 
 def redefine_mysql_primary_key const_str
-  const = Object.const_get const_str rescue return
+  const = Object.const_get(const_str) rescue return
   const[:primary_key] = "int(11) auto_increment PRIMARY KEY"
 end
 
 begin
-  load 'Rakefile'
+  load('Rakefile')
   Rake::Task['db:drop'].invoke
   Rake::Task['db:create'].invoke
   Rake::Task['db:migrate'].invoke

--- a/test/multiverse/suites/active_record_pg/config/database.rb
+++ b/test/multiverse/suites/active_record_pg/config/database.rb
@@ -31,13 +31,13 @@ RAILS_ENV = "test"
 RAILS_ROOT = File.join(db_dir, "..")
 
 ActiveRecord::Base.configurations = config_yml
-ActiveRecord::Base.establish_connection :test
+ActiveRecord::Base.establish_connection(:test)
 ActiveRecord::Base.logger = Logger.new(ENV["VERBOSE"] ? STDOUT : StringIO.new)
 
 begin
-  load 'active_record/railties/databases.rake'
+  load('active_record/railties/databases.rake')
 rescue LoadError, StandardError
-  load 'tasks/databases.rake'
+  load('tasks/databases.rake')
 end
 
 if defined?(ActiveRecord::Tasks)
@@ -79,6 +79,6 @@ else
   end
 
   Rake::Task.define_task("db:environment")
-  Rake::Task["db:load_config"].clear if Rake::Task.task_defined? "db:load_config"
+  Rake::Task["db:load_config"].clear if Rake::Task.task_defined?("db:load_config")
   Rake::Task.define_task("db:rails_env")
 end

--- a/test/multiverse/suites/active_record_pg/db/migrate/20141105131800_create_users_and_aliases.rb
+++ b/test/multiverse/suites/active_record_pg/db/migrate/20141105131800_create_users_and_aliases.rb
@@ -5,19 +5,19 @@
 
 class CreateUsersAndAliases < ActiveRecord::VERSION::STRING >= "5.0.0" ? ActiveRecord::Migration["#{ActiveRecord::VERSION::STRING[0]}.0"] : ActiveRecord::Migration
   def self.up
-    create_table :users do |t|
-      t.string :name, null: false
+    create_table(:users) do |t|
+      t.string(:name, null: false)
     end
-    add_index :users, :name, unique: true
+    add_index(:users, :name, unique: true)
 
-    create_table :aliases do |t|
-      t.integer :user_id
-      t.string :aka
+    create_table(:aliases) do |t|
+      t.integer(:user_id)
+      t.string(:aka)
     end
   end
 
   def self.down
-    drop_table :users
-    drop_table :aliases
+    drop_table(:users)
+    drop_table(:aliases)
   end
 end

--- a/test/multiverse/suites/active_record_pg/db/migrate/20141106082200_create_orders_and_shipments.rb
+++ b/test/multiverse/suites/active_record_pg/db/migrate/20141106082200_create_orders_and_shipments.rb
@@ -5,22 +5,22 @@
 
 class CreateOrdersAndShipments < ActiveRecord::VERSION::STRING >= "5.0.0" ? ActiveRecord::Migration["#{ActiveRecord::VERSION::STRING[0]}.0"] : ActiveRecord::Migration
   def self.up
-    create_table :orders do |t|
-      t.string :name
+    create_table(:orders) do |t|
+      t.string(:name)
     end
 
-    create_table :shipments, :force => true do |t|
+    create_table(:shipments, :force => true) do |t|
     end
 
-    create_table :order_shipments, :force => true, :id => false do |t|
-      t.integer :order_id
-      t.integer :shipment_id
+    create_table(:order_shipments, :force => true, :id => false) do |t|
+      t.integer(:order_id)
+      t.integer(:shipment_id)
     end
   end
 
   def self.down
-    drop_table :orders
-    drop_table :shipments
-    drop_table :order_shipments
+    drop_table(:orders)
+    drop_table(:shipments)
+    drop_table(:order_shipments)
   end
 end

--- a/test/multiverse/suites/active_record_pg/db/migrate/20150413011200_add_timestamps_to_orders.rb
+++ b/test/multiverse/suites/active_record_pg/db/migrate/20150413011200_add_timestamps_to_orders.rb
@@ -11,7 +11,7 @@ class AddTimestampsToOrders < ActiveRecord::VERSION::STRING >= "5.0.0" ? ActiveR
   end
 
   def self.down
-    remove_column :orders, :updated_at
-    remove_column :orders, :created_at
+    remove_column(:orders, :updated_at)
+    remove_column(:orders, :created_at)
   end
 end

--- a/test/multiverse/suites/active_record_pg/db/migrate/20150414084400_create_groups.rb
+++ b/test/multiverse/suites/active_record_pg/db/migrate/20150414084400_create_groups.rb
@@ -5,18 +5,18 @@
 
 class CreateGroups < ActiveRecord::VERSION::STRING >= "5.0.0" ? ActiveRecord::Migration["#{ActiveRecord::VERSION::STRING[0]}.0"] : ActiveRecord::Migration
   def self.up
-    create_table :groups do |t|
-      t.string :name
+    create_table(:groups) do |t|
+      t.string(:name)
     end
 
-    create_table :groups_users, :id => false do |t|
-      t.integer :group_id
-      t.integer :user_id
+    create_table(:groups_users, :id => false) do |t|
+      t.integer(:group_id)
+      t.integer(:user_id)
     end
   end
 
   def self.down
-    drop_table :groups
-    drop_table :groups_users
+    drop_table(:groups)
+    drop_table(:groups_users)
   end
 end

--- a/test/multiverse/suites/activemerchant/activemerchant_test.rb
+++ b/test/multiverse/suites/activemerchant/activemerchant_test.rb
@@ -6,7 +6,7 @@
 # Let ActiveSupport's auto-loading make sure the testing gateway's there.
 # require complains of redefine on certain Rubies, (looking at you REE)
 
-SimpleCovHelper.command_name "test:multiverse[activemerchant]"
+SimpleCovHelper.command_name("test:multiverse[activemerchant]")
 
 ActiveMerchant::Billing::BogusGateway
 
@@ -20,8 +20,8 @@ end
 
 class BadGateway < ActiveMerchant::Billing::BogusGateway
   def purchase(*args)
-    super *args
-    raise StandardError.new "whoops!"
+    super(*args)
+    raise StandardError.new("whoops!")
   end
 end
 

--- a/test/multiverse/suites/agent_only/adaptive_sampler_test.rb
+++ b/test/multiverse/suites/agent_only/adaptive_sampler_test.rb
@@ -3,7 +3,7 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
-SimpleCovHelper.command_name "test:multiverse[agent_only]"
+SimpleCovHelper.command_name("test:multiverse[agent_only]")
 
 module NewRelic
   module Agent
@@ -11,9 +11,9 @@ module NewRelic
       include MultiverseHelpers
 
       setup_and_teardown_agent do
-        NewRelic::Agent.config.add_config_for_testing :'distributed_tracing.enabled' => true
+        NewRelic::Agent.config.add_config_for_testing(:'distributed_tracing.enabled' => true)
         # hard reset on the adaptive_sampler
-        NewRelic::Agent.instance.instance_variable_set :@adaptive_sampler, AdaptiveSampler.new
+        NewRelic::Agent.instance.instance_variable_set(:@adaptive_sampler, AdaptiveSampler.new)
       end
 
       def test_adaptive_sampler_valid_stats_and_reset_after_harvest

--- a/test/multiverse/suites/agent_only/cross_application_tracing_test.rb
+++ b/test/multiverse/suites/agent_only/cross_application_tracing_test.rb
@@ -26,33 +26,33 @@ class CrossApplicationTracingTest < Minitest::Test
   include Rack::Test::Methods
 
   def app
-    Rack::Builder.app { run TestingApp.new }
+    Rack::Builder.app { run(TestingApp.new) }
   end
 
   def test_cross_app_doesnt_modify_without_header
-    get '/'
+    get('/')
     refute last_response.headers["X-NewRelic-App-Data"]
   end
 
   def test_cross_app_doesnt_modify_with_invalid_header
-    get '/', nil, {'HTTP_X_NEWRELIC_ID' => Base64.encode64('otherjunk')}
+    get('/', nil, {'HTTP_X_NEWRELIC_ID' => Base64.encode64('otherjunk')})
     refute last_response.headers["X-NewRelic-App-Data"]
   end
 
   def test_cross_app_writes_out_information
-    get '/', nil, {'HTTP_X_NEWRELIC_ID' => Base64.encode64('1#234')}
+    get('/', nil, {'HTTP_X_NEWRELIC_ID' => Base64.encode64('1#234')})
     refute_nil last_response.headers["X-NewRelic-App-Data"]
     assert_metrics_recorded(['ClientApplication/1#234/all'])
   end
 
   def test_cross_app_doesnt_modify_if_txn_is_ignored
-    get '/', {'transaction_name' => 'ignored_transaction'}, {'HTTP_X_NEWRELIC_ID' => Base64.encode64('1#234')}
+    get('/', {'transaction_name' => 'ignored_transaction'}, {'HTTP_X_NEWRELIC_ID' => Base64.encode64('1#234')})
     refute last_response.headers["X-NewRelic-App-Data"]
   end
 
   def test_cross_app_error_attaches_process_id_to_intrinsics
     assert_raises(RuntimeError) do
-      get '/', {'fail' => 'true'}, {'HTTP_X_NEWRELIC_ID' => Base64.encode64('1#234')}
+      get('/', {'fail' => 'true'}, {'HTTP_X_NEWRELIC_ID' => Base64.encode64('1#234')})
     end
 
     assert_includes attributes_for(last_traced_error, :intrinsic), :client_cross_process_id

--- a/test/multiverse/suites/agent_only/encoding_handling_test.rb
+++ b/test/multiverse/suites/agent_only/encoding_handling_test.rb
@@ -73,7 +73,7 @@ class EncodingHandlingTest < Minitest::Test
   end
 
   def test_handles_mis_encoded_strings_in_environment_report
-    NewRelic::Agent.instance.instance_variable_set :@environment_report, nil
+    NewRelic::Agent.instance.instance_variable_set(:@environment_report, nil)
     $collector.reset
     ::NewRelic::EnvironmentReport.report_on('Dummy') do
       bad_string

--- a/test/multiverse/suites/agent_only/error_events_test.rb
+++ b/test/multiverse/suites/agent_only/error_events_test.rb
@@ -26,7 +26,7 @@ class ErrorEventsTest < Minitest::Test
   end
 
   def test_error_events_honor_expected_option
-    txn = generate_errors 1, expected: true
+    txn = generate_errors(1, expected: true)
 
     NewRelic::Agent.agent.send(:harvest_and_send_error_event_data)
 
@@ -36,8 +36,8 @@ class ErrorEventsTest < Minitest::Test
   end
 
   def test_records_supportability_metrics
-    with_config :'error_collector.max_event_samples_stored' => 10 do
-      generate_errors 15
+    with_config(:'error_collector.max_event_samples_stored' => 10) do
+      generate_errors(15)
 
       NewRelic::Agent.agent.send(:harvest_and_send_error_event_data)
 
@@ -49,9 +49,9 @@ class ErrorEventsTest < Minitest::Test
   end
 
   def test_does_not_record_error_events_when_disabled
-    with_config :'error_collector.capture_events' => false do
+    with_config(:'error_collector.capture_events' => false) do
       NewRelic::Agent.config.notify_server_source_added
-      generate_errors 5
+      generate_errors(5)
 
       NewRelic::Agent.agent.send(:harvest_and_send_error_event_data)
       assert_equal(0, $collector.calls_for(:error_event_data).size)
@@ -59,10 +59,10 @@ class ErrorEventsTest < Minitest::Test
   end
 
   def test_does_not_record_error_events_after_error_collector_disabled_from_server
-    with_config :'error_collector.enabled' => true do
-      generate_errors 5
+    with_config(:'error_collector.enabled' => true) do
+      generate_errors(5)
 
-      with_server_source :'error_collector.enabled' => false do
+      with_server_source(:'error_collector.enabled' => false) do
         NewRelic::Agent.agent.send(:harvest_and_send_error_event_data)
       end
     end
@@ -77,7 +77,7 @@ class ErrorEventsTest < Minitest::Test
     })
     trigger_agent_reconnect
 
-    generate_errors 5
+    generate_errors(5)
 
     NewRelic::Agent.agent.send(:harvest_and_send_error_event_data)
     assert_equal(0, $collector.calls_for(:error_event_data).size)
@@ -93,7 +93,7 @@ class ErrorEventsTest < Minitest::Test
   end
 
   def test_error_events_created_outside_of_transaction
-    NewRelic::Agent.notice_error RuntimeError.new "No Txn"
+    NewRelic::Agent.notice_error(RuntimeError.new("No Txn"))
     NewRelic::Agent.agent.send(:harvest_and_send_error_event_data)
 
     intrinsics, _, _ = last_error_event
@@ -107,7 +107,7 @@ class ErrorEventsTest < Minitest::Test
 
   def test_error_events_during_txn_abide_by_custom_attributes_config
     with_config(:'custom_attributes.enabled' => false) do
-      generate_errors 1, {:foo => "bar"}
+      generate_errors(1, {:foo => "bar"})
     end
 
     NewRelic::Agent.agent.send(:harvest_and_send_error_event_data)
@@ -130,8 +130,8 @@ class ErrorEventsTest < Minitest::Test
   end
 
   def generate_errors num_errors = 1, options = {}
-    in_transaction :transaction_name => "Controller/blogs/index" do |t|
-      num_errors.times { t.notice_error RuntimeError.new("Big Controller"), options }
+    in_transaction(:transaction_name => "Controller/blogs/index") do |t|
+      num_errors.times { t.notice_error(RuntimeError.new("Big Controller"), options) }
     end
   end
 

--- a/test/multiverse/suites/agent_only/exclusive_time_test.rb
+++ b/test/multiverse/suites/agent_only/exclusive_time_test.rb
@@ -14,19 +14,19 @@ class ExclusiveTimeTest < Minitest::Test
       include NewRelic::Agent::MethodTracer
 
       def outer_a
-        advance_process_time 2
+        advance_process_time(2)
         outer_b
       end
       add_transaction_tracer :outer_a, :class_name => 'traced'
 
       def outer_b
-        advance_process_time 5
+        advance_process_time(5)
         inner
       end
       add_transaction_tracer :outer_b, :class_name => 'traced'
 
       def inner
-        advance_process_time 10
+        advance_process_time(10)
       end
       add_method_tracer :inner, 'inner'
     end
@@ -65,13 +65,13 @@ class ExclusiveTimeTest < Minitest::Test
       include NewRelic::Agent::MethodTracer
 
       def outer
-        advance_process_time 2
+        advance_process_time(2)
         inner
       end
       add_transaction_tracer :outer, :class_name => 'traced'
 
       def inner
-        advance_process_time 10
+        advance_process_time(10)
       end
       add_method_tracer :inner, 'inner'
     end

--- a/test/multiverse/suites/agent_only/harvest_timestamps_test.rb
+++ b/test/multiverse/suites/agent_only/harvest_timestamps_test.rb
@@ -13,12 +13,12 @@ class HarvestTimestampsTest < Minitest::Test
   def test_resets_metric_data_timestamps_after_forking
     nr_freeze_process_time
 
-    t1 = advance_process_time 10
+    t1 = advance_process_time(10)
 
     simulate_fork
     NewRelic::Agent.after_fork
 
-    t2 = advance_process_time 10
+    t2 = advance_process_time(10)
     trigger_metric_data_post
 
     metric_data_post = $collector.calls_for('metric_data').first

--- a/test/multiverse/suites/agent_only/marshaling_test.rb
+++ b/test/multiverse/suites/agent_only/marshaling_test.rb
@@ -21,7 +21,7 @@ class MarshalingTest < Minitest::Test
     in_transaction do
       trace_execution_scoped('a') do
         trace_execution_scoped('ab') do
-          advance_time 1
+          advance_time(1)
         end
       end
     end
@@ -42,8 +42,8 @@ class MarshalingTest < Minitest::Test
 
   def test_metric_data_marshalling
     metric = 'Custom/test/method'
-    NewRelic::Agent.record_metric metric, 1.0
-    NewRelic::Agent.record_metric metric, 2.0
+    NewRelic::Agent.record_metric(metric, 1.0)
+    NewRelic::Agent.record_metric(metric, 2.0)
 
     expected = [2, 3.0, 3.0, 1.0, 2.0, 5.0]
 

--- a/test/multiverse/suites/agent_only/pipe_manager_test.rb
+++ b/test/multiverse/suites/agent_only/pipe_manager_test.rb
@@ -21,9 +21,9 @@ class PipeManagerTest < Minitest::Test
   def test_old_pipes_are_cleaned_up_after_timeout
     @listener.timeout = 1
     NewRelic::Agent::PipeChannelManager.register_report_channel(:timeout_test)
-    sleep 2
+    sleep(2)
     @listener.start
-    sleep 0.5 # give the thread some time to start, and clean things up
+    sleep(0.5) # give the thread some time to start, and clean things up
     refute NewRelic::Agent::PipeChannelManager.channels[:timeout_test]
   end
 
@@ -32,11 +32,11 @@ class PipeManagerTest < Minitest::Test
     @listener.timeout = 2
     NewRelic::Agent::PipeChannelManager.register_report_channel(:select_test)
 
-    sleep 1.5
+    sleep(1.5)
     @listener.start
     assert NewRelic::Agent::PipeChannelManager.channels[:select_test]
 
-    sleep 1.5
+    sleep(1.5)
     refute NewRelic::Agent::PipeChannelManager.channels[:select_test]
   end
 end

--- a/test/multiverse/suites/agent_only/rum_instrumentation_test.rb
+++ b/test/multiverse/suites/agent_only/rum_instrumentation_test.rb
@@ -36,31 +36,31 @@ class RumAutoTest < Minitest::Test
 
   def test_autoinstrumentation_is_active
     @inner_app.response = "<html><head><title>W00t!</title></head><body><p>Hello World</p></body></html>"
-    get '/'
+    get('/')
     assert_response_includes("<script", JS_AGENT_LOADER, "NREUM")
   end
 
   def test_autoinstrumentation_with_basic_page_puts_header_at_beginning_of_head
     @inner_app.response = "<html><head><title>foo</title></head><body><p>Hello World</p></body></html>"
-    get '/'
+    get('/')
     assert_response_includes(%Q(<html><head>#{CONFIG_REGEX}#{LOADER_REGEX}<title>foo</title></head>))
   end
 
   def test_autoinstrumentation_with_body_only_puts_header_before_body
     @inner_app.response = "<html><body><p>Hello World</p></body></html>"
-    get '/'
+    get('/')
     assert_response_includes %Q(<html>#{CONFIG_REGEX}#{LOADER_REGEX}<body>)
   end
 
   def test_autoinstrumentation_with_X_UA_Compatible_puts_header_after_meta_tag
     @inner_app.response = '<html><head><meta http-equiv="X-UA-Compatible"/></head><body><p>Hello World</p></body></html>'
-    get '/'
+    get('/')
     assert_response_includes(%Q(<html><head><meta http-equiv="X-UA-Compatible"/>#{CONFIG_REGEX}#{LOADER_REGEX}</head><body>))
   end
 
   def test_autoinstrumentation_doesnt_run_for_crazy_shit_like_this
     @inner_app.response = '<html><head <body </body>'
-    get '/'
+    get('/')
     assert_response_includes('<html><head <body </body>')
   end
 
@@ -68,7 +68,7 @@ class RumAutoTest < Minitest::Test
     @inner_app.response = "<html><head><title>W00t!</title></head><body><p>Hello World</p></body></html>"
     content_length = @inner_app.response.length
     @inner_app.headers["Content-Length"] = content_length
-    get '/'
+    get('/')
     assert(last_response.headers['Content-Length'].to_i > content_length)
     assert_equal(last_response.body.length.to_s, last_response.headers['Content-Length'])
   end
@@ -77,14 +77,14 @@ class RumAutoTest < Minitest::Test
     body = "<html><head><title>W00t!</title></head><body><p>Hello World</p></body></html>"
     @inner_app.response = body
     @inner_app.headers["Content-Type"] = "text/xml"
-    get '/'
+    get('/')
     assert_equal(last_response.body, body)
   end
 
   def test_rum_headers_are_not_injected_in_ignored_txn
     body = "<html><head><title>W00t!</title></head><body><p>Hello World</p></body></html>"
     @inner_app.response = body
-    get '/', 'transaction_name' => 'ignored_transaction'
+    get('/', 'transaction_name' => 'ignored_transaction')
     assert_equal(last_response.body, body)
   end
 

--- a/test/multiverse/suites/agent_only/script/warnings.rb
+++ b/test/multiverse/suites/agent_only/script/warnings.rb
@@ -10,7 +10,7 @@ require 'newrelic_rpm'
 NewRelic::Agent::Tracer.in_transaction(name: 'ponies', category: :controller) do
 end
 
-NewRelic::Agent.notice_error 'oops'
+NewRelic::Agent.notice_error('oops')
 
 NewRelic::Agent.instance.send(:transmit_data)
 

--- a/test/multiverse/suites/agent_only/service_timeout_test.rb
+++ b/test/multiverse/suites/agent_only/service_timeout_test.rb
@@ -13,7 +13,7 @@ class ServiceTimeoutTest < Minitest::Test
     Thread.new {
       client = hk.accept
       client.gets
-      sleep 4
+      sleep(4)
       client.close
       Thread.exit
     }

--- a/test/multiverse/suites/agent_only/span_events_test.rb
+++ b/test/multiverse/suites/agent_only/span_events_test.rb
@@ -9,7 +9,7 @@ class SpanEventsTest < Minitest::Test
   setup_and_teardown_agent
 
   def test_span_events_are_submitted
-    with_config :'distributed_tracing.enabled' => true do
+    with_config(:'distributed_tracing.enabled' => true) do
       NewRelic::Agent.config.notify_server_source_added
       event = generate_event('test_event')
       NewRelic::Agent.instance.span_event_aggregator.record(event: event)
@@ -22,7 +22,7 @@ class SpanEventsTest < Minitest::Test
   end
 
   def test_span_events_are_not_recorded_when_disabled_by_feature_gate
-    with_config :'distributed_tracing.enabled' => true do
+    with_config(:'distributed_tracing.enabled' => true) do
       connect_response = {
         'agent_run_id' => 1,
         'collect_span_events' => false

--- a/test/multiverse/suites/agent_only/start_up_test.rb
+++ b/test/multiverse/suites/agent_only/start_up_test.rb
@@ -90,12 +90,12 @@ RUBY
 
   if RUBY_PLATFORM != 'java'
     def test_after_fork_clears_existing_transactions
-      with_config clear_transaction_state_after_fork: true do
+      with_config(clear_transaction_state_after_fork: true) do
         read, write = IO.pipe
 
         NewRelic::Agent.manual_start(:app_name => 'my great app')
 
-        in_transaction "outer txn" do
+        in_transaction("outer txn") do
           pid = Process.fork do
             read.close
             NewRelic::Agent.after_fork

--- a/test/multiverse/suites/agent_only/synthetics_test.rb
+++ b/test/multiverse/suites/agent_only/synthetics_test.rb
@@ -14,7 +14,7 @@ class SyntheticsTest < Minitest::Test
   setup_and_teardown_agent
 
   def app
-    Rack::Builder.app { run TestingApp.new }
+    Rack::Builder.app { run(TestingApp.new) }
   end
 
   def last_sent_analytics_event

--- a/test/multiverse/suites/agent_only/testing_app.rb
+++ b/test/multiverse/suites/agent_only/testing_app.rb
@@ -23,7 +23,7 @@ class TestingApp
       opts = {}
       if params['transaction_category']
         opts[:category] = params['transaction_category']
-        NewRelic::Agent::Tracer.current_transaction.stubs(:similar_category?).returns true
+        NewRelic::Agent::Tracer.current_transaction.stubs(:similar_category?).returns(true)
       end
       NewRelic::Agent.set_transaction_name(params['transaction_name'], opts)
     end

--- a/test/multiverse/suites/agent_only/transaction_events_test.rb
+++ b/test/multiverse/suites/agent_only/transaction_events_test.rb
@@ -19,8 +19,8 @@ class TransactionEventsTest < Minitest::Test
   end
 
   def test_transaction_event_error_flag_is_set
-    in_transaction :transaction_name => "Controller/blogs/index" do |t|
-      t.notice_error RuntimeError.new "Big Controller"
+    in_transaction(:transaction_name => "Controller/blogs/index") do |t|
+      t.notice_error(RuntimeError.new("Big Controller"))
     end
 
     NewRelic::Agent.agent.send(:harvest_and_send_analytic_event_data)
@@ -32,7 +32,7 @@ class TransactionEventsTest < Minitest::Test
 
   def test_transaction_events_abide_by_custom_attributes_config
     with_config(:'custom_attributes.enabled' => false) do
-      in_transaction :transaction_name => "Controller/blogs/index" do |t|
+      in_transaction(:transaction_name => "Controller/blogs/index") do |t|
         t.add_custom_attributes(:foo => "bar")
       end
     end

--- a/test/multiverse/suites/agent_only/utilization_data_collection_test.rb
+++ b/test/multiverse/suites/agent_only/utilization_data_collection_test.rb
@@ -37,7 +37,7 @@ class UtilizationDataCollectionTest < Minitest::Test
     NewRelic::Agent::SystemInfo.stubs(:ip_addresses).returns(["127.0.0.1"])
 
     aws_fixture_path = File.expand_path('../../../../fixtures/utilization/aws', __FILE__)
-    fixture = File.read File.join(aws_fixture_path, "valid.json")
+    fixture = File.read(File.join(aws_fixture_path, "valid.json"))
 
     with_fake_metadata_service do |service|
       NewRelic::Agent::Utilization::AWS.stubs(:imds_token).returns('J.R.R.')
@@ -85,7 +85,7 @@ class UtilizationDataCollectionTest < Minitest::Test
 
     redirect_link_local_address(metadata_service.port)
 
-    yield metadata_service
+    yield(metadata_service)
   ensure
     metadata_service.stop if metadata_service
     unredirect_link_local_address

--- a/test/multiverse/suites/bare/standalone_instrumentation_test.rb
+++ b/test/multiverse/suites/bare/standalone_instrumentation_test.rb
@@ -9,7 +9,7 @@
 # See https://newrelic.atlassian.net/browse/RUBY-1116 for details on how this
 # was broken previously.
 
-SimpleCovHelper.command_name "test:multiverse[bare]"
+SimpleCovHelper.command_name("test:multiverse[bare]")
 require 'new_relic/agent/method_tracer'
 
 class StandaloneInstrumentationTest < Minitest::Test

--- a/test/multiverse/suites/capistrano/deployment_test.rb
+++ b/test/multiverse/suites/capistrano/deployment_test.rb
@@ -3,7 +3,7 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
-SimpleCovHelper.command_name "test:multiverse[capistrano]"
+SimpleCovHelper.command_name("test:multiverse[capistrano]")
 require 'fake_rpm_site'
 require 'new_relic/cli/command'
 

--- a/test/multiverse/suites/capistrano2/deployment_test.rb
+++ b/test/multiverse/suites/capistrano2/deployment_test.rb
@@ -3,7 +3,7 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
-SimpleCovHelper.command_name "test:multiverse[capistrano2]"
+SimpleCovHelper.command_name("test:multiverse[capistrano2]")
 require 'fake_rpm_site'
 
 class DeploymentTest < Minitest::Test

--- a/test/multiverse/suites/config_file_loading/config_file_loading_test.rb
+++ b/test/multiverse/suites/config_file_loading/config_file_loading_test.rb
@@ -15,7 +15,7 @@
 # If this fails the agent will attempt to dial Lew Cirne's cell phone and ask
 # that he verbally describe how it should be configured.
 
-SimpleCovHelper.command_name "test:multiverse[config_file_loading]"
+SimpleCovHelper.command_name("test:multiverse[config_file_loading]")
 
 class ConfigFileLoadingTest < Minitest::Test
   include MultiverseHelpers
@@ -61,7 +61,7 @@ class ConfigFileLoadingTest < Minitest::Test
     teardown_agent
 
     FileUtils.mkdir_p(File.dirname(path))
-    Dir.chdir @cwd
+    Dir.chdir(@cwd)
     File.open(path, 'w') do |f|
       if config_file_content
         f.write(config_file_content)

--- a/test/multiverse/suites/curb/curb_test.rb
+++ b/test/multiverse/suites/curb/curb_test.rb
@@ -3,7 +3,7 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
-SimpleCovHelper.command_name "test:multiverse[curb]"
+SimpleCovHelper.command_name("test:multiverse[curb]")
 require 'curb'
 require 'newrelic_rpm'
 require 'http_client_test_cases'
@@ -18,7 +18,7 @@ class CurbTest < Minitest::Test
 
   def test_shouldnt_clobber_existing_header_callback
     headers = []
-    Curl::Easy.http_get default_url do |handle|
+    Curl::Easy.http_get(default_url) do |handle|
       handle.on_header do |header|
         headers << header
         header.length
@@ -30,7 +30,7 @@ class CurbTest < Minitest::Test
 
   def test_shouldnt_clobber_existing_completion_callback
     completed = false
-    Curl::Easy.http_get default_url do |handle|
+    Curl::Easy.http_get(default_url) do |handle|
       handle.on_complete do
         completed = true
       end
@@ -78,7 +78,7 @@ class CurbTest < Minitest::Test
   def test_get_via_multi_preserves_header_str
     header_str = nil
 
-    Curl::Multi.get [default_url] do |easy|
+    Curl::Multi.get([default_url]) do |easy|
       header_str = easy.header_str
     end
 
@@ -104,7 +104,7 @@ class CurbTest < Minitest::Test
     other_url = "http://localhost:#{$fake_server.port}/"
 
     in_transaction("test") do
-      Curl::Multi.get [default_url, other_url] do |easy|
+      Curl::Multi.get([default_url, other_url]) do |easy|
         results << easy.body_str
       end
 
@@ -160,7 +160,7 @@ class CurbTest < Minitest::Test
   end
 
   def simulate_error_response
-    get_response "http://localhost:666/evil"
+    get_response("http://localhost:666/evil")
   end
 
   def get_response url = nil, headers = nil
@@ -175,23 +175,23 @@ class CurbTest < Minitest::Test
   end
 
   def get_wrapped_response url
-    NewRelic::Agent::HTTPClients::CurbResponse.new get_response url
+    NewRelic::Agent::HTTPClients::CurbResponse.new(get_response(url))
   end
 
   def head_response
-    Curl::Easy.http_head default_url
+    Curl::Easy.http_head(default_url)
   end
 
   def post_response
-    Curl::Easy.http_post default_url, ''
+    Curl::Easy.http_post(default_url, '')
   end
 
   def put_response
-    Curl::Easy.http_put default_url, ''
+    Curl::Easy.http_put(default_url, '')
   end
 
   def delete_response
-    Curl::Easy.http_delete default_url
+    Curl::Easy.http_delete(default_url)
   end
 
   def body res
@@ -205,7 +205,7 @@ class CurbTest < Minitest::Test
   def response_instance headers = {}
     res = NewRelic::Agent::HTTPClients::CurbResponse.new(Curl::Easy.new("http://localhost"))
     headers.each do |hdr, val|
-      res.append_header_data "#{hdr}: #{val}"
+      res.append_header_data("#{hdr}: #{val}")
     end
 
     return res

--- a/test/multiverse/suites/datamapper/datamapper_test.rb
+++ b/test/multiverse/suites/datamapper/datamapper_test.rb
@@ -3,7 +3,7 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
-SimpleCovHelper.command_name "test:multiverse[datamapper]"
+SimpleCovHelper.command_name("test:multiverse[datamapper]")
 
 DataMapper::Logger.new("/dev/null", :debug)
 DataMapper.setup(:default, 'sqlite::memory:')
@@ -370,7 +370,7 @@ class DataMapperTest < Minitest::Test
   def test_should_not_bomb_out_if_a_query_is_in_an_invalid_encoding
     db = DummyConnection.new
     q = "select ICS95095010000000000083320000BS01030000004100+\xFF00000000000000000"
-    q.force_encoding 'UTF-8'
+    q.force_encoding('UTF-8')
 
     msg = mock
     msg.stubs(:duration).returns(1)

--- a/test/multiverse/suites/deferred_instrumentation/sinatra_test.rb
+++ b/test/multiverse/suites/deferred_instrumentation/sinatra_test.rb
@@ -3,7 +3,7 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
-SimpleCovHelper.command_name "test:multiverse[deferred_instrumentation]"
+SimpleCovHelper.command_name("test:multiverse[deferred_instrumentation]")
 require 'newrelic_rpm'
 require 'sinatra'
 require_relative '../sinatra/sinatra_test_cases'

--- a/test/multiverse/suites/delayed_job/before_suite.rb
+++ b/test/multiverse/suites/delayed_job/before_suite.rb
@@ -48,8 +48,8 @@ if Delayed::Worker.backend.to_s == "Delayed::Backend::ActiveRecord::Job"
   class CreatePelicans < ActiveRecord::VERSION::STRING >= "5.0.0" ? ActiveRecord::Migration["#{ActiveRecord::VERSION::STRING[0]}.0"] : ActiveRecord::Migration
     @connection = $db_connection
     def self.up
-      create_table :pelicans do |t|
-        t.string :name
+      create_table(:pelicans) do |t|
+        t.string(:name)
       end
     end
   end

--- a/test/multiverse/suites/delayed_job/delayed_job_instrumentation_test.rb
+++ b/test/multiverse/suites/delayed_job/delayed_job_instrumentation_test.rb
@@ -3,7 +3,7 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
-SimpleCovHelper.command_name "test:multiverse[delayed_job]"
+SimpleCovHelper.command_name("test:multiverse[delayed_job]")
 
 if defined?(Delayed::Backend::ActiveRecord) && Delayed::Worker.respond_to?(:delay_jobs)
   class DelayedJobInstrumentationTest < Minitest::Test
@@ -88,7 +88,7 @@ if defined?(Delayed::Backend::ActiveRecord) && Delayed::Worker.respond_to?(:dela
     end
 
     def test_enqueue_standalone_job
-      job = QuackJob.new rand(100)
+      job = QuackJob.new(rand(100))
       invoke_job(job)
 
       assert_metrics_recorded [

--- a/test/multiverse/suites/excon/excon_test.rb
+++ b/test/multiverse/suites/excon/excon_test.rb
@@ -3,7 +3,7 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
-SimpleCovHelper.command_name "test:multiverse[excon]"
+SimpleCovHelper.command_name("test:multiverse[excon]")
 require "excon"
 require "newrelic_rpm"
 require "http_client_test_cases"
@@ -16,7 +16,7 @@ class ExconTest < Minitest::Test
   end
 
   def new_timeout_error_class
-    Excon::Errors::Timeout.new 'read timeout reached'
+    Excon::Errors::Timeout.new('read timeout reached')
   end
 
   def timeout_error_class
@@ -33,7 +33,7 @@ class ExconTest < Minitest::Test
   end
 
   def get_wrapped_response url
-    NewRelic::Agent::HTTPClients::ExconHTTPResponse.new get_response url
+    NewRelic::Agent::HTTPClients::ExconHTTPResponse.new(get_response(url))
   end
 
   def get_response_multi(url, n)
@@ -69,7 +69,7 @@ class ExconTest < Minitest::Test
       :path => "",
       :headers => {}
     }
-    NewRelic::Agent::HTTPClients::ExconHTTPRequest.new params
+    NewRelic::Agent::HTTPClients::ExconHTTPRequest.new(params)
   end
 
   def response_instance(headers = {})

--- a/test/multiverse/suites/grape/grape_test.rb
+++ b/test/multiverse/suites/grape/grape_test.rb
@@ -3,7 +3,7 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
-SimpleCovHelper.command_name "test:multiverse[grape]"
+SimpleCovHelper.command_name("test:multiverse[grape]")
 require "grape"
 require "newrelic_rpm"
 require './grape_test_api'
@@ -16,17 +16,17 @@ class GrapeTest < Minitest::Test
 
   unless ::Grape::VERSION == '0.1.5'
     def app
-      Rack::Builder.app { run GrapeTestApi.new }
+      Rack::Builder.app { run(GrapeTestApi.new) }
     end
 
     def test_nonexistent_route
-      get '/not_grape_ape'
+      get('/not_grape_ape')
       assert_no_metrics_match(/grape_ape/)
     end
 
     def test_route_raises_an_error
       assert_raises(GrapeTestApiError) do
-        get '/self_destruct'
+        get('/self_destruct')
       end
 
       expected_txn_name = 'Controller/Grape/GrapeTestApi/self_destruct (GET)'
@@ -35,32 +35,32 @@ class GrapeTest < Minitest::Test
     end
 
     def test_getting_a_list_of_grape_apes
-      get '/grape_ape'
+      get('/grape_ape')
       assert_grape_metrics('Controller/Grape/GrapeTestApi/grape_ape (GET)')
     end
 
     def test_showing_a_grape_ape
-      get '/grape_ape/1'
+      get('/grape_ape/1')
       assert_grape_metrics('Controller/Grape/GrapeTestApi/grape_ape/:id (GET)')
     end
 
     def test_creating_a_grape_ape
-      post '/grape_ape', {}
+      post('/grape_ape', {})
       assert_grape_metrics('Controller/Grape/GrapeTestApi/grape_ape (POST)')
     end
 
     def test_updating_a_grape_ape
-      put '/grape_ape/1', {}
+      put('/grape_ape/1', {})
       assert_grape_metrics('Controller/Grape/GrapeTestApi/grape_ape/:id (PUT)')
     end
 
     def test_deleting_a_grape_ape
-      delete '/grape_ape/1'
+      delete('/grape_ape/1')
       assert_grape_metrics('Controller/Grape/GrapeTestApi/grape_ape/:id (DELETE)')
     end
 
     def test_transaction_renaming
-      get '/grape_ape/renamed'
+      get('/grape_ape/renamed')
       # The second node here is 'Rack' because of an idiosyncrasy of
       # the set_transaction_name API: when you call set_transaction_name and
       # don't provide an explicit category, you lock in the category prefix
@@ -75,7 +75,7 @@ class GrapeTest < Minitest::Test
 
     def test_params_are_not_captured_with_capture_params_disabled
       with_config(:capture_params => false) do
-        get '/grape_ape/10'
+        get('/grape_ape/10')
 
         expected = {}
         assert_equal expected, last_transaction_trace_request_params
@@ -84,7 +84,7 @@ class GrapeTest < Minitest::Test
 
     def test_route_params_are_captured
       with_config(:capture_params => true) do
-        get '/grape_ape/10'
+        get('/grape_ape/10')
 
         expected = {
           "request.parameters.id" => "10"
@@ -95,7 +95,7 @@ class GrapeTest < Minitest::Test
 
     def test_query_params_are_captured
       with_config(:capture_params => true) do
-        get '/grape_ape?q=1234&foo=bar'
+        get('/grape_ape?q=1234&foo=bar')
 
         expected = {
           'request.parameters.q' => '1234',
@@ -107,7 +107,7 @@ class GrapeTest < Minitest::Test
 
     def test_post_body_params_are_captured
       with_config(:capture_params => true) do
-        post '/grape_ape', {'q' => '1234', 'foo' => 'bar'}.to_json, "CONTENT_TYPE" => "application/json"
+        post('/grape_ape', {'q' => '1234', 'foo' => 'bar'}.to_json, "CONTENT_TYPE" => "application/json")
 
         expected = {
           'request.parameters.q' => '1234',
@@ -120,7 +120,7 @@ class GrapeTest < Minitest::Test
     def test_post_body_params_are_captured_with_error
       with_config(:capture_params => true) do
         assert_raises(GrapeTestApiError) do
-          post '/grape_ape_fail', {'q' => '1234', 'foo' => 'fail'}.to_json, "CONTENT_TYPE" => "application/json"
+          post('/grape_ape_fail', {'q' => '1234', 'foo' => 'fail'}.to_json, "CONTENT_TYPE" => "application/json")
         end
 
         agent_attributes = attributes_for(last_traced_error, :agent)
@@ -131,7 +131,7 @@ class GrapeTest < Minitest::Test
 
     def test_post_body_params_are_captured_with_rescue_from
       with_config(:capture_params => true) do
-        post '/grape_ape_fail_rescue', {'q' => '1234', 'foo' => 'fail'}.to_json, "CONTENT_TYPE" => "application/json"
+        post('/grape_ape_fail_rescue', {'q' => '1234', 'foo' => 'fail'}.to_json, "CONTENT_TYPE" => "application/json")
 
         agent_attributes = attributes_for(last_traced_error, :agent)
         assert_equal('1234', agent_attributes['request.parameters.q'])
@@ -142,7 +142,7 @@ class GrapeTest < Minitest::Test
     def test_post_body_with_nested_params_are_captured
       with_config(:capture_params => true) do
         params = {"ape" => {"first_name" => "koko", "last_name" => "gorilla"}}
-        post '/grape_ape', params.to_json, "CONTENT_TYPE" => "application/json"
+        post('/grape_ape', params.to_json, "CONTENT_TYPE" => "application/json")
 
         expected = {
           "request.parameters.ape.first_name" => "koko",
@@ -158,7 +158,7 @@ class GrapeTest < Minitest::Test
           :title => "blah",
           :file => Rack::Test::UploadedFile.new(__FILE__, 'text/plain')
         }
-        post '/grape_ape', params
+        post('/grape_ape', params)
 
         expected = {
           "request.parameters.title" => "blah",
@@ -170,7 +170,7 @@ class GrapeTest < Minitest::Test
 
     def test_404_with_params_does_not_capture_them
       with_config(:capture_params => true) do
-        post '/grape_catfish', {"foo" => "bar"}
+        post('/grape_catfish', {"foo" => "bar"})
         expected = {}
         assert_equal expected, last_transaction_trace_request_params
       end
@@ -184,7 +184,7 @@ class GrapeTest < Minitest::Test
           :bar => "baz"
         }.to_json
 
-        post '/grape_ape', json, {"CONTENT_TYPE" => "application/json"}
+        post('/grape_ape', json, {"CONTENT_TYPE" => "application/json"})
 
         expected = {"request.parameters.foo" => "bar", "request.parameters.bar" => "baz"}
         actual = agent_attributes_for_single_event_posted_without_ignored_attributes
@@ -194,7 +194,7 @@ class GrapeTest < Minitest::Test
     end
 
     def test_request_and_response_attributes_recorded_as_agent_attributes
-      post '/grape_ape'
+      post('/grape_ape')
 
       expected = {
         "response.headers.contentLength" => last_response.content_length.to_i,
@@ -210,7 +210,7 @@ class GrapeTest < Minitest::Test
       # so we remove it when it is zero since its not present in such cases.
       if Gem::Version.new(::Grape::VERSION) >= Gem::Version.new("1.3.0")
         if expected["response.headers.contentLength"] == 0
-          expected.delete "response.headers.contentLength"
+          expected.delete("response.headers.contentLength")
         end
       end
       actual = agent_attributes_for_single_event_posted_without_ignored_attributes
@@ -237,11 +237,11 @@ class GrapeApiInstanceTest < Minitest::Test
 
   if ::Grape::VERSION >= '1.2.0'
     def app
-      Rack::Builder.app { run GrapeApiInstanceTestApi.new }
+      Rack::Builder.app { run(GrapeApiInstanceTestApi.new) }
     end
 
     def test_subclass_of_grape_api_instance
-      get '/banjaxing'
+      get('/banjaxing')
 
       expected_node_name = 'Middleware/Grape/GrapeApiInstanceTestApi/call'
       expected_txn_name = 'Controller/Grape/GrapeApiInstanceTestApi/banjaxing (GET)'

--- a/test/multiverse/suites/grape/grape_versioning_test.rb
+++ b/test/multiverse/suites/grape/grape_versioning_test.rb
@@ -14,36 +14,36 @@ unless ::Grape::VERSION == '0.1.5'
 
     def app
       clazz = @app_class
-      Rack::Builder.app { run clazz.new }
+      Rack::Builder.app { run(clazz.new) }
     end
 
     def test_version_from_path_is_recorded_in_transaction_name
       @app_class = GrapeVersioning::ApiV1
-      get '/v1/fish'
+      get('/v1/fish')
       assert_metrics_recorded('Controller/Grape/GrapeVersioning::ApiV1-v1/fish (GET)')
     end
 
     def test_version_is_stripped_when_requesting_root_route
       @app_class = GrapeVersioning::ApiV1
-      get '/v1'
+      get('/v1')
       assert_metrics_recorded('Controller/Grape/GrapeVersioning::ApiV1-v1/ (GET)')
     end
 
     def test_version_is_stripped_when_requesting_root_route_with_trailing_slash
       @app_class = GrapeVersioning::ApiV1
-      get '/v1/'
+      get('/v1/')
       assert_metrics_recorded('Controller/Grape/GrapeVersioning::ApiV1-v1/ (GET)')
     end
 
     def test_version_from_param_version_is_recorded_in_transaction_name
       @app_class = GrapeVersioning::ApiV2
-      get '/fish?apiver=v2'
+      get('/fish?apiver=v2')
       assert_metrics_recorded('Controller/Grape/GrapeVersioning::ApiV2-v2/fish (GET)')
     end
 
     def test_version_from_header_is_recorded_in_transaction_name
       @app_class = GrapeVersioning::ApiV3
-      get '/fish', {}, 'HTTP_ACCEPT' => 'application/vnd.newrelic-v3+json'
+      get('/fish', {}, 'HTTP_ACCEPT' => 'application/vnd.newrelic-v3+json')
       assert_metrics_recorded('Controller/Grape/GrapeVersioning::ApiV3-v3/fish (GET)')
     end
 
@@ -51,33 +51,33 @@ unless ::Grape::VERSION == '0.1.5'
     if Gem::Version.new(Grape::VERSION) >= Gem::Version.new('0.16.0')
       def test_version_from_accept_version_header_is_recorded_in_transaction_name
         @app_class = GrapeVersioning::ApiV4
-        get '/fish', {}, 'HTTP_ACCEPT_VERSION' => 'v4'
+        get('/fish', {}, 'HTTP_ACCEPT_VERSION' => 'v4')
         assert_metrics_recorded('Controller/Grape/GrapeVersioning::ApiV4-v4/fish (GET)')
       end
 
       def test_version_from_accept_version_header_is_recorded_in_transaction_name_cascading_versions_penultimate
         @app_class = GrapeVersioning::CascadingAPI
-        get '/fish', {}, 'HTTP_ACCEPT_VERSION' => 'v4'
+        get('/fish', {}, 'HTTP_ACCEPT_VERSION' => 'v4')
         assert_metrics_recorded('Controller/Grape/GrapeVersioning::CascadingAPI-v4/fish (GET)')
       end
 
       def test_version_from_accept_version_header_is_recorded_in_transaction_name_cascading_versions_latest
         @app_class = GrapeVersioning::CascadingAPI
-        get '/fish', {}, 'HTTP_ACCEPT_VERSION' => 'v5'
+        get('/fish', {}, 'HTTP_ACCEPT_VERSION' => 'v5')
         assert_metrics_recorded('Controller/Grape/GrapeVersioning::CascadingAPI-v5/fish (GET)')
       end
     end
 
     def test_app_not_using_versioning_does_not_record_version_in_transaction_name
       @app_class = GrapeVersioning::Unversioned
-      get '/fish'
+      get('/fish')
       assert_metrics_recorded('Controller/Grape/GrapeVersioning::Unversioned/fish (GET)')
     end
 
     def test_shared_version_declaration_in_tranasaction_names
       @app_class = GrapeVersioning::SharedApi
       %w[ v1 v2 v3 v4 ].each do |v|
-        get "/#{v}/fish"
+        get("/#{v}/fish")
         assert_metrics_recorded("Controller/Grape/GrapeVersioning::SharedApi-#{v}/fish (GET)")
       end
     end
@@ -85,7 +85,7 @@ unless ::Grape::VERSION == '0.1.5'
     def test_shared_version_block_in_tranasaction_names
       @app_class = GrapeVersioning::SharedBlockApi
       %w[ v1 v2 v3 v4 ].each do |v|
-        get "/#{v}/fish"
+        get("/#{v}/fish")
         assert_metrics_recorded("Controller/Grape/GrapeVersioning::SharedBlockApi-#{v}/fish (GET)")
       end
     end
@@ -99,7 +99,7 @@ unless ::Grape::VERSION == '0.1.5'
     #
     def test_default_header_version_in_tranasaction_names
       @app_class = GrapeVersioning::DefaultHeaderApi
-      get "/fish", nil, 'HTTP_ACCEPT' => 'application/json'
+      get("/fish", nil, 'HTTP_ACCEPT' => 'application/json')
       assert_metrics_recorded("Controller/Grape/GrapeVersioning::DefaultHeaderApi-v2|v3/fish (GET)")
     end
 
@@ -110,7 +110,7 @@ unless ::Grape::VERSION == '0.1.5'
     if Gem::Version.new(Grape::VERSION) >= Gem::Version.new('0.5.0')
       def test_default_accept_version_header_version_in_tranasaction_names
         @app_class = GrapeVersioning::DefaultAcceptVersionHeaderApi
-        get "/fish", nil, 'HTTP_ACCEPT_VERSION' => ''
+        get("/fish", nil, 'HTTP_ACCEPT_VERSION' => '')
         assert_metrics_recorded("Controller/Grape/GrapeVersioning::DefaultAcceptVersionHeaderApi-v2|v3/fish (GET)")
       end
     end

--- a/test/multiverse/suites/grape/unsupported_version_test.rb
+++ b/test/multiverse/suites/grape/unsupported_version_test.rb
@@ -17,11 +17,11 @@ class UnsupportedGrapeTest < Minitest::Test
     end
 
     def test_unsupported_version
-      get '/grape_ape'
-      get '/grape_ape/1'
-      post '/grape_ape', {}
-      put '/grape_ape/1', {}
-      delete '/grape_ape/1'
+      get('/grape_ape')
+      get('/grape_ape/1')
+      post('/grape_ape', {})
+      put('/grape_ape/1', {})
+      delete('/grape_ape/1')
 
       assert_no_metrics_match(/grape_ape/)
     end

--- a/test/multiverse/suites/high_security/high_security_test.rb
+++ b/test/multiverse/suites/high_security/high_security_test.rb
@@ -3,7 +3,7 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
-SimpleCovHelper.command_name "test:multiverse[high_security]"
+SimpleCovHelper.command_name("test:multiverse[high_security]")
 require 'fake_server'
 
 # These tests are designed to work in conjunction with a local newrelic.yml

--- a/test/multiverse/suites/httpclient/httpclient_test.rb
+++ b/test/multiverse/suites/httpclient/httpclient_test.rb
@@ -3,7 +3,7 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
-SimpleCovHelper.command_name "test:multiverse[httpclient]"
+SimpleCovHelper.command_name("test:multiverse[httpclient]")
 require "httpclient"
 require "newrelic_rpm"
 require "http_client_test_cases"
@@ -29,7 +29,7 @@ class HTTPClientTest < Minitest::Test
   end
 
   def get_wrapped_response url
-    NewRelic::Agent::HTTPClients::HTTPClientResponse.new get_response url
+    NewRelic::Agent::HTTPClients::HTTPClientResponse.new(get_response(url))
   end
 
   def head_response
@@ -58,7 +58,7 @@ class HTTPClientTest < Minitest::Test
     headers.each do |k, v|
       httpclient_resp.http_header[k] = v
     end
-    NewRelic::Agent::HTTPClients::HTTPClientResponse.new httpclient_resp
+    NewRelic::Agent::HTTPClients::HTTPClientResponse.new(httpclient_resp)
   end
 
   def test_still_records_tt_node_when_pop_raises_an_exception

--- a/test/multiverse/suites/httprb/httprb_test.rb
+++ b/test/multiverse/suites/httprb/httprb_test.rb
@@ -3,7 +3,7 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
-SimpleCovHelper.command_name "test:multiverse[httprb]"
+SimpleCovHelper.command_name("test:multiverse[httprb]")
 require "http"
 require "newrelic_rpm"
 require "http_client_test_cases"
@@ -24,7 +24,7 @@ class HTTPTest < Minitest::Test
   end
 
   def get_wrapped_response url
-    NewRelic::Agent::HTTPClients::HTTPResponse.new get_response url
+    NewRelic::Agent::HTTPClients::HTTPResponse.new(get_response(url))
   end
 
   def head_response

--- a/test/multiverse/suites/infinite_tracing/infinite_tracing_test.rb
+++ b/test/multiverse/suites/infinite_tracing/infinite_tracing_test.rb
@@ -4,7 +4,7 @@
 # frozen_string_literal: true
 
 INFINITE_TRACING_TEST_PATH = File.expand_path('../../../../infinite_tracing/test')
-$LOAD_PATH.unshift INFINITE_TRACING_TEST_PATH
+$LOAD_PATH.unshift(INFINITE_TRACING_TEST_PATH)
 
 require 'test_helper'
 

--- a/test/multiverse/suites/json/json_test.rb
+++ b/test/multiverse/suites/json/json_test.rb
@@ -3,7 +3,7 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
-SimpleCovHelper.command_name "test:multiverse[json]"
+SimpleCovHelper.command_name("test:multiverse[json]")
 require File.join(File.dirname(__FILE__), '..', '..', '..', 'new_relic', 'marshalling_test_cases')
 
 # This is intended as a sanity check for our serialization to JSON via the

--- a/test/multiverse/suites/logger/logger_instrumentation_test.rb
+++ b/test/multiverse/suites/logger/logger_instrumentation_test.rb
@@ -3,7 +3,7 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
-SimpleCovHelper.command_name "test:multiverse[logger]"
+SimpleCovHelper.command_name("test:multiverse[logger]")
 
 class LoggerInstrumentationTest < Minitest::Test
   include MultiverseHelpers

--- a/test/multiverse/suites/marshalling/marshalling_test.rb
+++ b/test/multiverse/suites/marshalling/marshalling_test.rb
@@ -3,7 +3,7 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
-SimpleCovHelper.command_name "test:multiverse[marshalling]"
+SimpleCovHelper.command_name("test:multiverse[marshalling]")
 require File.join(File.dirname(__FILE__), '..', '..', '..', 'new_relic', 'marshalling_test_cases')
 
 # These tests are intended to exercise the basic marshalling functionality of

--- a/test/multiverse/suites/memcache/dalli_test.rb
+++ b/test/multiverse/suites/memcache/dalli_test.rb
@@ -3,7 +3,7 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
-SimpleCovHelper.command_name "test:multiverse[memcache]"
+SimpleCovHelper.command_name("test:multiverse[memcache]")
 require "./memcache_test_cases"
 
 if defined?(Dalli)
@@ -47,7 +47,7 @@ if defined?(Dalli)
             @cache.get_multi(key)
           end
           trace = last_transaction_trace
-          segment = find_node_with_name trace, 'Datastore/operation/Memcached/get_multi_request'
+          segment = find_node_with_name(trace, 'Datastore/operation/Memcached/get_multi_request')
           assert_equal "get_multi_request [\"#{key}\"]", segment[:statement]
         end
       end
@@ -55,28 +55,28 @@ if defined?(Dalli)
       def test_assign_instance_to_with_ip_and_port
         segment = mock('datastore_segment')
         segment.expects(:set_instance_info).with('127.0.0.1', 11211)
-        server = DALLI_SERVER_PROTOCOL.new '127.0.0.1:11211'
+        server = DALLI_SERVER_PROTOCOL.new('127.0.0.1:11211')
         DalliTracerHelper.assign_instance_to(segment, server)
       end
 
       def test_assign_instance_to_with_name_and_port
         segment = mock('datastore_segment')
         segment.expects(:set_instance_info).with('jonan.gummy_planet', 11211)
-        server = DALLI_SERVER_PROTOCOL.new 'jonan.gummy_planet:11211'
+        server = DALLI_SERVER_PROTOCOL.new('jonan.gummy_planet:11211')
         DalliTracerHelper.assign_instance_to(segment, server)
       end
 
       def test_assign_instance_to_with_unix_domain_socket
         segment = mock('datastore_segment')
         segment.expects(:set_instance_info).with('localhost', '/tmp/jonanfs.sock')
-        server = DALLI_SERVER_PROTOCOL.new '/tmp/jonanfs.sock'
+        server = DALLI_SERVER_PROTOCOL.new('/tmp/jonanfs.sock')
         DalliTracerHelper.assign_instance_to(segment, server)
       end
 
       def test_assign_instance_to_when_exception_raised
         segment = mock('datastore_segment')
         segment.expects(:set_instance_info).with('unknown', 'unknown')
-        server = DALLI_SERVER_PROTOCOL.new '/tmp/jonanfs.sock'
+        server = DALLI_SERVER_PROTOCOL.new('/tmp/jonanfs.sock')
         server.stubs(:hostname).raises("oops")
         DalliTracerHelper.assign_instance_to(segment, server)
       end
@@ -92,8 +92,8 @@ if defined?(Dalli)
       if ::NewRelic::Agent::Instrumentation::Memcache::Dalli.supports_datastore_instances?
         datastore_command = MULTI_OPERATIONS.include?(command) ? :get_multi_request : command
         metrics = super(datastore_command)
-        metrics.unshift instance_metric
-        metrics.unshift "Ruby/Memcached/Dalli/#{command}" if command != datastore_command
+        metrics.unshift(instance_metric)
+        metrics.unshift("Ruby/Memcached/Dalli/#{command}") if command != datastore_command
         metrics
       else
         super
@@ -104,8 +104,8 @@ if defined?(Dalli)
       if ::NewRelic::Agent::Instrumentation::Memcache::Dalli.supports_datastore_instances?
         datastore_command = MULTI_OPERATIONS.include?(command) ? :get_multi_request : command
         metrics = super(datastore_command)
-        metrics.unshift instance_metric
-        metrics.unshift "Ruby/Memcached/Dalli/#{command}" if command != datastore_command
+        metrics.unshift(instance_metric)
+        metrics.unshift("Ruby/Memcached/Dalli/#{command}") if command != datastore_command
         metrics
       else
         super

--- a/test/multiverse/suites/memcache/memcache_test_cases.rb
+++ b/test/multiverse/suites/memcache/memcache_test_cases.rb
@@ -339,7 +339,7 @@ module MemcacheTestCases
         @cache.get(key)
       end
       trace = last_transaction_trace
-      segment = find_node_with_name trace, 'Datastore/operation/Memcached/get'
+      segment = find_node_with_name(trace, 'Datastore/operation/Memcached/get')
       assert_equal "get \"#{key}\"", segment[:statement]
     end
   end

--- a/test/multiverse/suites/mongo/helpers/mongo_replica_set.rb
+++ b/test/multiverse/suites/mongo/helpers/mongo_replica_set.rb
@@ -44,10 +44,10 @@ class MongoReplicaSet
       yield
     rescue exception => e
       if message
-        raise e unless e.message.include? message
+        raise e unless e.message.include?(message)
       end
 
-      sleep 0.1
+      sleep(0.1)
       tries += 1
       retry unless tries > maximum_tries
       raise e
@@ -74,7 +74,7 @@ class MongoReplicaSet
     return nil unless running?
     self.servers.first.client['admin'].command({'replSetGetStatus' => 1})
   rescue Mongo::OperationFailure => e
-    raise e unless e.message.include? 'EMPTYCONFIG'
+    raise e unless e.message.include?('EMPTYCONFIG')
   end
 
   def config

--- a/test/multiverse/suites/mongo/helpers/mongo_server.rb
+++ b/test/multiverse/suites/mongo/helpers/mongo_server.rb
@@ -110,7 +110,7 @@ class MongoServer
 
   def wait_until(seconds = 10)
     Timeout.timeout(seconds) do
-      sleep 0.1 until yield
+      sleep(0.1) until yield
     end
   end
 
@@ -196,7 +196,7 @@ class MongoServer
   end
 
   def pid
-    File.read(pid_path).to_i if File.exist? pid_path
+    File.read(pid_path).to_i if File.exist?(pid_path)
   end
 
   def next_available_port
@@ -237,10 +237,10 @@ class MongoServer
       yield
     rescue exception => e
       if message
-        raise e unless e.message.include? message
+        raise e unless e.message.include?(message)
       end
 
-      sleep 0.1
+      sleep(0.1)
       tries += 1
       retry unless tries > maximum_tries
       raise e
@@ -248,7 +248,7 @@ class MongoServer
   end
 
   def release_port
-    FileUtils.rm port_lock_path, :force => true
+    FileUtils.rm(port_lock_path, :force => true)
     self.port = nil
   end
 

--- a/test/multiverse/suites/mongo/helpers/mongo_server_test.rb
+++ b/test/multiverse/suites/mongo/helpers/mongo_server_test.rb
@@ -92,12 +92,12 @@ class MongoServerTest < Test::Unit::TestCase
 
   def test_pingable_returns_true_if_ping_is_ok
     ok_status = {"ok" => 1.0}
-    @server.stubs(:ping).returns ok_status
+    @server.stubs(:ping).returns(ok_status)
     assert @server.pingable?
   end
 
   def test_server_start_times_out_if_it_isnt_pingable
-    @server.stubs(:pingable?).returns false
+    @server.stubs(:pingable?).returns(false)
 
     assert_raise Timeout::Error do
       @server.start

--- a/test/multiverse/suites/mongo/mongo2_instrumentation_test.rb
+++ b/test/multiverse/suites/mongo/mongo2_instrumentation_test.rb
@@ -319,7 +319,7 @@ if NewRelic::Agent::Datastores::Mongo.is_supported_version? &&
 
           def test_batched_queries
             25.times do |i|
-              @collection.insert_one :name => "test-#{i}", :active => true
+              @collection.insert_one(:name => "test-#{i}", :active => true)
             end
             NewRelic::Agent.drop_buffered_data
 
@@ -352,10 +352,10 @@ if NewRelic::Agent::Datastores::Mongo.is_supported_version? &&
 
           def test_batched_queries_have_node_per_query
             25.times do |i|
-              @collection.insert_one :name => "test-#{i}", :active => true
+              @collection.insert_one(:name => "test-#{i}", :active => true)
             end
             NewRelic::Agent.drop_buffered_data
-            in_transaction "webby" do
+            in_transaction("webby") do
               @collection.find(:active => true).batch_size(10).to_a
             end
 
@@ -368,21 +368,21 @@ if NewRelic::Agent::Datastores::Mongo.is_supported_version? &&
             trace = last_transaction_trace
             actual = []
             trace.each_node do |n|
-              actual << n.metric_name if n.metric_name.start_with? "Datastore/statement/MongoDB"
+              actual << n.metric_name if n.metric_name.start_with?("Datastore/statement/MongoDB")
             end
 
             assert_equal expected, actual
           end
 
           def test_trace_nodes_have_instance_attributes
-            @collection.insert_one :name => "test", :active => true
+            @collection.insert_one(:name => "test", :active => true)
             NewRelic::Agent.drop_buffered_data
-            in_transaction "webby" do
+            in_transaction("webby") do
               @collection.find(:active => true).to_a
             end
 
             trace = last_transaction_trace
-            node = find_node_with_name_matching trace, /^Datastore\//
+            node = find_node_with_name_matching(trace, /^Datastore\//)
 
             assert_equal mongo_host, node[:host]
             assert_equal '27017', node[:port_path_or_id]

--- a/test/multiverse/suites/mongo/mongo_connection_test.rb
+++ b/test/multiverse/suites/mongo/mongo_connection_test.rb
@@ -3,7 +3,7 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
-SimpleCovHelper.command_name "test:multiverse[mongo]"
+SimpleCovHelper.command_name("test:multiverse[mongo]")
 require 'mongo'
 require 'newrelic_rpm'
 require 'new_relic/agent/datastores/mongo'

--- a/test/multiverse/suites/net_http/net_http_test.rb
+++ b/test/multiverse/suites/net_http/net_http_test.rb
@@ -3,7 +3,7 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
-SimpleCovHelper.command_name "test:multiverse[net_http]"
+SimpleCovHelper.command_name("test:multiverse[net_http]")
 require "net_http_test_cases"
 
 class NetHttpTest < Minitest::Test

--- a/test/multiverse/suites/padrino/padrino_test.rb
+++ b/test/multiverse/suites/padrino/padrino_test.rb
@@ -3,7 +3,7 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
-SimpleCovHelper.command_name "test:multiverse[padrino]"
+SimpleCovHelper.command_name("test:multiverse[padrino]")
 # Shhhh
 Padrino::Logger::Config[:development][:stream] = :null
 
@@ -44,11 +44,11 @@ class PadrinoRoutesTest < Minitest::Test
   def test_tracing_is_involved
     klass = ENV['MULTIVERSE_INSTRUMENTATION_METHOD'] == 'chain' ? ::PadrinoTestApp : ::Padrino::Application
     klass.any_instance.expects(:invoke_route_with_tracing)
-    get '/user/login'
+    get('/user/login')
   end
 
   def test_basic_route
-    get '/user/login'
+    get('/user/login')
     assert_equal 200, last_response.status
     assert_equal 'please log in', last_response.body
 
@@ -59,7 +59,7 @@ class PadrinoRoutesTest < Minitest::Test
   end
 
   def test_regex_route
-    get '/regexes'
+    get('/regexes')
     assert_equal 200, last_response.status
     assert_equal "with extra regexes please!", last_response.body
 

--- a/test/multiverse/suites/rack/builder_map_test.rb
+++ b/test/multiverse/suites/rack/builder_map_test.rb
@@ -8,7 +8,7 @@
 # metrics. In internals changed across Rack versions, so it's important to
 # check as our middleware and Rack instrumentation has grown.
 
-SimpleCovHelper.command_name "test:multiverse[rack]"
+SimpleCovHelper.command_name("test:multiverse[rack]")
 require 'multiverse_helpers'
 
 if NewRelic::Agent::Instrumentation::RackHelpers.rack_version_supported?
@@ -48,29 +48,29 @@ if NewRelic::Agent::Instrumentation::RackHelpers.rack_version_supported?
 
     def app
       Rack::Builder.app do
-        use MiddlewareOne
-        use MiddlewareTwo
+        use(MiddlewareOne)
+        use(MiddlewareTwo)
 
-        map '/prefix1' do
-          run PrefixAppOne.new
+        map('/prefix1') do
+          run(PrefixAppOne.new)
         end
 
-        map '/prefix2' do
-          use MiddlewareThree
-          run PrefixAppTwo.new
+        map('/prefix2') do
+          use(MiddlewareThree)
+          run(PrefixAppTwo.new)
         end
 
         # Rack versions prior to 1.4 did not support combining map and run at the
         # top-level in the same Rack::Builder.
         if Rack::VERSION[1] >= 4
-          run ExampleApp.new
+          run(ExampleApp.new)
         end
       end
     end
 
     if Rack::VERSION[1] >= 4
       def test_metrics_for_default_prefix
-        get '/'
+        get('/')
 
         assert_metrics_recorded_exclusive([
           'Apdex',
@@ -90,7 +90,7 @@ if NewRelic::Agent::Instrumentation::RackHelpers.rack_version_supported?
     end
 
     def test_metrics_for_mapped_prefix
-      get '/prefix1'
+      get('/prefix1')
 
       assert_metrics_recorded([
         'Apdex',
@@ -110,7 +110,7 @@ if NewRelic::Agent::Instrumentation::RackHelpers.rack_version_supported?
     end
 
     def test_metrics_for_mapped_prefix_with_extra_middleware
-      get '/prefix2'
+      get('/prefix2')
 
       assert_metrics_recorded([
         'Apdex',

--- a/test/multiverse/suites/rack/http_response_code_test.rb
+++ b/test/multiverse/suites/rack/http_response_code_test.rb
@@ -18,29 +18,29 @@ if NewRelic::Agent::Instrumentation::RackHelpers.rack_version_supported?
 
     def app
       Rack::Builder.app do
-        use ResponseCodeMiddleware
-        use NewRelic::Rack::AgentHooks
-        run ExampleApp.new
+        use(ResponseCodeMiddleware)
+        use(NewRelic::Rack::AgentHooks)
+        run(ExampleApp.new)
       end
     end
 
     def test_records_http_response_code_on_analytics_events
-      rsp = get '/', {'override-response-code' => 404}
+      rsp = get('/', {'override-response-code' => 404})
       assert_equal(404, rsp.status)
       assert_equal(404, get_last_analytics_event[2][:'http.statusCode'])
 
-      rsp = get '/', {'override-response-code' => 302}
+      rsp = get('/', {'override-response-code' => 302})
       assert_equal(302, rsp.status)
       assert_equal(302, get_last_analytics_event[2][:'http.statusCode'])
     end
 
     def test_skips_http_response_code_if_middleware_tracing_disabled
       with_config(:disable_middleware_instrumentation => true) do
-        rsp = get '/', {'override-response-code' => 404}
+        rsp = get('/', {'override-response-code' => 404})
         assert_equal(404, rsp.status)
         refute get_last_analytics_event[2][:'http.statusCode']
 
-        rsp = get '/', {'override-response-code' => 302}
+        rsp = get('/', {'override-response-code' => 302})
         assert_equal(302, rsp.status)
         refute get_last_analytics_event[2][:'http.statusCode']
       end

--- a/test/multiverse/suites/rack/nested_non_rack_app_test.rb
+++ b/test/multiverse/suites/rack/nested_non_rack_app_test.rb
@@ -36,13 +36,13 @@ if NewRelic::Agent::Instrumentation::RackHelpers.rack_version_supported?
 
     def app
       Rack::Builder.app do
-        use ExampleMiddleware
-        run RailsishApp.new
+        use(ExampleMiddleware)
+        run(RailsishApp.new)
       end
     end
 
     def test_outermost_middleware_contributes_to_middleware_all_if_txn_name_is_non_rack
-      get '/'
+      get('/')
 
       assert_metrics_recorded_exclusive(
         [

--- a/test/multiverse/suites/rack/puma_rack_builder_test.rb
+++ b/test/multiverse/suites/rack/puma_rack_builder_test.rb
@@ -21,7 +21,7 @@ if NewRelic::Agent::Instrumentation::RackHelpers.puma_rack_version_supported?
 
       def call env
         env['MiddlewareOne'] = true
-        @app.call env
+        @app.call(env)
       end
     end
 
@@ -32,7 +32,7 @@ if NewRelic::Agent::Instrumentation::RackHelpers.puma_rack_version_supported?
 
       def call env
         env['MiddlewareTwo'] = true
-        @app.call env
+        @app.call(env)
       end
     end
 
@@ -47,20 +47,20 @@ if NewRelic::Agent::Instrumentation::RackHelpers.puma_rack_version_supported?
 
     def build_app
       Puma::Rack::Builder.app do
-        use MiddlewareOne
-        use MiddlewareTwo
-        run ExampleApp.new
+        use(MiddlewareOne)
+        use(MiddlewareTwo)
+        run(ExampleApp.new)
       end
     end
 
     def test_middlewares_are_visited_with_puma_rack
-      @app.call @env
+      @app.call(@env)
       assert @env['MiddlewareOne'], 'Expected MiddlewareOne to be present and true in env'
       assert @env['MiddlewareTwo'], 'Expected MiddlewareTwo to be present and true in env'
     end
 
     def test_puma_rack_builder_is_auto_instrumented
-      @app.call @env
+      @app.call(@env)
 
       assert_metrics_recorded_exclusive(
         [

--- a/test/multiverse/suites/rack/rack_cascade_test.rb
+++ b/test/multiverse/suites/rack/rack_cascade_test.rb
@@ -25,20 +25,20 @@ if NewRelic::Agent::Instrumentation::RackHelpers.rack_version_supported?
 
     def app
       Rack::Builder.app do
-        use NewRelic::Rack::AgentHooks
-        use NewRelic::Rack::BrowserMonitoring
-        use ResponseCodeMiddleware
-        run Rack::Cascade.new([FirstCascadeExampleApp.new, SecondCascadeExampleApp.new])
+        use(NewRelic::Rack::AgentHooks)
+        use(NewRelic::Rack::BrowserMonitoring)
+        use(ResponseCodeMiddleware)
+        run(Rack::Cascade.new([FirstCascadeExampleApp.new, SecondCascadeExampleApp.new]))
       end
     end
 
     def test_insert_js_does_not_fire_for_rack_cascade_404_responses
-      rsp = get '/', {'body' => '<html><head></head><body></body></html>', 'override-response-code' => 404}
+      rsp = get('/', {'body' => '<html><head></head><body></body></html>', 'override-response-code' => 404})
       refute(rsp.body.include?('script'), "\nExpected\n---\n#{rsp.body}\n---\nnot to include 'script'.")
     end
 
     def test_rack_cascade_transactions_are_named_for_the_last_app
-      rsp = get '/cascade'
+      rsp = get('/cascade')
       assert_metrics_recorded('Controller/SecondCascadeExampleApp/call')
     end
   end

--- a/test/multiverse/suites/rack/rack_env_mutation_test.rb
+++ b/test/multiverse/suites/rack/rack_env_mutation_test.rb
@@ -38,14 +38,14 @@ if NewRelic::Agent::Instrumentation::RackHelpers.rack_version_supported?
     def app
       inner_app = BadApp.new
       Rack::Builder.app do
-        use NewRelic::Rack::AgentHooks
-        run inner_app
+        use(NewRelic::Rack::AgentHooks)
+        run(inner_app)
       end
     end
 
     def test_safe_from_iterations_over_rack_env_from_background_threads
       100.times do
-        get '/'
+        get('/')
       end
     end
   end

--- a/test/multiverse/suites/rack/rack_parameter_filtering_test.rb
+++ b/test/multiverse/suites/rack/rack_parameter_filtering_test.rb
@@ -15,7 +15,7 @@ if NewRelic::Agent::Instrumentation::RackHelpers.rack_version_supported?
     include Rack::Test::Methods
 
     def app
-      Rack::Builder.app { run FilteringTestApp.new }
+      Rack::Builder.app { run(FilteringTestApp.new) }
     end
 
     def test_file_upload_params_are_filtered
@@ -24,7 +24,7 @@ if NewRelic::Agent::Instrumentation::RackHelpers.rack_version_supported?
           :title => "blah",
           :file => Rack::Test::UploadedFile.new(__FILE__, 'text/plain')
         }
-        post '/', params
+        post('/', params)
 
         expected = {
           "request.parameters.title" => "blah",
@@ -37,7 +37,7 @@ if NewRelic::Agent::Instrumentation::RackHelpers.rack_version_supported?
     def test_apply_filters_returns_params_when_rails_is_not_present
       with_config(:capture_params => true) do
         params = {"name" => "name", "password" => "mypass"}
-        post '/', params
+        post('/', params)
 
         expected = {
           "request.parameters.name" => "name",

--- a/test/multiverse/suites/rack/rack_unsupported_version_test.rb
+++ b/test/multiverse/suites/rack/rack_unsupported_version_test.rb
@@ -30,13 +30,13 @@ if !NewRelic::Agent::Instrumentation::RackHelpers.rack_version_supported? && def
 
     def app
       Rack::Builder.app do
-        use SimpleMiddleware
-        run ExampleApp.new
+        use(SimpleMiddleware)
+        run(ExampleApp.new)
       end
     end
 
     def test_no_instrumentation_when_not_supported
-      get '/'
+      get('/')
       assert_metrics_recorded_exclusive([], :ignore_filter => /^(Supportability|Logging)/)
     end
   end

--- a/test/multiverse/suites/rack/response_content_type_test.rb
+++ b/test/multiverse/suites/rack/response_content_type_test.rb
@@ -18,29 +18,29 @@ if NewRelic::Agent::Instrumentation::RackHelpers.rack_version_supported?
 
     def app
       Rack::Builder.app do
-        use ResponseContentTypeMiddleware
-        use NewRelic::Rack::AgentHooks
-        run ExampleApp.new
+        use(ResponseContentTypeMiddleware)
+        use(NewRelic::Rack::AgentHooks)
+        run(ExampleApp.new)
       end
     end
 
     def test_records_response_content_type_on_analytics_events
-      rsp = get '/', {'override-content-type' => 'application/json'}
+      rsp = get('/', {'override-content-type' => 'application/json'})
       assert_equal('application/json', rsp.headers['Content-Type'])
       assert_equal('application/json', get_last_analytics_event[2][:'response.headers.contentType'])
 
-      rsp = get '/', {'override-content-type' => 'application/xml'}
+      rsp = get('/', {'override-content-type' => 'application/xml'})
       assert_equal('application/xml', rsp.headers['Content-Type'])
       assert_equal('application/xml', get_last_analytics_event[2][:'response.headers.contentType'])
     end
 
     def test_skips_response_content_type_if_middleware_tracing_disabled
       with_config(:disable_middleware_instrumentation => true) do
-        rsp = get '/', {'override-content-type' => 'application/json'}
+        rsp = get('/', {'override-content-type' => 'application/json'})
         assert_equal('application/json', rsp.headers['Content-Type'])
         refute get_last_analytics_event[2][:'response.headers.contentType']
 
-        rsp = get '/', {'override-content-type' => 'application/xml'}
+        rsp = get('/', {'override-content-type' => 'application/xml'})
         assert_equal('application/xml', rsp.headers['Content-Type'])
         refute get_last_analytics_event[2][:'response.headers.contentType']
       end

--- a/test/multiverse/suites/rack/url_map_test.rb
+++ b/test/multiverse/suites/rack/url_map_test.rb
@@ -50,31 +50,31 @@ if NewRelic::Agent::Instrumentation::RackHelpers.version_supported?
 
     def rack_app
       Rack::Builder.app do
-        use MiddlewareOne
-        use MiddlewareTwo
+        use(MiddlewareOne)
+        use(MiddlewareTwo)
 
-        run Rack::URLMap.new(
+        run(Rack::URLMap.new(
           '/prefix1' => PrefixAppOne.new,
           '/prefix2' => PrefixAppTwo.new
-        )
+        ))
       end
     end
 
     def puma_rack_app
       Puma::Rack::Builder.app do
-        use MiddlewareOne
-        use MiddlewareTwo
+        use(MiddlewareOne)
+        use(MiddlewareTwo)
 
-        run Puma::Rack::URLMap.new(
+        run(Puma::Rack::URLMap.new(
           '/prefix1' => PrefixAppOne.new,
           '/prefix2' => PrefixAppTwo.new
-        )
+        ))
       end
     end
 
     if defined?(Rack) && Rack::VERSION[1] >= 4
       def test_metrics_for_default_prefix
-        get '/'
+        get('/')
 
         assert_metrics_recorded_exclusive([
           'Apdex',
@@ -96,7 +96,7 @@ if NewRelic::Agent::Instrumentation::RackHelpers.version_supported?
     end
 
     def test_metrics_for_mapped_prefix
-      get '/prefix1'
+      get('/prefix1')
 
       assert_metrics_recorded_exclusive([
         'Apdex',
@@ -123,7 +123,7 @@ if NewRelic::Agent::Instrumentation::RackHelpers.version_supported?
     end
 
     def test_metrics_for_mapped_prefix_with_extra_middleware
-      get '/prefix2'
+      get('/prefix2')
 
       assert_metrics_recorded_exclusive([
         'Apdex',
@@ -165,7 +165,7 @@ if NewRelic::Agent::Instrumentation::RackHelpers.version_supported?
         "SCRIPT_NAME" => ""
       }
 
-      app.call env
+      app.call(env)
     end
   end
 

--- a/test/multiverse/suites/rails/action_cable_test.rb
+++ b/test/multiverse/suites/rails/action_cable_test.rb
@@ -3,7 +3,7 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
-SimpleCovHelper.command_name "test:multiverse[rails]"
+SimpleCovHelper.command_name("test:multiverse[rails]")
 
 begin
   require 'action_cable'
@@ -25,7 +25,7 @@ if defined?(ActionCable::Channel)
       def initialize
         @transmissions = []
         @identifiers = []
-        @logger = Logger.new StringIO.new
+        @logger = Logger.new(StringIO.new)
       end
 
       def transmit data
@@ -33,13 +33,13 @@ if defined?(ActionCable::Channel)
       end
 
       def last_transmission
-        JSON.parse @transmissions.last
+        JSON.parse(@transmissions.last)
       end
     end
 
     class TestChannel < ActionCable::Channel::Base
       def test_action data
-        transmit data['content']
+        transmit(data['content'])
       end
 
       def boom data
@@ -49,7 +49,7 @@ if defined?(ActionCable::Channel)
 
     setup_and_teardown_agent do
       @connection = TestConnection.new
-      @channel = TestChannel.new @connection, "{id: 1}"
+      @channel = TestChannel.new(@connection, "{id: 1}")
     end
 
     def test_creates_trace

--- a/test/multiverse/suites/rails/action_controller_live_rum_test.rb
+++ b/test/multiverse/suites/rails/action_controller_live_rum_test.rb
@@ -11,11 +11,11 @@ if defined?(ActionController::Live)
     RESPONSE_BODY = "<html><head></head><body>Brains!</body></html>"
 
     def brains
-      render :inline => RESPONSE_BODY
+      render(:inline => RESPONSE_BODY)
     end
 
     def brain_stream
-      render :inline => RESPONSE_BODY, :stream => true
+      render(:inline => RESPONSE_BODY, :stream => true)
     end
   end
 
@@ -31,17 +31,17 @@ if defined?(ActionController::Live)
     setup_and_teardown_agent(:js_agent_loader => JS_LOADER, :beacon => "beacon", :browser_key => "key")
 
     def test_rum_instrumentation_when_not_streaming
-      get '/undead/brains'
+      get('/undead/brains')
       assert_includes(response.body, JS_LOADER)
     end
 
     def test_excludes_rum_instrumentation_when_streaming_with_action_controller_live
-      get '/live/brains'
+      get('/live/brains')
       assert_equal(LiveController::RESPONSE_BODY, response.body)
     end
 
     def test_excludes_rum_instrumentation_when_streaming_with_action_stream_true
-      get '/undead/brain_stream'
+      get('/undead/brain_stream')
 
       assert_includes(response.body, UndeadController::RESPONSE_BODY)
       assert_not_includes(response.body, JS_LOADER)

--- a/test/multiverse/suites/rails/active_support_logger_test.rb
+++ b/test/multiverse/suites/rails/active_support_logger_test.rb
@@ -15,7 +15,7 @@ if defined?(ActiveSupport::Logger)
       @logger = Logger.new(@output)
       @broadcasted_output = StringIO.new
       @broadcasted_logger = ActiveSupport::Logger.new(@broadcasted_output)
-      @logger.extend ActiveSupport::Logger.broadcast(@broadcasted_logger)
+      @logger.extend(ActiveSupport::Logger.broadcast(@broadcasted_logger))
 
       @aggregator = NewRelic::Agent.agent.log_event_aggregator
       @aggregator.reset!
@@ -29,7 +29,7 @@ if defined?(ActiveSupport::Logger)
     def test_logs_not_forwarded_by_broadcasted_logger
       message = 'Can you hear me, Major Tom?'
 
-      @logger.add Logger::DEBUG, message
+      @logger.add(Logger::DEBUG, message)
 
       assert @output.string.include?(message)
       assert @broadcasted_output.string.include?(message)

--- a/test/multiverse/suites/rails/activejob_test.rb
+++ b/test/multiverse/suites/rails/activejob_test.rb
@@ -98,9 +98,9 @@ if Rails::VERSION::STRING >= "4.2.0"
                     function: 'perform',
                     namespace: 'MyJob'}
         segment = MiniTest::Mock.new
-        segment.expect :code_information=, nil, [expected]
-        segment.expect :finish, []
-        NewRelic::Agent::Tracer.stub :start_segment, segment do
+        segment.expect(:code_information=, nil, [expected])
+        segment.expect(:finish, [])
+        NewRelic::Agent::Tracer.stub(:start_segment, segment) do
           MyJob.perform_later
         end
       end

--- a/test/multiverse/suites/rails/app.rb
+++ b/test/multiverse/suites/rails/app.rb
@@ -23,7 +23,7 @@ module RequestHelpersCompatibility
 end
 
 if Rails::VERSION::MAJOR.to_i < 5
-  ActionDispatch::Integration::Session.send :prepend, RequestHelpersCompatibility
+  ActionDispatch::Integration::Session.send(:prepend, RequestHelpersCompatibility)
 end
 
 # a basic active model compliant model we can render

--- a/test/multiverse/suites/rails/bad_instrumentation_test.rb
+++ b/test/multiverse/suites/rails/bad_instrumentation_test.rb
@@ -12,8 +12,8 @@ class BadInstrumentationController < ApplicationController
   # to fail.
   # https://newrelic.atlassian.net/browse/RUBY-1158
   def failwhale
-    NewRelic::Agent::Tracer.start_segment name: "Controller/BadInstrumentationController/failwhale"
-    render body: 'everything went great'
+    NewRelic::Agent::Tracer.start_segment(name: "Controller/BadInstrumentationController/failwhale")
+    render(body: 'everything went great')
   end
 end
 
@@ -22,7 +22,7 @@ class BadInstrumentationTest < ActionDispatch::IntegrationTest
   setup_and_teardown_agent
 
   def test_unbalanced_tt_stack_should_not_cause_request_to_fail
-    rsp = get '/bad_instrumentation/failwhale'
+    rsp = get('/bad_instrumentation/failwhale')
     assert_equal(200, rsp.to_i)
   end
 end

--- a/test/multiverse/suites/rails/error_tracing_test.rb
+++ b/test/multiverse/suites/rails/error_tracing_test.rb
@@ -22,7 +22,7 @@ class ErrorController < ApplicationController
   end
 
   def view_error
-    render :inline => "<% raise 'this is an uncaught view error' %>"
+    render(:inline => "<% raise 'this is an uncaught view error' %>")
   end
 
   def model_error
@@ -38,7 +38,7 @@ class ErrorController < ApplicationController
   end
 
   def ignored_status_code
-    render body: "Protip: you probably shouldn't ignore 500 errors", status: 500
+    render(body: "Protip: you probably shouldn't ignore 500 errors", status: 500)
   end
 
   def server_ignored_error
@@ -53,16 +53,16 @@ class ErrorController < ApplicationController
 
   def string_noticed_error
     NewRelic::Agent.notice_error("trilobites died out millions of years ago")
-    render body: 'trilobites'
+    render(body: 'trilobites')
   end
 
   def noticed_error
     NewRelic::Agent.notice_error(RuntimeError.new('this error should be noticed'))
-    render body: "Shoulda noticed an error"
+    render(body: "Shoulda noticed an error")
   end
 
   def middleware_error
-    render body: 'everything went great'
+    render(body: 'everything went great')
   end
 
   def error_with_custom_params
@@ -72,12 +72,12 @@ class ErrorController < ApplicationController
 
   def noticed_error_with_trace_only
     NewRelic::Agent.notice_error("Raise the gates!", :trace_only => true)
-    render body: 'Runner 5'
+    render(body: 'Runner 5')
   end
 
   def noticed_error_with_expected_error
     NewRelic::Agent.notice_error("Raise the gates!", :expected => true)
-    render body: 'Runner 5'
+    render(body: 'Runner 5')
   end
 end
 
@@ -107,22 +107,22 @@ class ErrorsWithoutSSCTest < ActionDispatch::IntegrationTest
   end
 
   def test_should_capture_routing_error
-    get '/bad_route'
+    get('/bad_route')
     assert_error_reported_once('this is an uncaught routing error', nil, nil)
   end
 
   def test_should_capture_errors_raised_in_middleware_before_call
-    get '/error/middleware_error/before'
+    get('/error/middleware_error/before')
     assert_error_reported_once('middleware error', nil, nil)
   end
 
   def test_should_capture_errors_raised_in_middleware_after_call
-    get '/error/middleware_error/after'
+    get('/error/middleware_error/after')
     assert_error_reported_once('middleware error', nil, nil)
   end
 
   def test_should_capture_request_uri_and_params
-    get '/error/controller_error?eat=static'
+    get('/error/controller_error?eat=static')
     assert_equal('/error/controller_error', attributes_for_single_error_posted("agentAttributes")["request.uri"])
 
     expected_params = {
@@ -137,37 +137,37 @@ class ErrorsWithoutSSCTest < ActionDispatch::IntegrationTest
   end
 
   def test_should_capture_error_raised_in_view
-    get '/error/view_error'
+    get('/error/view_error')
     assert_equal 1, errors.size
     assert_includes ['this is an uncaught view error', 'ActionView::Template::Error'], errors[0].message
   end
 
   def test_should_capture_error_raised_in_controller
-    get '/error/controller_error'
+    get('/error/controller_error')
     assert_error_reported_once('this is an uncaught controller error',
       'Controller/error/controller_error')
   end
 
   def test_should_capture_error_raised_in_model
-    get '/error/model_error'
+    get('/error/model_error')
     assert_error_reported_once('this is an uncaught model error',
       'Controller/error/model_error')
   end
 
   def test_should_capture_noticed_error_in_controller
-    get '/error/noticed_error'
+    get('/error/noticed_error')
     assert_error_reported_once('this error should be noticed',
       'Controller/error/noticed_error')
   end
 
   def test_should_capture_frozen_errors
-    get '/error/frozen_error'
+    get('/error/frozen_error')
     assert_error_reported_once("frozen errors make a refreshing treat on a hot summer day",
       "Controller/error/frozen_error")
   end
 
   def test_should_capture_string_noticed_errors
-    get '/error/string_noticed_error'
+    get('/error/string_noticed_error')
     assert_error_reported_once("trilobites died out millions of years ago",
       "Controller/error/string_noticed_error")
   end
@@ -176,7 +176,7 @@ class ErrorsWithoutSSCTest < ActionDispatch::IntegrationTest
   # transaction and the rack error collector, so risks multiple counting!
   def test_should_capture_multiple_errors
     40.times do
-      get '/error/controller_error'
+      get('/error/controller_error')
     end
 
     assert_errors_reported('this is an uncaught controller error',
@@ -190,33 +190,33 @@ class ErrorsWithoutSSCTest < ActionDispatch::IntegrationTest
   end
 
   def test_should_apply_parameter_filtering
-    get '/error/controller_error?secret=shouldnotbecaptured&other=whatever'
+    get('/error/controller_error?secret=shouldnotbecaptured&other=whatever')
     attributes = agent_attributes_for_single_error_posted
     assert_equal('[FILTERED]', attributes['request.parameters.secret'])
     assert_equal('whatever', attributes['request.parameters.other'])
   end
 
   def test_should_apply_parameter_filtering_for_non_standard_errors
-    get '/error/exception_error?secret=shouldnotbecaptured&other=whatever'
+    get('/error/exception_error?secret=shouldnotbecaptured&other=whatever')
     attributes = agent_attributes_for_single_error_posted
     assert_equal('[FILTERED]', attributes['request.parameters.secret'])
     assert_equal('whatever', attributes['request.parameters.other'])
   end
 
   def test_should_not_notice_errors_from_ignored_action
-    get '/error/ignored_action'
+    get('/error/ignored_action')
     assert(errors.empty?,
       'Noticed an error that should have been ignored')
   end
 
   def test_should_not_notice_ignored_error_classes
-    get '/error/ignored_error'
+    get('/error/ignored_error')
     assert(errors.empty?,
       'Noticed an error that should have been ignored')
   end
 
   def test_should_not_fail_apdex_for_ignored_error_class_noticed
-    get '/error/ignored_error'
+    get('/error/ignored_error')
     assert_metrics_recorded({
       'Apdex' => {:apdex_f => 0},
       'Apdex/error/ignored_error' => {:apdex_f => 0}
@@ -229,7 +229,7 @@ class ErrorsWithoutSSCTest < ActionDispatch::IntegrationTest
     end
 
     with_ignore_error_filter(filter) do
-      get '/error/controller_error'
+      get('/error/controller_error')
     end
 
     assert(errors.empty?,
@@ -238,20 +238,20 @@ class ErrorsWithoutSSCTest < ActionDispatch::IntegrationTest
 
   def test_should_not_notice_ignored_status_codes
     with_config(:'error_collector.ignore_status_codes' => '500') do
-      get '/error/ignored_status_code'
+      get('/error/ignored_status_code')
 
       assert(errors.empty?, 'Noticed an error that should have been ignored')
     end
   end
 
   def test_should_notice_server_ignored_error_if_no_server_side_config
-    get '/error/server_ignored_error'
+    get('/error/server_ignored_error')
     assert_error_reported_once('this is a server ignored error')
   end
 
   def test_captured_errors_should_include_custom_params
     with_config(:'error_collector.attributes.enabled' => true) do
-      get '/error/error_with_custom_params'
+      get('/error/error_with_custom_params')
       assert_error_reported_once('bad things')
 
       attributes = user_attributes_for_single_error_posted
@@ -261,7 +261,7 @@ class ErrorsWithoutSSCTest < ActionDispatch::IntegrationTest
 
   def test_captured_errors_should_include_custom_params_with_legacy_setting
     with_config(:'error_collector.capture_attributes' => true) do
-      get '/error/error_with_custom_params'
+      get('/error/error_with_custom_params')
       assert_error_reported_once('bad things')
 
       attributes = user_attributes_for_single_error_posted
@@ -271,7 +271,7 @@ class ErrorsWithoutSSCTest < ActionDispatch::IntegrationTest
 
   def test_captured_errors_should_not_include_custom_params_if_config_says_no
     with_config(:'error_collector.attributes.enabled' => false) do
-      get '/error/error_with_custom_params'
+      get('/error/error_with_custom_params')
       assert_error_reported_once('bad things')
 
       attributes = user_attributes_for_single_error_posted
@@ -281,7 +281,7 @@ class ErrorsWithoutSSCTest < ActionDispatch::IntegrationTest
 
   def test_captured_errors_should_not_include_custom_params_if_legacy_setting_says_no
     with_config(:'error_collector.capture_attributes' => false) do
-      get '/error/error_with_custom_params'
+      get('/error/error_with_custom_params')
       assert_error_reported_once('bad things')
 
       attributes = user_attributes_for_single_error_posted
@@ -290,7 +290,7 @@ class ErrorsWithoutSSCTest < ActionDispatch::IntegrationTest
   end
 
   def test_should_not_increment_metrics_on_expected_error_errors
-    get '/error/noticed_error_with_expected_error'
+    get('/error/noticed_error_with_expected_error')
 
     assert_equal(1, errors.size,
       'Error with :expected should have been recorded')
@@ -307,7 +307,7 @@ class ErrorsWithoutSSCTest < ActionDispatch::IntegrationTest
   protected
 
   def errors
-    @error_collector.error_trace_aggregator.instance_variable_get :@errors
+    @error_collector.error_trace_aggregator.instance_variable_get(:@errors)
   end
 
   def errors_with_message(message)
@@ -350,7 +350,7 @@ class ErrorsWithSSCTest < ErrorsWithoutSSCTest
   end
 
   def test_should_ignore_server_ignored_errors
-    get '/error/server_ignored_error'
+    get('/error/server_ignored_error')
 
     assert(errors.empty?,
       'Noticed an error that should have been ignored' + errors.join(', '))

--- a/test/multiverse/suites/rails/gc_instrumentation_test.rb
+++ b/test/multiverse/suites/rails/gc_instrumentation_test.rb
@@ -26,7 +26,7 @@ if !NewRelic::LanguageSupport.jruby?
         puts "Timed out waiting for GC..."
       end
 
-      render body: 'ha'
+      render(body: 'ha')
     end
   end
 
@@ -44,7 +44,7 @@ if !NewRelic::LanguageSupport.jruby?
 
     def test_records_accurate_time_for_gc_activity
       start = Process.clock_gettime(Process::CLOCK_REALTIME)
-      get :gc_action
+      get(:gc_action)
       elapsed = Process.clock_gettime(Process::CLOCK_REALTIME) - start
 
       stats_hash = NewRelic::Agent.instance.stats_engine.reset!
@@ -58,7 +58,7 @@ if !NewRelic::LanguageSupport.jruby?
 
     def test_records_transaction_param_for_gc_activity
       start = Process.clock_gettime(Process::CLOCK_REALTIME)
-      get :gc_action
+      get(:gc_action)
       elapsed = Process.clock_gettime(Process::CLOCK_REALTIME) - start
 
       trace = last_transaction_trace

--- a/test/multiverse/suites/rails/ignore_test.rb
+++ b/test/multiverse/suites/rails/ignore_test.rb
@@ -12,15 +12,15 @@ class IgnoredController < ApplicationController
   newrelic_ignore_apdex :only => :action_to_ignore_apdex
 
   def action_to_ignore
-    render body: "Ignore this"
+    render(body: "Ignore this")
   end
 
   def action_to_ignore_apdex
-    render body: "This too"
+    render(body: "This too")
   end
 
   def action_not_ignored
-    render body: "Not this!"
+    render(body: "Not this!")
   end
 end
 
@@ -51,39 +51,39 @@ class IgnoredActionsTest < ActionDispatch::IntegrationTest
   end
 
   def test_metric__ignore
-    get '/ignored/action_to_ignore'
+    get('/ignored/action_to_ignore')
     assert_metrics_recorded_exclusive([])
   end
 
   def test_metric__ignore_apdex
-    get '/ignored/action_to_ignore_apdex'
+    get('/ignored/action_to_ignore_apdex')
     assert_metrics_recorded(["Controller/ignored/action_to_ignore_apdex"])
     assert_metrics_not_recorded(["Apdex"])
   end
 
   def test_ignored_transaction_traces_dont_leak
-    get '/ignored/action_to_ignore'
-    get '/request_stats/stats_action'
+    get('/ignored/action_to_ignore')
+    get('/request_stats/stats_action')
 
     trace = last_transaction_trace
     assert_equal 1, trace.root_node.children.count
   end
 
   def test_should_not_write_cat_response_headers_for_ignored_transactions
-    get '/ignored/action_to_ignore',
-      headers: {'X-NewRelic-ID' => Base64.encode64('1#234')}
+    get('/ignored/action_to_ignore',
+      headers: {'X-NewRelic-ID' => Base64.encode64('1#234')})
     refute @response.headers["X-NewRelic-App-Data"]
   end
 
   def test_apdex_ignored_if_ignored_in_parent_class
-    get '/child/foo'
-    get '/child/bar'
+    get('/child/foo')
+    get('/child/bar')
 
     assert_metrics_not_recorded("Apdex")
   end
 
   def test_ignored_transaction_does_not_record_span_events
-    get '/ignored/action_to_ignore'
+    get('/ignored/action_to_ignore')
 
     last_span_events = NewRelic::Agent.agent.span_event_aggregator.harvest![1]
     assert_empty last_span_events
@@ -91,7 +91,7 @@ class IgnoredActionsTest < ActionDispatch::IntegrationTest
 
   def test_ignored_by_ignore_url_regexes_does_not_record_span_events
     with_config(:rules => {:ignore_url_regexes => ['/ignored/action_not_ignored']}) do
-      get '/ignored/action_not_ignored'
+      get('/ignored/action_not_ignored')
 
       last_span_events = NewRelic::Agent.agent.span_event_aggregator.harvest![1]
       assert_empty last_span_events

--- a/test/multiverse/suites/rails/parameter_capture_test.rb
+++ b/test/multiverse/suites/rails/parameter_capture_test.rb
@@ -7,12 +7,12 @@ require './app'
 
 class ParameterCaptureController < ApplicationController
   def transaction
-    render body: 'hi!'
+    render(body: 'hi!')
   end
 
   def create
     raise 'problem' if params[:raise]
-    render body: 'created'
+    render(body: 'created')
   end
 
   def sql
@@ -35,21 +35,21 @@ class ParameterCaptureTest < ActionDispatch::IntegrationTest
 
   def test_no_params_captured_on_errors_when_disabled
     with_config(:capture_params => false) do
-      get '/parameter_capture/error?other=1234&secret=4567'
+      get('/parameter_capture/error?other=1234&secret=4567')
       refute_contains_request_params(agent_attributes_for_single_error_posted)
     end
   end
 
   def test_no_params_captured_on_tts_when_disabled
     with_config(:capture_params => false) do
-      get '/parameter_capture/transaction?other=1234&secret=4567'
+      get('/parameter_capture/transaction?other=1234&secret=4567')
     end
     assert_equal({}, last_transaction_trace_request_params)
   end
 
   def test_uri_on_traced_errors_never_contains_query_string_without_capture_params
     with_config(:capture_params => false) do
-      get '/parameter_capture/error?other=1234&secret=4567'
+      get('/parameter_capture/error?other=1234&secret=4567')
 
       assert_equal('/parameter_capture/error', attributes_for_single_error_posted("agentAttributes")["request.uri"])
     end
@@ -57,15 +57,15 @@ class ParameterCaptureTest < ActionDispatch::IntegrationTest
 
   def test_uri_on_traced_errors_never_contains_query_string_with_capture_params
     with_config(:capture_params => true) do
-      get '/parameter_capture/error?other=1234&secret=4567'
+      get('/parameter_capture/error?other=1234&secret=4567')
       assert_equal('/parameter_capture/error', attributes_for_single_error_posted("agentAttributes")["request.uri"])
     end
   end
 
   def test_referrer_on_traced_errors_never_contains_query_string_without_capture_params
     with_config(:capture_params => false) do
-      get '/parameter_capture/error?other=1234&secret=4567',
-        headers: {'HTTP_REFERER' => '/foo/bar?other=123&secret=456'}
+      get('/parameter_capture/error?other=1234&secret=4567',
+        headers: {'HTTP_REFERER' => '/foo/bar?other=123&secret=456'})
       attributes = agent_attributes_for_single_error_posted
       assert_equal('/foo/bar', attributes["request.headers.referer"])
     end
@@ -73,8 +73,8 @@ class ParameterCaptureTest < ActionDispatch::IntegrationTest
 
   def test_referrer_on_traced_errors_never_contains_query_string_even_with_capture_params
     with_config(:capture_params => true) do
-      get '/parameter_capture/error?other=1234&secret=4567',
-        headers: {'HTTP_REFERER' => '/foo/bar?other=123&secret=456'}
+      get('/parameter_capture/error?other=1234&secret=4567',
+        headers: {'HTTP_REFERER' => '/foo/bar?other=123&secret=456'})
       attributes = agent_attributes_for_single_error_posted
       assert_equal('/foo/bar', attributes["request.headers.referer"])
     end
@@ -82,7 +82,7 @@ class ParameterCaptureTest < ActionDispatch::IntegrationTest
 
   def test_controller_and_action_excluded_from_error_parameters
     with_config(:capture_params => true) do
-      get '/parameter_capture/error'
+      get('/parameter_capture/error')
       run_harvest
 
       refute_error_has_agent_attribute('request.parameters.controller')
@@ -92,7 +92,7 @@ class ParameterCaptureTest < ActionDispatch::IntegrationTest
 
   def test_controller_and_action_excluded_from_transaction_trace_parameters
     with_config(:capture_params => true, :'transaction_tracer.transaction_threshold' => -10) do
-      get '/parameter_capture/transaction'
+      get('/parameter_capture/transaction')
       run_harvest
 
       refute_transaction_trace_has_agent_attribute('request.parameters.controller')
@@ -102,14 +102,14 @@ class ParameterCaptureTest < ActionDispatch::IntegrationTest
 
   def test_uri_on_tts_never_contains_query_string
     with_config(:capture_params => false) do
-      get '/parameter_capture/transaction?other=1234&secret=4567'
+      get('/parameter_capture/transaction?other=1234&secret=4567')
     end
 
     attributes = last_transaction_trace.attributes.agent_attributes_for(NewRelic::Agent::AttributeFilter::DST_TRANSACTION_TRACER)
     assert_equal('/parameter_capture/transaction', attributes[:'request.uri'])
 
     with_config(:capture_params => true) do
-      get '/parameter_capture/transaction?other=1234&secret=4567'
+      get('/parameter_capture/transaction?other=1234&secret=4567')
     end
 
     attributes = last_transaction_trace.attributes.agent_attributes_for(NewRelic::Agent::AttributeFilter::DST_TRANSACTION_TRACER)
@@ -118,7 +118,7 @@ class ParameterCaptureTest < ActionDispatch::IntegrationTest
 
   def test_filters_parameters_on_traced_errors
     with_config(:capture_params => true) do
-      get '/parameter_capture/error?other=1234&secret=4567'
+      get('/parameter_capture/error?other=1234&secret=4567')
 
       captured_params = agent_attributes_for_single_error_posted
       assert_equal('[FILTERED]', captured_params['request.parameters.secret'])
@@ -128,7 +128,7 @@ class ParameterCaptureTest < ActionDispatch::IntegrationTest
 
   def test_filters_parameters_on_transaction_traces
     with_config(:capture_params => true) do
-      get '/parameter_capture/transaction?other=1234&secret=4567'
+      get('/parameter_capture/transaction?other=1234&secret=4567')
     end
 
     captured_params = last_transaction_trace_request_params
@@ -138,14 +138,14 @@ class ParameterCaptureTest < ActionDispatch::IntegrationTest
 
   def test_no_traced_error_params_captured_when_bails_before_rails
     with_config(:capture_params => false) do
-      get '/middleware_error/before?other=1234&secret=4567'
+      get('/middleware_error/before?other=1234&secret=4567')
       refute_contains_request_params(agent_attributes_for_single_error_posted)
     end
   end
 
   def test_no_transaction_trace_params_captured_when_bails_before_rails
     with_config(:capture_params => false) do
-      get '/middleware_error/before?other=1234&secret=4567'
+      get('/middleware_error/before?other=1234&secret=4567')
     end
 
     assert_equal({}, last_transaction_trace_request_params)
@@ -153,21 +153,21 @@ class ParameterCaptureTest < ActionDispatch::IntegrationTest
 
   def test_no_params_captured_on_error_when_bails_before_rails_even_when_enabled
     with_config(:capture_params => true) do
-      get '/middleware_error/before?other=1234&secret=4567'
+      get('/middleware_error/before?other=1234&secret=4567')
       refute_contains_request_params(agent_attributes_for_single_error_posted)
     end
   end
 
   def test_no_params_captured_on_tt_when_bails_before_rails_even_when_enabled
     with_config(:capture_params => true) do
-      get '/middleware_error/before?other=1234&secret=4567'
+      get('/middleware_error/before?other=1234&secret=4567')
     end
     assert_equal({}, last_transaction_trace_request_params)
   end
 
   def test_uri_on_tt_should_not_contain_query_string_with_capture_params_off
     with_config(:capture_params => false) do
-      get '/parameter_capture/transaction?param1=value1&param2=value2'
+      get('/parameter_capture/transaction?param1=value1&param2=value2')
     end
     attributes = last_transaction_trace.attributes.agent_attributes_for(NewRelic::Agent::AttributeFilter::DST_TRANSACTION_TRACER)
     assert_equal('/parameter_capture/transaction', attributes[:'request.uri'])
@@ -175,7 +175,7 @@ class ParameterCaptureTest < ActionDispatch::IntegrationTest
 
   def test_uri_on_tt_should_not_contain_query_string_with_capture_params_on
     with_config(:capture_params => true) do
-      get '/parameter_capture/transaction?param1=value1&param2=value2'
+      get('/parameter_capture/transaction?param1=value1&param2=value2')
     end
     attributes = last_transaction_trace.attributes.agent_attributes_for(NewRelic::Agent::AttributeFilter::DST_TRANSACTION_TRACER)
     assert_equal('/parameter_capture/transaction', attributes[:'request.uri'])
@@ -183,28 +183,28 @@ class ParameterCaptureTest < ActionDispatch::IntegrationTest
 
   def test_uri_on_traced_error_should_not_contain_query_string_with_capture_params_off
     with_config(:capture_params => false) do
-      get '/parameter_capture/error?param1=value1&param2=value2'
+      get('/parameter_capture/error?param1=value1&param2=value2')
       assert_equal('/parameter_capture/error', attributes_for_single_error_posted("agentAttributes")["request.uri"])
     end
   end
 
   def test_uri_on_traced_error_should_not_contain_query_string_with_capture_params_on
     with_config(:capture_params => true) do
-      get '/parameter_capture/error?param1=value1&param2=value2'
+      get('/parameter_capture/error?param1=value1&param2=value2')
       assert_equal('/parameter_capture/error', attributes_for_single_error_posted("agentAttributes")["request.uri"])
     end
   end
 
   def test_uri_on_sql_trace_should_not_contain_query_string_with_capture_params_off
     with_config(:capture_params => false) do
-      get '/parameter_capture/sql?param1=value1&param2=value2'
+      get('/parameter_capture/sql?param1=value1&param2=value2')
     end
     assert_equal('/parameter_capture/sql', last_sql_trace.url)
   end
 
   def test_uri_on_sql_trace_should_not_contain_query_string_with_capture_params_on
     with_config(:capture_params => true) do
-      get '/parameter_capture/sql?param1=value1&param2=value2'
+      get('/parameter_capture/sql?param1=value1&param2=value2')
     end
     assert_equal('/parameter_capture/sql', last_sql_trace.url)
   end
@@ -212,7 +212,7 @@ class ParameterCaptureTest < ActionDispatch::IntegrationTest
   def test_parameters_attached_to_transaction_events_if_enabled
     with_config(:'attributes.include' => 'request.parameters.*',
       :'attributes.exclude' => ['request.*', 'response.*']) do
-      get '/parameter_capture/transaction?param1=value1&param2=value2'
+      get('/parameter_capture/transaction?param1=value1&param2=value2')
     end
 
     actual = agent_attributes_for_single_event_posted_without_ignored_attributes
@@ -224,7 +224,7 @@ class ParameterCaptureTest < ActionDispatch::IntegrationTest
   end
 
   def test_request_and_response_attributes_recorded_as_agent_attributes
-    get '/parameter_capture/transaction'
+    get('/parameter_capture/transaction')
 
     expected = {
       "response.headers.contentType" => "#{response.content_type}; charset=#{response.charset}",
@@ -257,7 +257,7 @@ class ParameterCaptureTest < ActionDispatch::IntegrationTest
   def test_params_tts_should_be_filtered_when_serviced_by_rack_app
     params = {"secret" => "shhhhhhh", "name" => "name"}
     with_config(:capture_params => true) do
-      post '/filtering_test/', params: params
+      post('/filtering_test/', params: params)
     end
 
     expected = {
@@ -270,7 +270,7 @@ class ParameterCaptureTest < ActionDispatch::IntegrationTest
   def test_params_on_errors_should_be_filtered_when_serviced_by_rack_app
     params = {"secret" => "shhhhhhh", "name" => "name"}
     with_config(:capture_params => true) do
-      post '/filtering_test?raise=1', params: params
+      post('/filtering_test?raise=1', params: params)
 
       expected = {
         "request.parameters.secret" => "[FILTERED]",
@@ -297,11 +297,11 @@ class ParameterCaptureTest < ActionDispatch::IntegrationTest
   if defined?(Sinatra)
     def test_params_tts_should_be_filtered_when_serviced_by_sinatra_app
       with_config(:capture_params => true) do
-        get '/sinatra_app/',
+        get('/sinatra_app/',
           params: {
             "secret" => "shhhhhhh",
             "name" => "name"
-          }
+          })
       end
 
       expected = {
@@ -313,11 +313,11 @@ class ParameterCaptureTest < ActionDispatch::IntegrationTest
 
     def test_params_on_errors_should_be_filtered_when_serviced_by_sinatra_app
       with_config(:capture_params => true) do
-        get '/sinatra_app?raise=1',
+        get('/sinatra_app?raise=1',
           params: {
             "secret" => "shhhhhhh",
             "name" => "name"
-          }
+          })
         attributes = agent_attributes_for_single_error_posted
         assert_equal "[FILTERED]", attributes["request.parameters.secret"]
         assert_equal "name", attributes["request.parameters.name"]
@@ -327,10 +327,10 @@ class ParameterCaptureTest < ActionDispatch::IntegrationTest
 
     def test_file_upload_params_are_replaced_with_placeholder
       with_config(:capture_params => true, :'transaction_tracer.transaction_threshold' => -10) do
-        post '/parameter_capture',
+        post('/parameter_capture',
           params: {
             file: Rack::Test::UploadedFile.new(__FILE__, 'text/plain')
-          }
+          })
 
         run_harvest
 

--- a/test/multiverse/suites/rails/queue_time_test.rb
+++ b/test/multiverse/suites/rails/queue_time_test.rb
@@ -10,13 +10,13 @@ require './app'
 class QueueController < ApplicationController
   def queued
     respond_to do |format|
-      format.html { render body: "<html><head></head><body>Queued</body></html>" }
+      format.html { render(body: "<html><head></head><body>Queued</body></html>") }
     end
   end
 
   def nested
     nested_transaction
-    render body: 'whatever'
+    render(body: 'whatever')
   end
 
   def nested_transaction; end

--- a/test/multiverse/suites/rails/rails3_app/app_rails3_plus.rb
+++ b/test/multiverse/suites/rails/rails3_app/app_rails3_plus.rb
@@ -73,17 +73,17 @@ if !defined?(MyApp)
     if Rails::VERSION::STRING >= "7.0.0"
       config.action_controller.default_protect_from_forgery = true
     end
-    if config.respond_to? :hosts
+    if config.respond_to?(:hosts)
       config.hosts << "www.example.com"
     end
     initializer "install_error_middleware" do
-      config.middleware.use ErrorMiddleware
+      config.middleware.use(ErrorMiddleware)
     end
     initializer "install_middleware_by_name" do
-      config.middleware.use NamedMiddleware
+      config.middleware.use(NamedMiddleware)
     end
     initializer "install_middleware_instance" do
-      config.middleware.use InstanceMiddleware.new
+      config.middleware.use(InstanceMiddleware.new)
     end
   end
   MyApp.initialize!

--- a/test/multiverse/suites/rails/request_statistics_test.rb
+++ b/test/multiverse/suites/rails/request_statistics_test.rb
@@ -9,18 +9,18 @@ require './app'
 
 class RequestStatsController < ApplicationController
   def stats_action
-    sleep 0.01
-    render body: 'some stuff'
+    sleep(0.01)
+    render(body: 'some stuff')
   end
 
   def cross_app_action
     ::NewRelic::Agent::Transaction.tl_current.distributed_tracer.is_cross_app_caller = true
-    render body: 'some stuff'
+    render(body: 'some stuff')
   end
 
   def stats_action_with_custom_params
     ::NewRelic::Agent.add_custom_attributes('color' => 'blue', 1 => :bar, 'bad' => {})
-    render body: 'some stuff'
+    render(body: 'some stuff')
   end
 end
 
@@ -36,7 +36,7 @@ class RequestStatsTest < ActionDispatch::IntegrationTest
 
   def test_doesnt_send_when_disabled
     with_config(:'analytics_events.enabled' => false) do
-      5.times { get '/request_stats/stats_action' }
+      5.times { get('/request_stats/stats_action') }
 
       NewRelic::Agent.agent.send(:harvest_and_send_analytic_event_data)
 
@@ -46,7 +46,7 @@ class RequestStatsTest < ActionDispatch::IntegrationTest
 
   def test_request_times_should_be_reported_if_enabled
     with_config(:'analytics_events.enabled' => true) do
-      5.times { get '/request_stats/stats_action' }
+      5.times { get('/request_stats/stats_action') }
 
       NewRelic::Agent.agent.send(:harvest_and_send_analytic_event_data)
 
@@ -76,7 +76,7 @@ class RequestStatsTest < ActionDispatch::IntegrationTest
 
   def test_request_should_include_guid_if_cross_app
     with_config(:'analytics_events.enabled' => true) do
-      5.times { get '/request_stats/cross_app_action' }
+      5.times { get('/request_stats/cross_app_action') }
 
       NewRelic::Agent.agent.send(:harvest_and_send_analytic_event_data)
 
@@ -105,7 +105,7 @@ class RequestStatsTest < ActionDispatch::IntegrationTest
         'HTTP_X_NEWRELIC_TRANSACTION' => Base64.encode64('["8badf00d",1]')
       }
 
-      get '/request_stats/cross_app_action', headers: rack_env
+      get('/request_stats/cross_app_action', headers: rack_env)
 
       NewRelic::Agent.agent.send(:harvest_and_send_analytic_event_data)
 
@@ -125,7 +125,7 @@ class RequestStatsTest < ActionDispatch::IntegrationTest
 
   def test_custom_params_should_be_reported_with_events_and_coerced_to_safe_types
     with_config(:'analytics_events.enabled' => true) do
-      5.times { get '/request_stats/stats_action_with_custom_params' }
+      5.times { get('/request_stats/stats_action_with_custom_params') }
 
       NewRelic::Agent.agent.send(:harvest_and_send_analytic_event_data)
 
@@ -156,7 +156,7 @@ class RequestStatsTest < ActionDispatch::IntegrationTest
 
   def test_request_samples_should_be_preserved_upon_failure
     with_config(:'analytics_events.enabled' => true) do
-      5.times { get '/request_stats/stats_action' }
+      5.times { get('/request_stats/stats_action') }
 
       # fail once
       $collector.stub('analytic_event_data', {}, 503)

--- a/test/multiverse/suites/rails/transaction_ignoring_test.rb
+++ b/test/multiverse/suites/rails/transaction_ignoring_test.rb
@@ -16,7 +16,7 @@ class TransactionIgnorerController < ApplicationController
         "Database/test/select",
         nil, 1.5, state)
     end
-    render body: 'some stuff'
+    render(body: 'some stuff')
   end
 end
 
@@ -25,25 +25,25 @@ class TransactionIgnoringTest < ActionDispatch::IntegrationTest
   include TransactionIgnoringTestCases
 
   def trigger_transaction(txn_name)
-    get '/transaction_ignorer/run_transaction',
+    get('/transaction_ignorer/run_transaction',
       params: {
         txn_name: txn_name
-      }
+      })
   end
 
   def trigger_transaction_with_error(txn_name, error_msg)
-    get '/transaction_ignorer/run_transaction',
+    get('/transaction_ignorer/run_transaction',
       params: {
         txn_name: txn_name,
         error_msg: error_msg
-      }
+      })
   end
 
   def trigger_transaction_with_slow_sql(txn_name)
-    get '/transaction_ignorer/run_transaction',
+    get('/transaction_ignorer/run_transaction',
       params: {
         txn_name: txn_name,
         slow_sql: 'true'
-      }
+      })
   end
 end

--- a/test/multiverse/suites/rails/view_instrumentation_test.rb
+++ b/test/multiverse/suites/rails/view_instrumentation_test.rb
@@ -10,56 +10,56 @@ ActionController::Base.view_paths = ['app/views']
 
 class ViewsController < ApplicationController
   def template_render_with_3_partial_renders
-    render 'index'
+    render('index')
   end
 
   def render_with_delays
     nr_freeze_process_time
     @delay = 1
-    render 'index'
+    render('index')
   end
 
   def deep_partial_render
-    render 'deep_partial'
+    render('deep_partial')
   end
 
   def text_render
-    render body: "Yay"
+    render(body: "Yay")
   end
 
   def json_render
-    render :json => {"a" => "b"}
+    render(:json => {"a" => "b"})
   end
 
   def xml_render
-    render :xml => {"a" => "b"}
+    render(:xml => {"a" => "b"})
   end
 
   def js_render
-    render :js => 'alert("this is js");'
+    render(:js => 'alert("this is js");')
   end
 
   def file_render
     # The choice of filename is significant here: we want a dot in the filename
     # in order to expose an issue on Rails 2.
     file = File.expand_path(File.join(File.dirname(__FILE__), "dummy.txt"))
-    render :file => file, :content_type => 'text/plain', :layout => false
+    render(:file => file, :content_type => 'text/plain', :layout => false)
   end
 
   def nothing_render
-    render body: nil
+    render(body: nil)
   end
 
   def inline_render
-    render :inline => "<% Time.now %><p><%= Time.now %></p>"
+    render(:inline => "<% Time.now %><p><%= Time.now %></p>")
   end
 
   def haml_render
-    render 'haml_view'
+    render('haml_view')
   end
 
   def no_template
-    render []
+    render([])
   end
 
   def collection_render
@@ -72,7 +72,7 @@ class ViewsController < ApplicationController
     streamer = Class.new do
       def each
         10_000.times do |i|
-          yield "This is line #{i}\n"
+          yield("This is line #{i}\n")
         end
       end
     end
@@ -105,12 +105,12 @@ class ViewInstrumentationTest < ActionDispatch::IntegrationTest
     end
 
     def test_should_allow_uncaught_exception_to_propagate
-      get "/views/raise_render"
+      get("/views/raise_render")
       assert_equal 500, status
     end
 
     def test_should_count_all_the_template_and_partial_nodes
-      get '/views/template_render_with_3_partial_renders'
+      get('/views/template_render_with_3_partial_renders')
       sample = last_transaction_trace
       nodes = find_all_nodes_with_name_matching(sample, ['^Nested/Controller/views', '^View'])
       nodes_list = "Found these nodes:\n  #{nodes.map(&:metric_name).join("\n  ")}"
@@ -118,7 +118,7 @@ class ViewInstrumentationTest < ActionDispatch::IntegrationTest
     end
 
     def test_should_have_3_nodes_with_the_correct_metric_name
-      get '/views/template_render_with_3_partial_renders'
+      get('/views/template_render_with_3_partial_renders')
 
       sample = last_transaction_trace
       partial_nodes = find_all_nodes_with_name_matching(sample, 'View/views/_a_partial.html.erb/Partial')
@@ -128,7 +128,7 @@ class ViewInstrumentationTest < ActionDispatch::IntegrationTest
     end
 
     def test_should_create_a_metric_for_the_rendered_inline_template
-      get '/views/inline_render'
+      get('/views/inline_render')
 
       sample = last_transaction_trace
       text_node = find_node_with_name(sample, 'View/inline template/Rendering')
@@ -140,13 +140,13 @@ class ViewInstrumentationTest < ActionDispatch::IntegrationTest
     # It doesn't seem worth it to get consistent behavior here.
     if Rails::VERSION::MAJOR.to_i == 3 && Rails::VERSION::MINOR.to_i == 0
       def test_should_not_instrument_rendering_of_text
-        get '/views/text_render'
+        get('/views/text_render')
         sample = last_transaction_trace
         refute find_node_with_name(sample, 'View/text template/Rendering')
       end
     else
       def test_should_create_a_metric_for_the_rendered_text
-        get '/views/text_render'
+        get('/views/text_render')
 
         sample = last_transaction_trace
         text_node = find_node_with_name(sample, 'View/text template/Rendering')
@@ -157,7 +157,7 @@ class ViewInstrumentationTest < ActionDispatch::IntegrationTest
     end
 
     def test_should_create_a_metric_for_the_rendered_haml_template
-      get '/views/haml_render'
+      get('/views/haml_render')
 
       sample = last_transaction_trace
       text_node = find_node_with_name(sample, 'View/views/haml_view.html.haml/Rendering')
@@ -167,7 +167,7 @@ class ViewInstrumentationTest < ActionDispatch::IntegrationTest
     end
 
     def test_should_create_a_proper_metric_when_the_template_is_unknown
-      get '/views/no_template'
+      get('/views/no_template')
       sample = last_transaction_trace
 
       # Different versions have significant difference in handling, but we're
@@ -182,7 +182,7 @@ class ViewInstrumentationTest < ActionDispatch::IntegrationTest
     end
 
     def test_should_create_a_proper_metric_when_we_render_a_collection
-      get '/views/collection_render'
+      get('/views/collection_render')
       sample = last_transaction_trace
       assert find_node_with_name(sample, "View/foos/_foo.html.haml/Partial")
     end
@@ -197,14 +197,14 @@ class ViewInstrumentationTest < ActionDispatch::IntegrationTest
     end
 
     def test_should_create_a_metric_for_rendered_file_that_does_not_include_the_filename_so_it_doesnt_metric_explode
-      get '/views/file_render'
+      get('/views/file_render')
       sample = last_transaction_trace
       assert find_node_with_name(sample, 'Nested/Controller/views/file_render')
       refute find_node_with_name_matching(sample, 'dummy')
     end
 
     def test_exclusive_time_for_template_render_metrics_should_not_include_partial_rendering_time
-      get '/views/render_with_delays'
+      get('/views/render_with_delays')
 
       expected_stats_partial = {
         :call_count => 3,

--- a/test/multiverse/suites/rails_prepend/newrelic_prepender/lib/newrelic_prepender.rb
+++ b/test/multiverse/suites/rails_prepend/newrelic_prepender/lib/newrelic_prepender.rb
@@ -8,37 +8,37 @@ require "newrelic_prepender/version"
 module NewRelic
   module Prepender
     def self.do_prepend *bases
-      bases.each { |b| b.__send__ :prepend, self }
+      bases.each { |b| b.__send__(:prepend, self) }
     end
   end
 end
 
 require 'action_controller'
 
-NewRelic::Prepender.do_prepend ::ActionController::Base
+NewRelic::Prepender.do_prepend(::ActionController::Base)
 
 if ::Rails::VERSION::MAJOR.to_i == 5
-  NewRelic::Prepender.do_prepend ::ActionController::API
+  NewRelic::Prepender.do_prepend(::ActionController::API)
 end
 
 require 'action_view'
 
-NewRelic::Prepender.do_prepend ::ActionView::Base,
+NewRelic::Prepender.do_prepend(::ActionView::Base,
   ::ActionView::Template,
-  ::ActionView::Renderer
+  ::ActionView::Renderer)
 
 if ::Rails::VERSION::MAJOR.to_i == 5
   require 'action_cable/engine'
 
-  NewRelic::Prepender.do_prepend ::ActionCable::Engine,
-    ::ActionCable::RemoteConnections
+  NewRelic::Prepender.do_prepend(::ActionCable::Engine,
+    ::ActionCable::RemoteConnections)
 
   require 'active_job'
 
-  NewRelic::Prepender.do_prepend ::ActiveJob::Base
+  NewRelic::Prepender.do_prepend(::ActiveJob::Base)
 end
 
 require 'active_record'
 
-NewRelic::Prepender.do_prepend ::ActiveRecord::Base,
-  ::ActiveRecord::Relation
+NewRelic::Prepender.do_prepend(::ActiveRecord::Base,
+  ::ActiveRecord::Relation)

--- a/test/multiverse/suites/rails_prepend/prepended_supportability_test.rb
+++ b/test/multiverse/suites/rails_prepend/prepended_supportability_test.rb
@@ -3,7 +3,7 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
-SimpleCovHelper.command_name "test:multiverse[rails_prepend]"
+SimpleCovHelper.command_name("test:multiverse[rails_prepend]")
 require '../rails/app'
 
 class PrependedSupportabilityMetricsTest < Minitest::Test

--- a/test/multiverse/suites/rake/multitask_test.rb
+++ b/test/multiverse/suites/rake/multitask_test.rb
@@ -3,7 +3,7 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
-SimpleCovHelper.command_name "test:multiverse[rake]"
+SimpleCovHelper.command_name("test:multiverse[rake]")
 require_relative 'rake_test_helper'
 
 if ::NewRelic::Agent::Instrumentation::Rake.should_install?

--- a/test/multiverse/suites/redis/redis_instrumentation_test.rb
+++ b/test/multiverse/suites/redis/redis_instrumentation_test.rb
@@ -3,7 +3,7 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
-SimpleCovHelper.command_name "test:multiverse[redis]"
+SimpleCovHelper.command_name("test:multiverse[redis]")
 require 'redis'
 require_relative '../../../helpers/docker'
 
@@ -31,7 +31,7 @@ if NewRelic::Agent::Datastores::Redis.is_supported_version?
     def test_records_metrics_for_connect
       redis = Redis.new(:host => redis_host)
 
-      in_transaction "test_txn" do
+      in_transaction("test_txn") do
         redis.get("foo")
       end
 
@@ -72,7 +72,7 @@ if NewRelic::Agent::Datastores::Redis.is_supported_version?
 
     def test_records_metrics_for_set
       in_transaction do
-        @redis.set 'time', 'walk'
+        @redis.set('time', 'walk')
       end
 
       expected = {
@@ -88,7 +88,7 @@ if NewRelic::Agent::Datastores::Redis.is_supported_version?
 
     def test_records_metrics_for_get_in_web_transaction
       in_web_transaction do
-        @redis.set 'prodigal', 'sorcerer'
+        @redis.set('prodigal', 'sorcerer')
       end
 
       expected = {
@@ -104,7 +104,7 @@ if NewRelic::Agent::Datastores::Redis.is_supported_version?
 
     def test_records_metrics_for_get_in_background_txn
       in_background_transaction do
-        @redis.get 'mox sapphire'
+        @redis.get('mox sapphire')
       end
 
       expected = {
@@ -120,7 +120,7 @@ if NewRelic::Agent::Datastores::Redis.is_supported_version?
 
     def test_records_tt_node_for_get
       in_transaction do
-        @redis.get 'mox sapphire'
+        @redis.get('mox sapphire')
       end
 
       tt = last_transaction_trace
@@ -130,7 +130,7 @@ if NewRelic::Agent::Datastores::Redis.is_supported_version?
 
     def test_does_not_record_statement_on_individual_command_node_by_default
       in_transaction do
-        @redis.get 'mox sapphire'
+        @redis.get('mox sapphire')
       end
 
       tt = last_transaction_trace
@@ -142,7 +142,7 @@ if NewRelic::Agent::Datastores::Redis.is_supported_version?
 
     def test_records_metrics_for_set_in_web_transaction
       in_web_transaction do
-        @redis.get 'timetwister'
+        @redis.get('timetwister')
       end
 
       expected = {
@@ -157,10 +157,10 @@ if NewRelic::Agent::Datastores::Redis.is_supported_version?
     end
 
     def test_records_metrics_for_pipelined_commands
-      in_transaction 'test_txn' do
+      in_transaction('test_txn') do
         @redis.pipelined do
-          @redis.get 'great log'
-          @redis.get 'late log'
+          @redis.get('great log')
+          @redis.get('late log')
         end
       end
 
@@ -184,8 +184,8 @@ if NewRelic::Agent::Datastores::Redis.is_supported_version?
     def test_records_commands_without_args_in_pipelined_block_by_default
       in_transaction do
         @redis.pipelined do
-          @redis.set 'late log', 'goof'
-          @redis.get 'great log'
+          @redis.set('late log', 'goof')
+          @redis.get('great log')
         end
       end
 
@@ -196,10 +196,10 @@ if NewRelic::Agent::Datastores::Redis.is_supported_version?
     end
 
     def test_records_metrics_for_multi_blocks
-      in_transaction 'test_txn' do
+      in_transaction('test_txn') do
         @redis.multi do
-          @redis.get 'darkpact'
-          @redis.get 'chaos orb'
+          @redis.get('darkpact')
+          @redis.get('chaos orb')
         end
       end
 
@@ -223,8 +223,8 @@ if NewRelic::Agent::Datastores::Redis.is_supported_version?
     def test_records_commands_without_args_in_tt_node_for_multi_blocks
       in_transaction do
         @redis.multi do
-          @redis.set 'darkpact', 'sorcery'
-          @redis.get 'chaos orb'
+          @redis.set('darkpact', 'sorcery')
+          @redis.get('chaos orb')
         end
       end
 
@@ -238,8 +238,8 @@ if NewRelic::Agent::Datastores::Redis.is_supported_version?
       with_config(:'transaction_tracer.record_redis_arguments' => true) do
         in_transaction do
           @redis.multi do
-            @redis.set 'darkpact', 'sorcery'
-            @redis.get 'chaos orb'
+            @redis.set('darkpact', 'sorcery')
+            @redis.get('chaos orb')
           end
         end
       end
@@ -312,7 +312,7 @@ if NewRelic::Agent::Datastores::Redis.is_supported_version?
 
     def test_records_unknown_unknown_metric_when_error_gathering_instance_data
       redis = Redis.new(:host => redis_host)
-      redis.send(client).stubs(:path).raises StandardError.new
+      redis.send(client).stubs(:path).raises(StandardError.new)
       in_transaction do
         redis.get("foo")
       end
@@ -327,7 +327,7 @@ if NewRelic::Agent::Datastores::Redis.is_supported_version?
     def simulate_read_error
       redis = Redis.new(:host => redis_host)
       redis.send(client).stubs("establish_connection").raises(simulated_error_class, "Error connecting to Redis")
-      redis.get "foo"
+      redis.get("foo")
     ensure
     end
 

--- a/test/multiverse/suites/resque/instrumentation_test.rb
+++ b/test/multiverse/suites/resque/instrumentation_test.rb
@@ -5,7 +5,7 @@
 
 # https://newrelic.atlassian.net/browse/RUBY-669
 
-SimpleCovHelper.command_name "test:multiverse[resque]"
+SimpleCovHelper.command_name("test:multiverse[resque]")
 require 'resque'
 require 'logger'
 require 'newrelic_rpm'
@@ -29,7 +29,7 @@ class ResqueTest < Minitest::Test
     end
 
     def self.perform(name, sleep_duration = 0)
-      sleep sleep_duration
+      sleep(sleep_duration)
       @count += 1
     end
 

--- a/test/multiverse/suites/sequel/database.rb
+++ b/test/multiverse/suites/sequel/database.rb
@@ -14,23 +14,23 @@ if !defined?(DB)
 
   def create_tables(db)
     db.create_table(:authors) do
-      primary_key :id
-      string :name
-      string :login
+      primary_key(:id)
+      string(:name)
+      string(:login)
     end
 
     db.create_table(:posts) do
-      primary_key :id
-      string :title
-      string :content
-      time :created_at
+      primary_key(:id)
+      string(:title)
+      string(:content)
+      time(:created_at)
     end
 
     db.create_table(:users) do
-      primary_key :uid
-      string :login
-      string :firstname
-      string :lastname
+      primary_key(:uid)
+      string(:login)
+      string(:firstname)
+      string(:lastname)
     end
   end
 
@@ -52,14 +52,14 @@ if !defined?(DB)
   # Version 4.0 of Sequel moved update_except off to a plugin
   # So we can test that we still instrument it, it's got to be included
   if defined?(Sequel::MAJOR) && Sequel::MAJOR >= 4
-    Sequel::Model.plugin :blacklist_security
+    Sequel::Model.plugin(:blacklist_security)
   end
 
   # Version 5.0 of Sequel moved update_all and update_only to a plugin
   # So we can test that we still instrument those methods, it needs to
   # be included
   if defined?(Sequel::MAJOR) && Sequel::MAJOR >= 5
-    Sequel::Model.plugin :whitelist_security
+    Sequel::Model.plugin(:whitelist_security)
   end
 
   Post.strict_param_setting = false

--- a/test/multiverse/suites/sequel/sequel_extension_test.rb
+++ b/test/multiverse/suites/sequel/sequel_extension_test.rb
@@ -3,7 +3,7 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
-SimpleCovHelper.command_name "test:multiverse[sequel]"
+SimpleCovHelper.command_name("test:multiverse[sequel]")
 require File.join(File.dirname(__FILE__), 'database.rb')
 require File.join(File.dirname(__FILE__), 'sequel_helpers.rb')
 
@@ -19,7 +19,7 @@ if Sequel.const_defined?(:MAJOR) &&
     def setup
       super
 
-      DB.extension :newrelic_instrumentation
+      DB.extension(:newrelic_instrumentation)
 
       @posts = DB[:posts]
 

--- a/test/multiverse/suites/sequel/sequel_helpers.rb
+++ b/test/multiverse/suites/sequel/sequel_helpers.rb
@@ -7,7 +7,7 @@ module SequelHelpers
   def setup
     super
 
-    DB.extension :newrelic_instrumentation
+    DB.extension(:newrelic_instrumentation)
 
     NewRelic::Agent.drop_buffered_data
   end

--- a/test/multiverse/suites/sequel/sequel_plugin_test.rb
+++ b/test/multiverse/suites/sequel/sequel_plugin_test.rb
@@ -221,7 +221,7 @@ if Sequel.const_defined?(:MAJOR) &&
         expected_metric_name = "Datastore/statement/#{product_name}/Post/all"
         recorded_metric_names = NewRelic::Agent.agent.sql_sampler.sql_traces.values.map(&:database_metric_name)
 
-        assert recorded_metric_names.include? expected_metric_name
+        assert recorded_metric_names.include?(expected_metric_name)
       end
     end
   end

--- a/test/multiverse/suites/sidekiq/sidekiq_instrumentation_test.rb
+++ b/test/multiverse/suites/sidekiq/sidekiq_instrumentation_test.rb
@@ -5,7 +5,7 @@
 
 # https://newrelic.atlassian.net/browse/RUBY-775
 
-SimpleCovHelper.command_name "test:multiverse[sidekiq]"
+SimpleCovHelper.command_name("test:multiverse[sidekiq]")
 require File.join(File.dirname(__FILE__), "sidekiq_server")
 SidekiqServer.instance.run
 
@@ -61,7 +61,7 @@ class SidekiqTest < Minitest::Test
   def run_and_transmit
     with_config(:'transaction_tracer.transaction_threshold' => 0.0) do
       TestWorker.run_jobs(JOB_COUNT) do |i|
-        yield i
+        yield(i)
       end
     end
 
@@ -104,7 +104,7 @@ class SidekiqTest < Minitest::Test
     NewRelic::Agent::DistributedTracePayload.stubs(:connected?).returns(true)
     NewRelic::Agent.config.add_config_for_testing(@config)
 
-    in_transaction 'test_txn' do |t|
+    in_transaction('test_txn') do |t|
       run_jobs
     end
 
@@ -200,7 +200,7 @@ class SidekiqTest < Minitest::Test
         assert_equal sample.metric_name, TRANSACTION_NAME, "Huh, that transaction shouldn't be in there!"
 
         actual = sample.agent_attributes.keys.to_set
-        expected = Set.new ["job.sidekiq.args.0", "job.sidekiq.args.1"]
+        expected = Set.new(["job.sidekiq.args.0", "job.sidekiq.args.1"])
         assert_equal expected, actual
       end
     end

--- a/test/multiverse/suites/sidekiq/test_worker.rb
+++ b/test/multiverse/suites/sidekiq/test_worker.rb
@@ -28,7 +28,7 @@ class TestWorker
   def self.run_jobs(count)
     reset(count)
     count.times do |i|
-      yield i
+      yield(i)
     end
     wait
   end

--- a/test/multiverse/suites/sinatra/ignoring_test.rb
+++ b/test/multiverse/suites/sinatra/ignoring_test.rb
@@ -3,7 +3,7 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
-SimpleCovHelper.command_name "test:multiverse[sinatra]"
+SimpleCovHelper.command_name("test:multiverse[sinatra]")
 
 class SinatraIgnoreTestApp < Sinatra::Base
   get '/record' do request.path_info end
@@ -84,8 +84,8 @@ class SinatraIgnoreTest < SinatraTestCase
   end
 
   def test_seen_route
-    get_and_assert_ok '/record'
-    segment = name_for_route 'record'
+    get_and_assert_ok('/record')
+    segment = name_for_route('record')
     assert_metrics_recorded([
       "Controller/Sinatra/#{app_name}/#{segment}",
       "Apdex/Sinatra/#{app_name}/#{segment}"
@@ -93,8 +93,8 @@ class SinatraIgnoreTest < SinatraTestCase
   end
 
   def test_ignores_exact_match
-    get_and_assert_ok '/ignore'
-    segment = name_for_route 'ignore'
+    get_and_assert_ok('/ignore')
+    segment = name_for_route('ignore')
     assert_metrics_not_recorded([
       "Controller/Sinatra/#{app_name}/#{segment}",
       "Apdex/Sinatra/#{app_name}/#{segment}"
@@ -102,8 +102,8 @@ class SinatraIgnoreTest < SinatraTestCase
   end
 
   def test_ignores_by_splats
-    get_and_assert_ok '/splattered'
-    segment = name_for_route 'splattered'
+    get_and_assert_ok('/splattered')
+    segment = name_for_route('splattered')
     assert_metrics_not_recorded([
       "Controller/Sinatra/#{app_name}/#{segment}",
       "Apdex/Sinatra/#{app_name}/#{segment}"
@@ -111,13 +111,13 @@ class SinatraIgnoreTest < SinatraTestCase
   end
 
   def test_ignores_can_be_declared_in_batches
-    get_and_assert_ok '/v1'
-    get_and_assert_ok '/v2'
-    get_and_assert_ok '/v3'
+    get_and_assert_ok('/v1')
+    get_and_assert_ok('/v2')
+    get_and_assert_ok('/v3')
 
-    v1_segment = name_for_route 'v1'
-    v2_segment = name_for_route 'v2'
-    v3_segment = name_for_route 'v3'
+    v1_segment = name_for_route('v1')
+    v2_segment = name_for_route('v2')
+    v3_segment = name_for_route('v3')
 
     assert_metrics_not_recorded([
       "Controller/Sinatra/#{app_name}/#{v1_segment}",
@@ -133,8 +133,8 @@ class SinatraIgnoreTest < SinatraTestCase
   end
 
   def test_seen_with_regex
-    get_and_assert_ok '/regex_seen'
-    segment = name_for_route 'regex_seen'
+    get_and_assert_ok('/regex_seen')
+    segment = name_for_route('regex_seen')
     assert_metrics_recorded([
       "Controller/Sinatra/#{app_name}/#{segment}",
       "Apdex/Sinatra/#{app_name}/#{segment}"
@@ -142,8 +142,8 @@ class SinatraIgnoreTest < SinatraTestCase
   end
 
   def test_ignores_by_regex
-    get_and_assert_ok '/skip_regex'
-    segment = name_for_route 'skip_regex'
+    get_and_assert_ok('/skip_regex')
+    segment = name_for_route('skip_regex')
     assert_metrics_not_recorded([
       "Controller/Sinatra/#{app_name}/#{segment}",
       "Apdex/Sinatra/#{app_name}/#{segment}"
@@ -151,15 +151,15 @@ class SinatraIgnoreTest < SinatraTestCase
   end
 
   def test_ignore_apdex
-    get_and_assert_ok '/no_apdex'
-    segment = name_for_route 'no_apdex'
+    get_and_assert_ok('/no_apdex')
+    segment = name_for_route('no_apdex')
     assert_metrics_recorded(["Controller/Sinatra/#{app_name}/#{segment}"])
     assert_metrics_not_recorded(["Apdex/Sinatra/#{app_name}/#{segment}"])
   end
 
   def test_ignore_enduser_should_only_apply_to_specified_route
-    get_and_assert_ok '/enduser'
-    segment = name_for_route 'enduser'
+    get_and_assert_ok('/enduser')
+    segment = name_for_route('enduser')
     refute_enduser_ignored(last_response)
     assert_metrics_recorded([
       "Controller/Sinatra/#{app_name}/#{segment}",
@@ -168,8 +168,8 @@ class SinatraIgnoreTest < SinatraTestCase
   end
 
   def test_ignore_enduser
-    get_and_assert_ok '/no_enduser'
-    segment = name_for_route 'no_enduser'
+    get_and_assert_ok('/no_enduser')
+    segment = name_for_route('no_enduser')
     assert_enduser_ignored(last_response)
     assert_metrics_recorded([
       "Controller/Sinatra/#{app_name}/#{segment}",
@@ -178,12 +178,12 @@ class SinatraIgnoreTest < SinatraTestCase
   end
 
   def test_ignore_errors_in_ignored_transactions
-    get '/ignored_erroring'
+    get('/ignored_erroring')
     assert_metrics_not_recorded(["Errors/all"])
   end
 
   def name_for_route path
-    if last_request.env.key? 'sinatra.route'
+    if last_request.env.key?('sinatra.route')
       "GET /#{path}"
     else
       "GET #{path}"
@@ -206,7 +206,7 @@ class SinatraIgnoreItAllTest < SinatraTestCase
   def test_ignores_everything
     # Ignores Supportability and Logging metrics, makes sure we don't see
     # transaction or other related metrics
-    get_and_assert_ok '/'
+    get_and_assert_ok('/')
     assert_metrics_recorded_exclusive(
       [],
       :ignore_filter => /^(Supportability|Logging)/
@@ -228,12 +228,12 @@ class SinatraIgnoreApdexAndEndUserTest < SinatraTestCase
   end
 
   def test_ignores_apdex
-    get_and_assert_ok '/'
+    get_and_assert_ok('/')
     assert_metrics_not_recorded(["Apdex/Sinatra/#{app.to_s}/GET /"])
   end
 
   def test_ignores_enduser
-    get_and_assert_ok '/'
+    get_and_assert_ok('/')
     assert_enduser_ignored(last_response)
   end
 end

--- a/test/multiverse/suites/sinatra/nested_middleware_test.rb
+++ b/test/multiverse/suites/sinatra/nested_middleware_test.rb
@@ -28,18 +28,18 @@ class NestedMiddlewareTest < Minitest::Test
   setup_and_teardown_agent
 
   def test_inner_transaction
-    get '/main'
+    get('/main')
     assert_metrics_recorded(["Controller/Sinatra/MainApp/#{name_for_route('main')}"])
     assert_metrics_not_recorded(["Controller/Sinatra/MiddlewareApp/GET (unknown)"])
   end
 
   def test_outer_transaction
-    get '/middle'
+    get('/middle')
     assert_metrics_recorded(["Controller/Sinatra/MiddlewareApp/#{name_for_route('middle')}"])
   end
 
   def name_for_route path
-    if last_request.env.key? 'sinatra.route'
+    if last_request.env.key?('sinatra.route')
       "GET /#{path}"
     else
       "GET #{path}"

--- a/test/multiverse/suites/sinatra/sinatra_error_tracing_test.rb
+++ b/test/multiverse/suites/sinatra/sinatra_error_tracing_test.rb
@@ -30,7 +30,7 @@ class SinatraErrorTracingTest < Minitest::Test
   end
 
   def test_traps_errors
-    get '/will_boom'
+    get('/will_boom')
     assert_equal 500, last_response.status
     assert_equal 'We are sorry', last_response.body
 
@@ -39,7 +39,7 @@ class SinatraErrorTracingTest < Minitest::Test
   end
 
   def test_ignores_notfound_errors_by_default
-    get '/ignored_boom'
+    get('/ignored_boom')
     assert_equal 404, last_response.status
     assert_match %r{Sinatra doesn(&rsquo;|’)t know this ditty\.}, last_response.body
     errors = harvest_error_traces!

--- a/test/multiverse/suites/sinatra/sinatra_metric_explosion_test.rb
+++ b/test/multiverse/suites/sinatra/sinatra_metric_explosion_test.rb
@@ -37,14 +37,14 @@ class SinatraMetricExplosionTest < Minitest::Test
   end
 
   def test_sinatra_returns_properly
-    get '/hello/world'
+    get('/hello/world')
     assert_equal 'hello world', last_response.body
   end
 
   def test_transaction_name_from_route
-    get '/hello/world'
+    get('/hello/world')
 
-    segment = if last_request.env.key? 'sinatra.route'
+    segment = if last_request.env.key?('sinatra.route')
       'GET /hello/:name'
     else
       'GET hello/([^/?#]+)'
@@ -56,7 +56,7 @@ class SinatraMetricExplosionTest < Minitest::Test
   end
 
   def test_transaction_name_from_path
-    get '/wrong'
+    get('/wrong')
     assert_metrics_recorded([
       'Controller/Sinatra/SinatraTestApp/GET (unknown)',
       'Apdex/Sinatra/SinatraTestApp/GET (unknown)'
@@ -64,11 +64,11 @@ class SinatraMetricExplosionTest < Minitest::Test
   end
 
   def test_transaction_name_does_not_explode
-    get '/hello/my%20darling'
-    get '/hello/my_honey'
-    get '/hello/my.ragtime.gal'
-    get '/hello/isitmeyourelookingfor?'
-    get '/another_controller'
+    get('/hello/my%20darling')
+    get('/hello/my_honey')
+    get('/hello/my.ragtime.gal')
+    get('/hello/isitmeyourelookingfor?')
+    get('/another_controller')
 
     metric_names = ::NewRelic::Agent.agent.stats_engine.to_h.keys.map(&:to_s)
     metric_names -= [
@@ -93,7 +93,7 @@ class SinatraMetricExplosionTest < Minitest::Test
   end
 
   def test_does_not_break_when_no_verb_matches
-    post '/some/garbage'
+    post('/some/garbage')
 
     assert_metrics_recorded([
       'Controller/Sinatra/SinatraTestApp/POST (unknown)',

--- a/test/multiverse/suites/sinatra/sinatra_parameter_capture_test.rb
+++ b/test/multiverse/suites/sinatra/sinatra_parameter_capture_test.rb
@@ -34,7 +34,7 @@ class SinatraParameterCaptureTest < Minitest::Test
         :foo => "bar",
         :bar => "baz"
       }
-      post '/capture_test', params
+      post('/capture_test', params)
     end
 
     expected = {
@@ -53,7 +53,7 @@ class SinatraParameterCaptureTest < Minitest::Test
         :title => "blah",
         :file => Rack::Test::UploadedFile.new(__FILE__, 'text/plain')
       }
-      post '/files', params
+      post('/files', params)
 
       expected = {
         "request.parameters.title" => "blah",
@@ -65,7 +65,7 @@ class SinatraParameterCaptureTest < Minitest::Test
   end
 
   def test_request_and_response_attributes_recorded_as_agent_attributes
-    post '/capture_test'
+    post('/capture_test')
 
     expected = {
       "response.headers.contentLength" => last_response.content_length.to_i,

--- a/test/multiverse/suites/sinatra/sinatra_routes_test.rb
+++ b/test/multiverse/suites/sinatra/sinatra_routes_test.rb
@@ -38,13 +38,13 @@ class SinatraRoutesTest < Minitest::Test
 
   # https://support.newrelic.com/tickets/24779
   def test_lower_priority_route_conditions_arent_applied_to_higher_priority_routes
-    get '/user/login'
+    get('/user/login')
     assert_equal 200, last_response.status
     assert_equal 'please log in', last_response.body
   end
 
   def test_conditions_are_applied_to_an_action_that_uses_them
-    get '/user/1'
+    get('/user/1')
     assert_equal 404, last_response.status
   end
 end

--- a/test/multiverse/suites/sinatra/sinatra_test_cases.rb
+++ b/test/multiverse/suites/sinatra/sinatra_test_cases.rb
@@ -62,66 +62,66 @@ module SinatraTestCases
 
   # https://support.newrelic.com/tickets/24779
   def test_lower_priority_route_conditions_arent_applied_to_higher_priority_routes
-    get '/user/login'
+    get('/user/login')
     assert_equal 200, last_response.status
     assert_equal 'please log in', last_response.body
   end
 
   def test_conditions_are_applied_to_an_action_that_uses_them
-    get '/user/1'
+    get('/user/1')
     assert_equal 404, last_response.status
   end
 
   def test_queue_time_headers_are_passed_to_agent
-    get '/user/login', {}, {'HTTP_X_REQUEST_START' => 't=1360973845'}
+    get('/user/login', {}, {'HTTP_X_REQUEST_START' => 't=1360973845'})
     assert_metrics_recorded(["WebFrontend/QueueTime"])
   end
 
   def test_shown_errors_get_caught
-    get '/raise'
+    get('/raise')
     errors = harvest_error_traces!
     assert_equal 1, errors.size
   end
 
   def test_does_not_break_pass
-    get '/pass'
+    get('/pass')
     assert_equal 200, last_response.status
     assert_equal "I'm not a teapot.", last_response.body
   end
 
   def test_does_not_break_error_handling
-    get '/error'
+    get('/error')
     assert_equal 200, last_response.status
     assert_equal "nothing happened", last_response.body
   end
 
   def test_sees_handled_error
-    get '/error'
+    get('/error')
     errors = harvest_error_traces!
     assert_equal 1, errors.size
   end
 
   def test_correct_pattern
-    get '/route/match'
+    get('/route/match')
     assert_equal 'first route', last_response.body
     assert_metrics_recorded(["Controller/Sinatra/#{app_name}/#{route_name_segment}"])
   end
 
   def test_finds_second_route
-    get '/route/no_match'
+    get('/route/no_match')
     assert_equal 'second route', last_response.body
     assert_metrics_recorded(["Controller/Sinatra/#{app_name}/#{route_no_match_segment}"])
   end
 
   def test_with_regex_pattern
-    get '/regexes'
+    get('/regexes')
     assert_equal "Yeah, regex's!", last_response.body
     assert_metrics_recorded(["Controller/Sinatra/#{app_name}/#{regex_segment}"])
   end
 
   # https://support.newrelic.com/tickets/31061
   def test_precondition_not_over_called
-    get '/precondition'
+    get('/precondition')
 
     assert_equal 200, last_response.status
     assert_equal 'precondition only happened once', last_response.body
@@ -129,14 +129,14 @@ module SinatraTestCases
   end
 
   def test_filter
-    get '/filtered'
+    get('/filtered')
 
     assert_equal 200, last_response.status
     assert_equal 'got filtered', last_response.body
   end
 
   def test_ignores_route_metrics
-    get '/ignored'
+    get('/ignored')
 
     assert_equal 200, last_response.status
     assert_metrics_not_recorded(["Controller/Sinatra/#{app_name}/#{ignored_segment}"])
@@ -145,7 +145,7 @@ module SinatraTestCases
   def test_rack_request_params_errors_are_swallowed
     trigger_error_on_params
 
-    get '/pass'
+    get('/pass')
 
     expected_status = Gem::Version.new(Sinatra::VERSION).segments[0] < 2 ? 200 : 400
 
@@ -158,7 +158,7 @@ module SinatraTestCases
 
     trigger_error_on_params
 
-    get '/pass'
+    get('/pass')
   end
 
   def test_injects_middleware
@@ -185,7 +185,7 @@ module SinatraTestCases
     def trigger_error_on_params
       Sinatra::Request.any_instance
         .stubs(:params).returns({})
-        .then.raises(StandardError.new "Rack::Request#params error")
+        .then.raises(StandardError.new("Rack::Request#params error"))
     end
   else
     def trigger_error_on_params
@@ -196,7 +196,7 @@ module SinatraTestCases
   end
 
   def test_root_path_naming
-    get '/'
+    get('/')
 
     assert_metrics_recorded ["Controller/Sinatra/#{app_name}/GET /"]
     refute_metrics_recorded ["Controller/Sinatra/#{app_name}/GET "]

--- a/test/multiverse/suites/sinatra_agent_disabled/shim_test.rb
+++ b/test/multiverse/suites/sinatra_agent_disabled/shim_test.rb
@@ -3,7 +3,7 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
-SimpleCovHelper.command_name "test:multiverse[sinatra_agent_disabled]"
+SimpleCovHelper.command_name("test:multiverse[sinatra_agent_disabled]")
 require 'sinatra'
 
 class MiddlewareApp < Sinatra::Base

--- a/test/multiverse/suites/tilt/tilt_instrumentation_test.rb
+++ b/test/multiverse/suites/tilt/tilt_instrumentation_test.rb
@@ -3,7 +3,7 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
-SimpleCovHelper.command_name "test:multiverse[tilt]"
+SimpleCovHelper.command_name("test:multiverse[tilt]")
 
 class TiltInstrumentationTest < Minitest::Test
   def setup

--- a/test/multiverse/suites/typhoeus/typhoeus_test.rb
+++ b/test/multiverse/suites/typhoeus/typhoeus_test.rb
@@ -3,7 +3,7 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
-SimpleCovHelper.command_name "test:multiverse[typhoeus]"
+SimpleCovHelper.command_name("test:multiverse[typhoeus]")
 require "typhoeus"
 require "newrelic_rpm"
 require "http_client_test_cases"
@@ -38,7 +38,7 @@ if NewRelic::Agent::Instrumentation::Typhoeus.is_supported_version?
     end
 
     def simulate_error_response
-      get_response "http://localhost:666/evil"
+      get_response("http://localhost:666/evil")
     end
 
     # We use the Typhoeus::Request rather than right on Typhoeus to support
@@ -49,7 +49,7 @@ if NewRelic::Agent::Instrumentation::Typhoeus.is_supported_version?
     end
 
     def get_wrapped_response url
-      NewRelic::Agent::HTTPClients::TyphoeusHTTPResponse.new get_response url
+      NewRelic::Agent::HTTPClients::TyphoeusHTTPResponse.new(get_response(url))
     end
 
     def head_response
@@ -152,7 +152,7 @@ if NewRelic::Agent::Instrumentation::Typhoeus.is_supported_version?
 
       trace = last_transaction_trace
 
-      hydra = find_node_with_name trace, "External/Multiple/Typhoeus::Hydra/run"
+      hydra = find_node_with_name(trace, "External/Multiple/Typhoeus::Hydra/run")
 
       assert_equal 5, hydra.children.size
 

--- a/test/multiverse/suites/yajl/yajl_test.rb
+++ b/test/multiverse/suites/yajl/yajl_test.rb
@@ -3,7 +3,7 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
-SimpleCovHelper.command_name "test:multiverse[yajl]"
+SimpleCovHelper.command_name("test:multiverse[yajl]")
 require File.join(File.dirname(__FILE__), '..', '..', '..', 'new_relic', 'marshalling_test_cases')
 
 # This is the problematic thing that overrides our JSON marshalling

--- a/test/new_relic/agent/adaptive_sampler_test.rb
+++ b/test/new_relic/agent/adaptive_sampler_test.rb
@@ -37,18 +37,18 @@ module NewRelic
       end
 
       def test_sampling_target_updated_when_config_changes
-        with_config sampling_target: 55 do
+        with_config(sampling_target: 55) do
           sampler = NewRelic::Agent.instance.adaptive_sampler
-          target = sampler.instance_variable_get :@target
+          target = sampler.instance_variable_get(:@target)
 
           assert_equal 55, target
         end
       end
 
       def test_sampling_period_updated_when_config_changes
-        with_config sampling_target_period_in_seconds: 500 do
+        with_config(sampling_target_period_in_seconds: 500) do
           sampler = NewRelic::Agent.instance.adaptive_sampler
-          period = sampler.instance_variable_get :@period_duration
+          period = sampler.instance_variable_get(:@period_duration)
 
           assert_equal 500, period
         end

--- a/test/new_relic/agent/agent/connect_test.rb
+++ b/test/new_relic/agent/agent/connect_test.rb
@@ -19,7 +19,7 @@ class NewRelic::Agent::Agent::ConnectTest < Minitest::Test
     events = NewRelic::Agent.instance.events
     @transaction_sampler = NewRelic::Agent::TransactionSampler.new
     @sql_sampler = NewRelic::Agent::SqlSampler.new
-    @error_collector = NewRelic::Agent::ErrorCollector.new events
+    @error_collector = NewRelic::Agent::ErrorCollector.new(events)
     @stats_engine = NewRelic::Agent::StatsEngine.new
     server = NewRelic::Control::Server.new('localhost', 30303)
     @service = NewRelic::Agent::NewRelicService.new('abcdef', server)

--- a/test/new_relic/agent/agent_logger_test.rb
+++ b/test/new_relic/agent/agent_logger_test.rb
@@ -287,7 +287,7 @@ class AgentLoggerTest < Minitest::Test
     end
   ensure
     Kernel.module_eval do
-      remove_method :debug
+      remove_method(:debug)
     end
   end
 
@@ -341,7 +341,7 @@ class AgentLoggerTest < Minitest::Test
 
     logger = create_basic_logger
     logger.log_formatter = log_formatter
-    logger.warn log_message
+    logger.warn(log_message)
 
     assert_logged log_message.reverse
   end

--- a/test/new_relic/agent/agent_test.rb
+++ b/test/new_relic/agent/agent_test.rb
@@ -127,7 +127,7 @@ module NewRelic
           # for more likely for the purposes of this test.
           harvester = @agent.harvester
           def harvester.mark_started
-            sleep 0.01
+            sleep(0.01)
             super
           end
 
@@ -178,7 +178,7 @@ module NewRelic
             :truncate => 4000)
 
           @agent.transaction_sampler.stubs(:harvest!).returns([trace])
-          @agent.send :harvest_and_send_transaction_traces
+          @agent.send(:harvest_and_send_transaction_traces)
         end
       end
 
@@ -189,7 +189,7 @@ module NewRelic
         @agent.service.stubs(:transaction_sample_data).raises("wat")
         @agent.transaction_sampler.expects(:merge!).with(traces)
 
-        @agent.send :harvest_and_send_transaction_traces
+        @agent.send(:harvest_and_send_transaction_traces)
       end
 
       def test_harvest_and_send_errors_merges_back_on_failure
@@ -199,7 +199,7 @@ module NewRelic
         @agent.service.stubs(:error_data).raises('wat')
         @agent.error_collector.error_trace_aggregator.expects(:merge!).with(errors)
 
-        @agent.send :harvest_and_send_errors
+        @agent.send(:harvest_and_send_errors)
       end
 
       def test_harvest_and_send_logs_merges_back_on_failure
@@ -209,7 +209,7 @@ module NewRelic
         @agent.service.stubs(:log_event_data).raises('wat')
         @agent.log_event_aggregator.expects(:merge!).with(logs)
 
-        @agent.send :harvest_and_send_log_event_data
+        @agent.send(:harvest_and_send_log_event_data)
       end
 
       # This test asserts nothing about correctness of logging data from multiple
@@ -238,18 +238,18 @@ module NewRelic
 
       def test_handle_for_agent_commands
         @agent.service.expects(:get_agent_commands).returns([]).once
-        @agent.send :check_for_and_handle_agent_commands
+        @agent.send(:check_for_and_handle_agent_commands)
       end
 
       def test_check_for_and_handle_agent_commands_with_error
         @agent.service.expects(:get_agent_commands).raises('bad news')
-        @agent.send :check_for_and_handle_agent_commands
+        @agent.send(:check_for_and_handle_agent_commands)
       end
 
       def test_harvest_and_send_for_agent_commands
         @agent.service.expects(:profile_data).with(any_parameters)
         @agent.agent_command_router.stubs(:harvest!).returns({:profile_data => [Object.new]})
-        @agent.send :harvest_and_send_for_agent_commands
+        @agent.send(:harvest_and_send_for_agent_commands)
       end
 
       def test_merge_data_for_endpoint_empty
@@ -765,7 +765,7 @@ module NewRelic
             gzip.byteslice(0..-2)
           ].join("\r\n")
 
-          server.accept.write headers.chomp
+          server.accept.write(headers.chomp)
         end
 
         @agent.unstub(:start_worker_thread)

--- a/test/new_relic/agent/api_tests/datastore_api_test.rb
+++ b/test/new_relic/agent/api_tests/datastore_api_test.rb
@@ -32,7 +32,7 @@ module NewRelic
                 port_path_or_id: params['port_path_or_id'],
                 database_name: params['database_name']
               )
-              segment.notice_sql "select * from foo"
+              segment.notice_sql("select * from foo")
               advance_process_time 2.0
               segment.finish
             end
@@ -51,7 +51,7 @@ module NewRelic
 
       def assert_expected_tt_segment_params segment_name, host, port_path_or_id, database_name
         trace = last_transaction_trace
-        segment = find_node_with_name trace, segment_name
+        segment = find_node_with_name(trace, segment_name)
 
         if host.nil?
           assert_nil segment[:host]

--- a/test/new_relic/agent/attribute_filter_test.rb
+++ b/test/new_relic/agent/attribute_filter_test.rb
@@ -70,7 +70,7 @@ module NewRelic::Agent
     def test_capture_params_false_adds_exclude_rule_for_request_parameters
       with_config(:capture_params => false) do
         filter = AttributeFilter.new(NewRelic::Agent.config)
-        result = filter.apply 'request.parameters.muggle', AttributeFilter::DST_NONE
+        result = filter.apply('request.parameters.muggle', AttributeFilter::DST_NONE)
 
         assert_destinations [], result
       end
@@ -79,7 +79,7 @@ module NewRelic::Agent
     def test_capture_params_true_allows_request_params_for_traces_and_errors
       with_config(:capture_params => true) do
         filter = AttributeFilter.new(NewRelic::Agent.config)
-        result = filter.apply 'request.parameters.muggle', AttributeFilter::DST_NONE
+        result = filter.apply('request.parameters.muggle', AttributeFilter::DST_NONE)
 
         assert_destinations ['transaction_tracer', 'error_collector'], result
       end
@@ -88,7 +88,7 @@ module NewRelic::Agent
     def test_resque_capture_params_false_adds_exclude_rule_for_request_parameters
       with_config(:'resque.capture_params' => false) do
         filter = AttributeFilter.new(NewRelic::Agent.config)
-        result = filter.apply 'job.resque.args.*', AttributeFilter::DST_NONE
+        result = filter.apply('job.resque.args.*', AttributeFilter::DST_NONE)
 
         assert_destinations [], result
       end
@@ -97,7 +97,7 @@ module NewRelic::Agent
     def test_resque_capture_params_true_allows_request_params_for_traces_and_errors
       with_config(:'resque.capture_params' => true) do
         filter = AttributeFilter.new(NewRelic::Agent.config)
-        result = filter.apply 'job.resque.args.*', AttributeFilter::DST_NONE
+        result = filter.apply('job.resque.args.*', AttributeFilter::DST_NONE)
 
         assert_destinations ['transaction_tracer', 'error_collector'], result
       end
@@ -106,7 +106,7 @@ module NewRelic::Agent
     def test_sidekiq_capture_params_false_adds_exclude_rule_for_request_parameters
       with_config(:'sidekiq.capture_params' => false) do
         filter = AttributeFilter.new(NewRelic::Agent.config)
-        result = filter.apply 'job.sidekiq.args.*', AttributeFilter::DST_NONE
+        result = filter.apply('job.sidekiq.args.*', AttributeFilter::DST_NONE)
 
         assert_destinations [], result
       end
@@ -115,7 +115,7 @@ module NewRelic::Agent
     def test_sidekiq_capture_params_true_allows_request_params_for_traces_errors
       with_config(:'sidekiq.capture_params' => true) do
         filter = AttributeFilter.new(NewRelic::Agent.config)
-        result = filter.apply 'job.sidekiq.args.*', AttributeFilter::DST_NONE
+        result = filter.apply('job.sidekiq.args.*', AttributeFilter::DST_NONE)
 
         assert_destinations ['transaction_tracer', 'error_collector'], result
       end
@@ -124,7 +124,7 @@ module NewRelic::Agent
     def test_datastore_tracer_instance_reporting_disabled_adds_exclude_rule
       with_config(:'datastore_tracer.instance_reporting.enabled' => false) do
         filter = AttributeFilter.new(NewRelic::Agent.config)
-        result = filter.apply 'host', AttributeFilter::DST_NONE
+        result = filter.apply('host', AttributeFilter::DST_NONE)
 
         assert_destinations [], result
       end
@@ -133,7 +133,7 @@ module NewRelic::Agent
     def test_datastore_tracer_instance_reporting_enabled_allows_instance_params
       with_config(:'datastore_tracer.instance_reporting.enabled' => true) do
         filter = AttributeFilter.new(NewRelic::Agent.config)
-        result = filter.apply 'host', AttributeFilter::DST_NONE
+        result = filter.apply('host', AttributeFilter::DST_NONE)
 
         assert_destinations ['transaction_segments'], result
       end
@@ -142,7 +142,7 @@ module NewRelic::Agent
     def test_database_name_reporting_disabled_adds_exclude_rule
       with_config(:'datastore_tracer.database_name_reporting.enabled' => false) do
         filter = AttributeFilter.new(NewRelic::Agent.config)
-        result = filter.apply 'database_name', AttributeFilter::DST_NONE
+        result = filter.apply('database_name', AttributeFilter::DST_NONE)
 
         assert_destinations [], result
       end
@@ -151,7 +151,7 @@ module NewRelic::Agent
     def test_database_name_reporting_enabled_allows_database_name
       with_config(:'datastore_tracer.database_name_reporting.enabled' => true) do
         filter = AttributeFilter.new(NewRelic::Agent.config)
-        result = filter.apply 'database_name', AttributeFilter::DST_NONE
+        result = filter.apply('database_name', AttributeFilter::DST_NONE)
 
         assert_destinations ['transaction_segments'], result
       end
@@ -216,7 +216,7 @@ module NewRelic::Agent
         :'attributes.exclude' => ['request.headers.*']) do
         filter = AttributeFilter.new(NewRelic::Agent.config)
 
-        result = filter.apply 'request.headers.contentType', AttributeFilter::DST_ALL
+        result = filter.apply('request.headers.contentType', AttributeFilter::DST_ALL)
 
         expected_destinations = [
           'transaction_events',
@@ -235,7 +235,7 @@ module NewRelic::Agent
         :'span_events.attributes.exclude' => ['request.headers.*']) do
         filter = AttributeFilter.new(NewRelic::Agent.config)
 
-        result = filter.apply 'request.headers.contentType', AttributeFilter::DST_SPAN_EVENTS
+        result = filter.apply('request.headers.contentType', AttributeFilter::DST_SPAN_EVENTS)
 
         expected_destinations = ['span_events']
 
@@ -245,8 +245,8 @@ module NewRelic::Agent
 
     def test_key_cache_global_include_exclude
       with_all_enabled do
-        with_config :'attributes.include' => ['request.headers.contentType'],
-          :'attributes.exclude' => ['request.headers.*'] do
+        with_config(:'attributes.include' => ['request.headers.contentType'],
+          :'attributes.exclude' => ['request.headers.*']) do
           filter = AttributeFilter.new(NewRelic::Agent.config)
 
           assert filter.allows_key?('request.headers.contentType', AttributeFilter::DST_ALL)
@@ -256,8 +256,8 @@ module NewRelic::Agent
     end
 
     def test_key_cache_span_include_exclude
-      with_config :'span_events.attributes.include' => ['request.headers.contentType'],
-        :'span_events.attributes.exclude' => ['request.headers.*'] do
+      with_config(:'span_events.attributes.include' => ['request.headers.contentType'],
+        :'span_events.attributes.exclude' => ['request.headers.*']) do
         filter = AttributeFilter.new(NewRelic::Agent.config)
 
         assert filter.allows_key?('request.headers.contentType', AttributeFilter::DST_SPAN_EVENTS)
@@ -266,7 +266,7 @@ module NewRelic::Agent
     end
 
     def test_excluding_url_attribute_excludes_all
-      with_config :'attributes.exclude' => ['request.uri'] do
+      with_config(:'attributes.exclude' => ['request.uri']) do
         filter = AttributeFilter.new(NewRelic::Agent.config)
 
         refute filter.allows_key?('uri', AttributeFilter::DST_ALL)

--- a/test/new_relic/agent/collector_response_code_test.rb
+++ b/test/new_relic/agent/collector_response_code_test.rb
@@ -21,40 +21,40 @@ module NewRelic
 
       def self.check_discards *response_codes
         response_codes.each do |response_code|
-          define_method "test_#{response_code}_discards" do
+          define_method("test_#{response_code}_discards") do
             klass = Net::HTTPResponse::CODE_TO_OBJ[response_code.to_s]
 
-            stub_service klass.new('1.1', response_code, 'Trash it')
+            stub_service(klass.new('1.1', response_code, 'Trash it'))
 
             @agent.error_collector.error_trace_aggregator.expects(:harvest!).returns(@errors)
             assert_empty @agent.error_collector.error_trace_aggregator.instance_variable_get(:@errors)
 
-            @agent.send :harvest_and_send_errors
+            @agent.send(:harvest_and_send_errors)
           end
         end
       end
 
       def self.check_merges *response_codes
         response_codes.each do |response_code|
-          define_method "test_#{response_code}_merges" do
+          define_method("test_#{response_code}_merges") do
             klass = Net::HTTPResponse::CODE_TO_OBJ[response_code.to_s]
 
-            stub_service klass.new('1.1', response_code, 'Keep it')
+            stub_service(klass.new('1.1', response_code, 'Keep it'))
 
             @agent.error_collector.error_trace_aggregator.expects(:harvest!).returns(@errors)
             @agent.error_collector.error_trace_aggregator.expects(:merge!).with(@errors)
 
-            @agent.send :harvest_and_send_errors
+            @agent.send(:harvest_and_send_errors)
           end
         end
       end
 
       def self.check_restarts *response_codes
         response_codes.each do |response_code|
-          define_method "test_#{response_code}_restarts" do
+          define_method("test_#{response_code}_restarts") do
             klass = Net::HTTPResponse::CODE_TO_OBJ[response_code.to_s]
 
-            stub_service klass.new('1.1', response_code, 'Try again')
+            stub_service(klass.new('1.1', response_code, 'Try again'))
 
             # The error-handling code in agent.rb calls `retry`; rather
             # than testing it directly, we'll just assert that our service
@@ -62,7 +62,7 @@ module NewRelic
             #
             assert_raises(NewRelic::Agent::ForceRestartException) do
               @agent.error_collector.error_trace_aggregator.expects(:harvest!).returns(@errors)
-              @agent.send :harvest_and_send_errors
+              @agent.send(:harvest_and_send_errors)
             end
           end
         end
@@ -70,16 +70,16 @@ module NewRelic
 
       def self.check_disconnects *response_codes
         response_codes.each do |response_code|
-          define_method "test_#{response_code}_disconnects" do
+          define_method("test_#{response_code}_disconnects") do
             klass = Net::HTTPResponse::CODE_TO_OBJ[response_code.to_s]
 
-            stub_service klass.new('1.1', klass, 'Go away')
+            stub_service(klass.new('1.1', klass, 'Go away'))
 
             @agent.error_collector.error_trace_aggregator.expects(:harvest!).returns(@errors)
             @agent.expects(:disconnect)
 
             @agent.send(:catch_errors) do
-              @agent.send :harvest_and_send_errors
+              @agent.send(:harvest_and_send_errors)
             end
           end
         end

--- a/test/new_relic/agent/configuration/default_source_test.rb
+++ b/test/new_relic/agent/configuration/default_source_test.rb
@@ -65,7 +65,7 @@ module NewRelic::Agent::Configuration
     def test_config_search_paths_include_application_root
       NewRelic::Control.instance.stubs(:root).returns('app_root')
       paths = DefaultSource.config_search_paths.call
-      assert paths.any? { |p| p.include? 'app_root' }
+      assert paths.any? { |p| p.include?('app_root') }
     end
 
     def fetch_config_value(key)

--- a/test/new_relic/agent/configuration/manager_test.rb
+++ b/test/new_relic/agent/configuration/manager_test.rb
@@ -306,7 +306,7 @@ module NewRelic::Agent::Configuration
     def test_high_security_source_addable
       refute @manager.config_classes_for_testing.include?(SecurityPolicySource)
       security_policy_source = SecurityPolicySource.new({'record_sql' => {'enabled' => false}})
-      @manager.replace_or_add_config security_policy_source
+      @manager.replace_or_add_config(security_policy_source)
       assert @manager.config_classes_for_testing.include?(SecurityPolicySource)
     end
 

--- a/test/new_relic/agent/configuration/orphan_configuration_test.rb
+++ b/test/new_relic/agent/configuration/orphan_configuration_test.rb
@@ -32,7 +32,7 @@ class OrphanedConfigTest < Minitest::Test
   end
 
   def test_all_default_source_config_keys_are_used_in_the_agent
-    scan_and_remove_used_entries @default_keys, non_test_files
+    scan_and_remove_used_entries(@default_keys, non_test_files)
 
     # Remove any config keys that are annotated with the 'external' setting
     # This indicates that these keys are referenced and implemented in
@@ -66,6 +66,6 @@ class OrphanedConfigTest < Minitest::Test
   end
 
   def non_test_files
-    all_rb_files.reject { |filename| filename.include? 'test.rb' }
+    all_rb_files.reject { |filename| filename.include?('test.rb') }
   end
 end

--- a/test/new_relic/agent/configuration/security_policy_source_test.rb
+++ b/test/new_relic/agent/configuration/security_policy_source_test.rb
@@ -13,10 +13,10 @@ module NewRelic
         def test_record_sql_enabled
           policies = generate_security_policies(default: false, enabled: ['record_sql'])
 
-          with_config :'transaction_tracer.record_sql' => 'raw',
+          with_config(:'transaction_tracer.record_sql' => 'raw',
             :'slow_sql.record_sql'           => 'raw',
             :'mongo.capture_queries'         => true,
-            :'mongo.obfuscate_queries'       => false do
+            :'mongo.obfuscate_queries'       => false) do
             source = SecurityPolicySource.new(policies)
 
             assert_equal 'obfuscated', source[:'transaction_tracer.record_sql']
@@ -28,9 +28,9 @@ module NewRelic
         def test_record_sql_disabled
           policies = generate_security_policies(default: true, disabled: ['record_sql'])
 
-          with_config :'transaction_tracer.record_sql' => 'raw',
+          with_config(:'transaction_tracer.record_sql' => 'raw',
             :'slow_sql.record_sql'           => 'raw',
-            :'mongo.capture_queries'         => true do
+            :'mongo.capture_queries'         => true) do
             source = SecurityPolicySource.new(policies)
 
             assert_equal 'off', source[:'transaction_tracer.record_sql']
@@ -41,13 +41,13 @@ module NewRelic
 
         def test_attributes_include_enabled
           policies = generate_security_policies(default: false, enabled: ['attributes_include'])
-          with_config :'attributes.include' => ['request.parameters.*'],
+          with_config(:'attributes.include' => ['request.parameters.*'],
             :'transaction_tracer.attributes.include'     => ['request.uri'],
             :'transaction_events.attributes.include'     => ['request.headers.*'],
             :'error_collector.attributes.include'        => ['request.method'],
             :'browser_monitoring.attributes.include'     => ['http.statusCode'],
             :'span_events.attributes.include'            => ['http.url'],
-            :'transaction_segments.attributes.include'   => ['sql_statement'] do
+            :'transaction_segments.attributes.include'   => ['sql_statement']) do
             source = SecurityPolicySource.new(policies)
 
             refute_includes source.keys, :'attributes.include'
@@ -62,13 +62,13 @@ module NewRelic
 
         def test_attributes_include_disabled
           policies = generate_security_policies(default: true, disabled: ['attributes_include'])
-          with_config :'attributes.include' => ['request.parameters.*'],
+          with_config(:'attributes.include' => ['request.parameters.*'],
             :'transaction_tracer.attributes.include'     => ['request.uri'],
             :'transaction_events.attributes.include'     => ['request.headers.*'],
             :'error_collector.attributes.include'        => ['request.method'],
             :'browser_monitoring.attributes.include'     => ['http.statusCode'],
             :'span_events.attributes.include'            => ['http.url'],
-            :'transaction_segments.attributes.include'   => ['sql_statement'] do
+            :'transaction_segments.attributes.include'   => ['sql_statement']) do
             source = SecurityPolicySource.new(policies)
 
             assert_equal [], source[:'attributes.include']
@@ -83,7 +83,7 @@ module NewRelic
 
         def test_allow_raw_exception_messages_enabled
           policies = generate_security_policies(default: false, enabled: ['allow_raw_exception_messages'])
-          with_config :'strip_exception_messages.enabled' => true do
+          with_config(:'strip_exception_messages.enabled' => true) do
             source = SecurityPolicySource.new(policies)
 
             refute_includes source.keys, :'strip_exception_messages'
@@ -92,7 +92,7 @@ module NewRelic
 
         def test_allow_raw_exception_messages_disabled
           policies = generate_security_policies(default: true, disabled: ['allow_raw_exception_messages'])
-          with_config :'strip_exception_messages.enabled' => true do
+          with_config(:'strip_exception_messages.enabled' => true) do
             source = SecurityPolicySource.new(policies)
 
             assert_equal false, source[:'strip_exception_messages.enabled']
@@ -101,7 +101,7 @@ module NewRelic
 
         def test_custom_events_enabled
           policies = generate_security_policies(default: false, enabled: ['custom_events'])
-          with_config :'custom_insights_events.enabled' => true do
+          with_config(:'custom_insights_events.enabled' => true) do
             source = SecurityPolicySource.new(policies)
 
             refute_includes source.keys, :'custom_insights_events.enabled'
@@ -110,7 +110,7 @@ module NewRelic
 
         def test_custom_events_disabled
           policies = generate_security_policies(default: true, disabled: ['custom_events'])
-          with_config :'custom_insights_events.enabled' => true do
+          with_config(:'custom_insights_events.enabled' => true) do
             source = SecurityPolicySource.new(policies)
 
             assert_equal false, source[:'custom_insights_events.enabled']
@@ -133,7 +133,7 @@ module NewRelic
 
         def test_message_parameters_enabled
           policies = generate_security_policies(default: false, enabled: ['message_parameters'])
-          with_config :'message_tracer.segment_parameters.enabled' => true do
+          with_config(:'message_tracer.segment_parameters.enabled' => true) do
             source = SecurityPolicySource.new(policies)
 
             refute_includes source.keys, :'message_tracer.segment_parameters.enabled'
@@ -142,7 +142,7 @@ module NewRelic
 
         def test_message_parameters_disabled
           policies = generate_security_policies(default: true, disabled: ['message_parameters'])
-          with_config :'message_tracer.segment_parameters.enabled' => true do
+          with_config(:'message_tracer.segment_parameters.enabled' => true) do
             source = SecurityPolicySource.new(policies)
 
             assert_equal false, source[:'message_tracer.segment_parameters.enabled']
@@ -151,8 +151,8 @@ module NewRelic
 
         def test_job_arguments_enabled
           policies = generate_security_policies(default: false, enabled: ['job_arguments'])
-          with_config :'resque.capture_params' => true,
-            :'sidekiq.capture_params' => true do
+          with_config(:'resque.capture_params' => true,
+            :'sidekiq.capture_params' => true) do
             source = SecurityPolicySource.new(policies)
 
             refute_includes source.keys, :'resque.capture_params'
@@ -162,8 +162,8 @@ module NewRelic
 
         def test_job_arguments_disabled
           policies = generate_security_policies(default: true, disabled: ['job_arguments'])
-          with_config :'resque.capture_params' => true,
-            :'sidekiq.capture_params' => true do
+          with_config(:'resque.capture_params' => true,
+            :'sidekiq.capture_params' => true) do
             source = SecurityPolicySource.new(policies)
 
             assert_equal false, source[:'resque.capture_params']

--- a/test/new_relic/agent/configuration/yaml_source_test.rb
+++ b/test/new_relic/agent/configuration/yaml_source_test.rb
@@ -127,7 +127,7 @@ module NewRelic::Agent::Configuration
       define_method(method_name) do
         config = {'key' => value}
         source = YamlSource.new(@test_yml_path, 'test')
-        source.send :booleanify_values, config, 'key'
+        source.send(:booleanify_values, config, 'key')
 
         assert source.failed?
         expected_message = "Unexpected value (#{value}) for 'key' in #{@test_yml_path}"
@@ -141,7 +141,7 @@ module NewRelic::Agent::Configuration
         config = {'key' => value}
         source = YamlSource.new(@test_yml_path, 'test')
         refute source.failed?
-        source.send :booleanify_values, config, 'key'
+        source.send(:booleanify_values, config, 'key')
 
         refute source.failed?
         assert_empty source.failures

--- a/test/new_relic/agent/connect/request_builder_test.rb
+++ b/test/new_relic/agent/connect/request_builder_test.rb
@@ -12,11 +12,12 @@ class NewRelic::Agent::Agent::RequestBuilderTest < Minitest::Test
     NewRelic::Agent.reset_config
     @event_harvest_config = NewRelic::Agent.agent.event_harvest_config
     @environment_report = []
-    @request_builder = NewRelic::Agent::Connect::RequestBuilder.new \
+    @request_builder = NewRelic::Agent::Connect::RequestBuilder.new( \
       @service,
       NewRelic::Agent.config,
       @event_harvest_config,
       @environment_report
+    )
   end
 
   def test_sanitize_environment_report
@@ -31,7 +32,7 @@ class NewRelic::Agent::Agent::RequestBuilderTest < Minitest::Test
   end
 
   def test_connect_settings
-    with_config :app_name => ["apps"] do
+    with_config(:app_name => ["apps"]) do
       keys = %w[pid host identifier display_host app_name language agent_version environment settings].map(&:to_sym)
 
       settings = @request_builder.connect_payload
@@ -43,7 +44,7 @@ class NewRelic::Agent::Agent::RequestBuilderTest < Minitest::Test
   end
 
   def test_connect_settings_includes_correct_identifier
-    with_config :app_name => "b;a;c" do
+    with_config(:app_name => "b;a;c") do
       NewRelic::Agent::Connect::RequestBuilder.any_instance.stubs(:local_host).returns('lo-calhost')
       @environment_report = {}
 

--- a/test/new_relic/agent/custom_event_aggregator_test.rb
+++ b/test/new_relic/agent/custom_event_aggregator_test.rb
@@ -13,7 +13,7 @@ module NewRelic::Agent
     def setup
       nr_freeze_process_time
       events = NewRelic::Agent.instance.events
-      @aggregator = NewRelic::Agent::CustomEventAggregator.new events
+      @aggregator = NewRelic::Agent::CustomEventAggregator.new(events)
     end
 
     # Helpers for DataContainerTests
@@ -39,7 +39,7 @@ module NewRelic::Agent
     def generate_request(name = 'Controller/whatever', options = {})
       payload = options.merge(:name => name)
 
-      @aggregator.record :custom, payload
+      @aggregator.record(:custom, payload)
     end
 
     def last_events
@@ -120,7 +120,7 @@ module NewRelic::Agent
     end
 
     def test_records_supportability_metrics_after_harvest
-      with_config :'custom_insights_events.max_samples_stored' => 5 do
+      with_config(:'custom_insights_events.max_samples_stored' => 5) do
         engine = NewRelic::Agent.instance.stats_engine
         engine.expects(:tl_record_supportability_metric_count).with("Events/Customer/Seen", 9)
         engine.expects(:tl_record_supportability_metric_count).with("Events/Customer/Sent", 5)
@@ -132,7 +132,7 @@ module NewRelic::Agent
     end
 
     def test_aggregator_defers_custom_event_creation
-      with_config aggregator.class.capacity_key => 5 do
+      with_config(aggregator.class.capacity_key => 5) do
         5.times { generate_event }
         aggregator.expects(:create_event).never
         aggregator.record('ImpossibleEvent', {priority: -999.0})

--- a/test/new_relic/agent/database_test.rb
+++ b/test/new_relic/agent/database_test.rb
@@ -484,7 +484,7 @@ class NewRelic::Agent::DatabaseTest < Minitest::Test
     table_name = 'a' * 17_000
     sql = "select * from #{table_name}"
     expected_sql = sql.dup
-    statement = NewRelic::Agent::Database::Statement.new sql, {:adapter => :mysql}
+    statement = NewRelic::Agent::Database::Statement.new(sql, {:adapter => :mysql})
     refute_equal sql, statement.sql
     assert_equal expected_sql, sql
   end
@@ -492,43 +492,43 @@ class NewRelic::Agent::DatabaseTest < Minitest::Test
   def test_append_sql_stops_at_limit
     table_name = 'a' * 1_000
     sql = "select * from #{table_name}"
-    statement = NewRelic::Agent::Database::Statement.new sql, {:adapter => :mysql}
+    statement = NewRelic::Agent::Database::Statement.new(sql, {:adapter => :mysql})
 
     # grow the statement larger than the 16384 character limit
-    16.times { statement.append_sql sql }
+    16.times { statement.append_sql(sql) }
 
     assert_equal NewRelic::Agent::Database::MAX_QUERY_LENGTH, statement.sql.size
   end
 
   def test_safe_sql_obfuscates_when_set
-    NewRelic::Agent::Database.stubs(:record_sql_method).returns :obfuscated
-    statement = NewRelic::Agent::Database::Statement.new "select * from mytable where name = '1337807';"
+    NewRelic::Agent::Database.stubs(:record_sql_method).returns(:obfuscated)
+    statement = NewRelic::Agent::Database::Statement.new("select * from mytable where name = '1337807';")
 
     assert_equal "select * from mytable where name = ?;", statement.safe_sql
   end
 
   def test_safe_sql_does_not_over_obfuscate_for_postgres
-    NewRelic::Agent::Database.stubs(:record_sql_method).returns :obfuscated
+    NewRelic::Agent::Database.stubs(:record_sql_method).returns(:obfuscated)
 
     conf = {:adapter => "postgresql", :encoding => "utf8", :pool => 10, :port => 5432, :prepared_statements => false, :ssl_mode => "require"}
     sql = "SELECT  \"users\".* FROM \"users\" WHERE \"users\".\"deleted_at\" IS NULL AND \"users\".\"id\" = 1602 LIMIT 1"
     expected_sql = "SELECT  \"users\".* FROM \"users\" WHERE \"users\".\"deleted_at\" IS ? AND \"users\".\"id\" = ? LIMIT ?"
 
-    stmt = NewRelic::Agent::Database::Statement.new sql, conf
+    stmt = NewRelic::Agent::Database::Statement.new(sql, conf)
 
     assert_equal expected_sql, stmt.safe_sql
   end
 
   def test_safe_sql_returns_raw_when_set
-    NewRelic::Agent::Database.stubs(:record_sql_method).returns :raw
-    statement = NewRelic::Agent::Database::Statement.new "select * from mytable where name = '1337807';"
+    NewRelic::Agent::Database.stubs(:record_sql_method).returns(:raw)
+    statement = NewRelic::Agent::Database::Statement.new("select * from mytable where name = '1337807';")
 
     assert_equal "select * from mytable where name = '1337807';", statement.safe_sql
   end
 
   def test_safe_sql_returns_nil_when_off
-    NewRelic::Agent::Database.stubs(:record_sql_method).returns :off
-    statement = NewRelic::Agent::Database::Statement.new "select * from mytable where name = '1337807';"
+    NewRelic::Agent::Database.stubs(:record_sql_method).returns(:off)
+    statement = NewRelic::Agent::Database::Statement.new("select * from mytable where name = '1337807';")
 
     assert_nil statement.safe_sql
   end

--- a/test/new_relic/agent/datastores/metric_helper_test.rb
+++ b/test/new_relic/agent/datastores/metric_helper_test.rb
@@ -190,13 +190,13 @@ module NewRelic
 
       def test_operation_from_sql
         sql = "SELECT * FROM blogs where id = 5"
-        operation = Datastores::MetricHelper.operation_from_sql sql
+        operation = Datastores::MetricHelper.operation_from_sql(sql)
         assert_equal "select", operation
       end
 
       def test_operation_from_sql_returns_other_for_unrecognized_operation
         sql = "DESCRIBE blogs"
-        operation = Datastores::MetricHelper.operation_from_sql sql
+        operation = Datastores::MetricHelper.operation_from_sql(sql)
         assert_equal "Other", operation
       end
     end

--- a/test/new_relic/agent/datastores_test.rb
+++ b/test/new_relic/agent/datastores_test.rb
@@ -22,15 +22,15 @@ class NewRelic::Agent::DatastoresTest < Minitest::Test
 
     private :internal
 
-    NewRelic::Agent::Datastores.trace self, :find, "MyFirstDatabase"
-    NewRelic::Agent::Datastores.trace self, :save, "MyFirstDatabase", "create"
-    NewRelic::Agent::Datastores.trace self, :internal, "MyFirstDatabase"
+    NewRelic::Agent::Datastores.trace(self, :find, "MyFirstDatabase")
+    NewRelic::Agent::Datastores.trace(self, :save, "MyFirstDatabase", "create")
+    NewRelic::Agent::Datastores.trace(self, :internal, "MyFirstDatabase")
 
     def boom
       raise "haha"
     end
 
-    NewRelic::Agent::Datastores.trace self, :boom, "MyFirstDatabase", "boom"
+    NewRelic::Agent::Datastores.trace(self, :boom, "MyFirstDatabase", "boom")
   end
 
   def setup
@@ -68,7 +68,7 @@ class NewRelic::Agent::DatastoresTest < Minitest::Test
 
   def test_safe_to_reinstrument
     MyFirstDatabase.class_eval do
-      NewRelic::Agent::Datastores.trace self, :find, "MyFirstDatabase", "find"
+      NewRelic::Agent::Datastores.trace(self, :find, "MyFirstDatabase", "find")
     end
 
     assert_equal MyFirstDatabase::THE_OBJECT, MyFirstDatabase.new.find
@@ -150,7 +150,7 @@ class NewRelic::Agent::DatastoresTest < Minitest::Test
         collection: "SomeThing"
       )
       NewRelic::Agent::Datastores.notice_sql(query, metric, elapsed)
-      advance_process_time elapsed
+      advance_process_time(elapsed)
       assert_equal segment, txn.current_segment
       segment.finish
       nr_unfreeze_process_time
@@ -171,7 +171,7 @@ class NewRelic::Agent::DatastoresTest < Minitest::Test
         collection: "key"
       )
       NewRelic::Agent::Datastores.notice_statement(query, elapsed)
-      advance_process_time elapsed
+      advance_process_time(elapsed)
       assert_equal segment, txn.current_segment
       segment.finish
       nr_unfreeze_process_time

--- a/test/new_relic/agent/deprecator_test.rb
+++ b/test/new_relic/agent/deprecator_test.rb
@@ -19,14 +19,14 @@ class DeprecatorTest < Minitest::Test
 
   def test_deprecator_logs_a_warning_with_the_name_of_the_method
     NewRelic::Agent.logger.expects(:warn).with do |messages|
-      messages.first.include? @old_method.to_s
+      messages.first.include?(@old_method.to_s)
     end
     NewRelic::Agent::Deprecator.deprecate(@old_method)
   end
 
   def test_deprecator_logs_once
     NewRelic::Agent.logger.expects(:warn).with do |messages|
-      messages.first.include? @old_method.to_s
+      messages.first.include?(@old_method.to_s)
     end
     NewRelic::Agent::Deprecator.deprecate(@old_method)
     NewRelic::Agent::Deprecator.deprecate(@old_method)
@@ -34,14 +34,14 @@ class DeprecatorTest < Minitest::Test
 
   def test_deprecator_logs_the_new_method_if_given
     NewRelic::Agent.logger.expects(:warn).with do |messages|
-      messages.last.include? @new_method.to_s
+      messages.last.include?(@new_method.to_s)
     end
     NewRelic::Agent::Deprecator.deprecate(@old_method, @new_method)
   end
 
   def test_deprecator_logs_the_version_if_given
     NewRelic::Agent.logger.expects(:warn).with do |messages|
-      messages[1].include? @version.to_s
+      messages[1].include?(@version.to_s)
     end
     NewRelic::Agent::Deprecator.deprecate(@old_method, @new_method, @version)
   end

--- a/test/new_relic/agent/distributed_tracing/distributed_trace_metrics_test.rb
+++ b/test/new_relic/agent/distributed_tracing/distributed_trace_metrics_test.rb
@@ -25,9 +25,9 @@ module NewRelic::Agent
     end
 
     def in_controller_transaction &blk
-      in_transaction "controller_txn", :category => :controller do |txn|
+      in_transaction("controller_txn", :category => :controller) do |txn|
         advance_process_time(1.0)
-        yield txn
+        yield(txn)
       end
     end
 
@@ -39,33 +39,33 @@ module NewRelic::Agent
     end
 
     def test_transaction_type_suffix
-      in_transaction "test_txn" do |txn|
+      in_transaction("test_txn") do |txn|
         txn.distributed_tracer.create_trace_state_payload
         assert_equal "allOther", DistributedTraceMetrics.transaction_type_suffix
       end
 
-      in_transaction "controller", :category => :controller do |txn|
+      in_transaction("controller", :category => :controller) do |txn|
         assert_equal "allWeb", DistributedTraceMetrics.transaction_type_suffix
       end
     end
 
     def test_prefix_for_metric
-      in_transaction "test_txn", :category => :controller do |txn|
+      in_transaction("test_txn", :category => :controller) do |txn|
         payload = txn.distributed_tracer.create_trace_state_payload
         assert payload, "payload should not be nil"
 
-        prefix = DistributedTraceMetrics.prefix_for_metric "Test", txn, payload
+        prefix = DistributedTraceMetrics.prefix_for_metric("Test", txn, payload)
         assert_equal "Test/App/190/46954/Unknown", prefix
       end
     end
 
     def test_record_metrics_for_transaction
-      in_transaction "test_txn", :category => :controller do |txn|
+      in_transaction("test_txn", :category => :controller) do |txn|
         advance_process_time(1.0)
         payload = txn.distributed_tracer.create_trace_state_payload
         assert payload, "payload should not be nil"
 
-        DistributedTraceMetrics.record_metrics_for_transaction txn
+        DistributedTraceMetrics.record_metrics_for_transaction(txn)
       end
 
       assert_metrics_recorded([
@@ -75,10 +75,10 @@ module NewRelic::Agent
     end
 
     def test_record_metrics_for_transaction_with_payload
-      in_transaction "controller_txn", :category => :controller do |txn|
+      in_transaction("controller_txn", :category => :controller) do |txn|
         advance_process_time(1.0)
-        DistributedTracing.accept_distributed_trace_headers valid_trace_context_headers, NewRelic::HTTP
-        DistributedTraceMetrics.record_metrics_for_transaction txn
+        DistributedTracing.accept_distributed_trace_headers(valid_trace_context_headers, NewRelic::HTTP)
+        DistributedTraceMetrics.record_metrics_for_transaction(txn)
       end
 
       assert_metrics_recorded([
@@ -96,10 +96,10 @@ module NewRelic::Agent
     end
 
     def test_record_metrics_for_transaction_with_garbage_transport_type
-      in_transaction "controller_txn", :category => :controller do |txn|
+      in_transaction("controller_txn", :category => :controller) do |txn|
         advance_process_time(1.0)
-        DistributedTracing.accept_distributed_trace_headers valid_trace_context_headers, "garbage"
-        DistributedTraceMetrics.record_metrics_for_transaction txn
+        DistributedTracing.accept_distributed_trace_headers(valid_trace_context_headers, "garbage")
+        DistributedTraceMetrics.record_metrics_for_transaction(txn)
       end
 
       assert_metrics_recorded([
@@ -117,14 +117,14 @@ module NewRelic::Agent
     end
 
     def test_record_metrics_for_transaction_with_exception_handling
-      in_transaction "controller_txn", :category => :controller do |txn|
+      in_transaction("controller_txn", :category => :controller) do |txn|
         begin
           advance_process_time(1.0)
-          DistributedTracing.accept_distributed_trace_headers valid_trace_context_headers, NewRelic::HTTP
+          DistributedTracing.accept_distributed_trace_headers(valid_trace_context_headers, NewRelic::HTTP)
           raise "oops"
         rescue Exception => e
           Transaction.notice_error(e)
-          DistributedTraceMetrics.record_metrics_for_transaction txn
+          DistributedTraceMetrics.record_metrics_for_transaction(txn)
         end
       end
 

--- a/test/new_relic/agent/distributed_tracing/distributed_trace_payload_test.rb
+++ b/test/new_relic/agent/distributed_tracing/distributed_trace_payload_test.rb
@@ -31,9 +31,9 @@ module NewRelic::Agent
     def test_payload_is_created_if_connected
       created_at, payload = nil, nil
 
-      in_transaction "test_txn" do |txn|
+      in_transaction("test_txn") do |txn|
         created_at = Process.clock_gettime(Process::CLOCK_REALTIME, :millisecond)
-        payload = DistributedTracePayload.for_transaction txn
+        payload = DistributedTracePayload.for_transaction(txn)
       end
 
       assert_equal "46954", payload.parent_app_id
@@ -46,8 +46,8 @@ module NewRelic::Agent
 
     def test_trusted_account_id_present_if_different_than_account_id
       payload = nil
-      in_transaction "test_txn" do |txn|
-        payload = DistributedTracePayload.for_transaction txn
+      in_transaction("test_txn") do |txn|
+        payload = DistributedTracePayload.for_transaction(txn)
       end
 
       assert_equal "trust_this!", payload.trusted_account_key
@@ -58,25 +58,25 @@ module NewRelic::Agent
     end
 
     def test_trusted_account_id_not_present_if_it_matches_account_id
-      with_config :trusted_account_key => "190" do
+      with_config(:trusted_account_key => "190") do
         payload = nil
-        in_transaction "test_txn" do |txn|
-          payload = DistributedTracePayload.for_transaction txn
+        in_transaction("test_txn") do |txn|
+          payload = DistributedTracePayload.for_transaction(txn)
         end
 
         assert_nil payload.trusted_account_key
 
         deserialized_payload = JSON.parse(payload.text)
 
-        refute deserialized_payload["d"].key? "tk"
+        refute deserialized_payload["d"].key?("tk")
       end
     end
 
     def test_attributes_are_copied_from_transaction
       payload = nil
 
-      transaction = in_transaction "test_txn" do |txn|
-        payload = DistributedTracePayload.for_transaction txn
+      transaction = in_transaction("test_txn") do |txn|
+        payload = DistributedTracePayload.for_transaction(txn)
       end
 
       assert_equal transaction.guid, payload.transaction_id
@@ -86,14 +86,14 @@ module NewRelic::Agent
 
     def test_sampled_flag_is_copied_from_transaction
       NewRelic::Agent.instance.adaptive_sampler.stubs(:sampled?).returns(false)
-      in_transaction "test_txn" do |txn|
-        payload = DistributedTracePayload.for_transaction txn
+      in_transaction("test_txn") do |txn|
+        payload = DistributedTracePayload.for_transaction(txn)
         assert_equal false, payload.sampled
       end
 
       NewRelic::Agent.instance.adaptive_sampler.stubs(:sampled?).returns(true)
-      in_transaction "test_txn2" do |txn|
-        payload = DistributedTracePayload.for_transaction txn
+      in_transaction("test_txn2") do |txn|
+        payload = DistributedTracePayload.for_transaction(txn)
         assert_equal true, payload.sampled
       end
     end
@@ -109,7 +109,7 @@ module NewRelic::Agent
         incoming_payload = txn.distributed_tracer.create_distributed_trace_payload
       end
 
-      payload = DistributedTracePayload.from_json incoming_payload.text
+      payload = DistributedTracePayload.from_json(incoming_payload.text)
 
       assert_equal DistributedTracePayload::VERSION, payload.version
       assert_equal "App", payload.parent_type
@@ -135,7 +135,7 @@ module NewRelic::Agent
         incoming_payload = txn.distributed_tracer.create_distributed_trace_payload
       end
 
-      payload = DistributedTracePayload.from_http_safe incoming_payload.http_safe
+      payload = DistributedTracePayload.from_http_safe(incoming_payload.http_safe)
 
       assert_equal DistributedTracePayload::VERSION, payload.version
       assert_equal "App", payload.parent_type
@@ -155,7 +155,7 @@ module NewRelic::Agent
       payload = nil
 
       in_transaction("test_txn") do |txn|
-        payload = DistributedTracePayload.for_transaction txn
+        payload = DistributedTracePayload.for_transaction(txn)
       end
 
       raw_payload = JSON.parse(payload.text)

--- a/test/new_relic/agent/distributed_tracing/distributed_tracing_cross_agent_test.rb
+++ b/test/new_relic/agent/distributed_tracing/distributed_tracing_cross_agent_test.rb
@@ -78,13 +78,13 @@ module NewRelic::Agent
         inbound_payloads = payloads_for(test_case)
         inbound_payloads.each do |payload|
           carrier = {"HTTP_NEWRELIC" => payload}
-          DistributedTracing.accept_distributed_trace_headers carrier, test_case['transport_type']
+          DistributedTracing.accept_distributed_trace_headers(carrier, test_case['transport_type'])
         end
       end
 
       def raise_exception(test_case)
         if test_case['raises_exception']
-          e = StandardError.new 'ouchies'
+          e = StandardError.new('ouchies')
           ::NewRelic::Agent.notice_error(e)
         end
       end
@@ -147,18 +147,18 @@ module NewRelic::Agent
       ALLOWED_EVENT_TYPES = %w[ Transaction TransactionError Span ]
 
       def intrinsics_for_event(test_case, event_type)
-        unless ALLOWED_EVENT_TYPES.include? event_type
+        unless ALLOWED_EVENT_TYPES.include?(event_type)
           raise %Q(Test fixture refers to unexpected event type "#{event_type}")
         end
 
         return {} unless (intrinsics = test_case['intrinsics'])
         target_events = intrinsics['target_events'] || []
-        return {} unless target_events.include? event_type
+        return {} unless target_events.include?(event_type)
 
         common_intrinsics = intrinsics['common'] || {}
         event_intrinsics = intrinsics[event_type.to_sym] || {}
 
-        merge_intrinsics [common_intrinsics, event_intrinsics]
+        merge_intrinsics([common_intrinsics, event_intrinsics])
       end
 
       def verify_attributes(test_case_attributes, actual_attributes, event_type)
@@ -183,7 +183,7 @@ module NewRelic::Agent
         return if test_case_intrinsics.empty?
 
         actual_intrinsics, *_ = last_transaction_event
-        verify_attributes test_case_intrinsics, actual_intrinsics, 'Transaction'
+        verify_attributes(test_case_intrinsics, actual_intrinsics, 'Transaction')
       end
 
       def verify_error_intrinsics(test_case)
@@ -193,7 +193,7 @@ module NewRelic::Agent
         return if test_case_intrinsics.empty?
 
         actual_intrinsics, *_ = last_error_event
-        verify_attributes test_case_intrinsics, actual_intrinsics, 'TransactionError'
+        verify_attributes(test_case_intrinsics, actual_intrinsics, 'TransactionError')
       end
 
       def verify_span_intrinsics(test_case)
@@ -205,7 +205,7 @@ module NewRelic::Agent
         last_span_events = NewRelic::Agent.agent.span_event_aggregator.harvest![1]
         actual_intrinsics = last_span_events[0][0]
 
-        verify_attributes test_case_intrinsics, actual_intrinsics, 'Span'
+        verify_attributes(test_case_intrinsics, actual_intrinsics, 'Span')
       end
 
       def verify_outbound_payloads(test_case, actual_payloads)
@@ -218,7 +218,7 @@ module NewRelic::Agent
               JSON.parse(actual.text)
             )
           )
-          verify_attributes test_case_data, actual, 'Payload'
+          verify_attributes(test_case_data, actual, 'Payload')
         end
       end
 

--- a/test/new_relic/agent/distributed_tracing/trace_context_cross_agent_test.rb
+++ b/test/new_relic/agent/distributed_tracing/trace_context_cross_agent_test.rb
@@ -90,15 +90,16 @@ module NewRelic
           inbound_headers = headers_for(test_case)
           inbound_headers << nil if inbound_headers.empty?
           inbound_headers.each do |carrier|
-            DistributedTracing.accept_distributed_trace_headers \
+            DistributedTracing.accept_distributed_trace_headers( \
               rack_format(test_case, carrier),
               test_case['transport_type']
+            )
           end
         end
 
         def raise_exception(test_case)
           if test_case['raises_exception']
-            e = StandardError.new 'ouchies'
+            e = StandardError.new('ouchies')
             ::NewRelic::Agent.notice_error(e)
           end
         end
@@ -119,7 +120,7 @@ module NewRelic
 
         def newrelic_key key
           const_name = "NewRelic::Agent::DistributedTracePayload::#{key.upcase}_KEY"
-          Object.const_get const_name
+          Object.const_get(const_name)
         end
 
         def assign_not_nil_value headers, key, value
@@ -137,16 +138,16 @@ module NewRelic
             newrelic_key(:data) => {}
           }
           data_payload = payload["newrelic"][newrelic_key(:data)]
-          assign_not_nil_value data_payload, :parent_type, newrelic_payload.parent_type
-          assign_not_nil_value data_payload, :parent_account_id, newrelic_payload.parent_account_id
-          assign_not_nil_value data_payload, :parent_app, newrelic_payload.parent_app_id
-          assign_not_nil_value data_payload, :trusted_account, newrelic_payload.trusted_account_key
-          assign_not_nil_value data_payload, :id, newrelic_payload.id
-          assign_not_nil_value data_payload, :tx, newrelic_payload.transaction_id
-          assign_not_nil_value data_payload, :trace_id, newrelic_payload.trace_id
-          assign_not_nil_value data_payload, :sampled, newrelic_payload.sampled
-          assign_not_nil_value data_payload, :timestamp, newrelic_payload.timestamp
-          assign_not_nil_value data_payload, :priority, newrelic_payload.priority
+          assign_not_nil_value(data_payload, :parent_type, newrelic_payload.parent_type)
+          assign_not_nil_value(data_payload, :parent_account_id, newrelic_payload.parent_account_id)
+          assign_not_nil_value(data_payload, :parent_app, newrelic_payload.parent_app_id)
+          assign_not_nil_value(data_payload, :trusted_account, newrelic_payload.trusted_account_key)
+          assign_not_nil_value(data_payload, :id, newrelic_payload.id)
+          assign_not_nil_value(data_payload, :tx, newrelic_payload.transaction_id)
+          assign_not_nil_value(data_payload, :trace_id, newrelic_payload.trace_id)
+          assign_not_nil_value(data_payload, :sampled, newrelic_payload.sampled)
+          assign_not_nil_value(data_payload, :timestamp, newrelic_payload.timestamp)
+          assign_not_nil_value(data_payload, :priority, newrelic_payload.priority)
         end
 
         def create_payloads(test_case, txn)
@@ -155,8 +156,8 @@ module NewRelic
 
           [1, payloads.count].max.times do |index|
             outbound_headers = {}
-            txn.distributed_tracer.append_payload outbound_headers
-            txn.distributed_tracer.insert_headers outbound_headers
+            txn.distributed_tracer.append_payload(outbound_headers)
+            txn.distributed_tracer.insert_headers(outbound_headers)
             outbound_payloads << outbound_headers
           end
 
@@ -205,25 +206,25 @@ module NewRelic
         ALLOWED_EVENT_TYPES = %w[ Transaction TransactionError Span ]
 
         def intrinsics_for_event(test_case, event_type)
-          unless ALLOWED_EVENT_TYPES.include? event_type
+          unless ALLOWED_EVENT_TYPES.include?(event_type)
             raise %Q(Test fixture refers to unexpected event type "#{event_type}")
           end
 
           return {} unless (intrinsics = test_case['intrinsics'])
           target_events = intrinsics['target_events'] || []
-          return {} unless target_events.include? event_type
+          return {} unless target_events.include?(event_type)
 
           common_intrinsics = intrinsics['common'] || {}
           event_intrinsics = intrinsics[event_type] || {}
 
-          merge_intrinsics [common_intrinsics, event_intrinsics]
+          merge_intrinsics([common_intrinsics, event_intrinsics])
         end
 
         def verify_attributes(test_case_attributes, actual_attributes, event_type)
           if verbose_attributes?
             puts "", "*" * 80
             puts event_type
-            pp actual_attributes
+            pp(actual_attributes)
             puts "*" * 80
           end
 
@@ -259,7 +260,7 @@ module NewRelic
           return if test_case_intrinsics.empty?
 
           actual_intrinsics, *_ = last_transaction_event
-          verify_attributes test_case_intrinsics, actual_intrinsics, 'Transaction'
+          verify_attributes(test_case_intrinsics, actual_intrinsics, 'Transaction')
         end
 
         def verify_error_intrinsics(test_case)
@@ -269,7 +270,7 @@ module NewRelic
           return if test_case_intrinsics.empty?
 
           actual_intrinsics, *_ = last_error_event
-          verify_attributes test_case_intrinsics, actual_intrinsics, 'TransactionError'
+          verify_attributes(test_case_intrinsics, actual_intrinsics, 'TransactionError')
         end
 
         def verify_span_intrinsics(test_case)
@@ -284,7 +285,7 @@ module NewRelic
 
           actual_intrinsics = last_span_events[0][0]
 
-          verify_attributes test_case_intrinsics, actual_intrinsics, 'Span'
+          verify_attributes(test_case_intrinsics, actual_intrinsics, 'Span')
         end
 
         def verify_outbound_payloads(test_case, actual_payloads)
@@ -292,12 +293,12 @@ module NewRelic
           assert_equal test_case_payloads.count, actual_payloads.count
 
           test_case_payloads.zip(actual_payloads).each do |test_case_data, actual|
-            context_hash = trace_context_headers_to_hash actual
-            add_newrelic_entries context_hash, actual["newrelic"]
+            context_hash = trace_context_headers_to_hash(actual)
+            add_newrelic_entries(context_hash, actual["newrelic"])
 
-            dotted_context_hash = NewRelic::Agent::Configuration::DottedHash.new context_hash
-            stringified_hash = stringify_keys_in_object dotted_context_hash
-            verify_attributes test_case_data, stringified_hash, 'TraceContext Payload'
+            dotted_context_hash = NewRelic::Agent::Configuration::DottedHash.new(context_hash)
+            stringified_hash = stringify_keys_in_object(dotted_context_hash)
+            verify_attributes(test_case_data, stringified_hash, 'TraceContext Payload')
           end
         end
 
@@ -320,9 +321,10 @@ module NewRelic
 
         def trace_context_headers_to_hash carrier
           entry_key = NewRelic::Agent::Transaction::TraceContext::AccountHelpers.trace_state_entry_key
-          header_data = TraceContext.parse \
+          header_data = TraceContext.parse( \
             carrier: carrier,
             trace_state_entry_key: entry_key
+          )
 
           return {} unless header_data
 
@@ -331,7 +333,7 @@ module NewRelic
             tracestate_str = header_data.trace_state_payload.to_s
             tracestate_values = tracestate_str.split('-')
 
-            tracestate['tenant_id'] = entry_key.sub '@nr', ''
+            tracestate['tenant_id'] = entry_key.sub('@nr', '')
             tracestate['version'] = tracestate_values[0]
             tracestate['parent_type'] = tracestate_values[1]
             tracestate['parent_account_id'] = tracestate_values[2]

--- a/test/new_relic/agent/distributed_tracing/trace_context_header_data_test.rb
+++ b/test/new_relic/agent/distributed_tracing/trace_context_header_data_test.rb
@@ -12,25 +12,25 @@ module NewRelic
         class TraceContextHeaderDataTest < Minitest::Test
           def test_tracestate_built_from_array
             other_entries = ['one', 'two']
-            header_data = HeaderData.new 'traceparent', 'tracestate_entry', other_entries, 0, ''
+            header_data = HeaderData.new('traceparent', 'tracestate_entry', other_entries, 0, '')
 
-            assert_nil header_data.instance_variable_get :@trace_state
-            refute_nil header_data.instance_variable_get :@trace_state_entries
+            assert_nil header_data.instance_variable_get(:@trace_state)
+            refute_nil header_data.instance_variable_get(:@trace_state_entries)
 
             assert_equal 'new_entry,one,two', header_data.trace_state('new_entry')
-            refute_nil header_data.instance_variable_get :@trace_state
-            assert_nil header_data.instance_variable_get :@trace_state_entries
+            refute_nil header_data.instance_variable_get(:@trace_state)
+            assert_nil header_data.instance_variable_get(:@trace_state_entries)
           end
 
           def test_trace_state_does_not_trim_unless_size_exceeds_512_bytes
             # Create a trace state array with 50 9 byte entries.  When joined
             # with a comma, this would be 499 bytes
             trace_state_array = (0...50).map { "#{random_text(2)}=#{random_text(6)}" }
-            header_data = HeaderData.new 'traceparent', 'payload', trace_state_array, 499, ''
+            header_data = HeaderData.new('traceparent', 'payload', trace_state_array, 499, '')
 
             # setting the entry size to something <= 12 shouldn't trim the trace state
             new_entry = 'a' * 12
-            trace_state = header_data.trace_state new_entry
+            trace_state = header_data.trace_state(new_entry)
             assert_equal 512, trace_state.length
           end
 
@@ -38,11 +38,11 @@ module NewRelic
             # Create a trace state array with 50 9 byte entries.  When joined
             # with a comma, this would be 499 bytes
             trace_state_array = (0...50).map { "#{random_text(2)}=#{random_text(6)}" }
-            header_data = HeaderData.new 'traceparent', 'payload', trace_state_array, 499, ''
+            header_data = HeaderData.new('traceparent', 'payload', trace_state_array, 499, '')
 
             # setting the entry size to something > 12 should result in a trimmed trace state
             new_entry = 'a' * 13
-            trace_state = header_data.trace_state new_entry
+            trace_state = header_data.trace_state(new_entry)
 
             expected_size = 499 - 9 + 13
             assert_equal expected_size, trace_state.bytesize
@@ -54,9 +54,9 @@ module NewRelic
             ]
             # also add 500 more bytes
             trace_state_array += (0...50).map { "#{random_text(2)}=#{random_text(6)}" }
-            header_data = HeaderData.new 'traceparent', 'payload', trace_state_array, 550, ''
+            header_data = HeaderData.new('traceparent', 'payload', trace_state_array, 550, '')
 
-            trace_state = header_data.trace_state 'new=entry'
+            trace_state = header_data.trace_state('new=entry')
             # if the big 133 byte entry gets dropped, the joined trace state
             # will be 50 nine byte entries plus 49 commas plus the new entry,
             # which is 9 more bytes, plus one more comma, so 50*9 + 49 + 9 + 1
@@ -70,9 +70,9 @@ module NewRelic
               "#{random_text(2)}=#{random_text(130)}", # 133 bytes
               'two=value'
             ]
-            header_data = HeaderData.new 'traceparent', 'payload', trace_state_array, 155, ''
+            header_data = HeaderData.new('traceparent', 'payload', trace_state_array, 155, '')
 
-            trace_state = header_data.trace_state 'new=entry'
+            trace_state = header_data.trace_state('new=entry')
             expected_trace_state = "new=entry,#{trace_state_array.join(',')}"
             assert_equal expected_trace_state, trace_state
           end

--- a/test/new_relic/agent/distributed_tracing/trace_context_payload_test.rb
+++ b/test/new_relic/agent/distributed_tracing/trace_context_payload_test.rb
@@ -9,13 +9,14 @@ module NewRelic
   module Agent
     class TraceContextPayloadTest < Minitest::Test
       def test_to_s
-        payload = TraceContextPayload.create \
+        payload = TraceContextPayload.create( \
           parent_account_id: "12345",
           parent_app_id: "6789",
           id: "f85f42fd82a4cf1d",
           transaction_id: "164d3b4b0d09cb05",
           sampled: true,
           priority: 0.123
+        )
 
         assert_equal "0-0-12345-6789-f85f42fd82a4cf1d-164d3b4b0d09cb05-1-0.123000-#{payload.timestamp}", payload.to_s
       end
@@ -24,24 +25,26 @@ module NewRelic
         # The id field will be nil if span events are disabled or the transaction is not sampled,
         # and to_s should be able to deal with that.
 
-        payload = TraceContextPayload.create \
+        payload = TraceContextPayload.create( \
           parent_account_id: "12345",
           parent_app_id: "6789",
           transaction_id: "164d3b4b0d09cb05",
           sampled: true,
           priority: 0.123
+        )
 
         assert_equal "0-0-12345-6789--164d3b4b0d09cb05-1-0.123000-#{payload.timestamp}", payload.to_s
       end
 
       def test_to_s_does_not_convert_to_scientific_notation
-        payload = TraceContextPayload.create \
+        payload = TraceContextPayload.create( \
           parent_account_id: "12345",
           parent_app_id: "6789",
           id: "f85f42fd82a4cf1d",
           transaction_id: "164d3b4b0d09cb05",
           sampled: true,
           priority: 0.000012
+        )
 
         assert_equal "0-0-12345-6789-f85f42fd82a4cf1d-164d3b4b0d09cb05-1-0.000012-#{payload.timestamp}", payload.to_s
       end
@@ -50,7 +53,7 @@ module NewRelic
         nr_freeze_process_time(Process.clock_gettime(Process::CLOCK_REALTIME, :millisecond))
 
         payload_str = "0-0-12345-6789-f85f42fd82a4cf1d-164d3b4b0d09cb05-1-0.123-#{now_ms}"
-        payload = TraceContextPayload.from_s payload_str
+        payload = TraceContextPayload.from_s(payload_str)
 
         assert_equal 0, payload.version
         assert_equal 0, payload.parent_type_id
@@ -65,7 +68,7 @@ module NewRelic
 
       def test_from_s_browser_payload_no_sampled_priority_or_transaction_id
         payload_str = '0-1-212311-51424-0996096a36a1cd29----1482959525577'
-        payload = TraceContextPayload.from_s payload_str
+        payload = TraceContextPayload.from_s(payload_str)
 
         assert_equal 0, payload.version
         assert_equal 1, payload.parent_type_id
@@ -83,7 +86,7 @@ module NewRelic
         nr_freeze_process_time(Process.clock_gettime(Process::CLOCK_REALTIME, :millisecond))
 
         payload_str = "1-0-12345-6789-f85f42fd82a4cf1d-164d3b4b0d09cb05-1-0.123-#{now_ms}-futureattr1"
-        payload = TraceContextPayload.from_s payload_str
+        payload = TraceContextPayload.from_s(payload_str)
 
         assert_equal 1, payload.version
         assert_equal 0, payload.parent_type_id
@@ -106,7 +109,7 @@ module NewRelic
         ]
 
         valid_payloads.each do |payload_str|
-          payload = TraceContextPayload.from_s payload_str
+          payload = TraceContextPayload.from_s(payload_str)
           assert payload.valid?, "Payload should be valid: '#{payload_str}'"
         end
 
@@ -119,7 +122,7 @@ module NewRelic
         ]
 
         invalid_payloads.each do |payload_str|
-          payload = TraceContextPayload.from_s payload_str
+          payload = TraceContextPayload.from_s(payload_str)
           refute payload.valid?, "Payload should be invalid: '#{payload_str}'"
         end
       end

--- a/test/new_relic/agent/distributed_tracing/trace_context_test.rb
+++ b/test/new_relic/agent/distributed_tracing/trace_context_test.rb
@@ -29,12 +29,12 @@ module NewRelic::Agent::DistributedTracing
       trace_flags = 0x1
       trace_state = 'k1=asdf,k2=qwerty'
 
-      TraceContext.insert format: NewRelic::FORMAT_NON_RACK,
+      TraceContext.insert(format: NewRelic::FORMAT_NON_RACK,
         carrier: carrier,
         trace_id: trace_id,
         parent_id: parent_id,
         trace_flags: trace_flags,
-        trace_state: trace_state
+        trace_state: trace_state)
 
       assert_equal "00-#{trace_id}-#{parent_id}-01", carrier['traceparent']
       assert_equal trace_state, carrier['tracestate']
@@ -48,9 +48,9 @@ module NewRelic::Agent::DistributedTracing
         NewRelic::TRACESTATE_KEY => "190@nr=#{payload.to_s},other=asdf"
       }
 
-      trace_context_header_data = TraceContext.parse format: NewRelic::FORMAT_NON_RACK,
+      trace_context_header_data = TraceContext.parse(format: NewRelic::FORMAT_NON_RACK,
         carrier: carrier,
-        trace_state_entry_key: "190@nr"
+        trace_state_entry_key: "190@nr")
 
       trace_parent = trace_context_header_data.trace_parent
 
@@ -71,9 +71,9 @@ module NewRelic::Agent::DistributedTracing
         NewRelic::HTTP_TRACESTATE_KEY => "190@nr=#{payload.to_s},other=asdf"
       }
 
-      trace_context_header_data = TraceContext.parse format: NewRelic::FORMAT_RACK,
+      trace_context_header_data = TraceContext.parse(format: NewRelic::FORMAT_RACK,
         carrier: carrier,
-        trace_state_entry_key: "190@nr"
+        trace_state_entry_key: "190@nr")
 
       trace_parent = trace_context_header_data.trace_parent
 
@@ -94,9 +94,9 @@ module NewRelic::Agent::DistributedTracing
         NewRelic::TRACESTATE_KEY => "other=asdf,190@nr=#{payload.to_s}"
       }
 
-      trace_context_header_data = TraceContext.parse format: NewRelic::FORMAT_NON_RACK,
+      trace_context_header_data = TraceContext.parse(format: NewRelic::FORMAT_NON_RACK,
         carrier: carrier,
-        trace_state_entry_key: "190@nr"
+        trace_state_entry_key: "190@nr")
 
       trace_parent = trace_context_header_data.trace_parent
 
@@ -117,9 +117,9 @@ module NewRelic::Agent::DistributedTracing
         NewRelic::TRACESTATE_KEY => "other=asdf,190@nr=#{payload.to_s},otherother=asdfasdf"
       }
 
-      trace_context_header_data = TraceContext.parse format: NewRelic::FORMAT_NON_RACK,
+      trace_context_header_data = TraceContext.parse(format: NewRelic::FORMAT_NON_RACK,
         carrier: carrier,
-        trace_state_entry_key: "190@nr"
+        trace_state_entry_key: "190@nr")
 
       trace_parent = trace_context_header_data.trace_parent
 
@@ -140,9 +140,9 @@ module NewRelic::Agent::DistributedTracing
         NewRelic::TRACESTATE_KEY => "other=asdf , \t190@nr=#{payload.to_s},\totherother=asdfasdf"
       }
 
-      trace_context_header_data = TraceContext.parse format: NewRelic::FORMAT_NON_RACK,
+      trace_context_header_data = TraceContext.parse(format: NewRelic::FORMAT_NON_RACK,
         carrier: carrier,
-        trace_state_entry_key: "190@nr"
+        trace_state_entry_key: "190@nr")
 
       trace_parent = trace_context_header_data.trace_parent
 
@@ -158,27 +158,27 @@ module NewRelic::Agent::DistributedTracing
     def test_parse_tracestate_no_other_entries
       payload = make_payload
       carrier = make_inbound_carrier({'tracestate' => "190@nr=#{payload.to_s}"})
-      trace_context_header_data = TraceContext.parse format: NewRelic::FORMAT_NON_RACK,
+      trace_context_header_data = TraceContext.parse(format: NewRelic::FORMAT_NON_RACK,
         carrier: carrier,
-        trace_state_entry_key: "190@nr"
+        trace_state_entry_key: "190@nr")
       assert_equal payload.to_s, trace_context_header_data.trace_state_payload.to_s
       assert_equal 'new=entry', trace_context_header_data.trace_state('new=entry')
     end
 
     def test_parse_tracestate_no_nr_entry
       carrier = make_inbound_carrier
-      trace_context_header_data = TraceContext.parse format: NewRelic::FORMAT_NON_RACK,
+      trace_context_header_data = TraceContext.parse(format: NewRelic::FORMAT_NON_RACK,
         carrier: carrier,
-        trace_state_entry_key: "190@nr"
+        trace_state_entry_key: "190@nr")
       assert_nil trace_context_header_data.trace_state_payload
       assert_equal 'new=entry,other=asdf', trace_context_header_data.trace_state('new=entry')
     end
 
     def test_parse_tracestate_nr_entry_malformed
       carrier = make_inbound_carrier({'tracestate' => "190@nr=somethingincorrect"})
-      trace_context_header_data = TraceContext.parse format: NewRelic::FORMAT_NON_RACK,
+      trace_context_header_data = TraceContext.parse(format: NewRelic::FORMAT_NON_RACK,
         carrier: carrier,
-        trace_state_entry_key: "190@nr"
+        trace_state_entry_key: "190@nr")
 
       refute trace_context_header_data.trace_state_payload, "no payload expected"
       assert_equal 'new=entry', trace_context_header_data.trace_state('new=entry')
@@ -190,8 +190,8 @@ module NewRelic::Agent::DistributedTracing
       carrier = make_inbound_carrier({
         NewRelic::TRACEPARENT_KEY => 'cc-12345678901234567890123456789012-1234567890123456-01'
       })
-      trace_parent = TraceContext.send :extract_traceparent, NewRelic::FORMAT_NON_RACK, carrier
-      assert TraceContext.send :trace_parent_valid?, trace_parent
+      trace_parent = TraceContext.send(:extract_traceparent, NewRelic::FORMAT_NON_RACK, carrier)
+      assert TraceContext.send(:trace_parent_valid?, trace_parent)
       assert_equal 'cc', trace_parent['version']
       assert_equal '12345678901234567890123456789012', trace_parent['trace_id']
     end
@@ -200,8 +200,8 @@ module NewRelic::Agent::DistributedTracing
       carrier = make_inbound_carrier({
         NewRelic::TRACEPARENT_KEY => 'cc-12345678901234567890123456789012-1234567890123456-01-what-the-future-will-be-like'
       })
-      trace_parent = TraceContext.send :extract_traceparent, NewRelic::FORMAT_NON_RACK, carrier
-      assert TraceContext.send :trace_parent_valid?, trace_parent
+      trace_parent = TraceContext.send(:extract_traceparent, NewRelic::FORMAT_NON_RACK, carrier)
+      assert TraceContext.send(:trace_parent_valid?, trace_parent)
       assert_equal 'cc', trace_parent['version']
       assert_equal '12345678901234567890123456789012', trace_parent['trace_id']
     end
@@ -210,8 +210,8 @@ module NewRelic::Agent::DistributedTracing
       carrier = make_inbound_carrier({
         NewRelic::TRACEPARENT_KEY => '00-12345678901234567890123456789012-1234567890123456-01-what-the-future-will-be-like'
       })
-      trace_parent = TraceContext.send :extract_traceparent, NewRelic::FORMAT_NON_RACK, carrier
-      refute TraceContext.send :trace_parent_valid?, trace_parent
+      trace_parent = TraceContext.send(:extract_traceparent, NewRelic::FORMAT_NON_RACK, carrier)
+      refute TraceContext.send(:trace_parent_valid?, trace_parent)
     end
 
     def test_trace_parent_valid
@@ -222,7 +222,7 @@ module NewRelic::Agent::DistributedTracing
         'trace_flags' => '01'
       }
 
-      assert TraceContext.send :trace_parent_valid?, valid_trace_parent
+      assert TraceContext.send(:trace_parent_valid?, valid_trace_parent)
     end
 
     def test_trace_parent_valid_invalid_trace_id
@@ -233,7 +233,7 @@ module NewRelic::Agent::DistributedTracing
         'trace_flags' => '01'
       }
 
-      assert_false TraceContext.send :trace_parent_valid?, invalid_trace_id
+      assert_false TraceContext.send(:trace_parent_valid?, invalid_trace_id)
     end
 
     def test_trace_parent_valid_invalid_parent_id
@@ -244,7 +244,7 @@ module NewRelic::Agent::DistributedTracing
         'trace_flags' => '01'
       }
 
-      assert_false TraceContext.send :trace_parent_valid?, invalid_trace_parent
+      assert_false TraceContext.send(:trace_parent_valid?, invalid_trace_parent)
     end
 
     def test_invalid_version
@@ -255,7 +255,7 @@ module NewRelic::Agent::DistributedTracing
         'trace_flags' => '01'
       }
 
-      assert_false TraceContext.send :trace_parent_valid?, invalid_trace_parent
+      assert_false TraceContext.send(:trace_parent_valid?, invalid_trace_parent)
     end
 
     def test_trace_parent_valid_version_zero_with_extra_fields
@@ -267,7 +267,7 @@ module NewRelic::Agent::DistributedTracing
         'undefined_fields' => '-these-are-some-extra-fields'
       }
 
-      assert_false TraceContext.send :trace_parent_valid?, invalid_trace_parent
+      assert_false TraceContext.send(:trace_parent_valid?, invalid_trace_parent)
     end
 
     def test_trace_parent_valid_future_version_with_extra_fields
@@ -279,7 +279,7 @@ module NewRelic::Agent::DistributedTracing
         'undefined_fields' => '-these-are-some-extra-fields'
       }
 
-      assert_false TraceContext.send :trace_parent_valid?, invalid_trace_parent
+      assert_false TraceContext.send(:trace_parent_valid?, invalid_trace_parent)
     end
 
     def make_inbound_carrier options = {}
@@ -290,7 +290,7 @@ module NewRelic::Agent::DistributedTracing
     end
 
     def make_payload
-      in_transaction "test_txn" do |txn|
+      in_transaction("test_txn") do |txn|
         return txn.distributed_tracer.create_trace_state_payload
       end
     end

--- a/test/new_relic/agent/distributed_tracing_test.rb
+++ b/test/new_relic/agent/distributed_tracing_test.rb
@@ -34,25 +34,25 @@ module NewRelic::Agent
 
       def test_accept_distributed_trace_headers_api
         carrier = {'HTTP_TRACEPARENT' => 'pretend_this_is_valid'}
-        in_transaction "test_txn" do |txn|
+        in_transaction("test_txn") do |txn|
           txn.distributed_tracer.expects(:accept_incoming_request)
-          DistributedTracing.accept_distributed_trace_headers carrier, "HTTP"
+          DistributedTracing.accept_distributed_trace_headers(carrier, "HTTP")
         end
       end
 
       def test_accept_distributed_trace_headers_api_with_non_rack
         carrier = {'tRaCePaReNt' => 'pretend_this_is_valid'}
-        in_transaction "test_txn" do |txn|
+        in_transaction("test_txn") do |txn|
           txn.distributed_tracer.expects(:accept_trace_context_incoming_request)
-          DistributedTracing.accept_distributed_trace_headers carrier, "Kafka"
+          DistributedTracing.accept_distributed_trace_headers(carrier, "Kafka")
         end
       end
 
       def test_insert_distributed_trace_headers_api
         carrier = {}
-        in_transaction "test_txn" do |txn|
+        in_transaction("test_txn") do |txn|
           txn.distributed_tracer.expects(:insert_headers)
-          DistributedTracing.insert_distributed_trace_headers carrier
+          DistributedTracing.insert_distributed_trace_headers(carrier)
         end
       end
 
@@ -62,8 +62,8 @@ module NewRelic::Agent
           'trAceSTatE' => "190@nr=0-0-190-2827902-7d3efb1b173fecfa-e8b91a159289ff74-1-1.23456-1518469636035"
         }
         trace_context_header_data = nil
-        in_transaction "test_txn" do |txn|
-          DistributedTracing.accept_distributed_trace_headers carrier, "Kafka"
+        in_transaction("test_txn") do |txn|
+          DistributedTracing.accept_distributed_trace_headers(carrier, "Kafka")
           trace_context_header_data = txn.distributed_tracer.trace_context_header_data
         end
 

--- a/test/new_relic/agent/error_event_aggregator_test.rb
+++ b/test/new_relic/agent/error_event_aggregator_test.rb
@@ -18,7 +18,7 @@ module NewRelic
 
         events = NewRelic::Agent.instance.events
         @span_id = NewRelic::Agent::GuidGenerator.generate_guid
-        @error_event_aggregator = ErrorEventAggregator.new events
+        @error_event_aggregator = ErrorEventAggregator.new(events)
       end
 
       def teardown
@@ -34,10 +34,10 @@ module NewRelic
 
       def populate_container(sampler, n)
         n.times do
-          error = NewRelic::NoticedError.new "Controller/blogs/index", RuntimeError.new("Big Controller")
+          error = NewRelic::NoticedError.new("Controller/blogs/index", RuntimeError.new("Big Controller"))
           payload = in_transaction {}.payload
 
-          @error_event_aggregator.record error, payload, @span_id
+          @error_event_aggregator.record(error, payload, @span_id)
         end
       end
 
@@ -66,7 +66,7 @@ module NewRelic
       # Tests specific to ErrorEventAggregator
 
       def test_generates_event_without_payload
-        aggregator.record create_noticed_error('blogs/index'), nil, @span_id
+        aggregator.record(create_noticed_error('blogs/index'), nil, @span_id)
 
         intrinsics, *_ = last_error_event
 
@@ -91,7 +91,7 @@ module NewRelic
       end
 
       def test_errors_not_noticed_when_disabled
-        with_server_source :'error_collector.capture_events' => false do
+        with_server_source(:'error_collector.capture_events' => false) do
           generate_error
           errors = last_error_events
           assert_empty errors
@@ -103,7 +103,7 @@ module NewRelic
           :'error_collector.enabled' => false,
           :'error_collector.capture_events' => true
         }
-        with_server_source config do
+        with_server_source(config) do
           generate_error
           errors = last_error_events
           assert_empty errors
@@ -112,12 +112,12 @@ module NewRelic
 
       class ImpossibleError < NoticedError
         def initialize
-          super 'nowhere.rb', RuntimeError.new('Impossible')
+          super('nowhere.rb', RuntimeError.new('Impossible'))
         end
       end
 
       def test_aggregator_defers_error_event_creation
-        with_config aggregator.class.capacity_key => 5 do
+        with_config(aggregator.class.capacity_key => 5) do
           5.times { generate_event }
           aggregator.expects(:create_event).never
           aggregator.record(ImpossibleError.new, {priority: -999.0}, @span_id)
@@ -139,9 +139,9 @@ module NewRelic
       def reset_error_event_buffer_state
         # this is not ideal, but we need to reset these counts to clear out state
         # between tests
-        buffer = aggregator.instance_variable_get :@buffer
-        buffer.instance_variable_set :@seen_lifetime, 0
-        buffer.instance_variable_set :@captured_lifetime, 0
+        buffer = aggregator.instance_variable_get(:@buffer)
+        buffer.instance_variable_set(:@seen_lifetime, 0)
+        buffer.instance_variable_set(:@captured_lifetime, 0)
       end
 
       def create_noticed_error txn_name, options = {}
@@ -168,13 +168,13 @@ module NewRelic
 
       def generate_error name = 'Controller/blogs/index', options = {}
         error_options = options[:error_options] || {}
-        error = create_noticed_error name, error_options
+        error = create_noticed_error(name, error_options)
 
         payload_options = options[:payload_options] || {}
         payload_options[:priority] = options[:priority] if options[:priority]
-        payload = create_transaction_payload name, payload_options
+        payload = create_transaction_payload(name, payload_options)
 
-        @error_event_aggregator.record error, payload, @span_id
+        @error_event_aggregator.record(error, payload, @span_id)
       end
     end
   end

--- a/test/new_relic/agent/error_filter_test.rb
+++ b/test/new_relic/agent/error_filter_test.rb
@@ -19,7 +19,7 @@ module NewRelic::Agent
       end
 
       def test_ignore_classes
-        with_config :'error_collector.ignore_classes' => ['TestExceptionA', 'TestExceptionC'] do
+        with_config(:'error_collector.ignore_classes' => ['TestExceptionA', 'TestExceptionC']) do
           @error_filter.load_all
           assert @error_filter.ignore?(TestExceptionA.new)
           refute @error_filter.ignore?(TestExceptionB.new)
@@ -27,7 +27,7 @@ module NewRelic::Agent
       end
 
       def test_ignore_messages
-        with_config :'error_collector.ignore_messages' => {'TestExceptionA' => ['message one', 'message two']} do
+        with_config(:'error_collector.ignore_messages' => {'TestExceptionA' => ['message one', 'message two']}) do
           @error_filter.load_all
           assert @error_filter.ignore?(TestExceptionA.new('message one'))
           assert @error_filter.ignore?(TestExceptionA.new('message two'))
@@ -37,7 +37,7 @@ module NewRelic::Agent
       end
 
       def test_ignore_status_codes
-        with_config :'error_collector.ignore_status_codes' => '401,405-409,501' do
+        with_config(:'error_collector.ignore_status_codes' => '401,405-409,501') do
           @error_filter.load_all
           assert @error_filter.ignore?(TestExceptionA.new, 401)
           assert @error_filter.ignore?(TestExceptionA.new, 501)
@@ -49,7 +49,7 @@ module NewRelic::Agent
       end
 
       def test_ignore_status_codes_by_array
-        with_config :'error_collector.ignore_status_codes' => ['401', '405-409', 501] do
+        with_config(:'error_collector.ignore_status_codes' => ['401', '405-409', 501]) do
           @error_filter.load_all
           assert @error_filter.ignore?(TestExceptionA.new, 401)
           assert @error_filter.ignore?(TestExceptionA.new, 501)
@@ -84,7 +84,7 @@ module NewRelic::Agent
       end
 
       def test_skip_invalid_status_codes
-        with_config :'error_collector.ignore_status_codes' => '401,sausage,foo-bar,500' do
+        with_config(:'error_collector.ignore_status_codes' => '401,sausage,foo-bar,500') do
           @error_filter.load_all
           refute @error_filter.ignore?(TestExceptionA.new, 400)
           assert @error_filter.ignore?(TestExceptionA.new, 401)
@@ -93,7 +93,7 @@ module NewRelic::Agent
       end
 
       def test_ignore_integer_status_codes
-        with_config :'error_collector.ignore_status_codes' => 418 do
+        with_config(:'error_collector.ignore_status_codes' => 418) do
           @error_filter.load_all
           assert @error_filter.ignore?(TestExceptionA.new, 418)
         end
@@ -101,7 +101,7 @@ module NewRelic::Agent
 
       # compatibility for deprecated config setting
       def test_ignore_errors
-        with_config :'error_collector.ignore_errors' => 'TestExceptionA,TestExceptionC' do
+        with_config(:'error_collector.ignore_errors' => 'TestExceptionA,TestExceptionC') do
           @error_filter.load_all
           assert @error_filter.ignore?(TestExceptionA.new)
           refute @error_filter.ignore?(TestExceptionB.new)
@@ -109,7 +109,7 @@ module NewRelic::Agent
       end
 
       def test_expected_classes
-        with_config :'error_collector.expected_classes' => ['TestExceptionA', 'TestExceptionC'] do
+        with_config(:'error_collector.expected_classes' => ['TestExceptionA', 'TestExceptionC']) do
           @error_filter.load_all
           assert @error_filter.expected?(TestExceptionA.new)
           refute @error_filter.expected?(TestExceptionB.new)
@@ -117,7 +117,7 @@ module NewRelic::Agent
       end
 
       def test_expected_messages
-        with_config :'error_collector.expected_messages' => {'TestExceptionA' => ['message one', 'message two']} do
+        with_config(:'error_collector.expected_messages' => {'TestExceptionA' => ['message one', 'message two']}) do
           @error_filter.load_all
           assert @error_filter.expected?(TestExceptionA.new('message one'))
           assert @error_filter.expected?(TestExceptionA.new('message two'))
@@ -127,7 +127,7 @@ module NewRelic::Agent
       end
 
       def test_expected_status_codes
-        with_config :'error_collector.expected_status_codes' => '401,405-409,501' do
+        with_config(:'error_collector.expected_status_codes' => '401,405-409,501') do
           @error_filter.load_all
           assert @error_filter.expected?(TestExceptionA.new, 401)
           assert @error_filter.expected?(TestExceptionA.new, 501)
@@ -164,7 +164,7 @@ module NewRelic::Agent
       def test_empty_settings_do_not_overwrite_existing_settings
         @error_filter.expect(['TestExceptionA'])
 
-        with_config 'error_collector.expected_classes' => [] do
+        with_config('error_collector.expected_classes' => []) do
           @error_filter.load_all
           assert @error_filter.expected?(TestExceptionA.new)
         end

--- a/test/new_relic/agent/error_trace_aggregator_test.rb
+++ b/test/new_relic/agent/error_trace_aggregator_test.rb
@@ -10,7 +10,7 @@ module NewRelic
   module Agent
     class ErrorTraceAggregatorTest < Minitest::Test
       def setup
-        @error_trace_aggregator = NewRelic::Agent::ErrorTraceAggregator.new ErrorCollector::MAX_ERROR_QUEUE_LENGTH
+        @error_trace_aggregator = NewRelic::Agent::ErrorTraceAggregator.new(ErrorCollector::MAX_ERROR_QUEUE_LENGTH)
       end
 
       def teardown
@@ -21,13 +21,13 @@ module NewRelic
       # Helpers for DataContainerTests
 
       def create_container
-        ErrorTraceAggregator.new ErrorCollector::MAX_ERROR_QUEUE_LENGTH
+        ErrorTraceAggregator.new(ErrorCollector::MAX_ERROR_QUEUE_LENGTH)
       end
 
       def populate_container(aggregator, n)
         n.times do |i|
           error = NewRelic::NoticedError.new(String.new('path'), String.new('yay errors'))
-          aggregator.add_to_error_queue error
+          aggregator.add_to_error_queue(error)
         end
       end
 
@@ -249,8 +249,8 @@ module NewRelic
       end
 
       def test_errors_not_noticed_when_disabled
-        with_config :'error_collector.enabled' => false do
-          notice_error StandardError.new "Red hands"
+        with_config(:'error_collector.enabled' => false) do
+          notice_error(StandardError.new("Red hands"))
           errors = error_trace_aggregator.harvest!
           assert_empty errors
         end
@@ -261,18 +261,18 @@ module NewRelic
           :'error_collector.enabled' => true,
           :'error_collector.capture_events' => false
         }
-        with_config config do
-          notice_error StandardError.new "Red hands"
+        with_config(config) do
+          notice_error(StandardError.new("Red hands"))
           errors = error_trace_aggregator.harvest!
           assert_equal 1, errors.size
         end
       end
 
       def test_errors_not_harvested_when_changing_from_enabled_to_disabled
-        with_config :'error_collector.enabled' => true do
-          notice_error StandardError.new "Red hands"
+        with_config(:'error_collector.enabled' => true) do
+          notice_error(StandardError.new("Red hands"))
 
-          with_config :'error_collector.enabled' => false do
+          with_config(:'error_collector.enabled' => false) do
             errors = error_trace_aggregator.harvest!
             assert_empty errors
           end
@@ -291,7 +291,7 @@ module NewRelic
 
       def notice_error(exception, options = {})
         error = create_noticed_error(exception, options)
-        @error_trace_aggregator.add_to_error_queue error
+        @error_trace_aggregator.add_to_error_queue(error)
       end
 
       def error_trace_aggregator

--- a/test/new_relic/agent/event_aggregator_test.rb
+++ b/test/new_relic/agent/event_aggregator_test.rb
@@ -48,7 +48,7 @@ module NewRelic
         )
 
         @events = NewRelic::Agent.instance.events
-        @aggregator = TestAggregator.new @events
+        @aggregator = TestAggregator.new(@events)
       end
 
       def create_container
@@ -56,7 +56,7 @@ module NewRelic
       end
 
       def populate_container(container, n)
-        n.times { |i| container.record i }
+        n.times { |i| container.record(i) }
       end
 
       include NewRelic::DataContainerTests
@@ -68,18 +68,18 @@ module NewRelic
       def test_enabled_relects_config_value
         assert @aggregator.enabled?, "Expected enabled? to be true"
 
-        with_server_source :enabled_key => false do
+        with_server_source(:enabled_key => false) do
           refute @aggregator.enabled?, "Expected enabled? to be false"
         end
       end
 
       def test_enabled_uses_multiple_keys_by_default
-        @aggregator = MultiKeyTestAggregator.new @events
-        with_server_source :enabled_key2 => true do
+        @aggregator = MultiKeyTestAggregator.new(@events)
+        with_server_source(:enabled_key2 => true) do
           assert @aggregator.enabled?
         end
 
-        with_server_source :enabled_key2 => false do
+        with_server_source(:enabled_key2 => false) do
           refute @aggregator.enabled?
         end
       end
@@ -92,53 +92,53 @@ module NewRelic
       end
 
       def test_notifies_full
-        expects_logging :debug, includes("TestAggregator capacity of 5 reached")
-        with_config :cap_key => 5 do
-          5.times { |i| @aggregator.record i }
+        expects_logging(:debug, includes("TestAggregator capacity of 5 reached"))
+        with_config(:cap_key => 5) do
+          5.times { |i| @aggregator.record(i) }
         end
       end
 
       def test_notifies_full_only_once
-        with_config :cap_key => 5 do
+        with_config(:cap_key => 5) do
           msg = "TestAggregator capacity of 5 reached"
           # this will trigger a message to be logged
-          5.times { |i| @aggregator.record i }
+          5.times { |i| @aggregator.record(i) }
 
           # we expect subsequent records not to trigger logging
-          expects_logging :debug, Not(includes(msg))
-          3.times { @aggregator.record 'no logs' }
+          expects_logging(:debug, Not(includes(msg)))
+          3.times { @aggregator.record('no logs') }
         end
       end
 
       def test_notifies_full_resets_after_harvest
         msg = "TestAggregator capacity of 5 reached"
 
-        expects_logging :debug, includes(msg)
-        with_config :cap_key => 5 do
-          5.times { |i| @aggregator.record i }
+        expects_logging(:debug, includes(msg))
+        with_config(:cap_key => 5) do
+          5.times { |i| @aggregator.record(i) }
         end
 
         @aggregator.harvest!
 
-        expects_logging :debug, includes(msg)
-        with_config :cap_key => 5 do
-          5.times { |i| @aggregator.record i }
+        expects_logging(:debug, includes(msg))
+        with_config(:cap_key => 5) do
+          5.times { |i| @aggregator.record(i) }
         end
       end
 
       def test_notifies_full_resets_after_buffer_reset
         msg = "TestAggregator capacity of 5 reached"
 
-        expects_logging :debug, includes(msg)
-        with_config :cap_key => 5 do
-          5.times { |i| @aggregator.record i }
+        expects_logging(:debug, includes(msg))
+        with_config(:cap_key => 5) do
+          5.times { |i| @aggregator.record(i) }
         end
 
         @aggregator.reset!
 
-        expects_logging :debug, includes(msg)
-        with_config :cap_key => 5 do
-          5.times { |i| @aggregator.record i }
+        expects_logging(:debug, includes(msg))
+        with_config(:cap_key => 5) do
+          5.times { |i| @aggregator.record(i) }
         end
       end
 
@@ -157,24 +157,24 @@ module NewRelic
           buffer_class TestBuffer
           attr_reader :buffer
         end
-        instance = klass.new @events
+        instance = klass.new(@events)
 
         assert_kind_of TestBuffer, instance.buffer
       end
 
       def test_buffer_adjusts_count_by_default_on_merge
-        with_config :cap_key => 5 do
+        with_config(:cap_key => 5) do
           buffer = @aggregator.buffer
 
-          4.times { |i| @aggregator.record i }
+          4.times { |i| @aggregator.record(i) }
           last_harvest = @aggregator.harvest!
 
           assert_equal 4, buffer.seen_lifetime
           assert_equal 4, buffer.captured_lifetime
           assert_equal 4, last_harvest[0][:events_seen]
 
-          4.times { |i| @aggregator.record i }
-          @aggregator.merge! last_harvest
+          4.times { |i| @aggregator.record(i) }
+          @aggregator.merge!(last_harvest)
 
           reservoir_stats, samples = @aggregator.harvest!
 
@@ -186,18 +186,18 @@ module NewRelic
       end
 
       def test_buffer_adds_to_original_count_on_merge_when_specified
-        with_config :cap_key => 5 do
+        with_config(:cap_key => 5) do
           buffer = @aggregator.buffer
 
-          4.times { |i| @aggregator.record i }
+          4.times { |i| @aggregator.record(i) }
           last_harvest = @aggregator.harvest!
 
           assert_equal 4, buffer.seen_lifetime
           assert_equal 4, buffer.captured_lifetime
           assert_equal 4, last_harvest[0][:events_seen]
 
-          4.times { |i| @aggregator.record i }
-          @aggregator.merge! last_harvest, false
+          4.times { |i| @aggregator.record(i) }
+          @aggregator.merge!(last_harvest, false)
 
           reservoir_stats, samples = @aggregator.harvest!
 

--- a/test/new_relic/agent/external_test.rb
+++ b/test/new_relic/agent/external_test.rb
@@ -14,7 +14,7 @@ module NewRelic
       def setup
         NewRelic::Agent::Harvester.any_instance.stubs(:harvest_thread_enabled?).returns(false)
 
-        @obfuscator = NewRelic::Agent::Obfuscator.new "jotorotoes"
+        @obfuscator = NewRelic::Agent::Obfuscator.new("jotorotoes")
         NewRelic::Agent::CrossAppTracing.stubs(:obfuscator).returns(@obfuscator)
         NewRelic::Agent::CrossAppTracing.stubs(:valid_encoding_key?).returns(true)
       end
@@ -26,14 +26,14 @@ module NewRelic
       # --- process_request_metadata
 
       def test_process_request_metadata
-        with_config cat_config do
-          rmd = @obfuscator.obfuscate ::JSON.dump({
+        with_config(cat_config) do
+          rmd = @obfuscator.obfuscate(::JSON.dump({
             NewRelicID: cat_config[:cross_process_id],
             NewRelicTransaction: ['abc', false, 'def', 'ghi']
-          })
+          }))
 
           in_transaction do |txn|
-            NewRelic::Agent::External.process_request_metadata rmd
+            NewRelic::Agent::External.process_request_metadata(rmd)
             ca_payload = txn.distributed_tracer.cross_app_payload
 
             assert_equal cat_config[:cross_process_id], ca_payload.id
@@ -45,17 +45,17 @@ module NewRelic
       end
 
       def test_process_request_metadata_with_synthetics
-        with_config cat_config do
-          raw_synth = @obfuscator.obfuscate ::JSON.dump('raw_synth')
+        with_config(cat_config) do
+          raw_synth = @obfuscator.obfuscate(::JSON.dump('raw_synth'))
 
-          rmd = @obfuscator.obfuscate ::JSON.dump({
+          rmd = @obfuscator.obfuscate(::JSON.dump({
             NewRelicID: cat_config[:cross_process_id],
             NewRelicTransaction: ['abc', false, 'def', 'ghi'],
             NewRelicSynthetics: 'raw_synth'
-          })
+          }))
 
           in_transaction do |txn|
-            NewRelic::Agent::External.process_request_metadata rmd
+            NewRelic::Agent::External.process_request_metadata(rmd)
 
             assert_equal raw_synth, txn.raw_synthetics_header
             assert_equal 'raw_synth', txn.synthetics_payload
@@ -64,14 +64,14 @@ module NewRelic
       end
 
       def test_process_request_metadata_not_in_transaction
-        with_config cat_config do
-          rmd = @obfuscator.obfuscate ::JSON.dump({
+        with_config(cat_config) do
+          rmd = @obfuscator.obfuscate(::JSON.dump({
             NewRelicID: cat_config[:cross_process_id],
             NewRelicTransaction: ['abc', false, 'def', 'ghi'],
             NewRelicSynthetics: 'raw_synth'
-          })
+          }))
 
-          l = with_array_logger { NewRelic::Agent::External.process_request_metadata rmd }
+          l = with_array_logger { NewRelic::Agent::External.process_request_metadata(rmd) }
           assert l.array.empty?, "process_request_metadata should not log errors without a current transaction"
 
           refute Tracer.current_transaction
@@ -79,15 +79,15 @@ module NewRelic
       end
 
       def test_process_request_metadata_with_invalid_id
-        with_config cat_config do
-          rmd = @obfuscator.obfuscate ::JSON.dump({
+        with_config(cat_config) do
+          rmd = @obfuscator.obfuscate(::JSON.dump({
             NewRelicID: 'bugz',
             NewRelicTransaction: ['abc', false, 'def', 'ghi'],
             NewRelicSynthetics: 'raw_synth'
-          })
+          }))
 
           in_transaction do |txn|
-            l = with_array_logger { NewRelic::Agent::External.process_request_metadata rmd }
+            l = with_array_logger { NewRelic::Agent::External.process_request_metadata(rmd) }
             refute l.array.empty?, "process_request_metadata should log error on invalid ID"
             assert l.array.first =~ %r{invalid/non-trusted ID}
 
@@ -97,15 +97,15 @@ module NewRelic
       end
 
       def test_process_request_metadata_with_non_trusted_id
-        with_config cat_config do
-          rmd = @obfuscator.obfuscate ::JSON.dump({
+        with_config(cat_config) do
+          rmd = @obfuscator.obfuscate(::JSON.dump({
             NewRelicID: '190#666',
             NewRelicTransaction: ['abc', false, 'def', 'ghi'],
             NewRelicSynthetics: 'raw_synth'
-          })
+          }))
 
           in_transaction do |txn|
-            l = with_array_logger { NewRelic::Agent::External.process_request_metadata rmd }
+            l = with_array_logger { NewRelic::Agent::External.process_request_metadata(rmd) }
             refute l.array.empty?, "process_request_metadata should log error on invalid ID"
             assert l.array.first =~ %r{invalid/non-trusted ID}
 
@@ -115,14 +115,14 @@ module NewRelic
       end
 
       def test_process_request_metadata_cross_app_disabled
-        with_config cat_config.merge(:'cross_application_tracer.enabled' => false) do
-          rmd = @obfuscator.obfuscate ::JSON.dump({
+        with_config(cat_config.merge(:'cross_application_tracer.enabled' => false)) do
+          rmd = @obfuscator.obfuscate(::JSON.dump({
             NewRelicID: cat_config[:cross_process_id],
             NewRelicTransaction: ['abc', false, 'def', 'ghi']
-          })
+          }))
 
           in_transaction do |txn|
-            l = with_array_logger { NewRelic::Agent::External.process_request_metadata rmd }
+            l = with_array_logger { NewRelic::Agent::External.process_request_metadata(rmd) }
             assert l.array.empty?, "process_request_metadata should not log errors when cross app tracing is disabled"
 
             refute txn.distributed_tracer.cross_app_payload
@@ -133,20 +133,20 @@ module NewRelic
       # --- get_response_metadata
 
       def test_get_response_metadata
-        with_config cat_config do
-          inbound_rmd = @obfuscator.obfuscate ::JSON.dump({
+        with_config(cat_config) do
+          inbound_rmd = @obfuscator.obfuscate(::JSON.dump({
             NewRelicID: '1#666',
             NewRelicTransaction: ['xyz', false, 'uvw', 'rst']
-          })
+          }))
 
           in_transaction do |txn|
             # simulate valid processed request metadata
-            NewRelic::Agent::External.process_request_metadata inbound_rmd
+            NewRelic::Agent::External.process_request_metadata(inbound_rmd)
 
             rmd = NewRelic::Agent::External.get_response_metadata
             assert_instance_of String, rmd
-            rmd = @obfuscator.deobfuscate rmd
-            rmd = JSON.parse rmd
+            rmd = @obfuscator.deobfuscate(rmd)
+            rmd = JSON.parse(rmd)
             assert_instance_of Hash, rmd
             assert_instance_of Array, rmd['NewRelicAppData']
 
@@ -161,13 +161,13 @@ module NewRelic
       end
 
       def test_get_response_metadata_not_in_transaction
-        with_config cat_config do
+        with_config(cat_config) do
           refute NewRelic::Agent::External.get_response_metadata
         end
       end
 
       def test_get_response_metadata_without_valid_id
-        with_config cat_config do
+        with_config(cat_config) do
           in_transaction do |txn|
             refute NewRelic::Agent::External.get_response_metadata
           end

--- a/test/new_relic/agent/guid_generator_test.rb
+++ b/test/new_relic/agent/guid_generator_test.rb
@@ -16,7 +16,7 @@ module NewRelic
       end
 
       def test_generate_guid_custom_length
-        guid = NewRelic::Agent::GuidGenerator.generate_guid 32
+        guid = NewRelic::Agent::GuidGenerator.generate_guid(32)
         # the result should be exactly 32 hexadecimal characters
         assert_match(/[a-f0-9]{32}/, guid)
       end

--- a/test/new_relic/agent/heap_test.rb
+++ b/test/new_relic/agent/heap_test.rb
@@ -10,20 +10,20 @@ module NewRelic
   module Agent
     class HeapTest < Minitest::Test
       def test_items_inserted_in_proper_order
-        heap = Heap.new [12, 5, 4, 8]
+        heap = Heap.new([12, 5, 4, 8])
 
         assert_equal [4, 8, 5, 12], heap.to_a
       end
 
       def test_tree_rebalanced_on_pop
-        heap = Heap.new [12, 5, 4, 8]
+        heap = Heap.new([12, 5, 4, 8])
         heap.pop
 
         assert_equal [5, 8, 12], heap.to_a
       end
 
       def test_items_can_be_modified_by_accessors
-        heap = Heap.new [12, 5, 4, 8]
+        heap = Heap.new([12, 5, 4, 8])
 
         assert_equal 5, heap[2]
 
@@ -33,7 +33,7 @@ module NewRelic
       end
 
       def test_fix_bubbles_up
-        heap = Heap.new [12, 5, 4, 8, 30, 7]
+        heap = Heap.new([12, 5, 4, 8, 30, 7])
 
         heap[1] = 1
         heap.fix(1)
@@ -66,7 +66,7 @@ module NewRelic
       end
 
       def test_fix_bubbles_down
-        heap = Heap.new [12, 5, 4, 8, 30, 7]
+        heap = Heap.new([12, 5, 4, 8, 30, 7])
 
         heap[1] = 50
         heap.fix(1)
@@ -98,7 +98,7 @@ module NewRelic
       end
 
       def test_fix_leaves_item_if_heap_rule_satisfied
-        heap = Heap.new [12, 5, 4, 8, 30, 7]
+        heap = Heap.new([12, 5, 4, 8, 30, 7])
 
         heap[1] = 9
         heap.fix(1)
@@ -116,7 +116,7 @@ module NewRelic
       end
 
       def test_items_are_popped_in_ascending_order
-        heap = Heap.new [12, 5, 4, 8, 30, 7]
+        heap = Heap.new([12, 5, 4, 8, 30, 7])
 
         ordered_items = []
 

--- a/test/new_relic/agent/instrumentation/controller_instrumentation_test.rb
+++ b/test/new_relic/agent/instrumentation/controller_instrumentation_test.rb
@@ -257,19 +257,19 @@ module NewRelic::Agent::Instrumentation
     def test_add_transaction_tracer_should_not_double_instrument
       TestObject.expects(:alias_method).never
       TestObject.class_eval do
-        add_transaction_tracer :public_transaction
-        add_transaction_tracer :protected_transaction
-        add_transaction_tracer :private_transaction
+        add_transaction_tracer(:public_transaction)
+        add_transaction_tracer(:protected_transaction)
+        add_transaction_tracer(:private_transaction)
       end
       TestObject.new
     end
 
     def test_add_transaction_tracer_defines_with_method
-      assert TestObject.method_defined? :public_transaction_with_newrelic_transaction_trace
+      assert TestObject.method_defined?(:public_transaction_with_newrelic_transaction_trace)
     end
 
     def test_add_transaction_tracer_defines_without_method
-      assert TestObject.method_defined? :public_transaction_without_newrelic_transaction_trace
+      assert TestObject.method_defined?(:public_transaction_without_newrelic_transaction_trace)
     end
 
     def test_parse_punctuation

--- a/test/new_relic/agent/instrumentation/instance_identification_test.rb
+++ b/test/new_relic/agent/instrumentation/instance_identification_test.rb
@@ -123,8 +123,8 @@ module NewRelic
               NewRelic::Agent::Hostname.stubs(:get).returns(test['system_hostname'])
 
               in_transaction do
-                config = convert_test_case_to_config test
-                product, operation, collection = ActiveRecordHelper.product_operation_collection_for "Blog Find", nil, config[:adapter]
+                config = convert_test_case_to_config(test)
+                product, operation, collection = ActiveRecordHelper.product_operation_collection_for("Blog Find", nil, config[:adapter])
                 host = ActiveRecordHelper::InstanceIdentification.host(config)
                 port_path_or_id = ActiveRecordHelper::InstanceIdentification.port_path_or_id(config)
 
@@ -156,7 +156,7 @@ module NewRelic
               end
               memo
             end
-            convert_product_to_adapter config
+            convert_product_to_adapter(config)
             config
           end
 

--- a/test/new_relic/agent/instrumentation/mongodb_command_subscriber_test.rb
+++ b/test/new_relic/agent/instrumentation/mongodb_command_subscriber_test.rb
@@ -90,7 +90,7 @@ class NewRelic::Agent::Instrumentation::MongodbCommandSubscriberTest < Minitest:
 
     tt = last_transaction_trace
 
-    node = find_node_with_name_matching tt, /^Datastore\//
+    node = find_node_with_name_matching(tt, /^Datastore\//)
 
     assert_equal(NewRelic::Agent::Hostname.get, node[:host])
     assert_equal('27017', node[:port_path_or_id])
@@ -106,7 +106,7 @@ class NewRelic::Agent::Instrumentation::MongodbCommandSubscriberTest < Minitest:
 
   def simulate_query
     @subscriber.started(@started_event)
-    advance_process_time @succeeded_event.duration
+    advance_process_time(@succeeded_event.duration)
     @subscriber.succeeded(@succeeded_event)
   end
 end

--- a/test/new_relic/agent/instrumentation/net_instrumentation_test.rb
+++ b/test/new_relic/agent/instrumentation/net_instrumentation_test.rb
@@ -32,8 +32,8 @@ class NewRelic::Agent::Instrumentation::NetInstrumentationTest < Minitest::Test
     @socket.stubs(:write).raises('fake network error')
     @socket.stubs(:write_nonblock).raises('fake network error')
     with_config(:"cross_application_tracer.enabled" => true) do
-      in_transaction "test" do
-        segment = NewRelic::Agent::Tracer.start_segment name: "dummy"
+      in_transaction("test") do
+        segment = NewRelic::Agent::Tracer.start_segment(name: "dummy")
         Net::HTTP.get(URI.parse('http://www.google.com/index.html')) rescue nil
         segment.finish
       end

--- a/test/new_relic/agent/instrumentation/rails/action_view_subscriber.rb
+++ b/test/new_relic/agent/instrumentation/rails/action_view_subscriber.rb
@@ -20,7 +20,7 @@ class NewRelic::Agent::Instrumentation::ActionViewSubscriberTest < Minitest::Tes
       @subscriber.start('render_template.action_view', :id, params)
       @subscriber.start('!render_template.action_view', :id,
         :virtual_path => 'model/index')
-      advance_process_time 2.0
+      advance_process_time(2.0)
       @subscriber.finish('!render_template.action_view', :id,
         :virtual_path => 'model/index')
       @subscriber.finish('render_template.action_view', :id, params)
@@ -36,7 +36,7 @@ class NewRelic::Agent::Instrumentation::ActionViewSubscriberTest < Minitest::Tes
       @subscriber.start('render_template.action_view', :id, params)
       @subscriber.start('!render_template.action_view', :id,
         :virtual_path => nil)
-      advance_process_time 2.0
+      advance_process_time(2.0)
       @subscriber.finish('!render_template.action_view', :id,
         :virtual_path => nil)
       @subscriber.finish('render_template.action_view', :id, params)
@@ -52,7 +52,7 @@ class NewRelic::Agent::Instrumentation::ActionViewSubscriberTest < Minitest::Tes
       @subscriber.start('render_template.action_view', :id, params)
       @subscriber.start('!render_template.action_view', :id,
         :virtual_path => nil)
-      advance_process_time 2.0
+      advance_process_time(2.0)
       @subscriber.finish('!render_template.action_view', :id,
         :virtual_path => nil)
       @subscriber.finish('render_template.action_view', :id, params)
@@ -66,7 +66,7 @@ class NewRelic::Agent::Instrumentation::ActionViewSubscriberTest < Minitest::Tes
     nr_freeze_process_time
     in_transaction do
       @subscriber.start('render_template.action_view', :id, params)
-      advance_process_time 2.0
+      advance_process_time(2.0)
       @subscriber.finish('render_template.action_view', :id, params)
     end
     expected = {:call_count => 1, :total_call_time => 2.0}
@@ -80,7 +80,7 @@ class NewRelic::Agent::Instrumentation::ActionViewSubscriberTest < Minitest::Tes
       @subscriber.start('render_partial.action_view', :id, params)
       @subscriber.start('!render_template.action_view', :id,
         :virtual_path => 'model/_form')
-      advance_process_time 2.0
+      advance_process_time(2.0)
       @subscriber.finish('!render_template.action_view', :id,
         :virtual_path => 'model/_form')
       @subscriber.finish('render_partial.action_view', :id, params)
@@ -96,7 +96,7 @@ class NewRelic::Agent::Instrumentation::ActionViewSubscriberTest < Minitest::Tes
       @subscriber.start('render_collection.action_view', :id, params)
       @subscriber.start('!render_template.action_view', :id,
         :virtual_path => 'model/_user')
-      advance_process_time 2.0
+      advance_process_time(2.0)
       @subscriber.finish('!render_template.action_view', :id,
         :virtual_path => 'model/_user')
       @subscriber.finish('render_collection.action_view', :id, params)
@@ -110,7 +110,7 @@ class NewRelic::Agent::Instrumentation::ActionViewSubscriberTest < Minitest::Tes
     in_transaction do
       @subscriber.start('!render_template.action_view', :id,
         :virtual_path => 'layouts/application')
-      advance_process_time 2.0
+      advance_process_time(2.0)
       @subscriber.finish('!render_template.action_view', :id,
         :virtual_path => 'layouts/application')
     end

--- a/test/new_relic/agent/instrumentation/rails/active_record_subscriber.rb
+++ b/test/new_relic/agent/instrumentation/rails/active_record_subscriber.rb
@@ -106,13 +106,13 @@ class NewRelic::Agent::Instrumentation::ActiveRecordSubscriberTest < Minitest::T
       in_transaction { simulate_query(2) }
     end
     sample = last_transaction_trace
-    node = find_node_with_name_matching sample, /Datastore\//
+    node = find_node_with_name_matching(sample, /Datastore\//)
     refute node.params.key?(:database_name)
   end
 
   def test_records_unknown_unknown_when_error_gathering_instance_data
-    NewRelic::Agent::Instrumentation::ActiveRecordHelper::InstanceIdentification.stubs(:postgres_unix_domain_socket_case?).raises StandardError.new
-    NewRelic::Agent::Instrumentation::ActiveRecordHelper::InstanceIdentification.stubs(:mysql_default_case?).raises StandardError.new
+    NewRelic::Agent::Instrumentation::ActiveRecordHelper::InstanceIdentification.stubs(:postgres_unix_domain_socket_case?).raises(StandardError.new)
+    NewRelic::Agent::Instrumentation::ActiveRecordHelper::InstanceIdentification.stubs(:mysql_default_case?).raises(StandardError.new)
 
     config = {:adapter => 'mysql', :host => "127.0.0.1"}
     @subscriber.stubs(:active_record_config).returns(config)
@@ -204,11 +204,11 @@ class NewRelic::Agent::Instrumentation::ActiveRecordSubscriberTest < Minitest::T
   end
 
   def test_segment_created
-    in_transaction 'test' do
+    in_transaction('test') do
       txn = NewRelic::Agent::Tracer.current_transaction
       assert_equal 1, txn.segments.size
 
-      simulate_query 1
+      simulate_query(1)
       assert_equal 2, txn.segments.size
       assert txn.segments.last.finished?, "Segment '#{txn.segments.last.name}'' was never finished.  "
       assert_equal \
@@ -221,10 +221,10 @@ class NewRelic::Agent::Instrumentation::ActiveRecordSubscriberTest < Minitest::T
     payload = {connection_id: 1138}
     config = {adapter: 'postgresql_makara'}
     spec = MiniTest::Mock.new
-    3.times { spec.expect :config, config }
+    3.times { spec.expect(:config, config) }
     handler = MiniTest::Mock.new
-    handler.expect :connections, []
-    4.times { handler.expect :spec, spec }
+    handler.expect(:connections, [])
+    4.times { handler.expect(:spec, spec) }
     ::ActiveRecord::Base.connection_handler.stub(:connection_pool_list, [handler]) do
       assert_equal config, @subscriber.active_record_config(payload)
     end

--- a/test/new_relic/agent/instrumentation/rails/active_storage_subscriber.rb
+++ b/test/new_relic/agent/instrumentation/rails/active_storage_subscriber.rb
@@ -32,9 +32,9 @@ module NewRelic
             "service_url.active_storage" => "url".freeze
           }
 
-          in_transaction 'test' do
+          in_transaction('test') do
             method_name_mapping.keys.each do |event_name|
-              generate_event event_name
+              generate_event(event_name)
             end
           end
 
@@ -44,24 +44,24 @@ module NewRelic
         end
 
         def test_metric_will_recorded_for_new_event_names
-          in_transaction 'test' do
-            generate_event 'service_new_method.active_storage'
+          in_transaction('test') do
+            generate_event('service_new_method.active_storage')
           end
 
           assert_metrics_recorded 'Ruby/ActiveStorage/DiskService/new_method'
         end
 
         def test_failsafe_if_event_does_not_match_expected_pattern
-          in_transaction 'test' do
-            generate_event 'wat?'
+          in_transaction('test') do
+            generate_event('wat?')
           end
 
           assert_metrics_recorded 'Ruby/ActiveStorage/DiskService/unknown'
         end
 
         def test_key_recorded_as_attribute_on_traces
-          in_transaction 'test' do
-            generate_event 'service_upload.active_storage', key: 'mykey'
+          in_transaction('test') do
+            generate_event('service_upload.active_storage', key: 'mykey')
           end
 
           trace = last_transaction_trace
@@ -71,23 +71,23 @@ module NewRelic
         end
 
         def test_exist_recorded_as_attribute_on_traces
-          in_transaction 'test' do
-            generate_event 'service_exist.active_storage', exist: false
+          in_transaction('test') do
+            generate_event('service_exist.active_storage', exist: false)
           end
 
           trace = last_transaction_trace
           tt_node = find_node_with_name(trace, "Ruby/ActiveStorage/DiskService/exist")
 
-          assert tt_node.params.key? :exist
+          assert tt_node.params.key?(:exist)
           assert_equal false, tt_node.params[:exist]
         end
 
         def test_segment_created
-          in_transaction 'test' do
+          in_transaction('test') do
             txn = NewRelic::Agent::Tracer.current_transaction
             assert_equal 1, txn.segments.size
 
-            generate_event 'service_exist.active_storage', exist: false
+            generate_event('service_exist.active_storage', exist: false)
             assert_equal 2, txn.segments.size
             assert_equal 'Ruby/ActiveStorage/DiskService/exist', txn.segments.last.name
             assert txn.segments.last.finished?, "Segment #{txn.segments.last.name} was never finished.  "
@@ -105,7 +105,7 @@ module NewRelic
 
           in_transaction do |test_txn|
             txn = test_txn
-            generate_event 'service_upload.active_storage', params
+            generate_event('service_upload.active_storage', params)
           end
 
           assert_segment_noticed_error txn, /upload/i, exception_class.name, /Natural 1/i
@@ -116,9 +116,9 @@ module NewRelic
         def generate_event(event_name, attributes = {})
           defaults = {key: fake_guid(32), service: "Disk"}
           payload = defaults.merge(attributes)
-          @subscriber.start event_name, @id, payload
+          @subscriber.start(event_name, @id, payload)
           yield if block_given?
-          @subscriber.finish event_name, @id, payload
+          @subscriber.finish(event_name, @id, payload)
         end
       end
     end

--- a/test/new_relic/agent/log_event_aggregator_test.rb
+++ b/test/new_relic/agent/log_event_aggregator_test.rb
@@ -86,7 +86,7 @@ module NewRelic::Agent
     end
 
     def test_records_customer_metrics_when_enabled
-      with_config LogEventAggregator::METRICS_ENABLED_KEY => true do
+      with_config(LogEventAggregator::METRICS_ENABLED_KEY => true) do
         2.times { @aggregator.record("Are you counting this?", "DEBUG") }
         @aggregator.harvest!
       end
@@ -115,7 +115,7 @@ module NewRelic::Agent
     end
 
     def test_doesnt_record_customer_metrics_when_disabled
-      with_config LogEventAggregator::METRICS_ENABLED_KEY => false do
+      with_config(LogEventAggregator::METRICS_ENABLED_KEY => false) do
         @aggregator.record("Are you counting this?", "DEBUG")
         @aggregator.harvest!
       end
@@ -295,7 +295,7 @@ module NewRelic::Agent
     end
 
     def test_records_metrics_on_harvest
-      with_config CAPACITY_KEY => 5 do
+      with_config(CAPACITY_KEY => 5) do
         9.times { @aggregator.record("Are you counting this?", "DEBUG") }
         @aggregator.harvest!
 
@@ -311,7 +311,7 @@ module NewRelic::Agent
     end
 
     def test_high_security_mode
-      with_config CAPACITY_KEY => 5, :high_security => true do
+      with_config(CAPACITY_KEY => 5, :high_security => true) do
         # We refresh the high security setting on this notification
         NewRelic::Agent.config.notify_server_source_added
 

--- a/test/new_relic/agent/logging_test.rb
+++ b/test/new_relic/agent/logging_test.rb
@@ -16,11 +16,11 @@ module NewRelic
         end
 
         def last_message
-          JSON.load @output.string.split("\n")[-1]
+          JSON.load(@output.string.split("\n")[-1])
         end
 
         def test_log_to_json
-          logger = DecoratingLogger.new @output
+          logger = DecoratingLogger.new(@output)
           logger.info('this is a test')
 
           message = last_message
@@ -43,13 +43,13 @@ module NewRelic
         end
 
         def test_app_name
-          logger = DecoratingLogger.new @output
+          logger = DecoratingLogger.new(@output)
 
-          with_config app_name: 'Unset' do
+          with_config(app_name: 'Unset') do
             logger.info('one')
             assert_equal 'Unset', last_message['entity.name']
 
-            with_config app_name: 'MyTotallySweetApplication' do
+            with_config(app_name: 'MyTotallySweetApplication') do
               logger.info('two')
               assert_equal 'MyTotallySweetApplication', last_message['entity.name']
             end
@@ -59,8 +59,8 @@ module NewRelic
         def test_constructor_arguments_shift_age
           shift_age = 350
           shift_size = 10000
-          logger = DecoratingLogger.new '/tmp/tmp.log', shift_age = 30, shift_size = 1000
-          device = logger.instance_variable_get :@logdev
+          logger = DecoratingLogger.new('/tmp/tmp.log', shift_age = 30, shift_size = 1000)
+          device = logger.instance_variable_get(:@logdev)
           assert_equal '/tmp/tmp.log', device.instance_variable_get(:@filename)
           assert_equal 30, device.instance_variable_get(:@shift_age)
           assert_equal 1000, device.instance_variable_get(:@shift_size)
@@ -81,8 +81,8 @@ module NewRelic
         }
         messages_to_escape.each do |name, message|
           define_method "test_escape_message_#{name}" do
-            logger = DecoratingLogger.new @output
-            logger.info message
+            logger = DecoratingLogger.new(@output)
+            logger.info(message)
             assert_equal message, last_message['message']
           end
         end
@@ -91,9 +91,9 @@ module NewRelic
           message = 'message with a non-unicode code '
           input = "#{message} \xb3"
           expectation = "#{message} #{DecoratingFormatter::REPLACEMENT_CHAR}"
-          logger = DecoratingLogger.new @output
+          logger = DecoratingLogger.new(@output)
 
-          logger.info input
+          logger.info(input)
           assert_equal expectation, last_message['message']
         end
 
@@ -102,23 +102,23 @@ module NewRelic
           char = String.new('č')
           input = "#{message} #{char.force_encoding(Encoding::ASCII_8BIT)}"
           expectation = "#{message} #{DecoratingFormatter::REPLACEMENT_CHAR}#{DecoratingFormatter::REPLACEMENT_CHAR}"
-          logger = DecoratingLogger.new @output
+          logger = DecoratingLogger.new(@output)
 
-          logger.info input
+          logger.info(input)
           assert_equal expectation, last_message['message']
         end
 
         if RUBY_VERSION >= '2.4.0'
           def test_constructor_arguments_level
-            logger = DecoratingLogger.new @output, level: :error
+            logger = DecoratingLogger.new(@output, level: :error)
             assert_equal Logger::ERROR, logger.level
           end
 
           def test_constructor_arguments_progname
-            logger = DecoratingLogger.new @output, progname: 'LoggingTest'
+            logger = DecoratingLogger.new(@output, progname: 'LoggingTest')
             logger.info('test')
 
-            message = JSON.load @output.string
+            message = JSON.load(@output.string)
             assert_equal 'LoggingTest', message['logger.name']
           end
 
@@ -127,7 +127,7 @@ module NewRelic
             # does this seem correct?  Maybe if they pass one in, we should keep
             # it and use it to format messages?
             formatter = ::Logger::Formatter.new
-            logger = DecoratingLogger.new @output, formatter: formatter
+            logger = DecoratingLogger.new(@output, formatter: formatter)
             refute_equal formatter, logger.formatter
           end
         end

--- a/test/new_relic/agent/messaging_test.rb
+++ b/test/new_relic/agent/messaging_test.rb
@@ -19,7 +19,7 @@ module NewRelic
       end
 
       def test_metrics_recorded_for_amqp_publish
-        in_transaction "test_txn" do
+        in_transaction("test_txn") do
           segment = NewRelic::Agent::Messaging.start_amqp_publish_segment(
             library: "RabbitMQ",
             destination_name: "Default",
@@ -35,7 +35,7 @@ module NewRelic
       end
 
       def test_metrics_recorded_for_amqp_consume
-        in_transaction "test_txn" do
+        in_transaction("test_txn") do
           segment = NewRelic::Agent::Messaging.start_amqp_consume_segment(
             library: "RabbitMQ",
             destination_name: "Default",
@@ -53,7 +53,7 @@ module NewRelic
       end
 
       def test_segment_parameters_recorded_for_publish
-        in_transaction "test_txn" do
+        in_transaction("test_txn") do
           headers = {foo: "bar"}
           segment = NewRelic::Agent::Messaging.start_amqp_publish_segment(
             library: "RabbitMQ",
@@ -75,7 +75,7 @@ module NewRelic
 
       def test_segment_params_not_recorded_for_publish_with_segment_params_disabled
         with_config(:'message_tracer.segment_parameters.enabled' => false) do
-          in_transaction "test_txn" do
+          in_transaction("test_txn") do
             headers = {foo: "bar"}
             segment = NewRelic::Agent::Messaging.start_amqp_publish_segment(
               library: "RabbitMQ",
@@ -97,7 +97,7 @@ module NewRelic
       end
 
       def test_segment_parameters_recorded_for_consume
-        in_transaction "test_txn" do
+        in_transaction("test_txn") do
           message_properties = {headers: {foo: "bar"}, reply_to: "blue", correlation_id: "abc"}
           delivery_info = {routing_key: "red", exchange_name: "foobar"}
 
@@ -121,7 +121,7 @@ module NewRelic
 
       def test_segment_params_not_recorded_for_consume_with_segment_params_disabled
         with_config(:'message_tracer.segment_parameters.enabled' => false) do
-          in_transaction "test_txn" do
+          in_transaction("test_txn") do
             message_properties = {headers: {foo: "bar"}, reply_to: "blue", correlation_id: "abc"}
             delivery_info = {routing_key: "red", exchange_name: "foobar"}
 
@@ -144,8 +144,8 @@ module NewRelic
       end
 
       def test_wrap_message_broker_consume_transaction
-        tap = mock 'tap'
-        tap.expects :tap
+        tap = mock('tap')
+        tap.expects(:tap)
 
         NewRelic::Agent::Messaging.wrap_message_broker_consume_transaction(
           library: "AwesomeBunniez",
@@ -166,8 +166,8 @@ module NewRelic
         NewRelic::Agent.instance.span_event_aggregator.stubs(:enabled?).returns(true)
         NewRelic::Agent::Transaction.any_instance.stubs(:sampled?).returns(true)
 
-        tap = mock 'tap'
-        tap.expects :tap
+        tap = mock('tap')
+        tap.expects(:tap)
 
         NewRelic::Agent::Messaging.wrap_message_broker_consume_transaction(
           library: "RabbitMQ",
@@ -189,9 +189,9 @@ module NewRelic
       end
 
       def test_header_attributes_assigned_for_generic_wrap_consume_transaction
-        with_config :"attributes.include" => "message.headers.*" do
-          tap = mock 'tap'
-          tap.expects :tap
+        with_config(:"attributes.include" => "message.headers.*") do
+          tap = mock('tap')
+          tap.expects(:tap)
 
           NewRelic::Agent::Messaging.wrap_message_broker_consume_transaction(
             library: "RabbitMQ",
@@ -207,9 +207,9 @@ module NewRelic
       end
 
       def test_cat_headers_removed_when_headers_assigned_as_attributes
-        with_config :"attributes.include" => "message.headers.*" do
-          tap = mock 'tap'
-          tap.expects :tap
+        with_config(:"attributes.include" => "message.headers.*") do
+          tap = mock('tap')
+          tap.expects(:tap)
 
           NewRelic::Agent::Messaging.wrap_message_broker_consume_transaction(
             library: "RabbitMQ",
@@ -225,8 +225,8 @@ module NewRelic
       end
 
       def test_header_attributes_not_assigned_when_headers_not_included_in_consume_transaction
-        tap = mock 'tap'
-        tap.expects :tap
+        tap = mock('tap')
+        tap.expects(:tap)
 
         NewRelic::Agent::Messaging.wrap_message_broker_consume_transaction(
           library: "RabbitMQ",
@@ -244,7 +244,7 @@ module NewRelic
         NewRelic::Agent::Transaction.any_instance.stubs(:sampled?).returns(true)
         NewRelic::Agent.instance.span_event_aggregator.stubs(:enabled?).returns(true)
 
-        in_transaction "test_txn" do
+        in_transaction("test_txn") do
           message_properties = {headers: {foo: "bar"}, reply_to: "blue", correlation_id: "abc"}
           delivery_info = {routing_key: "red", exchange_name: "foobar"}
 
@@ -375,9 +375,9 @@ module NewRelic
         NewRelic::Agent::Transaction.any_instance.stubs(:sampled?).returns(true)
         NewRelic::Agent.instance.span_event_aggregator.stubs(:enabled?).returns(true)
 
-        with_config :"attributes.include" => ["message.headers.*", "message.replyTo", "message.correlationId", "message.exchangeType"] do
-          tap = mock 'tap'
-          tap.expects :tap
+        with_config(:"attributes.include" => ["message.headers.*", "message.replyTo", "message.correlationId", "message.exchangeType"]) do
+          tap = mock('tap')
+          tap.expects(:tap)
 
           NewRelic::Agent::Messaging.wrap_amqp_consume_transaction(
             library: "AwesomeBunniez",
@@ -409,7 +409,7 @@ module NewRelic
       end
 
       def test_segment_records_proper_metrics_for_consume
-        in_transaction "test_txn" do |txn|
+        in_transaction("test_txn") do |txn|
           segment = NewRelic::Agent::Messaging.start_message_broker_segment(
             action: :consume,
             library: "RabbitMQ",
@@ -433,18 +433,18 @@ module NewRelic
         raw_txn_info = nil
         obfuscated_txn_info = nil
 
-        tap = mock 'tap'
-        tap.expects :tap
+        tap = mock('tap')
+        tap.expects(:tap)
 
-        with_config :"cross_application_tracer.enabled" => true,
+        with_config(:"cross_application_tracer.enabled" => true,
           :cross_process_id => cross_process_id,
           :'distributed_tracing.enabled' => false,
           :trusted_account_ids => [321],
-          :encoding_key => "abc" do
+          :encoding_key => "abc") do
           in_transaction do |txn|
-            obfuscated_id = obfuscator.obfuscate cross_process_id
+            obfuscated_id = obfuscator.obfuscate(cross_process_id)
             raw_txn_info = [guid, false, guid, txn.distributed_tracer.cat_path_hash]
-            obfuscated_txn_info = obfuscator.obfuscate raw_txn_info.to_json
+            obfuscated_txn_info = obfuscator.obfuscate(raw_txn_info.to_json)
           end
 
           NewRelic::Agent::Messaging.wrap_message_broker_consume_transaction(
@@ -472,18 +472,18 @@ module NewRelic
         raw_txn_info = nil
         obfuscated_txn_info = nil
 
-        tap = mock 'tap'
-        tap.expects :tap
+        tap = mock('tap')
+        tap.expects(:tap)
 
-        with_config :"cross_application_tracer.enabled" => true,
+        with_config(:"cross_application_tracer.enabled" => true,
           :cross_process_id => cross_process_id,
           :'distributed_tracing.enabled' => false,
           :trusted_account_ids => [321],
-          :encoding_key => "abc" do
-          in_transaction "test_txn" do |txn|
-            obfuscated_id = obfuscator.obfuscate cross_process_id
+          :encoding_key => "abc") do
+          in_transaction("test_txn") do |txn|
+            obfuscated_id = obfuscator.obfuscate(cross_process_id)
             raw_txn_info = [guid, false, guid, txn.distributed_tracer.cat_path_hash]
-            obfuscated_txn_info = obfuscator.obfuscate raw_txn_info.to_json
+            obfuscated_txn_info = obfuscator.obfuscate(raw_txn_info.to_json)
           end
 
           Messaging.wrap_message_broker_consume_transaction(

--- a/test/new_relic/agent/method_tracer_params_test.rb
+++ b/test/new_relic/agent/method_tracer_params_test.rb
@@ -123,7 +123,7 @@ class NewRelic::Agent::MethodTracerParamsTest < Minitest::Test
   def assert_common_tracing_behavior traced_class
     assert_expected_results traced_class
     refute_deprecation_warnings traced_class
-    call_expecting_warning_after_ruby_26 traced_class
+    call_expecting_warning_after_ruby_26(traced_class)
   end
 
   [["untraced_methods", UntracedMethods],

--- a/test/new_relic/agent/method_tracer_test.rb
+++ b/test/new_relic/agent/method_tracer_test.rb
@@ -41,7 +41,7 @@ module TestModuleWithLog
   class << self
     def other_method
       # just here to be traced
-      log "12345"
+      log("12345")
     end
 
     def log(msg)
@@ -120,7 +120,7 @@ class NewRelic::Agent::MethodTracerTest < Minitest::Test
 
     in_transaction do
       self.class.trace_execution_scoped(metric) do
-        advance_process_time 0.05
+        advance_process_time(0.05)
       end
     end
 
@@ -129,7 +129,7 @@ class NewRelic::Agent::MethodTracerTest < Minitest::Test
 
   def test_trace_execution_scoped_with_no_metrics_skips_out
     self.class.trace_execution_scoped([]) do
-      advance_process_time 0.05
+      advance_process_time(0.05)
     end
 
     assert_metrics_recorded_exclusive(['Supportability/API/trace_execution_scoped'])
@@ -148,13 +148,13 @@ class NewRelic::Agent::MethodTracerTest < Minitest::Test
 
   def test_add_method_tracer
     @metric_name = METRIC
-    self.class.add_method_tracer :method_to_be_traced, METRIC
+    self.class.add_method_tracer(:method_to_be_traced, METRIC)
     in_transaction do
-      method_to_be_traced 1, 2, 3, true, METRIC
+      method_to_be_traced(1, 2, 3, true, METRIC)
     end
 
     begin
-      self.class.remove_method_tracer :method_to_be_traced
+      self.class.remove_method_tracer(:method_to_be_traced)
     rescue RuntimeError
       # ignore 'no tracer' errors from remove method tracer
     end
@@ -163,7 +163,7 @@ class NewRelic::Agent::MethodTracerTest < Minitest::Test
   end
 
   def test_add_method_tracer__default
-    self.class.add_method_tracer :simple_method
+    self.class.add_method_tracer(:simple_method)
 
     in_transaction do
       simple_method
@@ -251,9 +251,9 @@ class NewRelic::Agent::MethodTracerTest < Minitest::Test
   end
 
   def test_add_method_tracer__reentry
-    self.class.add_method_tracer :simple_method
-    self.class.add_method_tracer :simple_method
-    self.class.add_method_tracer :simple_method
+    self.class.add_method_tracer(:simple_method)
+    self.class.add_method_tracer(:simple_method)
+    self.class.add_method_tracer(:simple_method)
 
     in_transaction do
       simple_method
@@ -265,7 +265,7 @@ class NewRelic::Agent::MethodTracerTest < Minitest::Test
 
   def test_add_method_tracer_keyword_args
     # Test we are not raising errors in e.g. Ruby 2.7
-    self.class.add_method_tracer :method_with_kwargs
+    self.class.add_method_tracer(:method_with_kwargs)
 
     in_transaction do
       _out, err = capture_io do
@@ -278,19 +278,19 @@ class NewRelic::Agent::MethodTracerTest < Minitest::Test
 
   def test_method_traced?
     assert !self.class.method_traced?(:method_to_be_traced)
-    self.class.add_method_tracer :method_to_be_traced, METRIC
+    self.class.add_method_tracer(:method_to_be_traced, METRIC)
     assert self.class.method_traced?(:method_to_be_traced)
     begin
-      self.class.remove_method_tracer :method_to_be_traced
+      self.class.remove_method_tracer(:method_to_be_traced)
     rescue RuntimeError
       # ignore 'no tracer' errors from remove method tracer
     end
   end
 
   def test_tt_only
-    self.class.add_method_tracer :method_c1, "c1", :push_scope => true
-    self.class.add_method_tracer :method_c2, "c2", :metric => false
-    self.class.add_method_tracer :method_c3, "c3", :push_scope => false
+    self.class.add_method_tracer(:method_c1, "c1", :push_scope => true)
+    self.class.add_method_tracer(:method_c2, "c2", :metric => false)
+    self.class.add_method_tracer(:method_c3, "c3", :push_scope => false)
 
     in_transaction do
       method_c1
@@ -301,8 +301,8 @@ class NewRelic::Agent::MethodTracerTest < Minitest::Test
   end
 
   def test_nested_scope_tracer
-    Insider.add_method_tracer :catcher, "catcher", :push_scope => true
-    Insider.add_method_tracer :thrower, "thrower", :push_scope => true
+    Insider.add_method_tracer(:catcher, "catcher", :push_scope => true)
+    Insider.add_method_tracer(:thrower, "thrower", :push_scope => true)
 
     mock = Insider.new(@stats_engine)
 
@@ -322,15 +322,15 @@ class NewRelic::Agent::MethodTracerTest < Minitest::Test
 
   def test_add_same_tracer_twice
     @metric_name = METRIC
-    self.class.add_method_tracer :method_to_be_traced, METRIC
-    self.class.add_method_tracer :method_to_be_traced, METRIC
+    self.class.add_method_tracer(:method_to_be_traced, METRIC)
+    self.class.add_method_tracer(:method_to_be_traced, METRIC)
 
     in_transaction do
-      method_to_be_traced 1, 2, 3, true, METRIC
+      method_to_be_traced(1, 2, 3, true, METRIC)
     end
 
     begin
-      self.class.remove_method_tracer :method_to_be_traced
+      self.class.remove_method_tracer(:method_to_be_traced)
     rescue RuntimeError
       # ignore 'no tracer' errors from remove method tracer
     end
@@ -342,14 +342,14 @@ class NewRelic::Agent::MethodTracerTest < Minitest::Test
     metric_code = -> (*args) { "#{args[0]}.#{args[1]}" }
     @metric_name = metric_code
     expected_metric = "1.2"
-    self.class.add_method_tracer :method_to_be_traced, metric_code
+    self.class.add_method_tracer(:method_to_be_traced, metric_code)
 
     in_transaction do
-      method_to_be_traced 1, 2, 3, true, expected_metric
+      method_to_be_traced(1, 2, 3, true, expected_metric)
     end
 
     begin
-      self.class.remove_method_tracer :method_to_be_traced
+      self.class.remove_method_tracer(:method_to_be_traced)
     rescue RuntimeError
       # ignore 'no tracer' errors from remove method tracer
     end
@@ -358,10 +358,10 @@ class NewRelic::Agent::MethodTracerTest < Minitest::Test
   end
 
   def test_trace_method_with_block
-    self.class.add_method_tracer :method_with_block, METRIC
+    self.class.add_method_tracer(:method_with_block, METRIC)
     in_transaction do
       method_with_block(1, 2, 3, true, METRIC) do
-        advance_process_time 0.1
+        advance_process_time(0.1)
       end
     end
 
@@ -369,10 +369,10 @@ class NewRelic::Agent::MethodTracerTest < Minitest::Test
   end
 
   def test_remove
-    self.class.add_method_tracer :method_to_be_traced, METRIC
-    self.class.remove_method_tracer :method_to_be_traced
+    self.class.add_method_tracer(:method_to_be_traced, METRIC)
+    self.class.remove_method_tracer(:method_to_be_traced)
 
-    method_to_be_traced 1, 2, 3, false, METRIC
+    method_to_be_traced(1, 2, 3, false, METRIC)
 
     assert_metrics_not_recorded METRIC
   end
@@ -380,8 +380,8 @@ class NewRelic::Agent::MethodTracerTest < Minitest::Test
   def test_multiple_metrics__scoped
     metrics = %w[first second third]
     in_transaction do
-      self.class.trace_execution_scoped metrics do
-        advance_process_time 0.05
+      self.class.trace_execution_scoped(metrics) do
+        advance_process_time(0.05)
       end
     end
 
@@ -394,8 +394,8 @@ class NewRelic::Agent::MethodTracerTest < Minitest::Test
 
   def test_multiple_metrics__unscoped
     metrics = %w[first second third]
-    self.class.trace_execution_unscoped metrics do
-      advance_process_time 0.05
+    self.class.trace_execution_unscoped(metrics) do
+      advance_process_time(0.05)
     end
 
     assert_metrics_recorded({
@@ -423,12 +423,12 @@ class NewRelic::Agent::MethodTracerTest < Minitest::Test
 
   def test_add_multiple_tracers
     in_transaction('test_txn') do
-      self.class.add_method_tracer :method_to_be_traced, 'XX', :push_scope => false
-      method_to_be_traced 1, 2, 3, true, nil
-      self.class.remove_method_tracer :method_to_be_traced
-      method_to_be_traced 1, 2, 3, true, nil
-      self.class.add_method_tracer :method_to_be_traced, 'YY'
-      method_to_be_traced 1, 2, 3, true, 'YY'
+      self.class.add_method_tracer(:method_to_be_traced, 'XX', :push_scope => false)
+      method_to_be_traced(1, 2, 3, true, nil)
+      self.class.remove_method_tracer(:method_to_be_traced)
+      method_to_be_traced(1, 2, 3, true, nil)
+      self.class.add_method_tracer(:method_to_be_traced, 'YY')
+      method_to_be_traced(1, 2, 3, true, 'YY')
     end
 
     assert_metrics_recorded({
@@ -438,8 +438,8 @@ class NewRelic::Agent::MethodTracerTest < Minitest::Test
 
   def test_add_multiple_metrics
     in_transaction('test_txn') do
-      self.class.add_method_tracer :method_to_be_traced, ['XX', 'YY', -> (*) { 'ZZ' }]
-      method_to_be_traced 1, 2, 3, true, nil
+      self.class.add_method_tracer(:method_to_be_traced, ['XX', 'YY', -> (*) { 'ZZ' }])
+      method_to_be_traced(1, 2, 3, true, nil)
     end
 
     assert_metrics_recorded([
@@ -472,7 +472,7 @@ class NewRelic::Agent::MethodTracerTest < Minitest::Test
   def test_method_tracer_on_basic_object
     proxy = MyProxyClass.new
 
-    in_transaction 'test_txn' do
+    in_transaction('test_txn') do
       proxy.hello
     end
 
@@ -480,11 +480,11 @@ class NewRelic::Agent::MethodTracerTest < Minitest::Test
   end
 
   def trace_no_push_scope
-    in_transaction 'test_txn' do
-      self.class.add_method_tracer :method_to_be_traced, 'X', :push_scope => false
-      method_to_be_traced 1, 2, 3, true, nil
-      self.class.remove_method_tracer :method_to_be_traced
-      method_to_be_traced 1, 2, 3, false, 'X'
+    in_transaction('test_txn') do
+      self.class.add_method_tracer(:method_to_be_traced, 'X', :push_scope => false)
+      method_to_be_traced(1, 2, 3, true, nil)
+      self.class.remove_method_tracer(:method_to_be_traced)
+      method_to_be_traced(1, 2, 3, false, 'X')
     end
 
     assert_metrics_not_recorded ['X', 'test_txn']
@@ -497,14 +497,14 @@ class NewRelic::Agent::MethodTracerTest < Minitest::Test
   # =======================================================
   # test methods to be traced
   def method_to_be_traced(x, y, z, is_traced, expected_metric)
-    advance_process_time 0.05
+    advance_process_time(0.05)
     assert x == 1
     assert y == 2
     assert z == 3
   end
 
   def method_with_block(x, y, z, is_traced, expected_metric, &block)
-    advance_process_time 0.05
+    advance_process_time(0.05)
     assert x == 1
     assert y == 2
     assert z == 3
@@ -512,7 +512,7 @@ class NewRelic::Agent::MethodTracerTest < Minitest::Test
   end
 
   def method_with_kwargs(arg1, arg2: true)
-    advance_process_time 0.05
+    advance_process_time(0.05)
     arg1 == arg2
   end
 

--- a/test/new_relic/agent/monitors/cross_app_monitor_test.rb
+++ b/test/new_relic/agent/monitors/cross_app_monitor_test.rb
@@ -61,13 +61,13 @@ module NewRelic::Agent
     def test_adds_response_header
       Transaction.any_instance.stubs(:queue_time).returns(QUEUE_TIME)
 
-      when_request_runs for_id(REQUEST_CROSS_APP_ID), 'transaction', APP_TIME
+      when_request_runs(for_id(REQUEST_CROSS_APP_ID), 'transaction', APP_TIME)
 
       assert_equal [AGENT_CROSS_APP_ID, TRANSACTION_NAME, QUEUE_TIME, APP_TIME, -1, TRANSACTION_GUID, false], unpacked_response
     end
 
     def test_encodes_transaction_name
-      when_request_runs for_id(REQUEST_CROSS_APP_ID), %("'goo), APP_TIME
+      when_request_runs(for_id(REQUEST_CROSS_APP_ID), %("'goo), APP_TIME)
       assert_equal "\"'goo", unpacked_response[TRANSACTION_NAME_POSITION]
     end
 

--- a/test/new_relic/agent/monitors/distributed_trace_monitor_test.rb
+++ b/test/new_relic/agent/monitors/distributed_trace_monitor_test.rb
@@ -36,16 +36,16 @@ module NewRelic::Agent
       def after_notify_event rack_scheme = nil
         payload = nil
 
-        in_transaction "referring_txn" do |txn|
+        in_transaction("referring_txn") do |txn|
           payload = txn.distributed_tracer.create_distributed_trace_payload
         end
 
         env = {NEWRELIC_TRACE_KEY => payload.http_safe}
         env['rack.url_scheme'] = rack_scheme if rack_scheme
 
-        in_transaction "receiving_txn" do |txn|
+        in_transaction("receiving_txn") do |txn|
           @events.notify(:before_call, env)
-          yield txn
+          yield(txn)
         end
       end
 
@@ -56,13 +56,13 @@ module NewRelic::Agent
       end
 
       def test_sets_transport_type_for_http_scheme
-        after_notify_event 'http' do |txn|
+        after_notify_event('http') do |txn|
           assert_equal 'HTTP', txn.distributed_tracer.caller_transport_type
         end
       end
 
       def test_sets_transport_type_for_https_scheme
-        after_notify_event 'https' do |txn|
+        after_notify_event('https') do |txn|
           assert_equal 'HTTPS', txn.distributed_tracer.caller_transport_type
         end
       end

--- a/test/new_relic/agent/monitors/distributed_tracing_monitor_test.rb
+++ b/test/new_relic/agent/monitors/distributed_tracing_monitor_test.rb
@@ -46,8 +46,8 @@ module NewRelic::Agent
       end
 
       def test_invokes_accept_incoming_request
-        with_notify_after_config distributed_tracing_enabled do
-          in_transaction "receiving_txn" do |receiving_txn|
+        with_notify_after_config(distributed_tracing_enabled) do
+          in_transaction("receiving_txn") do |receiving_txn|
             receiving_txn.distributed_tracer.expects(:accept_incoming_request).at_least_once
             @events.notify(:before_call, {})
           end
@@ -55,8 +55,8 @@ module NewRelic::Agent
       end
 
       def test_invokes_accept_incoming_request_when_cat_enabled_too
-        with_notify_after_config cat_and_distributed_tracing_enabled do
-          in_transaction "receiving_txn" do |receiving_txn|
+        with_notify_after_config(cat_and_distributed_tracing_enabled) do
+          in_transaction("receiving_txn") do |receiving_txn|
             receiving_txn.distributed_tracer.expects(:accept_incoming_request).at_least_once
             @events.notify(:before_call, {})
           end
@@ -64,8 +64,8 @@ module NewRelic::Agent
       end
 
       def test_skips_accept_incoming_request
-        with_notify_after_config distributed_tracing_disabled do
-          in_transaction "receiving_txn" do |receiving_txn|
+        with_notify_after_config(distributed_tracing_disabled) do
+          in_transaction("receiving_txn") do |receiving_txn|
             receiving_txn.distributed_tracer.expects(:accept_incoming_request).never
             @events.notify(:before_call, {})
           end

--- a/test/new_relic/agent/monitors/trace_context_request_monitor_test.rb
+++ b/test/new_relic/agent/monitors/trace_context_request_monitor_test.rb
@@ -35,7 +35,7 @@ module NewRelic
       def test_accepts_trace_context
         parent_txn, carrier = build_parent_transaction_headers
 
-        child_txn = in_transaction "receiving_txn" do |txn|
+        child_txn = in_transaction("receiving_txn") do |txn|
           @events.notify(:before_call, carrier)
         end
 
@@ -46,7 +46,7 @@ module NewRelic
 
       def test_accepts_trace_context_with_trace_parent_and_no_trace_state
         carrier = {'HTTP_TRACEPARENT' => '00-12345678901234567890123456789012-1234567890123456-01'}
-        txn = in_transaction "receiving_txn" do |txn|
+        txn = in_transaction("receiving_txn") do |txn|
           @events.notify(:before_call, carrier)
         end
 
@@ -58,7 +58,7 @@ module NewRelic
           'HTTP_TRACEPARENT' => '00-12345678901234567890123456789012-1234567890123456-00',
           'HTTP_TRACESTATE' => ''
         }
-        txn = in_transaction "receiving_txn" do |txn|
+        txn = in_transaction("receiving_txn") do |txn|
           @events.notify(:before_call, carrier)
         end
 
@@ -70,7 +70,7 @@ module NewRelic
           'HTTP_TRACEPARENT' => '00-00000000000000000000000000000000-1234567890123456-00',
           'HTTP_TRACESTATE' => ''
         }
-        txn = in_transaction "receiving_txn" do |txn|
+        txn = in_transaction("receiving_txn") do |txn|
           @events.notify(:before_call, carrier)
         end
 
@@ -84,7 +84,7 @@ module NewRelic
 
       def test_does_not_accept_trace_context_if_no_trace_context_headers
         carrier = {}
-        child_txn = in_transaction 'child' do |txn|
+        child_txn = in_transaction('child') do |txn|
           @events.notify(:before_call, carrier)
         end
         assert_nil child_txn.distributed_tracer.trace_context_header_data
@@ -96,7 +96,7 @@ module NewRelic
           'HTTP_TRACEPARENT' => 'alkjhdsfasdf'
         }
 
-        child_txn = in_transaction 'child' do |txn|
+        child_txn = in_transaction('child') do |txn|
           @events.notify(:before_call, carrier)
         end
 
@@ -108,10 +108,10 @@ module NewRelic
 
         # stubbing contexted allows trace_context_active? to pass
         # which, in turn, allows us to insert a trace_context header here.
-        parent_txn = in_transaction "referring_txn" do |txn|
+        parent_txn = in_transaction("referring_txn") do |txn|
           Agent.instance.stubs(:connected?).returns(true)
           txn.sampled = true
-          txn.distributed_tracer.insert_trace_context_header carrier, NewRelic::FORMAT_RACK
+          txn.distributed_tracer.insert_trace_context_header(carrier, NewRelic::FORMAT_RACK)
           Agent.instance.unstub(:connected?)
         end
         [parent_txn, carrier]

--- a/test/new_relic/agent/new_relic_service/json_marshaller_test.rb
+++ b/test/new_relic/agent/new_relic_service/json_marshaller_test.rb
@@ -18,7 +18,7 @@ module NewRelic
 
         def test_default_encoder_is_identity_with_simple_compression_enabled
           marshaller = JsonMarshaller.new
-          with_config :simple_compression => true do
+          with_config(:simple_compression => true) do
             assert_equal Encoders::Identity, marshaller.default_encoder
           end
         end

--- a/test/new_relic/agent/new_relic_service_test.rb
+++ b/test/new_relic/agent/new_relic_service_test.rb
@@ -222,7 +222,7 @@ class NewRelicServiceTest < Minitest::Test
 
   def test_initialize_uses_license_key_from_manual_start
     service = NewRelic::Agent::NewRelicService.new
-    NewRelic::Agent.manual_start :license_key => "geronimo"
+    NewRelic::Agent.manual_start(:license_key => "geronimo")
 
     assert_equal 'geronimo', service.send(:license_key)
     NewRelic::Agent.shutdown
@@ -427,9 +427,9 @@ class NewRelicServiceTest < Minitest::Test
     dummy_rsp = 'met rick date uhh'
     @http_handle.respond_to(:metric_data, dummy_rsp)
 
-    advance_process_time 10
+    advance_process_time(10)
     stats_hash = NewRelic::Agent::StatsHash.new
-    advance_process_time 1
+    advance_process_time(1)
     stats_hash.harvested_at = Process.clock_gettime(Process::CLOCK_REALTIME)
 
     @service.metric_data(stats_hash)
@@ -548,7 +548,7 @@ class NewRelicServiceTest < Minitest::Test
   def self.check_status_code_handling(expected_exceptions)
     expected_exceptions.each do |status_code, exception_type|
       method_name = "test_#{status_code}_raises_#{exception_type.name.split('::').last}"
-      define_method method_name do
+      define_method(method_name) do
         @http_handle.respond_to(:metric_data, 'payload', :code => status_code)
         assert_raises exception_type do
           stats_hash = NewRelic::Agent::StatsHash.new
@@ -1155,7 +1155,7 @@ class NewRelicServiceTest < Minitest::Test
         raise response if response.kind_of?(Exception)
         response
       else
-        create_response_mock 'not found', :code => 404
+        create_response_mock('not found', :code => 404)
       end
     end
 

--- a/test/new_relic/agent/payload_metric_mapping_test.rb
+++ b/test/new_relic/agent/payload_metric_mapping_test.rb
@@ -15,57 +15,57 @@ module NewRelic
       end
 
       def test_maps_datastore_all
-        @metrics.record_unscoped 'Datastore/all' do |stats|
+        @metrics.record_unscoped('Datastore/all') do |stats|
           stats.total_call_time = 42
           stats.call_count = 3
         end
 
         result = {}
-        PayloadMetricMapping.append_mapped_metrics @metrics, result
+        PayloadMetricMapping.append_mapped_metrics(@metrics, result)
 
         assert_equal 42, result['databaseDuration']
         assert_equal 3, result['databaseCallCount']
       end
 
       def test_maps_gc_transaction_all
-        @metrics.record_unscoped 'GC/Transaction/all', 42
+        @metrics.record_unscoped('GC/Transaction/all', 42)
 
         result = {}
-        PayloadMetricMapping.append_mapped_metrics @metrics, result
+        PayloadMetricMapping.append_mapped_metrics(@metrics, result)
 
         assert_equal 42, result['gcCumulative']
       end
 
       def test_maps_web_frontend_queue_time
-        @metrics.record_unscoped 'WebFrontend/QueueTime', 42
+        @metrics.record_unscoped('WebFrontend/QueueTime', 42)
 
         result = {}
-        PayloadMetricMapping.append_mapped_metrics @metrics, result
+        PayloadMetricMapping.append_mapped_metrics(@metrics, result)
 
         assert_equal 42, result['queueDuration']
       end
 
       def test_maps_external_all_web
-        @metrics.record_unscoped 'External/allWeb' do |stats|
+        @metrics.record_unscoped('External/allWeb') do |stats|
           stats.total_call_time = 42
           stats.call_count = 3
         end
 
         result = {}
-        PayloadMetricMapping.append_mapped_metrics @metrics, result
+        PayloadMetricMapping.append_mapped_metrics(@metrics, result)
 
         assert_equal 42, result['externalDuration']
         assert_equal 3, result['externalCallCount']
       end
 
       def test_maps_external_all_other
-        @metrics.record_unscoped 'External/allOther' do |stats|
+        @metrics.record_unscoped('External/allOther') do |stats|
           stats.total_call_time = 42
           stats.call_count = 3
         end
 
         result = {}
-        PayloadMetricMapping.append_mapped_metrics @metrics, result
+        PayloadMetricMapping.append_mapped_metrics(@metrics, result)
 
         assert_equal 42, result['externalDuration']
         assert_equal 3, result['externalCallCount']

--- a/test/new_relic/agent/pipe_channel_manager_test.rb
+++ b/test/new_relic/agent/pipe_channel_manager_test.rb
@@ -85,39 +85,39 @@ class NewRelic::Agent::PipeChannelManagerTest < Minitest::Test
         :request_params => {:x => 'y'})
       NewRelic::Agent.agent.merge_data_for_endpoint(:error_data, sampler.error_trace_aggregator.harvest!)
 
-      errors = NewRelic::Agent.agent.error_collector.error_trace_aggregator.instance_variable_get :@errors
+      errors = NewRelic::Agent.agent.error_collector.error_trace_aggregator.instance_variable_get(:@errors)
       assert_equal(1, errors.size)
 
       start_listener_with_pipe(668)
 
       run_child(668) do
         NewRelic::Agent.after_fork
-        new_sampler = NewRelic::Agent::ErrorCollector.new NewRelic::Agent.instance.events
+        new_sampler = NewRelic::Agent::ErrorCollector.new(NewRelic::Agent.instance.events)
         new_sampler.notice_error(Exception.new("new message"), :uri => '/myurl/',
           :metric => 'path', :referer => 'test_referer',
           :request_params => {:x => 'y'})
         service = NewRelic::Agent::PipeService.new(668)
         service.error_data(new_sampler.error_trace_aggregator.harvest!)
       end
-      errors = NewRelic::Agent.agent.error_collector.error_trace_aggregator.instance_variable_get :@errors
+      errors = NewRelic::Agent.agent.error_collector.error_trace_aggregator.instance_variable_get(:@errors)
       assert_equal(2, errors.size)
     end
 
     def test_listener_merges_analytics_events
       transaction_event_aggregator = NewRelic::Agent.agent.transaction_event_aggregator
-      reset_lifetime_counts! transaction_event_aggregator
+      reset_lifetime_counts!(transaction_event_aggregator)
 
       start_listener_with_pipe(699)
       NewRelic::Agent.agent.stubs(:connected?).returns(true)
       run_child(699) do
         NewRelic::Agent.after_fork(:report_to_channel => 699)
-        transaction_event_aggregator.record event: NewRelic::Agent::TransactionEventPrimitive.create({
+        transaction_event_aggregator.record(event: NewRelic::Agent::TransactionEventPrimitive.create({
           :start_timestamp => Process.clock_gettime(Process::CLOCK_REALTIME),
           :name => 'whatever',
           :duration => 10,
           :type => :controller,
           :priority => 0.5
-        })
+        }))
         NewRelic::Agent.agent.send(:transmit_analytic_event_data)
       end
 
@@ -129,7 +129,7 @@ class NewRelic::Agent::PipeChannelManagerTest < Minitest::Test
 
     def test_listener_merges_error_events
       error_event_aggregator = NewRelic::Agent.agent.error_collector.error_event_aggregator
-      reset_lifetime_counts! error_event_aggregator
+      reset_lifetime_counts!(error_event_aggregator)
 
       sampler = NewRelic::Agent.agent.error_collector
       sampler.notice_error(Exception.new("message"), :uri => '/myurl/',
@@ -140,7 +140,7 @@ class NewRelic::Agent::PipeChannelManagerTest < Minitest::Test
 
       run_child(668) do
         NewRelic::Agent.after_fork
-        new_sampler = NewRelic::Agent::ErrorCollector.new NewRelic::Agent.instance.events
+        new_sampler = NewRelic::Agent::ErrorCollector.new(NewRelic::Agent.instance.events)
         new_sampler.notice_error(Exception.new("new message"), :uri => '/myurl/',
           :metric => 'path', :referer => 'test_referer',
           :request_params => {:x => 'y'})
@@ -300,7 +300,7 @@ class NewRelic::Agent::PipeChannelManagerTest < Minitest::Test
 
     Process.wait(pid)
     until pipe_finished?(channel_id)
-      sleep 0.01
+      sleep(0.01)
     end
   end
 
@@ -309,14 +309,14 @@ class NewRelic::Agent::PipeChannelManagerTest < Minitest::Test
 
     wake_mock = MiniTest::Mock.new
     out_mock = MiniTest::Mock.new
-    4.times { wake_mock.expect :out, out_mock }
+    4.times { wake_mock.expect(:out, out_mock) }
     error_stub = Proc.new { |msg| desired_error_messages_seen += 1 if msg =~ /^(?:Issue while|Ready pipes)/ }
     ready_pipes_mock = MiniTest::Mock.new
 
-    ::IO.stub :select, [ready_pipes_mock] do
-      ready_pipes_mock.expect :each, nil
-      ready_pipes_mock.expect :map, []
-      ready_pipes_mock.expect :include?, true do
+    ::IO.stub(:select, [ready_pipes_mock]) do
+      ready_pipes_mock.expect(:each, nil)
+      ready_pipes_mock.expect(:map, [])
+      ready_pipes_mock.expect(:include?, true) do
         true
       end
 
@@ -330,7 +330,7 @@ class NewRelic::Agent::PipeChannelManagerTest < Minitest::Test
         raise error
       end
 
-      NewRelic::Agent.logger.stub :error, error_stub do
+      NewRelic::Agent.logger.stub(:error, error_stub) do
         listener = NewRelic::Agent::PipeChannelManager::Listener.new
         listener.instance_variable_set(:@wake, wake_mock)
         listener.start
@@ -342,14 +342,14 @@ class NewRelic::Agent::PipeChannelManagerTest < Minitest::Test
   end
 
   def assert_lifetime_counts container, value
-    buffer = container.instance_variable_get :@buffer
+    buffer = container.instance_variable_get(:@buffer)
     assert_equal value, buffer.captured_lifetime
     assert_equal value, buffer.seen_lifetime
   end
 
   def reset_lifetime_counts! container
-    buffer = container.instance_variable_get :@buffer
-    buffer.instance_variable_set :@captured_lifetime, 0
-    buffer.instance_variable_set :@seen_lifetime, 0
+    buffer = container.instance_variable_get(:@buffer)
+    buffer.instance_variable_set(:@captured_lifetime, 0)
+    buffer.instance_variable_set(:@seen_lifetime, 0)
   end
 end

--- a/test/new_relic/agent/priority_sampled_buffer_test.rb
+++ b/test/new_relic/agent/priority_sampled_buffer_test.rb
@@ -150,9 +150,9 @@ module NewRelic::Agent
     end
 
     def test_append_with_zero_capacity
-      buffer = PrioritySampledBuffer.new 0
+      buffer = PrioritySampledBuffer.new(0)
 
-      buffer.append event: create_event
+      buffer.append(event: create_event)
 
       assert_equal 1, buffer.num_dropped
       assert_equal 0, buffer.size
@@ -193,8 +193,8 @@ module NewRelic::Agent
       }
 
       metadata = buffer.metadata
-      metadata.delete :captured_lifetime
-      metadata.delete :seen_lifetime
+      metadata.delete(:captured_lifetime)
+      metadata.delete(:seen_lifetime)
 
       assert_equal expected, metadata
     end

--- a/test/new_relic/agent/range_extensions_test.rb
+++ b/test/new_relic/agent/range_extensions_test.rb
@@ -10,45 +10,45 @@ module NewRelic
   module Agent
     class RangeExtensionsTest < Minitest::Test
       def test_intersects_truthy_when_overlapping
-        assert RangeExtensions.intersects? (1..3), (3..5)
+        assert RangeExtensions.intersects?((1..3), (3..5))
       end
 
       def test_intersects_false_when_disjoint
-        refute RangeExtensions.intersects? (1...3), (3..5)
+        refute RangeExtensions.intersects?((1...3), (3..5))
       end
 
       def test_merge_merges_intersecting_ranges
-        merged = RangeExtensions.merge (1..5), (3..8)
+        merged = RangeExtensions.merge((1..5), (3..8))
         assert_equal (1..8), merged
       end
 
       def test_merge_nil_for_disjoint_ranges
-        merged = RangeExtensions.merge (1...3), (3..5)
+        merged = RangeExtensions.merge((1...3), (3..5))
         assert_nil merged
       end
 
       def test_merge_or_append_merges_intersecting_ranges
-        result = RangeExtensions.merge_or_append (3..8), [(1..5), (9..13)]
+        result = RangeExtensions.merge_or_append((3..8), [(1..5), (9..13)])
         assert_equal [(1..8), (9..13)], result
       end
 
       def test_merge_or_append_appends_disjoint_ranges
-        result = RangeExtensions.merge_or_append (6..8), [(1..5), (9..13)]
+        result = RangeExtensions.merge_or_append((6..8), [(1..5), (9..13)])
         assert_equal [(1..5), (9..13), (6..8)], result
       end
 
       def test_compute_overlap
-        result = RangeExtensions.compute_overlap 0..10, [-4..2, 6..7, 9..15]
+        result = RangeExtensions.compute_overlap(0..10, [-4..2, 6..7, 9..15])
         assert_equal 4, result
       end
 
       def test_compute_overlap_disjoint
-        result = RangeExtensions.compute_overlap 20..30, [2..4, 6..7, 9..15]
+        result = RangeExtensions.compute_overlap(20..30, [2..4, 6..7, 9..15])
         assert_equal 0, result
       end
 
       def test_compute_overlap_intersecting
-        result = RangeExtensions.compute_overlap 0..10, [0..5, 5..8, 8..10]
+        result = RangeExtensions.compute_overlap(0..10, [0..5, 5..8, 8..10])
         assert_equal 10, result
       end
     end

--- a/test/new_relic/agent/rpm_agent_test.rb
+++ b/test/new_relic/agent/rpm_agent_test.rb
@@ -36,7 +36,7 @@ class NewRelic::Agent::RpmAgentTest < Minitest::Test
 
   def test_startup_shutdown_real
     with_config(:agent_enabled => true, :monitor_mode => true) do
-      NewRelic::Agent.manual_start :monitor_mode => true, :license_key => ('x' * 40)
+      NewRelic::Agent.manual_start(:monitor_mode => true, :license_key => ('x' * 40))
       agent = NewRelic::Agent.instance
       assert agent.started?
       agent.shutdown
@@ -47,27 +47,27 @@ class NewRelic::Agent::RpmAgentTest < Minitest::Test
   def test_manual_start
     NewRelic::Agent.instance.expects(:connect).once
     NewRelic::Agent.instance.expects(:start_worker_thread).once
-    NewRelic::Agent.instance.instance_variable_set :@started, nil
-    NewRelic::Agent.manual_start :monitor_mode => true, :license_key => ('x' * 40)
+    NewRelic::Agent.instance.instance_variable_set(:@started, nil)
+    NewRelic::Agent.manual_start(:monitor_mode => true, :license_key => ('x' * 40))
     NewRelic::Agent.shutdown
   end
 
   def test_post_fork_handler
-    NewRelic::Agent.manual_start :monitor_mode => true, :license_key => ('x' * 40)
+    NewRelic::Agent.manual_start(:monitor_mode => true, :license_key => ('x' * 40))
     NewRelic::Agent.after_fork
     NewRelic::Agent.after_fork
     NewRelic::Agent.shutdown
   end
 
   def test_manual_overrides
-    NewRelic::Agent.manual_start :app_name => "testjobs"
+    NewRelic::Agent.manual_start(:app_name => "testjobs")
     assert_equal "testjobs", NewRelic::Agent.config[:app_name][0]
     NewRelic::Agent.shutdown
   end
 
   def test_agent_restart
-    NewRelic::Agent.manual_start :app_name => "noapp"
-    NewRelic::Agent.manual_start :app_name => "testjobs"
+    NewRelic::Agent.manual_start(:app_name => "noapp")
+    NewRelic::Agent.manual_start(:app_name => "testjobs")
     assert_equal "testjobs", NewRelic::Agent.config[:app_name][0]
     NewRelic::Agent.shutdown
   end

--- a/test/new_relic/agent/sampler_test.rb
+++ b/test/new_relic/agent/sampler_test.rb
@@ -20,7 +20,7 @@ class NewRelic::Agent::SamplerTest < Minitest::Test
 
   def test_inherited_should_append_subclasses_to_sampler_classes
     test_class = Class.new(NewRelic::Agent::Sampler)
-    sampler_classes = NewRelic::Agent::Sampler.instance_variable_get :@sampler_classes
+    sampler_classes = NewRelic::Agent::Sampler.instance_variable_get(:@sampler_classes)
     assert(sampler_classes.include?(test_class), "Sampler classes (#{sampler_classes.inspect}) does not include #{test_class.inspect}")
     # cleanup the sampler created above
     NewRelic::Agent::Sampler.instance_eval { @sampler_classes.delete(test_class) }

--- a/test/new_relic/agent/samplers/cpu_sampler_test.rb
+++ b/test/new_relic/agent/samplers/cpu_sampler_test.rb
@@ -19,13 +19,13 @@ class NewRelic::Agent::Samplers::CpuSamplerTest < Minitest::Test
 
   def test_correctly_detecting_jruby_support_for_correct_cpu_sampling
     if defined?(JRuby)
-      set_jruby_version_constant '1.6.8'
+      set_jruby_version_constant('1.6.8')
       refute_supported_on_platform
 
-      set_jruby_version_constant '1.7.0'
+      set_jruby_version_constant('1.7.0')
       assert_supported_on_platform
 
-      set_jruby_version_constant '1.7.4'
+      set_jruby_version_constant('1.7.4')
       assert_supported_on_platform
     else
       assert_supported_on_platform

--- a/test/new_relic/agent/samplers/memory_sampler_test.rb
+++ b/test/new_relic/agent/samplers/memory_sampler_test.rb
@@ -24,7 +24,7 @@ class NewRelic::Agent::Samplers::MemorySamplerTest < Minitest::Test
 
   def test_memory__linux
     return if RUBY_PLATFORM =~ /darwin/
-    NewRelic::Agent::Samplers::MemorySampler.any_instance.stubs(:platform).returns 'linux'
+    NewRelic::Agent::Samplers::MemorySampler.any_instance.stubs(:platform).returns('linux')
     stub_sampler_get_memory
     s = NewRelic::Agent::Samplers::MemorySampler.new
     s.poll
@@ -36,8 +36,8 @@ class NewRelic::Agent::Samplers::MemorySamplerTest < Minitest::Test
 
   def test_memory__solaris
     return if defined? JRuby
-    NewRelic::Agent::Samplers::MemorySampler.any_instance.stubs(:platform).returns 'solaris'
-    NewRelic::Agent::Samplers::MemorySampler::ShellPS.any_instance.stubs(:get_memory).returns 999
+    NewRelic::Agent::Samplers::MemorySampler.any_instance.stubs(:platform).returns('solaris')
+    NewRelic::Agent::Samplers::MemorySampler::ShellPS.any_instance.stubs(:get_memory).returns(999)
     s = NewRelic::Agent::Samplers::MemorySampler.new
     s.poll
     assert_metrics_recorded "Memory/Physical" => {:call_count => 1, :total_call_time => 999}
@@ -45,14 +45,14 @@ class NewRelic::Agent::Samplers::MemorySamplerTest < Minitest::Test
 
   def test_memory__windows
     return if defined? JRuby
-    NewRelic::Agent::Samplers::MemorySampler.any_instance.stubs(:platform).returns 'win32'
+    NewRelic::Agent::Samplers::MemorySampler.any_instance.stubs(:platform).returns('win32')
     assert_raises NewRelic::Agent::Sampler::Unsupported do
       NewRelic::Agent::Samplers::MemorySampler.new
     end
   end
 
   def test_memory__is_supported
-    NewRelic::Agent::Samplers::MemorySampler.stubs(:platform).returns 'windows'
+    NewRelic::Agent::Samplers::MemorySampler.stubs(:platform).returns('windows')
     assert !NewRelic::Agent::Samplers::MemorySampler.supported_on_this_platform? || defined? JRuby
   end
 
@@ -86,10 +86,10 @@ class NewRelic::Agent::Samplers::MemorySamplerTest < Minitest::Test
 
   def stub_sampler_get_memory
     if defined? JRuby
-      NewRelic::Agent::Samplers::MemorySampler::JavaHeapSampler.any_instance.stubs(:get_memory).returns 333
+      NewRelic::Agent::Samplers::MemorySampler::JavaHeapSampler.any_instance.stubs(:get_memory).returns(333)
     else
-      NewRelic::Agent::Samplers::MemorySampler::ShellPS.any_instance.stubs(:get_memory).returns 333
-      NewRelic::Agent::Samplers::MemorySampler::ProcStatus.any_instance.stubs(:get_memory).returns 333
+      NewRelic::Agent::Samplers::MemorySampler::ShellPS.any_instance.stubs(:get_memory).returns(333)
+      NewRelic::Agent::Samplers::MemorySampler::ProcStatus.any_instance.stubs(:get_memory).returns(333)
     end
   end
 end

--- a/test/new_relic/agent/span_event_aggregator_test.rb
+++ b/test/new_relic/agent/span_event_aggregator_test.rb
@@ -17,7 +17,7 @@ module NewRelic
 
         nr_freeze_process_time
         events = NewRelic::Agent.instance.events
-        @event_aggregator = SpanEventAggregator.new events
+        @event_aggregator = SpanEventAggregator.new(events)
       end
 
       def teardown
@@ -59,7 +59,7 @@ module NewRelic
           {}
         ]
 
-        @event_aggregator.record event: event
+        @event_aggregator.record(event: event)
       end
 
       def last_events
@@ -81,7 +81,7 @@ module NewRelic
       include NewRelic::CommonAggregatorTests
 
       def test_supportability_metrics_for_span_events
-        with_config aggregator.class.capacity_key => 5 do
+        with_config(aggregator.class.capacity_key => 5) do
           12.times { generate_event }
         end
 

--- a/test/new_relic/agent/span_event_primitive_test.rb
+++ b/test/new_relic/agent/span_event_primitive_test.rb
@@ -103,15 +103,15 @@ module NewRelic
           external_segment = nil
           in_transaction('test_txn') do |txn|
             external_segment = NewRelic::Agent::Tracer \
-              .start_external_request_segment library: "net/http",
+              .start_external_request_segment(library: "net/http",
                 uri: "http://docs.newrelic.com",
-                procedure: "GET"
+                procedure: "GET")
             payload = txn.distributed_tracer.create_distributed_trace_payload
           end
 
           in_transaction('test_txn2') do |txn|
             incoming_payload = payload.text
-            txn.distributed_tracer.accept_distributed_trace_payload incoming_payload
+            txn.distributed_tracer.accept_distributed_trace_payload(incoming_payload)
           end
 
           last_span_event = NewRelic::Agent.agent.span_event_aggregator.harvest![-1][-1]
@@ -126,8 +126,8 @@ module NewRelic
         def test_empty_error_message_can_override_previous_error_message_attribute
           begin
             with_segment do |segment|
-              segment.notice_error RuntimeError.new "oops!"
-              segment.notice_error StandardError.new
+              segment.notice_error(RuntimeError.new("oops!"))
+              segment.notice_error(StandardError.new)
               error_attributes = SpanEventPrimitive::error_attributes(segment)
               assert segment.noticed_error, "segment.noticed_error should NOT be nil!"
               assert_equal "StandardError", error_attributes["error.class"]
@@ -140,7 +140,7 @@ module NewRelic
         def test_includes_custom_attributes_in_event
           in_transaction do |txn|
             txn.current_segment.attributes.merge_custom_attributes('bing' => 2)
-            _, custom_attrs, _ = SpanEventPrimitive.for_segment txn.current_segment
+            _, custom_attrs, _ = SpanEventPrimitive.for_segment(txn.current_segment)
             assert_equal 2, custom_attrs['bing']
           end
         end
@@ -149,7 +149,7 @@ module NewRelic
           with_config('span_events.attributes.enabled' => false) do
             with_segment do |segment|
               segment.attributes.merge_custom_attributes('bing' => 2)
-              _, custom_attrs, _ = SpanEventPrimitive.for_segment segment
+              _, custom_attrs, _ = SpanEventPrimitive.for_segment(segment)
               assert_empty custom_attrs
             end
           end
@@ -158,7 +158,7 @@ module NewRelic
         def test_custom_attributes_in_event_cant_override_reserved_attributes
           with_segment do |segment|
             segment.attributes.merge_custom_attributes('type' => 'giraffe', 'duration' => 'hippo')
-            event, custom_attrs, _ = SpanEventPrimitive.for_segment segment
+            event, custom_attrs, _ = SpanEventPrimitive.for_segment(segment)
 
             assert_equal 'Span', event['type']
             assert_equal 0.0, event['duration']
@@ -185,9 +185,9 @@ module NewRelic
               :error => false,
               :priority => 0.123
             }
-            _, custom_txn_attrs, _ = TransactionEventPrimitive.create payload
+            _, custom_txn_attrs, _ = TransactionEventPrimitive.create(payload)
 
-            _, custom_span_attrs, _ = SpanEventPrimitive.for_segment segment
+            _, custom_span_attrs, _ = SpanEventPrimitive.for_segment(segment)
 
             assert_empty custom_txn_attrs
             assert_equal expected_span_attrs, custom_span_attrs
@@ -291,7 +291,7 @@ module NewRelic
                                                     function: function,
                                                     lineno: lineno,
                                                     namespace: namespace}
-            _intrinsics, _custom, agent_attributes = SpanEventPrimitive.for_segment txn.current_segment
+            _intrinsics, _custom, agent_attributes = SpanEventPrimitive.for_segment(txn.current_segment)
             assert_equal [filepath, function, lineno, namespace],
               agent_attributes.values_at('code.filepath',
                 'code.function',
@@ -302,7 +302,7 @@ module NewRelic
 
         def test_code_level_metrics_absent_if_unset
           in_transaction do |txn|
-            _intrinsics, _custom, agent_attributes = SpanEventPrimitive.for_segment txn.current_segment
+            _intrinsics, _custom, agent_attributes = SpanEventPrimitive.for_segment(txn.current_segment)
             existence = %w[code.filepath code.function code.lineno code.namespace].map do |attribute|
               agent_attributes.key?(attribute)
             end

--- a/test/new_relic/agent/span_events_test.rb
+++ b/test/new_relic/agent/span_events_test.rb
@@ -34,9 +34,9 @@ module NewRelic
         external_segment = nil
         transaction = in_transaction('test_txn') do |txn|
           external_segment = NewRelic::Agent::Tracer \
-            .start_external_request_segment library: "net/http",
+            .start_external_request_segment(library: "net/http",
               uri: "http://docs.newrelic.com",
-              procedure: "GET"
+              procedure: "GET")
           payload = txn.distributed_tracer.create_distributed_trace_payload
         end
 
@@ -51,14 +51,14 @@ module NewRelic
         external_segment = nil
         in_transaction('test_txn') do |txn|
           external_segment = NewRelic::Agent::Tracer \
-            .start_external_request_segment library: "net/http",
+            .start_external_request_segment(library: "net/http",
               uri: "http://docs.newrelic.com",
-              procedure: "GET"
+              procedure: "GET")
           payload = txn.distributed_tracer.create_distributed_trace_payload
         end
 
         in_transaction('test_txn2') do |txn|
-          txn.distributed_tracer.accept_distributed_trace_payload payload.text
+          txn.distributed_tracer.accept_distributed_trace_payload(payload.text)
         end
 
         last_span_events = NewRelic::Agent.agent.span_event_aggregator.harvest![1]

--- a/test/new_relic/agent/sql_sampler_test.rb
+++ b/test/new_relic/agent/sql_sampler_test.rb
@@ -71,7 +71,7 @@ class NewRelic::Agent::SqlSamplerTest < Minitest::Test
 
     sql = "select * from test"
     metric_name = "Database/test/select"
-    statement = NewRelic::Agent::Database::Statement.new sql, {:adapter => :mysql}
+    statement = NewRelic::Agent::Database::Statement.new(sql, {:adapter => :mysql})
 
     @sampler.notice_sql_statement(statement, metric_name, 1.5)
 
@@ -92,12 +92,12 @@ class NewRelic::Agent::SqlSamplerTest < Minitest::Test
     data = NewRelic::Agent::TransactionSqlData.new
     data.set_transaction_info("/c/a", 'guid')
     data.set_transaction_name("WebTransaction/Controller/c/a")
-    data.sql_data.concat [
+    data.sql_data.concat([
       NewRelic::Agent::SlowSql.new(NewRelic::Agent::Database::Statement.new("select * from test"), "Database/test/select", 1.5),
       NewRelic::Agent::SlowSql.new(NewRelic::Agent::Database::Statement.new("select * from test"), "Database/test/select", 1.2),
       NewRelic::Agent::SlowSql.new(NewRelic::Agent::Database::Statement.new("select * from test2"), "Database/test2/select", 1.1)
-    ]
-    @sampler.save_slow_sql data
+    ])
+    @sampler.save_slow_sql(data)
 
     assert_equal 2, @sampler.sql_traces.size
   end
@@ -108,8 +108,8 @@ class NewRelic::Agent::SqlSamplerTest < Minitest::Test
 
     sql_trace = NewRelic::Agent::SqlTrace.new(query, slow_sql, "tx_name", "uri")
 
-    sql_trace.aggregate NewRelic::Agent::SlowSql.new(NewRelic::Agent::Database::Statement.new(query), "Database/test/select", 1.5), "slowest_tx_name", "slow_uri"
-    sql_trace.aggregate NewRelic::Agent::SlowSql.new(NewRelic::Agent::Database::Statement.new(query), "Database/test/select", 1.1), "other_tx_name", "uri2"
+    sql_trace.aggregate(NewRelic::Agent::SlowSql.new(NewRelic::Agent::Database::Statement.new(query), "Database/test/select", 1.5), "slowest_tx_name", "slow_uri")
+    sql_trace.aggregate(NewRelic::Agent::SlowSql.new(NewRelic::Agent::Database::Statement.new(query), "Database/test/select", 1.1), "other_tx_name", "uri2")
 
     assert_equal 3, sql_trace.call_count
     assert_equal "slowest_tx_name", sql_trace.path
@@ -121,10 +121,10 @@ class NewRelic::Agent::SqlSamplerTest < Minitest::Test
     data = NewRelic::Agent::TransactionSqlData.new
     data.set_transaction_info("/c/a", 'guid')
     data.set_transaction_name("WebTransaction/Controller/c/a")
-    data.sql_data.concat [NewRelic::Agent::SlowSql.new(NewRelic::Agent::Database::Statement.new("select * from test"), "Database/test/select", 1.5),
+    data.sql_data.concat([NewRelic::Agent::SlowSql.new(NewRelic::Agent::Database::Statement.new("select * from test"), "Database/test/select", 1.5),
       NewRelic::Agent::SlowSql.new(NewRelic::Agent::Database::Statement.new("select * from test"), "Database/test/select", 1.2),
-      NewRelic::Agent::SlowSql.new(NewRelic::Agent::Database::Statement.new("select * from test2"), "Database/test2/select", 1.1)]
-    @sampler.save_slow_sql data
+      NewRelic::Agent::SlowSql.new(NewRelic::Agent::Database::Statement.new("select * from test2"), "Database/test2/select", 1.1)])
+    @sampler.save_slow_sql(data)
 
     sql_traces = @sampler.harvest!
     assert_equal 2, sql_traces.size
@@ -139,7 +139,7 @@ class NewRelic::Agent::SqlSamplerTest < Minitest::Test
       data.sql_data << NewRelic::Agent::SlowSql.new(statement, "Database/test#{(i + 97).chr}/select", i)
     end
 
-    @sampler.save_slow_sql data
+    @sampler.save_slow_sql(data)
     result = @sampler.harvest!
 
     assert_equal(10, result.size)
@@ -156,7 +156,7 @@ class NewRelic::Agent::SqlSamplerTest < Minitest::Test
       NewRelic::Agent::SlowSql.new(NewRelic::Agent::Database::Statement.new("select * from test2 where foo in (1,2)"), "Database/test2/select", 1.1)
     ]
     data.sql_data.concat(queries)
-    @sampler.save_slow_sql data
+    @sampler.save_slow_sql(data)
 
     sql_traces = @sampler.harvest!
     assert_equal 2, sql_traces.size
@@ -182,7 +182,7 @@ class NewRelic::Agent::SqlSamplerTest < Minitest::Test
         "Database/test2/select", 1.1)
     ]
     data.sql_data.concat(queries)
-    @sampler.save_slow_sql data
+    @sampler.save_slow_sql(data)
     sql_traces = @sampler.harvest!.sort_by(&:total_call_time).reverse
 
     assert_equal(["header0", "header1", "header2"],
@@ -211,7 +211,7 @@ class NewRelic::Agent::SqlSamplerTest < Minitest::Test
           "Database/test/select", 1.5)
       ]
       data.sql_data.concat(queries)
-      @sampler.save_slow_sql data
+      @sampler.save_slow_sql(data)
       sql_traces = @sampler.harvest!
       assert_nil(sql_traces[0].params[:explain_plan])
     end
@@ -292,7 +292,7 @@ class NewRelic::Agent::SqlSamplerTest < Minitest::Test
 
       in_transaction do
         sql = %Q[INSERT INTO "items" ("name", "price") VALUES ('continuum transfunctioner', 100000) RETURNING "id"]
-        sampler.notice_sql sql, "Database/test/insert", {:adapter => "postgres"}, 1.23
+        sampler.notice_sql(sql, "Database/test/insert", {:adapter => "postgres"}, 1.23)
       end
       sql_traces = sampler.harvest!
       assert_equal(%Q[INSERT INTO "items" ("name", "price") VALUES (?, ?) RETURNING "id"], sql_traces[0].sql)
@@ -391,8 +391,8 @@ class NewRelic::Agent::SqlSamplerTest < Minitest::Test
 
       params = trace.to_collector_array(encoder).last
 
-      refute params.key? :host
-      refute params.key? :port_path_or_id
+      refute params.key?(:host)
+      refute params.key?(:port_path_or_id)
       assert_equal "pizza_cube", params[:database_name]
     end
   end
@@ -408,7 +408,7 @@ class NewRelic::Agent::SqlSamplerTest < Minitest::Test
 
       assert_equal "jonan.gummy_planet", params[:host]
       assert_equal "1337", params[:port_path_or_id]
-      refute params.key? :database_name
+      refute params.key?(:database_name)
     end
   end
 
@@ -479,14 +479,14 @@ class NewRelic::Agent::SqlSamplerTest < Minitest::Test
       # massage the payload timestamp to milliseconds here for this test.
       payload.timestamp = (payload.timestamp * 1000).round
 
-      advance_process_time 2.0
+      advance_process_time(2.0)
 
       segment = nil
       txn = nil
       sampled = nil
-      txn = in_web_transaction "test_txn" do |t|
+      txn = in_web_transaction("test_txn") do |t|
         t.sampled = true
-        t.distributed_tracer.accept_distributed_trace_payload payload.text
+        t.distributed_tracer.accept_distributed_trace_payload(payload.text)
         sampled = t.sampled?
         segment = NewRelic::Agent::Tracer.start_datastore_segment(
           product: "SQLite",

--- a/test/new_relic/agent/stats_engine_test.rb
+++ b/test/new_relic/agent/stats_engine_test.rb
@@ -259,9 +259,9 @@ class NewRelic::Agent::StatsEngineTest < Minitest::Test
   def test_harvest
     @engine.clear_stats
 
-    @engine.tl_record_unscoped_metrics "a", 10
-    @engine.tl_record_unscoped_metrics "c", 1
-    @engine.tl_record_unscoped_metrics "c", 3
+    @engine.tl_record_unscoped_metrics("a", 10)
+    @engine.tl_record_unscoped_metrics("c", 1)
+    @engine.tl_record_unscoped_metrics("c", 3)
 
     assert_metrics_recorded({
       "a" => {:call_count => 1, :total_call_time => 10},
@@ -321,14 +321,14 @@ class NewRelic::Agent::StatsEngineTest < Minitest::Test
   end
 
   def test_harvest_with_merge
-    @engine.tl_record_unscoped_metrics "a", 1
+    @engine.tl_record_unscoped_metrics("a", 1)
     assert_metrics_recorded "a" => {:call_count => 1, :total_call_time => 1}
 
     harvest = @engine.harvest!
 
     assert_metrics_not_recorded "a"
 
-    @engine.tl_record_unscoped_metrics "a", 2
+    @engine.tl_record_unscoped_metrics("a", 2)
     assert_metrics_recorded "a" => {:call_count => 1, :total_call_time => 2}
 
     # this should merge the contents of the previous harvest,
@@ -341,7 +341,7 @@ class NewRelic::Agent::StatsEngineTest < Minitest::Test
   end
 
   def test_merge_merges
-    @engine.tl_record_unscoped_metrics "foo", 1
+    @engine.tl_record_unscoped_metrics("foo", 1)
 
     other_stats_hash = NewRelic::Agent::StatsHash.new()
     other_stats_hash.record(NewRelic::MetricSpec.new('foo'), 1)

--- a/test/new_relic/agent/stats_test.rb
+++ b/test/new_relic/agent/stats_test.rb
@@ -30,7 +30,7 @@ class NewRelic::Agent::StatsTest < Minitest::Test
     b = NewRelic::Agent::Stats.new
     a.reset
     b.reset
-    yield a, b
+    yield(a, b)
     a.merge(b)
   end
 
@@ -49,19 +49,19 @@ class NewRelic::Agent::StatsTest < Minitest::Test
 
   def test_simple
     stats = NewRelic::Agent::Stats.new
-    validate stats, 0, 0, 0, 0
+    validate(stats, 0, 0, 0, 0)
 
     assert_equal stats.call_count, 0
-    stats.trace_call 10
-    stats.trace_call 20
-    stats.trace_call 30
+    stats.trace_call(10)
+    stats.trace_call(20)
+    stats.trace_call(30)
 
-    validate stats, 3, (10 + 20 + 30), 10, 30
+    validate(stats, 3, (10 + 20 + 30), 10, 30)
   end
 
   def test_to_s
     s1 = NewRelic::Agent::Stats.new
-    s1.trace_call 10
+    s1.trace_call(10)
     assert_equal("[ 1 calls 10.0000s / 10.0000s ex]", s1.to_s)
   end
 
@@ -83,19 +83,19 @@ class NewRelic::Agent::StatsTest < Minitest::Test
     s1 = NewRelic::Agent::Stats.new
     s2 = NewRelic::Agent::Stats.new
 
-    s1.trace_call 10
-    s2.trace_call 20
+    s1.trace_call(10)
+    s2.trace_call(20)
     s2.freeze
 
-    validate s2, 1, 20, 20, 20
-    s3 = s1.merge s2
-    validate s3, 2, (10 + 20), 10, 20
-    validate s1, 1, 10, 10, 10
-    validate s2, 1, 20, 20, 20
+    validate(s2, 1, 20, 20, 20)
+    s3 = s1.merge(s2)
+    validate(s3, 2, (10 + 20), 10, 20)
+    validate(s1, 1, 10, 10, 10)
+    validate(s2, 1, 20, 20, 20)
 
-    s1.merge! s2
-    validate s1, 2, (10 + 20), 10, 20
-    validate s2, 1, 20, 20, 20
+    s1.merge!(s2)
+    validate(s1, 2, (10 + 20), 10, 20)
+    validate(s2, 1, 20, 20, 20)
   end
 
   def test_merge_with_exclusive
@@ -103,45 +103,45 @@ class NewRelic::Agent::StatsTest < Minitest::Test
 
     s2 = NewRelic::Agent::Stats.new
 
-    s1.trace_call 10, 5
-    s2.trace_call 20, 10
+    s1.trace_call(10, 5)
+    s2.trace_call(20, 10)
     s2.freeze
 
-    validate s2, 1, 20, 20, 20, 10
-    s3 = s1.merge s2
-    validate s3, 2, (10 + 20), 10, 20, (10 + 5)
-    validate s1, 1, 10, 10, 10, 5
-    validate s2, 1, 20, 20, 20, 10
+    validate(s2, 1, 20, 20, 20, 10)
+    s3 = s1.merge(s2)
+    validate(s3, 2, (10 + 20), 10, 20, (10 + 5))
+    validate(s1, 1, 10, 10, 10, 5)
+    validate(s2, 1, 20, 20, 20, 10)
 
-    s1.merge! s2
-    validate s1, 2, (10 + 20), 10, 20, (5 + 10)
-    validate s2, 1, 20, 20, 20, 10
+    s1.merge!(s2)
+    validate(s1, 2, (10 + 20), 10, 20, (5 + 10))
+    validate(s2, 1, 20, 20, 20, 10)
   end
 
   def test_freeze
     s1 = NewRelic::Agent::Stats.new
 
-    s1.trace_call 10
+    s1.trace_call(10)
     s1.freeze
 
     begin
       # the following should throw an exception because s1 is frozen
-      s1.trace_call 20
+      s1.trace_call(20)
       assert false
     rescue StandardError
       assert s1.frozen?
-      validate s1, 1, 10, 10, 10
+      validate(s1, 1, 10, 10, 10)
     end
   end
 
   def test_sum_of_squares_merge
     s1 = NewRelic::Agent::Stats.new
-    s1.trace_call 4
-    s1.trace_call 7
+    s1.trace_call(4)
+    s1.trace_call(7)
 
     s2 = NewRelic::Agent::Stats.new
-    s2.trace_call 13
-    s2.trace_call 16
+    s2.trace_call(13)
+    s2.trace_call(16)
 
     s3 = s1.merge(s2)
 
@@ -151,8 +151,8 @@ class NewRelic::Agent::StatsTest < Minitest::Test
 
   def test_to_json_enforces_float_values
     s1 = NewRelic::Agent::Stats.new
-    s1.trace_call 3.to_r
-    s1.trace_call 7.to_r
+    s1.trace_call(3.to_r)
+    s1.trace_call(7.to_r)
 
     assert_equal 3.0, JSON.load(s1.to_json)['min_call_time']
   end

--- a/test/new_relic/agent/supportability_test.rb
+++ b/test/new_relic/agent/supportability_test.rb
@@ -53,7 +53,7 @@ class APISupportabilityMetricsTest < Minitest::Test
   end
 
   def test_add_instrumentation_records_supportability_metric
-    NewRelic::Agent.add_instrumentation 'foo.rb'
+    NewRelic::Agent.add_instrumentation('foo.rb')
     assert_api_supportability_metric_recorded(:add_instrumentation)
   end
 
@@ -229,7 +229,7 @@ class ExternalAPISupportabilityMetricsTest < Minitest::Test
   end
 
   def test_process_request_metadata_records_supportability_metric
-    NewRelic::Agent::External.process_request_metadata ''
+    NewRelic::Agent::External.process_request_metadata('')
     assert_api_supportability_metric_recorded(:process_request_metadata)
   end
 
@@ -239,7 +239,7 @@ class ExternalAPISupportabilityMetricsTest < Minitest::Test
   end
 
   def test_process_response_metadata_records_supportability_metric
-    @segment.process_response_metadata ''
+    @segment.process_response_metadata('')
     assert_api_supportability_metric_recorded(:process_response_metadata)
   end
 end

--- a/test/new_relic/agent/synthetics_event_aggregator_test.rb
+++ b/test/new_relic/agent/synthetics_event_aggregator_test.rb
@@ -16,7 +16,7 @@ module NewRelic
         nr_freeze_process_time
         @attributes = nil
         events = NewRelic::Agent.instance.events
-        @synthetics_event_aggregator = SyntheticsEventAggregator.new events
+        @synthetics_event_aggregator = SyntheticsEventAggregator.new(events)
       end
 
       def teardown
@@ -58,7 +58,7 @@ module NewRelic
       def test_includes_custom_attributes
         attrs = {"user" => "Wes Mantooth", "channel" => 9}
 
-        attributes.merge_custom_attributes attrs
+        attributes.merge_custom_attributes(attrs)
 
         generate_request
 
@@ -68,7 +68,7 @@ module NewRelic
       end
 
       def test_does_not_record_supportability_metric_when_no_events_dropped
-        with_config :'synthetics.events_limit' => 20 do
+        with_config(:'synthetics.events_limit' => 20) do
           20.times do
             generate_request
           end
@@ -81,7 +81,7 @@ module NewRelic
       end
 
       def test_synthetics_event_dropped_records_supportability_metrics
-        with_config :'synthetics.events_limit' => 10 do
+        with_config(:'synthetics.events_limit' => 10) do
           20.times do
             generate_request
           end
@@ -94,8 +94,8 @@ module NewRelic
       end
 
       def test_lower_priority_events_discarded_in_favor_higher_priority_events
-        with_config aggregator.class.capacity_key => 5 do
-          10.times { |i| generate_event "event_#{i}" }
+        with_config(aggregator.class.capacity_key => 5) do
+          10.times { |i| generate_event("event_#{i}") }
           # Each event gets a timestamp, which is used to determine priority
           # (older events are higher priority)
 
@@ -108,8 +108,8 @@ module NewRelic
       end
 
       def test_includes_agent_attributes
-        attributes.add_agent_attribute :'request.headers.referer', "http://blog.site/home", AttributeFilter::DST_TRANSACTION_EVENTS
-        attributes.add_agent_attribute :'http.statusCode', 200, AttributeFilter::DST_TRANSACTION_EVENTS
+        attributes.add_agent_attribute(:'request.headers.referer', "http://blog.site/home", AttributeFilter::DST_TRANSACTION_EVENTS)
+        attributes.add_agent_attribute(:'http.statusCode', 200, AttributeFilter::DST_TRANSACTION_EVENTS)
 
         generate_request
 
@@ -120,7 +120,7 @@ module NewRelic
       end
 
       def test_aggregator_defers_synthetics_event_creation
-        with_config aggregator.class.capacity_key => 5 do
+        with_config(aggregator.class.capacity_key => 5) do
           5.times { generate_event }
           aggregator.expects(:create_event).never
 
@@ -130,7 +130,7 @@ module NewRelic
             :priority => 0.123
           }
 
-          aggregator.record TransactionEventPrimitive.create(payload)
+          aggregator.record(TransactionEventPrimitive.create(payload))
         end
       end
 
@@ -154,7 +154,7 @@ module NewRelic
           :priority => rand
         }.merge(options)
 
-        @synthetics_event_aggregator.record TransactionEventPrimitive.create(payload)
+        @synthetics_event_aggregator.record(TransactionEventPrimitive.create(payload))
       end
 
       def attributes

--- a/test/new_relic/agent/system_info_test.rb
+++ b/test/new_relic/agent/system_info_test.rb
@@ -124,9 +124,9 @@ class NewRelic::Agent::SystemInfoTest < Minitest::Test
   def test_processor_info_is_darwin
     info = 'darwin'
     info_stub = Proc.new { NewRelic::Agent::SystemInfo.instance_variable_set(:@processor_info, info) }
-    NewRelic::Agent::SystemInfo.stub :darwin?, true do
-      NewRelic::Agent::SystemInfo.stub :processor_info_darwin, info_stub do
-        NewRelic::Agent::SystemInfo.stub :remove_bad_values, nil do
+    NewRelic::Agent::SystemInfo.stub(:darwin?, true) do
+      NewRelic::Agent::SystemInfo.stub(:processor_info_darwin, info_stub) do
+        NewRelic::Agent::SystemInfo.stub(:remove_bad_values, nil) do
           assert_equal info, NewRelic::Agent::SystemInfo.processor_info
         end
       end
@@ -136,10 +136,10 @@ class NewRelic::Agent::SystemInfoTest < Minitest::Test
   def test_processor_info_is_linux
     info = 'linux'
     info_stub = Proc.new { NewRelic::Agent::SystemInfo.instance_variable_set(:@processor_info, info) }
-    NewRelic::Agent::SystemInfo.stub :darwin?, false do
-      NewRelic::Agent::SystemInfo.stub :linux?, true do
-        NewRelic::Agent::SystemInfo.stub :processor_info_linux, info_stub do
-          NewRelic::Agent::SystemInfo.stub :remove_bad_values, nil do
+    NewRelic::Agent::SystemInfo.stub(:darwin?, false) do
+      NewRelic::Agent::SystemInfo.stub(:linux?, true) do
+        NewRelic::Agent::SystemInfo.stub(:processor_info_linux, info_stub) do
+          NewRelic::Agent::SystemInfo.stub(:remove_bad_values, nil) do
             assert_equal info, NewRelic::Agent::SystemInfo.processor_info
           end
         end
@@ -150,11 +150,11 @@ class NewRelic::Agent::SystemInfoTest < Minitest::Test
   def test_processor_info_is_bsd
     info = 'bsd'
     info_stub = Proc.new { NewRelic::Agent::SystemInfo.instance_variable_set(:@processor_info, info) }
-    NewRelic::Agent::SystemInfo.stub :darwin?, false do
-      NewRelic::Agent::SystemInfo.stub :linux?, false do
-        NewRelic::Agent::SystemInfo.stub :bsd?, true do
-          NewRelic::Agent::SystemInfo.stub :processor_info_bsd, info_stub do
-            NewRelic::Agent::SystemInfo.stub :remove_bad_values, nil do
+    NewRelic::Agent::SystemInfo.stub(:darwin?, false) do
+      NewRelic::Agent::SystemInfo.stub(:linux?, false) do
+        NewRelic::Agent::SystemInfo.stub(:bsd?, true) do
+          NewRelic::Agent::SystemInfo.stub(:processor_info_bsd, info_stub) do
+            NewRelic::Agent::SystemInfo.stub(:remove_bad_values, nil) do
               assert_equal info, NewRelic::Agent::SystemInfo.processor_info
             end
           end
@@ -167,7 +167,7 @@ class NewRelic::Agent::SystemInfoTest < Minitest::Test
     mappings = {'hw.packages' => :num_physical_packages, 'hw.physicalcpu_max' => :num_physical_cores, 'hw.logicalcpu_max' => :num_logical_processors}
     counts = {'hw.packages' => 1, 'hw.physicalcpu_max' => 2, 'hw.logicalcpu_max' => 3}
     sysctl_stub = Proc.new { |param| counts[param] }
-    NewRelic::Agent::SystemInfo.stub :sysctl_value, sysctl_stub do
+    NewRelic::Agent::SystemInfo.stub(:sysctl_value, sysctl_stub) do
       NewRelic::Agent::SystemInfo.processor_info_darwin
       info = NewRelic::Agent::SystemInfo.instance_variable_get(:@processor_info)
       counts.each do |key, value|
@@ -185,7 +185,7 @@ class NewRelic::Agent::SystemInfoTest < Minitest::Test
               'hw.logicalcpu' => 0,
               'hw.ncpu' => 3}
     sysctl_stub = Proc.new { |param| counts[param] }
-    NewRelic::Agent::SystemInfo.stub :sysctl_value, sysctl_stub do
+    NewRelic::Agent::SystemInfo.stub(:sysctl_value, sysctl_stub) do
       NewRelic::Agent::SystemInfo.processor_info_darwin
       info = NewRelic::Agent::SystemInfo.instance_variable_get(:@processor_info)
       assert_equal 2, info[:num_physical_packages]
@@ -195,8 +195,8 @@ class NewRelic::Agent::SystemInfoTest < Minitest::Test
   end
 
   def test_processor_info_linux_is_cpuinfo
-    NewRelic::Agent::SystemInfo.stub :proc_try_read, "T. Rex" do
-      NewRelic::Agent::SystemInfo.stub :parse_cpuinfo, "Rawr" do
+    NewRelic::Agent::SystemInfo.stub(:proc_try_read, "T. Rex") do
+      NewRelic::Agent::SystemInfo.stub(:parse_cpuinfo, "Rawr") do
         NewRelic::Agent::SystemInfo.processor_info_linux
         assert_equal "Rawr", NewRelic::Agent::SystemInfo.instance_variable_get(:@processor_info)
       end
@@ -204,8 +204,8 @@ class NewRelic::Agent::SystemInfoTest < Minitest::Test
   end
 
   def test_processor_info_linux_is_empty
-    NewRelic::Agent::SystemInfo.stub :proc_try_read, nil do
-      NewRelic::Agent::SystemInfo.stub :parse_cpuinfo, "Rawr" do
+    NewRelic::Agent::SystemInfo.stub(:proc_try_read, nil) do
+      NewRelic::Agent::SystemInfo.stub(:parse_cpuinfo, "Rawr") do
         NewRelic::Agent::SystemInfo.processor_info_linux
         assert_equal NewRelic::EMPTY_HASH, NewRelic::Agent::SystemInfo.instance_variable_get(:@processor_info)
       end
@@ -213,7 +213,7 @@ class NewRelic::Agent::SystemInfoTest < Minitest::Test
   end
 
   def test_processor_info_bsd
-    NewRelic::Agent::SystemInfo.stub :sysctl_value, 1 do
+    NewRelic::Agent::SystemInfo.stub(:sysctl_value, 1) do
       NewRelic::Agent::SystemInfo.processor_info_bsd
       info = NewRelic::Agent::SystemInfo.instance_variable_get(:@processor_info)
       assert_equal nil, info[:num_physical_packages]
@@ -230,9 +230,9 @@ class NewRelic::Agent::SystemInfoTest < Minitest::Test
   end
 
   def test_processor_info_os_unknown
-    NewRelic::Agent::SystemInfo.stub :darwin?, false do
-      NewRelic::Agent::SystemInfo.stub :linux?, false do
-        NewRelic::Agent::SystemInfo.stub :bsd?, false do
+    NewRelic::Agent::SystemInfo.stub(:darwin?, false) do
+      NewRelic::Agent::SystemInfo.stub(:linux?, false) do
+        NewRelic::Agent::SystemInfo.stub(:bsd?, false) do
           NewRelic::Agent::SystemInfo.processor_info
           assert_equal NewRelic::EMPTY_HASH, NewRelic::Agent::SystemInfo.instance_variable_get(:@processor_info)
         end
@@ -266,7 +266,7 @@ class NewRelic::Agent::SystemInfoTest < Minitest::Test
 
   def test_supportability_metric_recorded_when_docker_id_unavailable
     NewRelic::Agent::SystemInfo.stubs(:ruby_os_identifier).returns("linux")
-    cgroup_info = File.read File.join(cross_agent_tests_dir, 'docker_container_id', 'invalid-length.txt')
+    cgroup_info = File.read(File.join(cross_agent_tests_dir, 'docker_container_id', 'invalid-length.txt'))
     NewRelic::Agent::SystemInfo.expects(:proc_try_read).with('/proc/self/cgroup').returns(cgroup_info)
     in_transaction('txn') do
       assert_nil NewRelic::Agent::SystemInfo.docker_container_id

--- a/test/new_relic/agent/threading/agent_thread_test.rb
+++ b/test/new_relic/agent/threading/agent_thread_test.rb
@@ -33,11 +33,11 @@ module NewRelic::Agent::Threading
       t = Thread.new do
         begin
           in_web_transaction do
-            q0.push 'unblock main thread'
+            q0.push('unblock main thread')
             q1.pop
           end
         rescue => e
-          q0.push 'unblock main thread'
+          q0.push('unblock main thread')
           fail e
         end
       end
@@ -45,7 +45,7 @@ module NewRelic::Agent::Threading
       q0.pop # wait until thread has had a chance to start up
       assert_equal :request, AgentThread.bucket_thread(t, DONT_CARE)
 
-      q1.push 'unblock background thread'
+      q1.push('unblock background thread')
       t.join
     end
 
@@ -56,11 +56,11 @@ module NewRelic::Agent::Threading
       t = ::Thread.new do
         begin
           in_transaction do
-            q0.push 'unblock main thread'
+            q0.push('unblock main thread')
             q1.pop
           end
         rescue => e
-          q0.push 'unblock main thread'
+          q0.push('unblock main thread')
           fail e
         end
       end
@@ -68,7 +68,7 @@ module NewRelic::Agent::Threading
       q0.pop # wait until thread pushes to q
       assert_equal :background, AgentThread.bucket_thread(t, DONT_CARE)
 
-      q1.push 'unblock background thread'
+      q1.push('unblock background thread')
       t.join
     end
 
@@ -120,12 +120,12 @@ module NewRelic::Agent::Threading
     end
 
     def with_thread_report_on_exception_disabled(&blk)
-      if Thread.respond_to? :report_on_exception
+      if Thread.respond_to?(:report_on_exception)
         report_on_exception_original_value = Thread.report_on_exception
         Thread.report_on_exception = false
       end
       blk.call
-      if Thread.respond_to? :report_on_exception
+      if Thread.respond_to?(:report_on_exception)
         Thread.report_on_exception = report_on_exception_original_value
       end
     end

--- a/test/new_relic/agent/threading/backtrace_service_test.rb
+++ b/test/new_relic/agent/threading/backtrace_service_test.rb
@@ -490,7 +490,7 @@ if NewRelic::Agent::Threading::BacktraceService.is_supported?
         # avoid method redefinition warnings
         class << @service
           begin
-            remove_method :adjust_polling_time
+            remove_method(:adjust_polling_time)
           rescue NameError
           end
         end

--- a/test/new_relic/agent/tracer_test.rb
+++ b/test/new_relic/agent/tracer_test.rb
@@ -50,7 +50,7 @@ module NewRelic
       end
 
       def test_sampled?
-        with_config :'distributed_tracing.enabled' => true do
+        with_config(:'distributed_tracing.enabled' => true) do
           in_transaction do |txn|
             refute_nil Tracer.sampled?
           end
@@ -66,7 +66,7 @@ module NewRelic
           end
         end
 
-        with_config :'distributed_tracing.enabled' => false do
+        with_config(:'distributed_tracing.enabled' => false) do
           in_transaction do |txn|
             assert_nil Tracer.sampled?
           end
@@ -350,7 +350,7 @@ module NewRelic
         parent = Transaction::Segment.new("parent")
         start_time = Process.clock_gettime(Process::CLOCK_REALTIME)
 
-        in_transaction 'test' do
+        in_transaction('test') do
           segment = Tracer.start_segment(
             name: name,
             unscoped_metrics: unscoped_metrics,
@@ -374,7 +374,7 @@ module NewRelic
         start_time = Process.clock_gettime(Process::CLOCK_REALTIME)
         parent = Transaction::Segment.new("parent")
 
-        in_transaction 'test' do
+        in_transaction('test') do
           segment = Tracer.start_datastore_segment(
             product: product,
             operation: operation,
@@ -399,7 +399,7 @@ module NewRelic
         start_time = Process.clock_gettime(Process::CLOCK_REALTIME)
         parent = Transaction::Segment.new("parent")
 
-        in_transaction 'test' do
+        in_transaction('test') do
           segment = Tracer.start_external_request_segment(
             library: library,
             uri: uri,

--- a/test/new_relic/agent/transaction/datastore_segment_test.rb
+++ b/test/new_relic/agent/transaction/datastore_segment_test.rb
@@ -24,19 +24,19 @@ module NewRelic
         end
 
         def test_datastore_segment_name_with_collection
-          segment = DatastoreSegment.new "SQLite", "insert", "Blog"
+          segment = DatastoreSegment.new("SQLite", "insert", "Blog")
           assert_equal "Datastore/statement/SQLite/Blog/insert", segment.name
         end
 
         def test_datastore_segment_name_with_operation
-          segment = DatastoreSegment.new "SQLite", "select"
+          segment = DatastoreSegment.new("SQLite", "select")
           assert_equal "Datastore/operation/SQLite/select", segment.name
         end
 
         def test_segment_does_not_record_metrics_outside_of_txn
-          segment = DatastoreSegment.new "SQLite", "insert", "Blog"
+          segment = DatastoreSegment.new("SQLite", "insert", "Blog")
           segment.start
-          advance_process_time 1
+          advance_process_time(1)
           segment.finish
 
           refute_metrics_recorded [
@@ -50,14 +50,14 @@ module NewRelic
         end
 
         def test_segment_records_expected_metrics
-          in_web_transaction "text_txn" do
+          in_web_transaction("text_txn") do
             segment = NewRelic::Agent::Tracer.start_datastore_segment(
               product: "SQLite",
               operation: "insert",
               collection: "Blog"
             )
             segment.start
-            advance_process_time 1
+            advance_process_time(1)
             segment.finish
           end
 
@@ -72,13 +72,13 @@ module NewRelic
         end
 
         def test_segment_records_expected_metrics_without_collection
-          in_web_transaction "text_txn" do
+          in_web_transaction("text_txn") do
             segment = Tracer.start_datastore_segment(
               product: "SQLite",
               operation: "select"
             )
             segment.start
-            advance_process_time 1
+            advance_process_time(1)
             segment.finish
           end
 
@@ -92,7 +92,7 @@ module NewRelic
         end
 
         def test_segment_records_expected_metrics_with_instance_identifier
-          in_web_transaction "text_txn" do
+          in_web_transaction("text_txn") do
             segment = Tracer.start_datastore_segment(
               product: "SQLite",
               operation: "select",
@@ -100,7 +100,7 @@ module NewRelic
               port_path_or_id: "1337807"
             )
             segment.start
-            advance_process_time 1
+            advance_process_time(1)
             segment.finish
           end
 
@@ -115,14 +115,14 @@ module NewRelic
         end
 
         def test_segment_records_expected_metrics_with_instance_identifier_host_only
-          in_web_transaction "text_txn" do
+          in_web_transaction("text_txn") do
             segment = Tracer.start_datastore_segment(
               product: "SQLite",
               operation: "select",
               host: "jonan-01"
             )
             segment.start
-            advance_process_time 1
+            advance_process_time(1)
             segment.finish
           end
 
@@ -137,14 +137,14 @@ module NewRelic
         end
 
         def test_segment_records_expected_metrics_with_instance_identifier_port_only
-          in_web_transaction "text_txn" do
+          in_web_transaction("text_txn") do
             segment = Tracer.start_datastore_segment(
               product: "SQLite",
               operation: "select",
               port_path_or_id: 1337807
             )
             segment.start
-            advance_process_time 1
+            advance_process_time(1)
             segment.finish
           end
 
@@ -159,13 +159,13 @@ module NewRelic
         end
 
         def test_segment_does_not_record_expected_metrics_with_empty_data
-          in_web_transaction "text_txn" do
+          in_web_transaction("text_txn") do
             segment = Tracer.start_datastore_segment(
               product: "SQLite",
               operation: "select"
             )
             segment.start
-            advance_process_time 1
+            advance_process_time(1)
             segment.finish
           end
 
@@ -174,7 +174,7 @@ module NewRelic
 
         def test_segment_does_not_record_instance_id_metrics_when_disabled
           with_config(:'datastore_tracer.instance_reporting.enabled' => false) do
-            in_web_transaction "text_txn" do
+            in_web_transaction("text_txn") do
               segment = Tracer.start_datastore_segment(
                 product: "SQLite",
                 operation: "select",
@@ -182,7 +182,7 @@ module NewRelic
                 port_path_or_id: "1337807"
               )
               segment.start
-              advance_process_time 1
+              advance_process_time(1)
               segment.finish
             end
 
@@ -201,7 +201,7 @@ module NewRelic
             )
 
             segment.start
-            advance_process_time 1.0
+            advance_process_time(1.0)
             segment.finish
           end
 
@@ -220,7 +220,7 @@ module NewRelic
             )
 
             segment.start
-            advance_process_time 1.0
+            advance_process_time(1.0)
             segment.finish
           end
 
@@ -248,8 +248,8 @@ module NewRelic
               database_name: "calzone_zone"
             )
 
-            segment.notice_sql sql_statement
-            advance_process_time 1
+            segment.notice_sql(sql_statement)
+            advance_process_time(1)
             segment.finish
 
             timestamp = Integer(segment.start_time.to_f * 1000.0)
@@ -289,7 +289,7 @@ module NewRelic
         end
 
         def test_sql_statement_not_added_to_span_event_if_disabled
-          with_config :'transaction_tracer.record_sql' => "off" do
+          with_config(:'transaction_tracer.record_sql' => "off") do
             sql = "SELECT * FROM mytable WHERE super_secret=1"
 
             in_web_transaction('wat') do |txn|
@@ -303,8 +303,8 @@ module NewRelic
                 database_name: "calzone_zone"
               )
 
-              segment.notice_sql sql
-              advance_process_time 1
+              segment.notice_sql(sql)
+              advance_process_time(1)
               segment.finish
             end
 
@@ -317,7 +317,7 @@ module NewRelic
         end
 
         def test_verify_sql_statement_obfuscated_on_span_event
-          with_config :'transaction_tracer.record_sql' => "obfuscated" do
+          with_config(:'transaction_tracer.record_sql' => "obfuscated") do
             sql = "SELECT * FROM mytable WHERE super_secret=1"
 
             in_web_transaction('wat') do |txn|
@@ -331,8 +331,8 @@ module NewRelic
                 database_name: "calzone_zone"
               )
 
-              segment.notice_sql sql
-              advance_process_time 1
+              segment.notice_sql(sql)
+              advance_process_time(1)
               segment.finish
             end
 
@@ -359,8 +359,8 @@ module NewRelic
               database_name: "calzone_zone"
             )
 
-            segment.notice_nosql_statement nosql_statement
-            advance_process_time 1
+            segment.notice_nosql_statement(nosql_statement)
+            advance_process_time(1)
             segment.finish
           end
 
@@ -372,7 +372,7 @@ module NewRelic
         end
 
         def test_span_event_truncates_long_sql_statement
-          with_config :'transaction_tracer.record_sql' => 'raw' do
+          with_config(:'transaction_tracer.record_sql' => 'raw') do
             in_transaction('wat') do |txn|
               txn.stubs(:sampled?).returns(true)
 
@@ -383,7 +383,7 @@ module NewRelic
 
               sql_statement = "select * from #{'a' * 2500}"
 
-              segment.notice_sql sql_statement
+              segment.notice_sql(sql_statement)
               segment.finish
             end
           end
@@ -405,7 +405,7 @@ module NewRelic
             )
             statement = "set mykey #{'a' * 2500}"
 
-            segment.notice_nosql_statement statement
+            segment.notice_nosql_statement(statement)
             segment.finish
           end
 
@@ -474,7 +474,7 @@ module NewRelic
               host: "jonan-01",
               port_path_or_id: "1337807"
             )
-            advance_process_time 1
+            advance_process_time(1)
             segment.finish
           end
 
@@ -511,7 +511,7 @@ module NewRelic
               operation: "select",
               database_name: "pizza_cube"
             )
-            advance_process_time 1
+            advance_process_time(1)
             segment.finish
           end
 
@@ -531,14 +531,14 @@ module NewRelic
                 operation: "select",
                 database_name: "pizza_cube"
               )
-              advance_process_time 1
+              advance_process_time(1)
               segment.finish
             end
 
             sample = last_transaction_trace
             node = find_node_with_name(sample, segment.name)
 
-            refute node.params.key? :database_name
+            refute node.params.key?(:database_name)
           end
         end
 
@@ -548,8 +548,8 @@ module NewRelic
               product: "SQLite",
               operation: "select"
             )
-            segment.notice_sql "select * from blogs"
-            advance_process_time 2.0
+            segment.notice_sql("select * from blogs")
+            advance_process_time(2.0)
             Agent.instance.sql_sampler.expects(:notice_sql_statement) do |statement, name, duration|
               assert_equal segment.sql_statement.sql, statement.sql_statement
               assert_equal segment.name, name
@@ -568,7 +568,7 @@ module NewRelic
               product: "SQLite",
               operation: "select"
             )
-            segment.notice_sql "select * from blogs"
+            segment.notice_sql("select * from blogs")
             assert_nil segment.sql_statement
             segment.finish
           end
@@ -582,7 +582,7 @@ module NewRelic
               operation: "select"
             )
             segment.record_sql = false
-            segment.notice_sql "select * from blogs"
+            segment.notice_sql("select * from blogs")
             assert_nil segment.sql_statement
             segment.finish
           end
@@ -596,7 +596,7 @@ module NewRelic
               host: "jonan.gummy_planet",
               port_path_or_id: "1337"
             )
-            segment.notice_sql "select * from blogs"
+            segment.notice_sql("select * from blogs")
             segment.finish
 
             assert_equal "jonan.gummy_planet", segment.sql_statement.host
@@ -611,7 +611,7 @@ module NewRelic
               operation: "select",
               database_name: "pizza_cube"
             )
-            segment.notice_sql "select * from blogs"
+            segment.notice_sql("select * from blogs")
             segment.finish
 
             assert_equal "pizza_cube", segment.sql_statement.database_name
@@ -624,7 +624,7 @@ module NewRelic
               product: "SQLite",
               operation: "select"
             )
-            segment.notice_sql "select * from blogs where " + ("something is nothing" * 16_384)
+            segment.notice_sql("select * from blogs where " + ("something is nothing" * 16_384))
             segment.finish
             assert_equal segment.params[:sql].sql.length, 16_384
           end
@@ -637,8 +637,8 @@ module NewRelic
               product: "SQLite",
               operation: "select"
             )
-            segment._notice_sql "select * from blogs", {:adapter => :sqlite}, explainer
-            advance_process_time 2.0
+            segment._notice_sql("select * from blogs", {:adapter => :sqlite}, explainer)
+            advance_process_time(2.0)
             Agent.instance.sql_sampler.expects(:notice_sql_statement) do |statement, name, duration|
               assert_equal segment.sql_statement.sql, statement.sql_statement
               assert_equal segment.name, name
@@ -656,8 +656,8 @@ module NewRelic
               product: "Redis",
               operation: "set"
             )
-            segment.notice_nosql_statement statement
-            advance_process_time 2.0
+            segment.notice_nosql_statement(statement)
+            advance_process_time(2.0)
 
             segment.finish
             assert_equal segment.params[:statement], statement
@@ -672,7 +672,7 @@ module NewRelic
               product: "SQLite",
               operation: "select"
             )
-            segment.notice_nosql_statement "hgetall somehash"
+            segment.notice_nosql_statement("hgetall somehash")
             assert_nil segment.nosql_statement
             segment.finish
           end
@@ -680,48 +680,48 @@ module NewRelic
         end
 
         def test_set_instance_info_with_valid_data
-          segment = DatastoreSegment.new "SQLite", "select", nil
-          segment.set_instance_info 'jonan.gummy_planet', 1337807
+          segment = DatastoreSegment.new("SQLite", "select", nil)
+          segment.set_instance_info('jonan.gummy_planet', 1337807)
           assert_equal 'jonan.gummy_planet', segment.host
           assert_equal '1337807', segment.port_path_or_id
         end
 
         def test_set_instance_info_with_empty_host
-          segment = DatastoreSegment.new "SQLite", "select", nil
-          segment.set_instance_info nil, 1337807
+          segment = DatastoreSegment.new("SQLite", "select", nil)
+          segment.set_instance_info(nil, 1337807)
           assert_equal 'unknown', segment.host
           assert_equal '1337807', segment.port_path_or_id
         end
 
         def test_set_instance_info_with_empty_port_path_or_id
-          segment = DatastoreSegment.new "SQLite", "select", nil
-          segment.set_instance_info 'jonan.gummy_planet', nil
+          segment = DatastoreSegment.new("SQLite", "select", nil)
+          segment.set_instance_info('jonan.gummy_planet', nil)
           assert_equal 'jonan.gummy_planet', segment.host
           assert_equal 'unknown', segment.port_path_or_id
         end
 
         def test_set_instance_info_with_empty_data
-          segment = DatastoreSegment.new "SQLite", "select", nil
-          segment.set_instance_info nil, nil
+          segment = DatastoreSegment.new("SQLite", "select", nil)
+          segment.set_instance_info(nil, nil)
           assert_nil segment.host
           assert_nil segment.port_path_or_id
 
-          segment.set_instance_info '', ''
+          segment.set_instance_info('', '')
           assert_nil segment.host
           assert_nil segment.port_path_or_id
         end
 
         def test_backtrace_not_appended_if_not_over_duration
           segment = nil
-          with_config :'transaction_tracer.stack_trace_threshold' => 2.0 do
-            in_web_transaction "test_txn" do
+          with_config(:'transaction_tracer.stack_trace_threshold' => 2.0) do
+            in_web_transaction("test_txn") do
               segment = NewRelic::Agent::Tracer.start_datastore_segment(
                 product: "SQLite",
                 operation: "insert",
                 collection: "Blog"
               )
               segment.start
-              advance_process_time 1.0
+              advance_process_time(1.0)
               segment.finish
             end
           end
@@ -735,15 +735,15 @@ module NewRelic
 
         def test_backtrace_appended_when_over_duration
           segment = nil
-          with_config :'transaction_tracer.stack_trace_threshold' => 1.0 do
-            in_web_transaction "test_txn" do
+          with_config(:'transaction_tracer.stack_trace_threshold' => 1.0) do
+            in_web_transaction("test_txn") do
               segment = NewRelic::Agent::Tracer.start_datastore_segment(
                 product: "SQLite",
                 operation: "insert",
                 collection: "Blog"
               )
               segment.start
-              advance_process_time 2.0
+              advance_process_time(2.0)
               segment.finish
             end
           end

--- a/test/new_relic/agent/transaction/distributed_tracer_test.rb
+++ b/test/new_relic/agent/transaction/distributed_tracer_test.rb
@@ -25,7 +25,7 @@ module NewRelic::Agent
       end
 
       def exclude_newrelic_header_setting value
-        distributed_tracing_enabled.merge :'exclude_newrelic_header' => value
+        distributed_tracing_enabled.merge(:'exclude_newrelic_header' => value)
       end
 
       def build_trace_context_header env = {}
@@ -37,8 +37,8 @@ module NewRelic::Agent
       def build_distributed_trace_header env = {}
         begin
           NewRelic::Agent::DistributedTracePayload.stubs(:connected?).returns(true)
-          with_config distributed_tracing_enabled do
-            in_transaction "referring_txn" do |txn|
+          with_config(distributed_tracing_enabled) do
+            in_transaction("referring_txn") do |txn|
               payload = txn.distributed_tracer.create_distributed_trace_payload
               assert payload, "failed to build a distributed_trace payload!"
               env['HTTP_NEWRELIC'] = payload.http_safe
@@ -57,7 +57,7 @@ module NewRelic::Agent
 
         with_config(distributed_tracing_enabled) do
           in_transaction do |txn|
-            txn.distributed_tracer.accept_incoming_request env
+            txn.distributed_tracer.accept_incoming_request(env)
             assert txn.distributed_tracer.trace_context_header_data, "Expected to accept trace context headers"
             refute txn.distributed_tracer.distributed_trace_payload, "Did not expect to accept a distributed trace payload"
           end
@@ -71,7 +71,7 @@ module NewRelic::Agent
 
         with_config(distributed_tracing_enabled) do
           in_transaction do |txn|
-            txn.distributed_tracer.accept_incoming_request env
+            txn.distributed_tracer.accept_incoming_request(env)
             refute txn.distributed_tracer.trace_context_header_data, "Did not expect to accept trace context headers"
             assert txn.distributed_tracer.distributed_trace_payload, "Expected to accept a distributed trace payload"
           end
@@ -79,13 +79,13 @@ module NewRelic::Agent
       end
 
       def tests_ignores_distributed_trace_header_when_context_trace_header_present
-        env = build_distributed_trace_header build_trace_context_header
+        env = build_distributed_trace_header(build_trace_context_header)
         assert env['HTTP_NEWRELIC']
         assert env['HTTP_TRACEPARENT']
 
         with_config(distributed_tracing_enabled) do
           in_transaction do |txn|
-            txn.distributed_tracer.accept_incoming_request env
+            txn.distributed_tracer.accept_incoming_request(env)
             assert txn.distributed_tracer.trace_context_header_data, "Expected to accept trace context headers"
             refute txn.distributed_tracer.distributed_trace_payload, "Did not expect to accept a distributed trace payload"
           end
@@ -101,16 +101,16 @@ module NewRelic::Agent
       end
 
       def tests_outbound_distributed_trace_headers_present_when_exclude_is_false
-        env = build_distributed_trace_header build_trace_context_header
+        env = build_distributed_trace_header(build_trace_context_header)
         assert env['HTTP_NEWRELIC']
         assert env['HTTP_TRACEPARENT']
 
-        with_config exclude_newrelic_header_setting(true) do
+        with_config(exclude_newrelic_header_setting(true)) do
           NewRelic::Agent.instance.stubs(:connected?).returns(true)
           request = {}
           in_transaction do |txn|
-            txn.distributed_tracer.accept_incoming_request env
-            txn.distributed_tracer.insert_headers request
+            txn.distributed_tracer.accept_incoming_request(env)
+            txn.distributed_tracer.insert_headers(request)
             assert request['traceparent'], "expected traceparent header to be present in #{request.keys}"
             assert request['tracestate'], "expected tracestate header to be present #{request.keys}"
             refute request['newrelic'], "expected distributed trace header to NOT be present in #{request.keys}"
@@ -119,16 +119,16 @@ module NewRelic::Agent
       end
 
       def tests_does_not_insert_distributed_tracing_headers_when_agent_not_connected
-        env = build_distributed_trace_header build_trace_context_header
+        env = build_distributed_trace_header(build_trace_context_header)
         assert env['HTTP_NEWRELIC']
         assert env['HTTP_TRACEPARENT']
 
-        with_config exclude_newrelic_header_setting(false) do
+        with_config(exclude_newrelic_header_setting(false)) do
           NewRelic::Agent.instance.stubs(:connected?).returns(false)
           request = {}
           in_transaction do |txn|
-            txn.distributed_tracer.accept_incoming_request env
-            txn.distributed_tracer.insert_headers request
+            txn.distributed_tracer.accept_incoming_request(env)
+            txn.distributed_tracer.insert_headers(request)
             refute request['traceparent'], "expected traceparent header to be present in #{request.keys}"
             refute request['tracestate'], "expected tracestate header to be present #{request.keys}"
             refute request['newrelic'], "expected distributed trace header to NOT be present in #{request.keys}"
@@ -137,16 +137,16 @@ module NewRelic::Agent
       end
 
       def tests_outbound_distributed_trace_headers_omitted_when_exclude_is_true
-        env = build_distributed_trace_header build_trace_context_header
+        env = build_distributed_trace_header(build_trace_context_header)
         assert env['HTTP_NEWRELIC']
         assert env['HTTP_TRACEPARENT']
 
-        with_config exclude_newrelic_header_setting(false) do
+        with_config(exclude_newrelic_header_setting(false)) do
           NewRelic::Agent.instance.stubs(:connected?).returns(true)
           request = {}
           in_transaction do |txn|
-            txn.distributed_tracer.accept_incoming_request env
-            txn.distributed_tracer.insert_headers request
+            txn.distributed_tracer.accept_incoming_request(env)
+            txn.distributed_tracer.insert_headers(request)
             assert request['traceparent'], "expected traceparent header to be present in #{request.keys}"
             assert request['tracestate'], "expected tracestate header to be present #{request.keys}"
             assert request['newrelic'], "expected distributed trace header to be present in #{request.keys}"

--- a/test/new_relic/agent/transaction/distributed_tracing_test.rb
+++ b/test/new_relic/agent/transaction/distributed_tracing_test.rb
@@ -37,7 +37,7 @@ module NewRelic
           created_at = Process.clock_gettime(Process::CLOCK_REALTIME, :millisecond)
           payload = nil
 
-          transaction = in_transaction "test_txn" do |t|
+          transaction = in_transaction("test_txn") do |t|
             payload = t.distributed_tracer.create_distributed_trace_payload
           end
 
@@ -59,7 +59,7 @@ module NewRelic
 
           NewRelic::Agent::DistributedTracePayload.stubs(:connected?).returns(false)
 
-          in_transaction "test_txn" do |t|
+          in_transaction("test_txn") do |t|
             payload = t.distributed_tracer.create_distributed_trace_payload
           end
 
@@ -69,8 +69,8 @@ module NewRelic
         def test_accept_distributed_trace_payload_assigns_json_payload
           payload = create_distributed_trace_payload
 
-          transaction = in_transaction "test_txn" do |txn|
-            txn.distributed_tracer.accept_distributed_trace_payload payload.text
+          transaction = in_transaction("test_txn") do |txn|
+            txn.distributed_tracer.accept_distributed_trace_payload(payload.text)
           end
 
           refute_nil transaction.distributed_tracer.distributed_trace_payload
@@ -81,8 +81,8 @@ module NewRelic
         def test_accept_distributed_trace_payload_assigns_http_safe_payload
           payload = create_distributed_trace_payload
 
-          transaction = in_transaction "test_txn" do |txn|
-            txn.distributed_tracer.accept_distributed_trace_payload payload.http_safe
+          transaction = in_transaction("test_txn") do |txn|
+            txn.distributed_tracer.accept_distributed_trace_payload(payload.http_safe)
           end
 
           refute_nil transaction.distributed_tracer.distributed_trace_payload
@@ -97,8 +97,8 @@ module NewRelic
           accepted = nil
 
           with_config(trusted_account_key: "somekey") do
-            transaction = in_transaction "test_txn" do |txn|
-              accepted = txn.distributed_tracer.accept_distributed_trace_payload payload.http_safe
+            transaction = in_transaction("test_txn") do |txn|
+              accepted = txn.distributed_tracer.accept_distributed_trace_payload(payload.http_safe)
             end
           end
 
@@ -116,8 +116,8 @@ module NewRelic
           accepted = nil
 
           with_config(trusted_account_key: "somekey") do
-            transaction = in_transaction "test_txn" do |txn|
-              accepted = txn.distributed_tracer.accept_distributed_trace_payload payload.http_safe
+            transaction = in_transaction("test_txn") do |txn|
+              accepted = txn.distributed_tracer.accept_distributed_trace_payload(payload.http_safe)
             end
           end
 
@@ -135,8 +135,8 @@ module NewRelic
           accepted = nil
 
           with_config(trusted_account_key: "500") do
-            transaction = in_transaction "test_txn" do |txn|
-              accepted = txn.distributed_tracer.accept_distributed_trace_payload payload.http_safe
+            transaction = in_transaction("test_txn") do |txn|
+              accepted = txn.distributed_tracer.accept_distributed_trace_payload(payload.http_safe)
             end
           end
 
@@ -147,8 +147,8 @@ module NewRelic
         def test_accept_distributed_trace_payload_records_duration_metrics
           payload = create_distributed_trace_payload
 
-          in_transaction "test_txn" do |txn|
-            txn.distributed_tracer.accept_distributed_trace_payload payload.text
+          in_transaction("test_txn") do |txn|
+            txn.distributed_tracer.accept_distributed_trace_payload(payload.text)
           end
 
           assert_metrics_recorded ['DurationByCaller/App/190/46954/Unknown/all',
@@ -164,9 +164,9 @@ module NewRelic
         def test_accept_distributed_trace_payload_with_error_records_error_metrics
           payload = create_distributed_trace_payload
 
-          in_transaction "test_txn" do |txn|
-            txn.distributed_tracer.accept_distributed_trace_payload payload.text
-            NewRelic::Agent.notice_error StandardError.new "Nooo!"
+          in_transaction("test_txn") do |txn|
+            txn.distributed_tracer.accept_distributed_trace_payload(payload.text)
+            NewRelic::Agent.notice_error(StandardError.new("Nooo!"))
           end
 
           assert_metrics_recorded ['ErrorsByCaller/App/190/46954/Unknown/all',
@@ -178,9 +178,9 @@ module NewRelic
 
           NewRelic::Agent.instance.adaptive_sampler.stubs(:sampled?).returns(false)
 
-          in_transaction "test_txn" do |txn|
+          in_transaction("test_txn") do |txn|
             refute txn.sampled?
-            txn.distributed_tracer.accept_distributed_trace_payload payload.text
+            txn.distributed_tracer.accept_distributed_trace_payload(payload.text)
             assert txn.sampled?
           end
         end
@@ -190,9 +190,9 @@ module NewRelic
 
           NewRelic::Agent.instance.adaptive_sampler.stubs(:sampled?).returns(true)
 
-          in_transaction "test_txn" do |txn|
+          in_transaction("test_txn") do |txn|
             assert txn.sampled?
-            txn.distributed_tracer.accept_distributed_trace_payload payload.text
+            txn.distributed_tracer.accept_distributed_trace_payload(payload.text)
             refute txn.sampled?
           end
         end
@@ -209,7 +209,7 @@ module NewRelic
           assert_nil intrinsics['parentId']
           assert intrinsics['sampled']
 
-          txn_intrinsics = transaction.attributes.intrinsic_attributes_for AttributeFilter::DST_TRANSACTION_TRACER
+          txn_intrinsics = transaction.attributes.intrinsic_attributes_for(AttributeFilter::DST_TRANSACTION_TRACER)
 
           assert_equal transaction.guid, txn_intrinsics['guid']
           assert_equal transaction.trace_id, intrinsics['traceId']
@@ -221,7 +221,7 @@ module NewRelic
           NewRelic::Agent.instance.adaptive_sampler.stubs(:sampled?).returns(true)
           transaction = nil
 
-          transaction = in_transaction "test_txn" do |txn|
+          transaction = in_transaction("test_txn") do |txn|
             # simulate legacy cat
             referring_txn_info = [
               "b854df4feb2b1f06",
@@ -239,7 +239,7 @@ module NewRelic
           intrinsics, _, _ = last_transaction_event
           assert_equal transaction.trace_id, intrinsics['traceId']
 
-          transaction.attributes.intrinsic_attributes_for AttributeFilter::DST_TRANSACTION_TRACER
+          transaction.attributes.intrinsic_attributes_for(AttributeFilter::DST_TRANSACTION_TRACER)
           assert_equal transaction.trace_id, intrinsics['traceId']
         end
 
@@ -276,8 +276,8 @@ module NewRelic
           payload = create_distributed_trace_payload(sampled: false)
           payload.id = "abc123"
 
-          txn = in_transaction "test_txn" do |t|
-            t.distributed_tracer.accept_distributed_trace_payload payload.text
+          txn = in_transaction("test_txn") do |t|
+            t.distributed_tracer.accept_distributed_trace_payload(payload.text)
           end
 
           intrinsics = txn.attributes.intrinsic_attributes_for(NewRelic::Agent::AttributeFilter::DST_TRANSACTION_TRACER)
@@ -290,8 +290,8 @@ module NewRelic
         def test_assign_distributed_trace_attributes_properly_assigned_on_initial_trace
           payload = create_distributed_trace_payload(sampled: false)
 
-          txn = in_transaction "test_txn" do |t|
-            t.distributed_tracer.accept_distributed_trace_payload payload.text
+          txn = in_transaction("test_txn") do |t|
+            t.distributed_tracer.accept_distributed_trace_payload(payload.text)
           end
 
           intrinsics = txn.attributes.intrinsic_attributes_for(NewRelic::Agent::AttributeFilter::DST_TRANSACTION_TRACER)
@@ -306,8 +306,8 @@ module NewRelic
         def test_sampled_is_false_in_transaction_event_when_indicated_by_upstream
           payload = create_distributed_trace_payload(sampled: false)
 
-          in_transaction "test_txn" do |txn|
-            txn.distributed_tracer.accept_distributed_trace_payload payload.text
+          in_transaction("test_txn") do |txn|
+            txn.distributed_tracer.accept_distributed_trace_payload(payload.text)
           end
 
           intrinsics, _, _ = last_transaction_event
@@ -330,14 +330,14 @@ module NewRelic
           payload = nil
           referring_transaction = nil
 
-          in_transaction "test_txn" do |txn|
+          in_transaction("test_txn") do |txn|
             referring_transaction = txn
             payload = referring_transaction.distributed_tracer.create_distributed_trace_payload
           end
 
-          transaction = in_transaction "text_txn2" do |txn|
-            txn.distributed_tracer.accept_distributed_trace_payload payload.text
-            NewRelic::Agent.notice_error StandardError.new "Nooo!"
+          transaction = in_transaction("text_txn2") do |txn|
+            txn.distributed_tracer.accept_distributed_trace_payload(payload.text)
+            NewRelic::Agent.notice_error(StandardError.new("Nooo!"))
           end
 
           intrinsics, _, _ = last_error_event
@@ -362,9 +362,9 @@ module NewRelic
 
           NewRelic::Agent.instance.adaptive_sampler.stubs(:sampled?).returns(true)
 
-          in_transaction "text_txn" do |txn|
-            txn.distributed_tracer.accept_distributed_trace_payload payload.text
-            NewRelic::Agent.notice_error StandardError.new "Nooo!"
+          in_transaction("text_txn") do |txn|
+            txn.distributed_tracer.accept_distributed_trace_payload(payload.text)
+            NewRelic::Agent.notice_error(StandardError.new("Nooo!"))
           end
 
           intrinsics, _, _ = last_error_event
@@ -377,8 +377,8 @@ module NewRelic
 
           NewRelic::Agent.instance.adaptive_sampler.stubs(:sampled?).returns(true)
 
-          transaction = in_transaction "test_txn" do |txn|
-            txn.distributed_tracer.accept_distributed_trace_payload payload.text
+          transaction = in_transaction("test_txn") do |txn|
+            txn.distributed_tracer.accept_distributed_trace_payload(payload.text)
           end
 
           intrinsics, _, _ = last_transaction_event
@@ -391,7 +391,7 @@ module NewRelic
           NewRelic::Agent.instance.adaptive_sampler.stubs(:sampled?).returns(true)
 
           transaction = in_transaction("test_txn") do
-            NewRelic::Agent.notice_error StandardError.new("Sorry!")
+            NewRelic::Agent.notice_error(StandardError.new("Sorry!"))
           end
 
           txn_intrinsics, _, _ = last_transaction_event
@@ -406,7 +406,7 @@ module NewRelic
           NewRelic::Agent.instance.adaptive_sampler.stubs(:sampled?).returns(false)
 
           transaction = in_transaction("test_txn") do
-            NewRelic::Agent.notice_error StandardError.new("Sorry!")
+            NewRelic::Agent.notice_error(StandardError.new("Sorry!"))
           end
 
           txn_intrinsics, _, _ = last_transaction_event
@@ -420,8 +420,8 @@ module NewRelic
         def test_transaction_inherits_priority_from_distributed_trace_payload
           payload = create_distributed_trace_payload(sampled: true)
 
-          transaction = in_transaction "test_txn" do |txn|
-            txn.distributed_tracer.accept_distributed_trace_payload payload.text
+          transaction = in_transaction("test_txn") do |txn|
+            txn.distributed_tracer.accept_distributed_trace_payload(payload.text)
           end
 
           assert_equal transaction.priority, payload.priority
@@ -433,9 +433,9 @@ module NewRelic
           payload.priority = nil
 
           priority = nil
-          transaction = in_transaction "test_txn2" do |txn|
+          transaction = in_transaction("test_txn2") do |txn|
             priority = txn.priority
-            txn.distributed_tracer.accept_distributed_trace_payload payload.text
+            txn.distributed_tracer.accept_distributed_trace_payload(payload.text)
           end
 
           assert_equal priority, transaction.priority
@@ -451,9 +451,9 @@ module NewRelic
           payload.sampled = nil
 
           priority = nil
-          transaction = in_transaction "test_txn2" do |txn|
+          transaction = in_transaction("test_txn2") do |txn|
             priority = txn.priority
-            txn.distributed_tracer.accept_distributed_trace_payload payload.text
+            txn.distributed_tracer.accept_distributed_trace_payload(payload.text)
           end
 
           assert_equal priority, transaction.priority
@@ -569,14 +569,14 @@ module NewRelic
           # this is a little ugly, but the code below forces the adaptive
           # sampler into a new interval and resets the counts
           adaptive_sampler = NewRelic::Agent.instance.adaptive_sampler
-          interval_duration = adaptive_sampler.instance_variable_get :@period_duration
+          interval_duration = adaptive_sampler.instance_variable_get(:@period_duration)
           nr_freeze_process_time(Process.clock_gettime(Process::CLOCK_REALTIME, :millisecond))
           advance_process_time(interval_duration)
           adaptive_sampler.send(:reset_if_period_expired!)
 
           20.times do
             in_transaction('test_txn') do |txn|
-              txn.distributed_tracer.accept_distributed_trace_payload payload.text
+              txn.distributed_tracer.accept_distributed_trace_payload(payload.text)
             end
           end
           assert_equal 0, adaptive_sampler.stats[:seen]
@@ -604,14 +604,14 @@ module NewRelic
         def create_distributed_transactions
           result = {}
 
-          result[:grandparent_transaction] = in_transaction "test_txn" do |txn|
+          result[:grandparent_transaction] = in_transaction("test_txn") do |txn|
             result[:grandparent_payload] =
               txn.distributed_tracer.create_distributed_trace_payload
           end
 
           result[:grandparent_intrinsics], _, _ = last_transaction_event
 
-          result[:parent_transaction] = in_transaction "text_txn2" do |txn|
+          result[:parent_transaction] = in_transaction("text_txn2") do |txn|
             txn.distributed_tracer.accept_distributed_trace_payload(
               result[:grandparent_payload].text
             )
@@ -622,7 +622,7 @@ module NewRelic
 
           result[:parent_intrinsics], _, _ = last_transaction_event
 
-          result[:child_transaction] = in_transaction "text_txn3" do |txn|
+          result[:child_transaction] = in_transaction("text_txn3") do |txn|
             txn.distributed_tracer.accept_distributed_trace_payload(
               result[:parent_payload].text
             )

--- a/test/new_relic/agent/transaction/external_request_segment_test.rb
+++ b/test/new_relic/agent/transaction/external_request_segment_test.rb
@@ -37,7 +37,7 @@ module NewRelic::Agent
       TRANSACTION_GUID = 'BEC1BC64675138B9'
 
       def setup
-        @obfuscator = NewRelic::Agent::Obfuscator.new "jotorotoes"
+        @obfuscator = NewRelic::Agent::Obfuscator.new("jotorotoes")
         NewRelic::Agent.agent.stubs(:connected?).returns(true)
 
         NewRelic::Agent::CrossAppTracing.stubs(:obfuscator).returns(@obfuscator)
@@ -51,17 +51,17 @@ module NewRelic::Agent
       end
 
       def test_generates_expected_name
-        segment = ExternalRequestSegment.new "Typhoeus", "http://remotehost.com/blogs/index", "GET"
+        segment = ExternalRequestSegment.new("Typhoeus", "http://remotehost.com/blogs/index", "GET")
         assert_equal "External/remotehost.com/Typhoeus/GET", segment.name
       end
 
       def test_downcases_hostname
-        segment = ExternalRequestSegment.new "Typhoeus", "http://ReMoTeHoSt.Com/blogs/index", "GET"
+        segment = ExternalRequestSegment.new("Typhoeus", "http://ReMoTeHoSt.Com/blogs/index", "GET")
         assert_equal "External/remotehost.com/Typhoeus/GET", segment.name
       end
 
       def test_segment_does_not_record_metrics_outside_of_txn
-        segment = ExternalRequestSegment.new "Net::HTTP", "http://remotehost.com/blogs/index", "GET"
+        segment = ExternalRequestSegment.new("Net::HTTP", "http://remotehost.com/blogs/index", "GET")
         segment.finish
 
         refute_metrics_recorded [
@@ -74,7 +74,7 @@ module NewRelic::Agent
       end
 
       def test_segment_records_expected_metrics_for_non_cat_txn
-        in_transaction "test", :category => :controller do
+        in_transaction("test", :category => :controller) do
           segment = Tracer.start_external_request_segment(
             library: "Net::HTTP",
             uri: "http://remotehost.com/blogs/index",
@@ -106,14 +106,14 @@ module NewRelic::Agent
         }
 
         with_config(cat_config.merge({:"cross_application_tracer.enabled" => false})) do
-          in_transaction "test", :category => :controller do
+          in_transaction("test", :category => :controller) do
             segment = Tracer.start_external_request_segment(
               library: "Net::HTTP",
               uri: "http://remotehost.com/blogs/index",
               procedure: "GET"
             )
-            segment.add_request_headers request
-            segment.process_response_headers response
+            segment.add_request_headers(request)
+            segment.process_response_headers(response)
             segment.finish
           end
 
@@ -141,14 +141,14 @@ module NewRelic::Agent
         }
 
         with_config(cat_config.merge({:cross_process_id => ''})) do
-          in_transaction "test", :category => :controller do
+          in_transaction("test", :category => :controller) do
             segment = Tracer.start_external_request_segment(
               library: "Net::HTTP",
               uri: "http://remotehost.com/blogs/index",
               procedure: "GET"
             )
-            segment.add_request_headers request
-            segment.process_response_headers response
+            segment.add_request_headers(request)
+            segment.process_response_headers(response)
             segment.finish
           end
 
@@ -177,14 +177,14 @@ module NewRelic::Agent
         }
 
         with_config(cat_config.merge({:encoding_key => ''})) do
-          in_transaction "test", :category => :controller do
+          in_transaction("test", :category => :controller) do
             segment = Tracer.start_external_request_segment(
               library: "Net::HTTP",
               uri: "http://remotehost.com/blogs/index",
               procedure: "GET"
             )
-            segment.add_request_headers request
-            segment.process_response_headers response
+            segment.add_request_headers(request)
+            segment.process_response_headers(response)
             segment.finish
           end
 
@@ -210,14 +210,14 @@ module NewRelic::Agent
           'X-NewRelic-App-Data' => make_app_data_payload("1#1884", "txn-name", 2, 8, 0, TRANSACTION_GUID)
         }
 
-        with_config cat_config do
-          in_transaction "test", :category => :controller do |txn|
+        with_config(cat_config) do
+          in_transaction("test", :category => :controller) do |txn|
             segment = Tracer.start_external_request_segment(
               library: "Net::HTTP",
               uri: "http://newrelic.com/blogs/index",
               procedure: "GET"
             )
-            segment.process_response_headers response
+            segment.process_response_headers(response)
             segment.finish
           end
 
@@ -245,7 +245,7 @@ module NewRelic::Agent
           request = RequestWrapper.new
           payload = nil
 
-          with_config account_id: "190", primary_application_id: "46954" do
+          with_config(account_id: "190", primary_application_id: "46954") do
             in_transaction do |txn|
               payload = txn.distributed_tracer.create_distributed_trace_payload
             end
@@ -254,15 +254,15 @@ module NewRelic::Agent
           NewRelic::Agent.drop_buffered_data
           transport_type = nil
 
-          in_transaction "test_txn2", :category => :controller do |txn|
-            txn.distributed_tracer.accept_distributed_trace_payload payload.text
+          in_transaction("test_txn2", :category => :controller) do |txn|
+            txn.distributed_tracer.accept_distributed_trace_payload(payload.text)
             segment = Tracer.start_external_request_segment(
               library: "Net::HTTP",
               uri: "http://newrelic.com/blogs/index",
               procedure: "GET"
             )
             transport_type = txn.distributed_tracer.caller_transport_type
-            segment.add_request_headers request
+            segment.add_request_headers(request)
             segment.finish
           end
 
@@ -289,7 +289,7 @@ module NewRelic::Agent
           request = RequestWrapper.new
           payload = nil
 
-          with_config account_id: "190", primary_application_id: "46954" do
+          with_config(account_id: "190", primary_application_id: "46954") do
             in_transaction do |txn|
               payload = txn.distributed_tracer.create_distributed_trace_payload
             end
@@ -298,17 +298,17 @@ module NewRelic::Agent
           NewRelic::Agent.drop_buffered_data
           transport_type = nil
 
-          in_transaction "test_txn2", :category => :controller do |txn|
-            txn.distributed_tracer.accept_distributed_trace_payload payload.text
+          in_transaction("test_txn2", :category => :controller) do |txn|
+            txn.distributed_tracer.accept_distributed_trace_payload(payload.text)
             segment = Tracer.start_external_request_segment(
               library: "Net::HTTP",
               uri: "http://newrelic.com/blogs/index",
               procedure: "GET"
             )
             transport_type = txn.distributed_tracer.caller_transport_type
-            segment.add_request_headers request
+            segment.add_request_headers(request)
             segment.finish
-            NewRelic::Agent.notice_error StandardError.new("Sorry!")
+            NewRelic::Agent.notice_error(StandardError.new("Sorry!"))
           end
 
           expected_metrics = [
@@ -330,14 +330,14 @@ module NewRelic::Agent
 
       def test_segment_writes_outbound_request_headers
         request = RequestWrapper.new
-        with_config cat_config do
-          in_transaction :category => :controller do
+        with_config(cat_config) do
+          in_transaction(:category => :controller) do
             segment = Tracer.start_external_request_segment(
               library: "Net::HTTP",
               uri: "http://remotehost.com/blogs/index",
               procedure: "GET"
             )
-            segment.add_request_headers request
+            segment.add_request_headers(request)
             segment.finish
           end
         end
@@ -347,14 +347,14 @@ module NewRelic::Agent
 
       def test_segment_writes_outbound_request_headers_for_trace_context
         request = RequestWrapper.new
-        with_config trace_context_config do
-          in_transaction :category => :controller do
+        with_config(trace_context_config) do
+          in_transaction(:category => :controller) do
             segment = Tracer.start_external_request_segment(
               library: "Net::HTTP",
               uri: "http://remotehost.com/blogs/index",
               procedure: "GET"
             )
-            segment.add_request_headers request
+            segment.add_request_headers(request)
             segment.finish
           end
         end
@@ -364,15 +364,15 @@ module NewRelic::Agent
 
       def test_segment_writes_synthetics_header_for_synthetics_txn
         request = RequestWrapper.new
-        with_config cat_config do
-          in_transaction :category => :controller do |txn|
-            txn.raw_synthetics_header = json_dump_and_encode [1, 42, 100, 200, 300]
+        with_config(cat_config) do
+          in_transaction(:category => :controller) do |txn|
+            txn.raw_synthetics_header = json_dump_and_encode([1, 42, 100, 200, 300])
             segment = Tracer.start_external_request_segment(
               library: "Net::HTTP",
               uri: "http://remotehost.com/blogs/index",
               procedure: "GET"
             )
-            segment.add_request_headers request
+            segment.add_request_headers(request)
             segment.finish
           end
         end
@@ -381,15 +381,15 @@ module NewRelic::Agent
 
       def test_add_request_headers_renames_segment_based_on_host_header
         request = RequestWrapper.new({"host" => "anotherhost.local"})
-        with_config cat_config do
-          in_transaction :category => :controller do
+        with_config(cat_config) do
+          in_transaction(:category => :controller) do
             segment = Tracer.start_external_request_segment(
               library: "Net::HTTP",
               uri: "http://remotehost.com/blogs/index",
               procedure: "GET"
             )
             assert_equal "External/remotehost.com/Net::HTTP/GET", segment.name
-            segment.add_request_headers request
+            segment.add_request_headers(request)
             assert_equal "External/anotherhost.local/Net::HTTP/GET", segment.name
             segment.finish
           end
@@ -401,14 +401,14 @@ module NewRelic::Agent
           'X-NewRelic-App-Data' => make_app_data_payload("1#1884", "txn-name", 2, 8, 0, TRANSACTION_GUID)
         }
 
-        with_config cat_config do
-          in_transaction :category => :controller do |txn|
+        with_config(cat_config) do
+          in_transaction(:category => :controller) do |txn|
             segment = Tracer.start_external_request_segment(
               library: "Net::HTTP",
               uri: "http://remotehost.com/blogs/index",
               procedure: "GET"
             )
-            segment.process_response_headers response
+            segment.process_response_headers(response)
             segment.finish
 
             assert segment.cross_app_request?
@@ -424,12 +424,12 @@ module NewRelic::Agent
       def with_external_segment headers, config, segment_params
         segment = nil
         http_response = nil
-        with_config config do
-          in_transaction :category => :controller do |txn|
+        with_config(config) do
+          in_transaction(:category => :controller) do |txn|
             segment = Tracer.start_external_request_segment(**segment_params)
-            segment.add_request_headers headers
-            http_response = mock_http_response headers
-            segment.process_response_headers http_response
+            segment.add_request_headers(headers)
+            http_response = mock_http_response(headers)
+            segment.process_response_headers(http_response)
             yield if block_given?
             segment.finish
           end
@@ -475,14 +475,14 @@ module NewRelic::Agent
         response = {
           'X-NewRelic-App-Data' => make_app_data_payload("1#1884", "txn-name", 2, 8, 0, TRANSACTION_GUID)
         }
-        with_config trace_context_config do
-          in_transaction :category => :controller do |txn|
+        with_config(trace_context_config) do
+          in_transaction(:category => :controller) do |txn|
             segment = Tracer.start_external_request_segment(
               library: "Net::HTTP",
               uri: "http://remotehost.com/blogs/index",
               procedure: "GET"
             )
-            segment.process_response_headers response
+            segment.process_response_headers(response)
             segment.finish
 
             refute segment.cross_app_request?
@@ -518,14 +518,14 @@ module NewRelic::Agent
           'X-NewRelic-App-Data' => make_app_data_payload("not_an_ID", "txn-name", 2, 8, 0, TRANSACTION_GUID)
         }
 
-        with_config cat_config do
-          in_transaction :category => :controller do |txn|
+        with_config(cat_config) do
+          in_transaction(:category => :controller) do |txn|
             segment = Tracer.start_external_request_segment(
               library: "Net::HTTP",
               uri: "http://remotehost.com/blogs/index",
               procedure: "GET"
             )
-            segment.process_response_headers response
+            segment.process_response_headers(response)
             segment.finish
 
             refute segment.cross_app_request?
@@ -540,7 +540,7 @@ module NewRelic::Agent
         segment = nil
         uri = "http://newrelic.com/blogs/index"
 
-        in_transaction :category => :controller do
+        in_transaction(:category => :controller) do
           segment = Tracer.start_external_request_segment(
             library: "Net::HTTP",
             uri: uri,
@@ -562,14 +562,14 @@ module NewRelic::Agent
           'X-NewRelic-App-Data' => make_app_data_payload("1#1884", "txn-name", 2, 8, 0, TRANSACTION_GUID)
         }
 
-        with_config cat_config do
-          in_transaction :category => :controller do
+        with_config(cat_config) do
+          in_transaction(:category => :controller) do
             segment = Tracer.start_external_request_segment(
               library: "Net::HTTP",
               uri: "http://remotehost.com/blogs/index",
               procedure: "GET"
             )
-            segment.process_response_headers response
+            segment.process_response_headers(response)
             segment.finish
           end
         end
@@ -583,12 +583,12 @@ module NewRelic::Agent
       # --- get_request_metadata
 
       def test_get_request_metadata
-        with_config cat_config.merge(:'cross_application_tracer.enabled' => true) do
+        with_config(cat_config.merge(:'cross_application_tracer.enabled' => true)) do
           in_transaction do |txn|
             rmd = external_request_segment { |s| s.get_request_metadata }
             assert_instance_of String, rmd
-            rmd = @obfuscator.deobfuscate rmd
-            rmd = JSON.parse rmd
+            rmd = @obfuscator.deobfuscate(rmd)
+            rmd = JSON.parse(rmd)
             assert_instance_of Hash, rmd
 
             assert_equal '269975#22824', rmd['NewRelicID']
@@ -600,7 +600,7 @@ module NewRelic::Agent
             assert_equal txn.distributed_tracer.cat_trip_id, rmd['NewRelicTransaction'][2]
             assert_equal txn.distributed_tracer.cat_path_hash, rmd['NewRelicTransaction'][3]
 
-            refute rmd.key? 'NewRelicSynthetics'
+            refute rmd.key?('NewRelicSynthetics')
 
             assert txn.distributed_tracer.is_cross_app_caller?
           end
@@ -608,7 +608,7 @@ module NewRelic::Agent
       end
 
       def test_get_request_metadata_with_cross_app_tracing_disabled
-        with_config cat_config.merge(:'cross_application_tracer.enabled' => false) do
+        with_config(cat_config.merge(:'cross_application_tracer.enabled' => false)) do
           in_transaction do |txn|
             rmd = external_request_segment { |s| s.get_request_metadata }
             refute rmd, "`get_request_metadata` should return nil with cross app tracing disabled"
@@ -617,14 +617,14 @@ module NewRelic::Agent
       end
 
       def test_get_request_metadata_with_synthetics_header
-        with_config cat_config do
+        with_config(cat_config) do
           in_transaction do |txn|
             txn.raw_synthetics_header = 'raw_synth'
 
             rmd = external_request_segment { |s| s.get_request_metadata }
 
-            rmd = @obfuscator.deobfuscate rmd
-            rmd = JSON.parse rmd
+            rmd = @obfuscator.deobfuscate(rmd)
+            rmd = JSON.parse(rmd)
 
             assert_equal 'raw_synth', rmd['NewRelicSynthetics']
           end
@@ -632,7 +632,7 @@ module NewRelic::Agent
       end
 
       def test_get_request_metadata_not_in_transaction
-        with_config cat_config do
+        with_config(cat_config) do
           refute external_request_segment { |s| s.get_request_metadata }
         end
       end
@@ -640,9 +640,9 @@ module NewRelic::Agent
       # --- process_response_metadata
 
       def test_process_response_metadata
-        with_config cat_config do
+        with_config(cat_config) do
           in_transaction do |txn|
-            rmd = @obfuscator.obfuscate ::JSON.dump({
+            rmd = @obfuscator.obfuscate(::JSON.dump({
               NewRelicAppData: [
                 NewRelic::Agent.config[:cross_process_id],
                 'Controller/root/index',
@@ -651,17 +651,17 @@ module NewRelic::Agent
                 60,
                 txn.guid
               ]
-            })
+            }))
 
-            segment = external_request_segment { |s| s.process_response_metadata rmd; s }
+            segment = external_request_segment { |s| s.process_response_metadata(rmd); s }
             assert_equal 'ExternalTransaction/example.com/269975#22824/Controller/root/index', segment.name
           end
         end
       end
 
       def test_process_response_metadata_not_in_transaction
-        with_config cat_config do
-          rmd = @obfuscator.obfuscate ::JSON.dump({
+        with_config(cat_config) do
+          rmd = @obfuscator.obfuscate(::JSON.dump({
             NewRelicAppData: [
               NewRelic::Agent.config[:cross_process_id],
               'Controller/root/index',
@@ -670,17 +670,17 @@ module NewRelic::Agent
               60,
               'abcdef'
             ]
-          })
+          }))
 
-          segment = external_request_segment { |s| s.process_response_metadata rmd; s }
+          segment = external_request_segment { |s| s.process_response_metadata(rmd); s }
           assert_equal 'External/example.com/foo/get', segment.name
         end
       end
 
       def test_process_response_metadata_with_invalid_cross_app_id
-        with_config cat_config do
+        with_config(cat_config) do
           in_transaction do |txn|
-            rmd = @obfuscator.obfuscate ::JSON.dump({
+            rmd = @obfuscator.obfuscate(::JSON.dump({
               NewRelicAppData: [
                 'bugz',
                 'Controller/root/index',
@@ -689,11 +689,11 @@ module NewRelic::Agent
                 60,
                 txn.guid
               ]
-            })
+            }))
 
             segment = nil
             l = with_array_logger do
-              segment = external_request_segment { |s| s.process_response_metadata rmd; s }
+              segment = external_request_segment { |s| s.process_response_metadata(rmd); s }
             end
             refute l.array.empty?, "process_response_metadata should log error on invalid ID"
             assert l.array.first =~ %r{invalid/non-trusted ID}
@@ -704,9 +704,9 @@ module NewRelic::Agent
       end
 
       def test_process_response_metadata_with_untrusted_cross_app_id
-        with_config cat_config do
+        with_config(cat_config) do
           in_transaction do |txn|
-            rmd = @obfuscator.obfuscate ::JSON.dump({
+            rmd = @obfuscator.obfuscate(::JSON.dump({
               NewRelicAppData: [
                 '190#666',
                 'Controller/root/index',
@@ -715,11 +715,11 @@ module NewRelic::Agent
                 60,
                 txn.guid
               ]
-            })
+            }))
 
             segment = nil
             l = with_array_logger do
-              segment = external_request_segment { |s| s.process_response_metadata rmd; s }
+              segment = external_request_segment { |s| s.process_response_metadata(rmd); s }
             end
             refute l.array.empty?, "process_response_metadata should log error on invalid ID"
             assert l.array.first =~ %r{invalid/non-trusted ID}
@@ -741,14 +741,14 @@ module NewRelic::Agent
 
         with_config(distributed_tracing_config) do
           request = RequestWrapper.new
-          with_config cat_config.merge(distributed_tracing_config) do
-            in_transaction :category => :controller do |txn|
+          with_config(cat_config.merge(distributed_tracing_config)) do
+            in_transaction(:category => :controller) do |txn|
               segment = Tracer.start_external_request_segment(
                 library: "Net::HTTP",
                 uri: "http://remotehost.com/blogs/index",
                 procedure: "GET"
               )
-              segment.add_request_headers request
+              segment.add_request_headers(request)
               segment.finish
             end
           end
@@ -784,12 +784,12 @@ module NewRelic::Agent
           in_transaction('wat') do |txn|
             txn.stubs(:sampled?).returns(true)
 
-            segment = ExternalRequestSegment.new "Typhoeus",
+            segment = ExternalRequestSegment.new("Typhoeus",
               "http://remotehost.com/blogs/index",
-              "GET"
-            txn.add_segment segment
+              "GET")
+            txn.add_segment(segment)
             segment.start
-            advance_process_time 1.0
+            advance_process_time(1.0)
             segment.finish
 
             timestamp = Integer(segment.start_time * 1000.0)
@@ -833,12 +833,12 @@ module NewRelic::Agent
           in_transaction('wat') do |txn|
             txn.stubs(:sampled?).returns(true)
 
-            segment = ExternalRequestSegment.new "Typhoeus",
+            segment = ExternalRequestSegment.new("Typhoeus",
               "#{filtered_url}?a=1&b=2#fragment",
-              "GET"
-            txn.add_segment segment
+              "GET")
+            txn.add_segment(segment)
             segment.start
-            advance_process_time 1.0
+            advance_process_time(1.0)
             segment.finish
           end
 
@@ -855,12 +855,12 @@ module NewRelic::Agent
         in_transaction('wat') do |txn|
           txn.stubs(:sampled?).returns(false)
 
-          segment = ExternalRequestSegment.new "Typhoeus",
+          segment = ExternalRequestSegment.new("Typhoeus",
             "http://remotehost.com/blogs/index",
-            "GET"
-          txn.add_segment segment
+            "GET")
+          txn.add_segment(segment)
           segment.start
-          advance_process_time 1.0
+          advance_process_time(1.0)
           segment.finish
         end
 
@@ -872,12 +872,12 @@ module NewRelic::Agent
         in_transaction('wat') do |txn|
           txn.stubs(:ignore?).returns(true)
 
-          segment = ExternalRequestSegment.new "Typhoeus",
+          segment = ExternalRequestSegment.new("Typhoeus",
             "http://remotehost.com/blogs/index",
-            "GET"
-          txn.add_segment segment
+            "GET")
+          txn.add_segment(segment)
           segment.start
-          advance_process_time 1.0
+          advance_process_time(1.0)
           segment.finish
         end
 
@@ -889,10 +889,11 @@ module NewRelic::Agent
         with_config(distributed_tracing_config) do
           in_transaction('wat') do |txn|
             txn.stubs(:sampled?).returns(true)
-            segment = NewRelic::Agent::Tracer.start_external_request_segment \
+            segment = NewRelic::Agent::Tracer.start_external_request_segment( \
               library: "Typhoeus",
               uri: "http://#{'a' * 300}.com",
               procedure: "GET"
+            )
             segment.finish
           end
 
@@ -941,7 +942,7 @@ module NewRelic::Agent
           uri: 'http://example.com/root/index',
           procedure: :get
         )
-        v = yield segment
+        v = yield(segment)
         segment.finish
         v
       end

--- a/test/new_relic/agent/transaction/message_broker_segment_test.rb
+++ b/test/new_relic/agent/transaction/message_broker_segment_test.rb
@@ -15,7 +15,7 @@ module NewRelic
         end
 
         def test_metrics_recorded_for_produce
-          in_transaction "test_txn" do
+          in_transaction("test_txn") do
             segment = NewRelic::Agent::Tracer.start_message_broker_segment(
               action: :produce,
               library: "RabbitMQ",
@@ -32,7 +32,7 @@ module NewRelic
         end
 
         def test_metrics_recorded_for_consume
-          in_transaction "test_txn" do
+          in_transaction("test_txn") do
             segment = NewRelic::Agent::Tracer.start_message_broker_segment(
               action: :consume,
               library: "RabbitMQ",
@@ -49,7 +49,7 @@ module NewRelic
         end
 
         def test_segment_copies_parameters
-          in_transaction "test_txn" do
+          in_transaction("test_txn") do
             segment = NewRelic::Agent::Tracer.start_message_broker_segment(
               action: :produce,
               library: "RabbitMQ",
@@ -64,7 +64,7 @@ module NewRelic
         end
 
         def test_allows_symbol_exhange_names
-          in_transaction "test_txn" do
+          in_transaction("test_txn") do
             segment = NewRelic::Agent::Tracer.start_message_broker_segment(
               action: :produce,
               library: "RabbitMQ",
@@ -79,8 +79,8 @@ module NewRelic
         end
 
         def test_segment_adds_cat_headers_to_message_properties_for_produce
-          with_config :"cross_application_tracer.enabled" => true, :"distributed_tracing.enabled" => false, :cross_process_id => "321#123", :encoding_key => "abc" do
-            in_transaction "test_txn" do
+          with_config(:"cross_application_tracer.enabled" => true, :"distributed_tracing.enabled" => false, :cross_process_id => "321#123", :encoding_key => "abc") do
+            in_transaction("test_txn") do
               segment = NewRelic::Agent::Tracer.start_message_broker_segment(
                 action: :produce,
                 library: "RabbitMQ",
@@ -97,8 +97,8 @@ module NewRelic
         end
 
         def test_segment_adds_synthetics_and_cat_headers_to_message_properties_for_produce
-          with_config :"cross_application_tracer.enabled" => true, :"distributed_tracing.enabled" => false, :cross_process_id => "321#123", :encoding_key => "abc" do
-            in_transaction "test_txn" do |txn|
+          with_config(:"cross_application_tracer.enabled" => true, :"distributed_tracing.enabled" => false, :cross_process_id => "321#123", :encoding_key => "abc") do
+            in_transaction("test_txn") do |txn|
               txn.raw_synthetics_header = "boo"
               segment = NewRelic::Agent::Tracer.start_message_broker_segment(
                 action: :produce,
@@ -117,10 +117,10 @@ module NewRelic
 
         def test_segment_adds_distributed_trace_headers_to_message_properties_for_produce
           NewRelic::Agent::DistributedTracePayload.stubs(:connected?).returns(true)
-          with_config :"distributed_tracing.enabled" => true,
+          with_config(:"distributed_tracing.enabled" => true,
             :account_id => "190",
-            :primary_application_id => "46954" do
-            transaction = in_transaction "test_txn" do |txn|
+            :primary_application_id => "46954") do
+            transaction = in_transaction("test_txn") do |txn|
               segment = NewRelic::Agent::Tracer.start_message_broker_segment(
                 action: :produce,
                 library: "RabbitMQ",
@@ -140,18 +140,18 @@ module NewRelic
         def test_sets_start_time_from_constructor
           t = Process.clock_gettime(Process::CLOCK_REALTIME)
 
-          segment = MessageBrokerSegment.new action: :produce,
+          segment = MessageBrokerSegment.new(action: :produce,
             library: "RabbitMQ",
             destination_type: :exchange,
             destination_name: "Default",
-            start_time: t
+            start_time: t)
           assert_equal t, segment.start_time
 
-          segment = NewRelic::Agent::Tracer.start_message_broker_segment action: :produce,
+          segment = NewRelic::Agent::Tracer.start_message_broker_segment(action: :produce,
             library: "RabbitMQ",
             destination_type: :exchange,
             destination_name: "Default",
-            start_time: t
+            start_time: t)
           assert_equal t, segment.start_time
         end
       end

--- a/test/new_relic/agent/transaction/request_attributes_test.rb
+++ b/test/new_relic/agent/transaction/request_attributes_test.rb
@@ -11,8 +11,8 @@ module NewRelic
     class Transaction
       class RequestAttributesTest < Minitest::Test
         def test_tolerates_request_without_desired_methods
-          request = stub 'request'
-          attrs = RequestAttributes.new request
+          request = stub('request')
+          attrs = RequestAttributes.new(request)
 
           assert_equal "/", attrs.request_path
           assert_nil attrs.referer
@@ -24,57 +24,57 @@ module NewRelic
         end
 
         def test_sets_referer_from_request
-          request = stub 'request', :referer => "http://site.com/page"
-          attrs = RequestAttributes.new request
+          request = stub('request', :referer => "http://site.com/page")
+          attrs = RequestAttributes.new(request)
 
           assert_equal "http://site.com/page", attrs.referer
         end
 
         def test_sets_accept_from_request_headers
-          request = stub 'request', :env => {"HTTP_ACCEPT" => "application/json"}
-          attrs = RequestAttributes.new request
+          request = stub('request', :env => {"HTTP_ACCEPT" => "application/json"})
+          attrs = RequestAttributes.new(request)
 
           assert_equal "application/json", attrs.accept
         end
 
         def test_sets_content_length_from_request
-          request = stub 'request', :content_length => "111"
-          attrs = RequestAttributes.new request
+          request = stub('request', :content_length => "111")
+          attrs = RequestAttributes.new(request)
 
           assert_equal 111, attrs.content_length
         end
 
         def test_sets_content_type_from_request
-          request = stub 'request', :content_type => "application/json"
-          attrs = RequestAttributes.new request
+          request = stub('request', :content_type => "application/json")
+          attrs = RequestAttributes.new(request)
 
           assert_equal "application/json", attrs.content_type
         end
 
         def test_sets_host_from_request
-          request = stub 'request', :host => "localhost"
-          attrs = RequestAttributes.new request
+          request = stub('request', :host => "localhost")
+          attrs = RequestAttributes.new(request)
 
           assert_equal "localhost", attrs.host
         end
 
         def test_sets_port_from_request
-          request = stub 'request', :port => "3000"
-          attrs = RequestAttributes.new request
+          request = stub('request', :port => "3000")
+          attrs = RequestAttributes.new(request)
 
           assert_equal 3000, attrs.port
         end
 
         def test_sets_user_agent_from_request
-          request = stub 'request', :user_agent => "use this!"
-          attrs = RequestAttributes.new request
+          request = stub('request', :user_agent => "use this!")
+          attrs = RequestAttributes.new(request)
 
           assert_equal "use this!", attrs.user_agent
         end
 
         def test_sets_method_from_request
-          request = stub 'request', :request_method => "POST"
-          attrs = RequestAttributes.new request
+          request = stub('request', :request_method => "POST")
+          attrs = RequestAttributes.new(request)
 
           assert_equal "POST", attrs.request_method
         end

--- a/test/new_relic/agent/transaction/segment_test.rb
+++ b/test/new_relic/agent/transaction/segment_test.rb
@@ -92,32 +92,32 @@ module NewRelic
         end
 
         def test_assigns_unscoped_metrics
-          segment = Segment.new "Custom/simple/segment", "Segment/all"
+          segment = Segment.new("Custom/simple/segment", "Segment/all")
           assert_equal "Custom/simple/segment", segment.name
           assert_equal "Segment/all", segment.unscoped_metrics
         end
 
         def test_assigns_unscoped_metrics_as_array
-          segment = Segment.new "Custom/simple/segment", ["Segment/all", "Other/all"]
+          segment = Segment.new("Custom/simple/segment", ["Segment/all", "Other/all"])
           assert_equal "Custom/simple/segment", segment.name
           assert_equal ["Segment/all", "Other/all"], segment.unscoped_metrics
         end
 
         def test_segment_does_not_record_metrics_outside_of_txn
-          segment = Segment.new "Custom/simple/segment", "Segment/all"
+          segment = Segment.new("Custom/simple/segment", "Segment/all")
           segment.start
-          advance_process_time 1.0
+          advance_process_time(1.0)
           segment.finish
 
           refute_metrics_recorded ["Custom/simple/segment", "Segment/all"]
         end
 
         def test_segment_records_metrics
-          in_transaction "test" do |txn|
-            segment = Segment.new "Custom/simple/segment", "Segment/all"
-            txn.add_segment segment
+          in_transaction("test") do |txn|
+            segment = Segment.new("Custom/simple/segment", "Segment/all")
+            txn.add_segment(segment)
             segment.start
-            advance_process_time 1.0
+            advance_process_time(1.0)
             segment.finish
           end
 
@@ -136,10 +136,10 @@ module NewRelic
 
         def test_segment_records_metrics_when_given_as_array
           in_transaction do |txn|
-            segment = Segment.new "Custom/simple/segment", ["Segment/all", "Other/all"]
-            txn.add_segment segment
+            segment = Segment.new("Custom/simple/segment", ["Segment/all", "Other/all"])
+            txn.add_segment(segment)
             segment.start
-            advance_process_time 1.0
+            advance_process_time(1.0)
             segment.finish
           end
 
@@ -148,11 +148,11 @@ module NewRelic
 
         def test_segment_can_disable_scoped_metric_recording
           in_transaction('test') do |txn|
-            segment = Segment.new "Custom/simple/segment", "Segment/all"
+            segment = Segment.new("Custom/simple/segment", "Segment/all")
             segment.record_scoped_metric = false
-            txn.add_segment segment
+            txn.add_segment(segment)
             segment.start
-            advance_process_time 1.0
+            advance_process_time(1.0)
             segment.finish
           end
 
@@ -171,11 +171,11 @@ module NewRelic
 
         def test_segment_can_disable_scoped_metric_recording_with_unscoped_as_frozen_array
           in_transaction('test') do |txn|
-            segment = Segment.new "Custom/simple/segment", ["Segment/all", "Segment/allOther"].freeze
+            segment = Segment.new("Custom/simple/segment", ["Segment/all", "Segment/allOther"].freeze)
             segment.record_scoped_metric = false
-            txn.add_segment segment
+            txn.add_segment(segment)
             segment.start
-            advance_process_time 1.0
+            advance_process_time(1.0)
             segment.finish
           end
 
@@ -196,10 +196,10 @@ module NewRelic
           in_transaction('wat') do |txn|
             txn.stubs(:sampled?).returns(false)
 
-            segment = Segment.new 'Ummm'
-            txn.add_segment segment
+            segment = Segment.new('Ummm')
+            txn.add_segment(segment)
             segment.start
-            advance_process_time 1.0
+            advance_process_time(1.0)
             segment.finish
           end
 
@@ -211,10 +211,10 @@ module NewRelic
           in_transaction('wat') do |txn|
             txn.stubs(:ignore?).returns(true)
 
-            segment = Segment.new 'Ummm'
-            txn.add_segment segment
+            segment = Segment.new('Ummm')
+            txn.add_segment(segment)
             segment.start
-            advance_process_time 1.0
+            advance_process_time(1.0)
             segment.finish
           end
 
@@ -232,10 +232,10 @@ module NewRelic
           in_transaction('wat') do |txn|
             txn.stubs(:sampled?).returns(true)
 
-            segment = Segment.new 'Ummm'
-            txn.add_segment segment
+            segment = Segment.new('Ummm')
+            txn.add_segment(segment)
             segment.start
-            advance_process_time 1.0
+            advance_process_time(1.0)
             segment.finish
 
             timestamp = Integer(segment.start_time * 1000.0)
@@ -267,7 +267,7 @@ module NewRelic
 
         def test_sets_start_time_from_constructor
           t = Process.clock_gettime(Process::CLOCK_REALTIME)
-          segment = Segment.new nil, nil, t
+          segment = Segment.new(nil, nil, t)
           assert_equal t, segment.start_time
         end
 
@@ -286,7 +286,7 @@ module NewRelic
             assert_raises(Errno::EIO, Errno::EMFILE, Errno::ENFILE) do
               while true
                 file_descriptors << IO.sysopen(__FILE__)
-                Segment.new "Test #{file_descriptors[-1]}"
+                Segment.new("Test #{file_descriptors[-1]}")
               end
             end
           ensure
@@ -370,7 +370,7 @@ module NewRelic
           rescue Exception => exception
             segment_with_error.finish
             assert segment_with_error, "expected to have a segment_with_error"
-            build_deferred_error_attributes segment_with_error
+            build_deferred_error_attributes(segment_with_error)
             refute_equal parent_segment, segment_with_error
             return segment_with_error, parent_segment, exception
           end

--- a/test/new_relic/agent/transaction/trace_builder_test.rb
+++ b/test/new_relic/agent/transaction/trace_builder_test.rb
@@ -17,22 +17,22 @@ module NewRelic
         def test_builds_trace_for_transaction
           txn = nil
           state = Tracer.state
-          Tracer.in_transaction name: "test_txn", category: :controller do
+          Tracer.in_transaction(name: "test_txn", category: :controller) do
             txn = state.current_transaction
-            advance_process_time 1
-            segment_a = Tracer.start_segment name: "segment_a"
+            advance_process_time(1)
+            segment_a = Tracer.start_segment(name: "segment_a")
             segment_a.params[:foo] = "bar"
-            advance_process_time 1
-            segment_b = Tracer.start_segment name: "segment_b"
-            advance_process_time 2
+            advance_process_time(1)
+            segment_b = Tracer.start_segment(name: "segment_b")
+            advance_process_time(2)
             segment_b.finish
-            segment_c = Tracer.start_segment name: "segment_c"
-            advance_process_time 3
+            segment_c = Tracer.start_segment(name: "segment_c")
+            advance_process_time(3)
             segment_c.finish
             segment_a.finish
           end
 
-          trace = TraceBuilder.build_trace txn
+          trace = TraceBuilder.build_trace(txn)
 
           root = trace.root_node
           assert_equal "ROOT", root.metric_name
@@ -64,14 +64,14 @@ module NewRelic
         def test_trace_built_if_segment_left_unfinished
           txn = nil
           state = Tracer.state
-          Tracer.in_transaction name: "test_txn", category: :controller do
+          Tracer.in_transaction(name: "test_txn", category: :controller) do
             txn = state.current_transaction
-            advance_process_time 1
-            Tracer.start_segment name: "segment_a"
-            advance_process_time 1
+            advance_process_time(1)
+            Tracer.start_segment(name: "segment_a")
+            advance_process_time(1)
           end
 
-          trace = TraceBuilder.build_trace txn
+          trace = TraceBuilder.build_trace(txn)
 
           root = trace.root_node
           assert_equal "ROOT", root.metric_name

--- a/test/new_relic/agent/transaction/trace_context_test.rb
+++ b/test/new_relic/agent/transaction/trace_context_test.rb
@@ -41,7 +41,7 @@ module NewRelic::Agent
 
           txn = in_transaction do |t|
             t.sampled = true
-            inserted = t.distributed_tracer.insert_trace_context_header carrier
+            inserted = t.distributed_tracer.insert_trace_context_header(carrier)
             trace_state = t.distributed_tracer.create_trace_state
             parent_id = t.current_segment.guid
             trace_id = t.trace_id
@@ -67,11 +67,12 @@ module NewRelic::Agent
             parent.sampled = false
             payload = parent.distributed_tracer.create_trace_state_payload
             trace_parent = make_trace_parent({'trace_id' => parent.trace_id, 'parent_id' => parent.guid})
-            parent_trace_context_header_data = make_trace_context_header_data \
+            parent_trace_context_header_data = make_trace_context_header_data( \
               trace_parent: trace_parent,
               trace_state_payload: payload
+            )
             trace_id = parent.trace_id
-            other_trace_state = parent_trace_context_header_data.instance_variable_get :@trace_state_entries
+            other_trace_state = parent_trace_context_header_data.instance_variable_get(:@trace_state_entries)
           end
 
           carrier = {}
@@ -80,8 +81,8 @@ module NewRelic::Agent
 
           in_transaction do |child|
             child.sampled = false
-            child.distributed_tracer.accept_trace_context parent_trace_context_header_data
-            child.distributed_tracer.insert_trace_context_header carrier
+            child.distributed_tracer.accept_trace_context(parent_trace_context_header_data)
+            child.distributed_tracer.insert_trace_context_header(carrier)
             child_trace_state_payload = child.distributed_tracer.create_trace_state_payload
             parent_id = child.current_segment.guid
           end
@@ -101,8 +102,8 @@ module NewRelic::Agent
 
           in_transaction do |parent|
             parent.sampled = true
-            parent_trace_context_header_data = make_trace_context_header_data trace_state: ['other=asdf,other2=jkl;']
-            other_trace_state = parent_trace_context_header_data.instance_variable_get :@trace_state_entries
+            parent_trace_context_header_data = make_trace_context_header_data(trace_state: ['other=asdf,other2=jkl;'])
+            other_trace_state = parent_trace_context_header_data.instance_variable_get(:@trace_state_entries)
           end
 
           carrier = {}
@@ -110,8 +111,8 @@ module NewRelic::Agent
 
           in_transaction do |child|
             child.sampled = true
-            child.distributed_tracer.accept_trace_context parent_trace_context_header_data
-            child.distributed_tracer.insert_trace_context_header carrier
+            child.distributed_tracer.accept_trace_context(parent_trace_context_header_data)
+            child.distributed_tracer.insert_trace_context_header(carrier)
             child_trace_state_payload = child.distributed_tracer.create_trace_state_payload
           end
 
@@ -128,10 +129,11 @@ module NewRelic::Agent
             parent.sampled = true
             payload = parent.distributed_tracer.create_trace_state_payload
             trace_parent = make_trace_parent({'trace_id' => parent.trace_id, 'parent_id' => parent.guid})
-            parent_trace_context_header_data = make_trace_context_header_data \
+            parent_trace_context_header_data = make_trace_context_header_data( \
               trace_parent: trace_parent,
               trace_state_payload: payload,
               trace_state: []
+            )
           end
 
           carrier = {}
@@ -140,8 +142,8 @@ module NewRelic::Agent
 
           in_transaction do |child|
             child.sampled = true
-            child.distributed_tracer.accept_trace_context parent_trace_context_header_data
-            child.distributed_tracer.insert_trace_context_header carrier
+            child.distributed_tracer.accept_trace_context(parent_trace_context_header_data)
+            child.distributed_tracer.insert_trace_context_header(carrier)
             child_trace_state_payload = child.distributed_tracer.create_trace_state_payload
             parent_id = child.current_segment.guid
           end
@@ -162,7 +164,7 @@ module NewRelic::Agent
           trace_context_header_data = make_trace_context_header_data
 
           t = in_transaction do |txn|
-            txn.distributed_tracer.accept_trace_context trace_context_header_data
+            txn.distributed_tracer.accept_trace_context(trace_context_header_data)
           end
 
           assert_same trace_context_header_data, t.distributed_tracer.trace_context_header_data
@@ -172,17 +174,18 @@ module NewRelic::Agent
         def test_accept_trace_state_actually_sets_transaction_attributes
           carrier = {}
 
-          parent_txn = in_transaction 'parent' do |txn|
+          parent_txn = in_transaction('parent') do |txn|
             txn.sampled = true
-            txn.distributed_tracer.insert_trace_context_header carrier
+            txn.distributed_tracer.insert_trace_context_header(carrier)
           end
 
-          trace_context_header_data = NewRelic::Agent::DistributedTracing::TraceContext.parse \
+          trace_context_header_data = NewRelic::Agent::DistributedTracing::TraceContext.parse( \
             carrier: carrier,
             trace_state_entry_key: AccountHelpers.trace_state_entry_key
-          child_txn = in_transaction 'new' do |txn|
+          )
+          child_txn = in_transaction('new') do |txn|
             txn.sampled = true
-            txn.distributed_tracer.accept_trace_context trace_context_header_data
+            txn.distributed_tracer.accept_trace_context(trace_context_header_data)
           end
 
           assert_equal parent_txn.guid, child_txn.distributed_tracer.parent_transaction_id
@@ -205,20 +208,21 @@ module NewRelic::Agent
           txn_two = nil
 
           with_config(account_one) do
-            txn_one = in_transaction 'parent' do |txn|
+            txn_one = in_transaction('parent') do |txn|
               txn.sampled = true
-              txn.distributed_tracer.insert_trace_context_header carrier
+              txn.distributed_tracer.insert_trace_context_header(carrier)
             end
           end
 
           uncache_trusted_account_key
 
           with_config(account_two) do
-            trace_context_header_data = NewRelic::Agent::DistributedTracing::TraceContext.parse \
+            trace_context_header_data = NewRelic::Agent::DistributedTracing::TraceContext.parse( \
               carrier: carrier,
               trace_state_entry_key: AccountHelpers.trace_state_entry_key
-            txn_two = in_transaction 'child' do |txn|
-              txn.distributed_tracer.accept_trace_context trace_context_header_data
+            )
+            txn_two = in_transaction('child') do |txn|
+              txn.distributed_tracer.accept_trace_context(trace_context_header_data)
             end
           end
 
@@ -247,20 +251,21 @@ module NewRelic::Agent
           txn_two = nil
 
           with_config(account_one) do
-            txn_one = in_transaction 'parent' do |txn|
+            txn_one = in_transaction('parent') do |txn|
               txn.sampled = true
-              txn.distributed_tracer.insert_trace_context_header carrier
+              txn.distributed_tracer.insert_trace_context_header(carrier)
             end
           end
 
           uncache_trusted_account_key
 
           with_config(account_two) do
-            trace_context_header_data = NewRelic::Agent::DistributedTracing::TraceContext.parse \
+            trace_context_header_data = NewRelic::Agent::DistributedTracing::TraceContext.parse( \
               carrier: carrier,
               trace_state_entry_key: AccountHelpers.trace_state_entry_key
-            txn_two = in_transaction 'child' do |txn|
-              txn.distributed_tracer.accept_trace_context trace_context_header_data
+            )
+            txn_two = in_transaction('child') do |txn|
+              txn.distributed_tracer.accept_trace_context(trace_context_header_data)
             end
           end
 
@@ -273,7 +278,7 @@ module NewRelic::Agent
           in_transaction do |txn|
             txn.sampled = true
             trace_state_payload = txn.distributed_tracer.create_trace_state_payload
-            trace_context_header_data = make_trace_context_header_data trace_state_payload: trace_state_payload
+            trace_context_header_data = make_trace_context_header_data(trace_state_payload: trace_state_payload)
 
             assert txn.distributed_tracer.accept_trace_context(trace_context_header_data), "Expected first trace context to be accepted"
             refute txn.distributed_tracer.accept_trace_context(trace_context_header_data), "Expected second trace context not to be accepted"
@@ -286,15 +291,15 @@ module NewRelic::Agent
 
           in_transaction do |parent|
             parent.sampled = true
-            parent_trace_context_header_data = make_trace_context_header_data trace_state: ['other=asdf,other2=jkl;']
+            parent_trace_context_header_data = make_trace_context_header_data(trace_state: ['other=asdf,other2=jkl;'])
           end
 
           carrier = {}
 
           in_transaction do |child|
             child.sampled = true
-            child.distributed_tracer.accept_trace_context parent_trace_context_header_data
-            child.distributed_tracer.insert_trace_context_header carrier
+            child.distributed_tracer.accept_trace_context(parent_trace_context_header_data)
+            child.distributed_tracer.insert_trace_context_header(carrier)
           end
 
           assert_metrics_recorded "Supportability/TraceContext/TraceState/NoNrEntry"
@@ -304,7 +309,7 @@ module NewRelic::Agent
           in_transaction do |txn|
             txn.sampled = true
             trace_state_payload = txn.distributed_tracer.create_trace_state_payload
-            trace_context_header_data = make_trace_context_header_data trace_state_payload: trace_state_payload
+            trace_context_header_data = make_trace_context_header_data(trace_state_payload: trace_state_payload)
             trace_state_payload.stubs(:valid?).returns(false)
             refute txn.distributed_tracer.accept_trace_context(trace_context_header_data), "Expected trace context to be rejected"
           end
@@ -317,10 +322,10 @@ module NewRelic::Agent
 
           in_transaction do |txn|
             txn.sampled = true
-            txn.distributed_tracer.insert_trace_context_header carrier
+            txn.distributed_tracer.insert_trace_context_header(carrier)
             trace_context_header_data = make_trace_context_header_data
 
-            refute txn.distributed_tracer.accept_trace_context trace_context_header_data
+            refute txn.distributed_tracer.accept_trace_context(trace_context_header_data)
           end
           assert_metrics_recorded "Supportability/TraceContext/Accept/Ignored/CreateBeforeAccept"
         end
@@ -358,7 +363,7 @@ module NewRelic::Agent
             :'analytics_events.enabled' => false
           })
 
-          with_config disabled_analytics_events do
+          with_config(disabled_analytics_events) do
             refute Agent.config[:'analytics_events.enabled']
             txn = in_transaction do |t|
               t.sampled = true
@@ -386,7 +391,7 @@ module NewRelic::Agent
             :'span_events.enabled' => false
           })
 
-          with_config disabled_span_events do
+          with_config(disabled_span_events) do
             refute Agent.config[:'span_events.enabled']
             txn = in_transaction do |t|
               t.sampled = true
@@ -411,12 +416,13 @@ module NewRelic::Agent
             'tracestate' => '190@nr=0-1-212311-51424-0996096a36a1cd29----1482959525577'
           }
 
-          trace_context_header_data = NewRelic::Agent::DistributedTracing::TraceContext.parse \
+          trace_context_header_data = NewRelic::Agent::DistributedTracing::TraceContext.parse( \
             carrier: carrier,
             trace_state_entry_key: '190@nr'
+          )
 
           txn = in_transaction do |t|
-            t.distributed_tracer.accept_trace_context trace_context_header_data
+            t.distributed_tracer.accept_trace_context(trace_context_header_data)
           end
 
           assert_equal 'a8e67265afe2773a3c611b94306ee5c2', txn.trace_id
@@ -433,14 +439,14 @@ module NewRelic::Agent
             'trace_id' => '',
             'parent_id' => '',
             'sampled' => '01'
-          }.update options
+          }.update(options)
         end
 
         def make_trace_context_header_data trace_parent: "00-a8e67265afe2773a3c611b94306ee5c2-fb1010463ea28a38-01",
           trace_state_payload: nil,
           trace_state: ["other=asdf"],
           trace_state_vendors: ''
-          NewRelic::Agent::DistributedTracing::TraceContext::HeaderData.new trace_parent, trace_state_payload, trace_state, 10, trace_state_vendors
+          NewRelic::Agent::DistributedTracing::TraceContext::HeaderData.new(trace_parent, trace_state_payload, trace_state, 10, trace_state_vendors)
         end
       end
     end

--- a/test/new_relic/agent/transaction/trace_test.rb
+++ b/test/new_relic/agent/transaction/trace_test.rb
@@ -77,7 +77,7 @@ class NewRelic::Agent::Transaction::TraceTest < Minitest::Test
   end
 
   def test_prepare_to_send_is_idempotent
-    NewRelic::Agent::Database.stubs(:should_record_sql?).returns true
+    NewRelic::Agent::Database.stubs(:should_record_sql?).returns(true)
     @trace.expects(:collect_explain_plans!).once
     @trace.expects(:prepare_sql_for_transmission!).once
     @trace.prepare_to_send!
@@ -85,7 +85,7 @@ class NewRelic::Agent::Transaction::TraceTest < Minitest::Test
   end
 
   def test_prepare_to_send_handles_sql_and_does_not_strip_if_should_record_sql_is_true
-    NewRelic::Agent::Database.stubs(:should_record_sql?).returns true
+    NewRelic::Agent::Database.stubs(:should_record_sql?).returns(true)
     @trace.expects(:collect_explain_plans!).once
     @trace.expects(:prepare_sql_for_transmission!).once
     @trace.expects(:strip_sql!).never
@@ -93,7 +93,7 @@ class NewRelic::Agent::Transaction::TraceTest < Minitest::Test
   end
 
   def test_prepare_to_send_strips_and_does_not_handle_sql_if_should_record_sql_is_false
-    NewRelic::Agent::Database.stubs(:should_record_sql?).returns false
+    NewRelic::Agent::Database.stubs(:should_record_sql?).returns(false)
     @trace.expects(:collect_explain_plans!).never
     @trace.expects(:prepare_sql_for_transmission!).never
     @trace.expects(:strip_sql!).once
@@ -104,7 +104,7 @@ class NewRelic::Agent::Transaction::TraceTest < Minitest::Test
     node = @trace.create_node(0.0, 'has_sql')
     node.stubs(:duration).returns(2)
     node.stubs(:explain_sql).returns('')
-    node[:sql] = NewRelic::Agent::Database::Statement.new "select * from pelicans"
+    node[:sql] = NewRelic::Agent::Database::Statement.new("select * from pelicans")
 
     @trace.root_node.children << node
 
@@ -116,11 +116,11 @@ class NewRelic::Agent::Transaction::TraceTest < Minitest::Test
   end
 
   def test_prepare_to_send_prepares_sql_for_transmission
-    NewRelic::Agent::Database.stubs(:record_sql_method).returns :obfuscated
+    NewRelic::Agent::Database.stubs(:record_sql_method).returns(:obfuscated)
 
     node = @trace.create_node(0.0, 'has_sql')
     node.stubs(:duration).returns(2)
-    node[:sql] = NewRelic::Agent::Database::Statement.new "select * from pelicans where name = '1337807';"
+    node[:sql] = NewRelic::Agent::Database::Statement.new("select * from pelicans where name = '1337807';")
     @trace.root_node.children << node
 
     @trace.prepare_to_send!
@@ -128,11 +128,11 @@ class NewRelic::Agent::Transaction::TraceTest < Minitest::Test
   end
 
   def test_prepare_to_send_strips_sql
-    NewRelic::Agent::Database.stubs(:should_record_sql?).returns false
+    NewRelic::Agent::Database.stubs(:should_record_sql?).returns(false)
     node = @trace.create_node(0.0, 'has_sql')
     node.stubs(:duration).returns(2)
     node.stubs(:explain_sql).returns('')
-    node[:sql] = NewRelic::Agent::Database::Statement.new 'select * from pelicans;'
+    node[:sql] = NewRelic::Agent::Database::Statement.new('select * from pelicans;')
 
     @trace.root_node.children << node
     @trace.prepare_to_send!
@@ -203,10 +203,10 @@ class NewRelic::Agent::Transaction::TraceTest < Minitest::Test
   end
 
   def test_prepare_sql_for_transmission_obfuscates_sql_if_record_sql_method_is_obfuscated
-    NewRelic::Agent::Database.stubs(:record_sql_method).returns :obfuscated
+    NewRelic::Agent::Database.stubs(:record_sql_method).returns(:obfuscated)
 
     node = @trace.create_node(0.0, 'has_sql')
-    node[:sql] = NewRelic::Agent::Database::Statement.new "select * from pelicans where name = '1337807';"
+    node[:sql] = NewRelic::Agent::Database::Statement.new("select * from pelicans where name = '1337807';")
     @trace.root_node.children << node
 
     @trace.prepare_sql_for_transmission!
@@ -214,10 +214,10 @@ class NewRelic::Agent::Transaction::TraceTest < Minitest::Test
   end
 
   def test_prepare_sql_for_transmission_does_not_modify_sql_if_record_sql_method_is_raw
-    NewRelic::Agent::Database.stubs(:record_sql_method).returns :raw
+    NewRelic::Agent::Database.stubs(:record_sql_method).returns(:raw)
 
     node = @trace.create_node(0.0, 'has_sql')
-    node[:sql] = NewRelic::Agent::Database::Statement.new "select * from pelicans where name = '1337807';"
+    node[:sql] = NewRelic::Agent::Database::Statement.new("select * from pelicans where name = '1337807';")
     @trace.root_node.children << node
 
     @trace.prepare_sql_for_transmission!
@@ -225,10 +225,10 @@ class NewRelic::Agent::Transaction::TraceTest < Minitest::Test
   end
 
   def test_prepare_sql_for_transmission_removes_sql_if_record_sql_method_is_off
-    NewRelic::Agent::Database.stubs(:record_sql_method).returns :off
+    NewRelic::Agent::Database.stubs(:record_sql_method).returns(:off)
 
     node = @trace.create_node(0.0, 'has_sql')
-    node[:sql] = NewRelic::Agent::Database::Statement.new "select * from pelicans where name = '1337807';"
+    node[:sql] = NewRelic::Agent::Database::Statement.new("select * from pelicans where name = '1337807';")
     @trace.root_node.children << node
 
     @trace.prepare_sql_for_transmission!
@@ -239,7 +239,7 @@ class NewRelic::Agent::Transaction::TraceTest < Minitest::Test
     node = @trace.create_node(0.0, 'has_sql')
     node.stubs(:duration).returns(2)
     node.stubs(:explain_sql).returns('')
-    node[:sql] = NewRelic::Agent::Database::Statement.new 'select * from pelicans;'
+    node[:sql] = NewRelic::Agent::Database::Statement.new('select * from pelicans;')
 
     @trace.root_node.children << node
     @trace.strip_sql!

--- a/test/new_relic/agent/transaction/tracing_test.rb
+++ b/test/new_relic/agent/transaction/tracing_test.rb
@@ -21,13 +21,13 @@ module NewRelic
         end
 
         def test_segment_bound_to_transaction_records_metrics
-          in_transaction "test_txn" do
+          in_transaction("test_txn") do
             segment = Tracer.start_segment(
               name: "Custom/simple/segment",
               unscoped_metrics: "Segment/all"
             )
             segment.start
-            advance_process_time 1.0
+            advance_process_time(1.0)
             segment.finish
 
             refute_metrics_recorded ["Custom/simple/segment", "Segment/all"]
@@ -37,14 +37,14 @@ module NewRelic
         end
 
         def test_segment_bound_to_transaction_invokes_complete_callback_when_finished
-          in_transaction "test_txn" do |txn|
+          in_transaction("test_txn") do |txn|
             segment = Tracer.start_segment(
               name: "Custom/simple/segment",
               unscoped_metrics: "Segment/all"
             )
             txn.expects(:segment_complete).with(segment)
             segment.start
-            advance_process_time 1.0
+            advance_process_time(1.0)
             segment.finish
 
             # clean up traced method stack
@@ -56,13 +56,13 @@ module NewRelic
         def test_segment_data_is_copied_to_trace
           segment = nil
           segment_name = "Custom/simple/segment"
-          in_transaction "test_txn" do
+          in_transaction("test_txn") do
             segment = Tracer.start_segment(
               name: segment_name,
               unscoped_metrics: "Segment/all"
             )
             segment.start
-            advance_process_time 1.0
+            advance_process_time(1.0)
             segment.finish
           end
 
@@ -74,12 +74,12 @@ module NewRelic
         end
 
         def test_start_segment
-          in_transaction "test_txn" do |txn|
-            segment = Tracer.start_segment name: "Custom/segment/method"
+          in_transaction("test_txn") do |txn|
+            segment = Tracer.start_segment(name: "Custom/segment/method")
             assert_equal Process.clock_gettime(Process::CLOCK_REALTIME), segment.start_time
             assert_equal txn, segment.transaction
 
-            advance_process_time 1
+            advance_process_time(1)
             segment.finish
             assert_equal Process.clock_gettime(Process::CLOCK_REALTIME), segment.end_time
           end
@@ -87,15 +87,15 @@ module NewRelic
 
         def test_start_segment_with_time_override
           start_time = Process.clock_gettime(Process::CLOCK_REALTIME)
-          advance_process_time 2
+          advance_process_time(2)
 
-          in_transaction "test_txn" do |txn|
+          in_transaction("test_txn") do |txn|
             segment = Tracer.start_segment(
               name: "Custom/segment/method",
               start_time: start_time
             )
 
-            advance_process_time 1
+            advance_process_time(1)
             segment.finish
 
             assert_equal start_time, segment.start_time
@@ -103,7 +103,7 @@ module NewRelic
         end
 
         def test_start_datastore_segment
-          in_transaction "test_txn" do |txn|
+          in_transaction("test_txn") do |txn|
             segment = Tracer.start_datastore_segment(
               product: "SQLite",
               operation: "insert",
@@ -112,7 +112,7 @@ module NewRelic
             assert_equal Process.clock_gettime(Process::CLOCK_REALTIME), segment.start_time
             assert_equal txn, segment.transaction
 
-            advance_process_time 1
+            advance_process_time(1)
             segment.finish
             assert_equal Process.clock_gettime(Process::CLOCK_REALTIME), segment.end_time
           end
@@ -134,7 +134,7 @@ module NewRelic
             collection: "Blog"
           )
           segment.start
-          advance_process_time 1
+          advance_process_time(1)
           segment.finish
 
           refute_metrics_recorded [
@@ -149,13 +149,13 @@ module NewRelic
 
         def test_start_segment_with_tracing_disabled_in_transaction
           segment = nil
-          in_transaction "test_txn" do |txn|
+          in_transaction("test_txn") do |txn|
             NewRelic::Agent.disable_all_tracing do
               segment = Tracer.start_segment(
                 name: "Custom/segment/method",
                 unscoped_metrics: "Custom/all"
               )
-              advance_process_time 1
+              advance_process_time(1)
               segment.finish
             end
           end
@@ -164,7 +164,7 @@ module NewRelic
         end
 
         def test_current_segment_in_transaction
-          in_transaction "test_txn" do |txn|
+          in_transaction("test_txn") do |txn|
             assert_equal txn.initial_segment, txn.current_segment
             ds_segment = Tracer.start_datastore_segment(
               product: "SQLite",
@@ -173,7 +173,7 @@ module NewRelic
             )
             assert_equal ds_segment, txn.current_segment
 
-            segment = Tracer.start_segment name: "Custom/basic/segment"
+            segment = Tracer.start_segment(name: "Custom/basic/segment")
             assert_equal segment, txn.current_segment
 
             segment.finish
@@ -185,7 +185,7 @@ module NewRelic
         end
 
         def test_segments_are_properly_parented
-          in_transaction "test_txn" do |txn|
+          in_transaction("test_txn") do |txn|
             assert_nil txn.initial_segment.parent
 
             ds_segment = Tracer.start_datastore_segment(
@@ -195,7 +195,7 @@ module NewRelic
             )
             assert_equal txn.initial_segment, ds_segment.parent
 
-            segment = Tracer.start_segment name: "Custom/basic/segment"
+            segment = Tracer.start_segment(name: "Custom/basic/segment")
             assert_equal ds_segment, segment.parent
 
             segment.finish
@@ -208,7 +208,7 @@ module NewRelic
             name: "Custom/segment/method",
             unscoped_metrics: "Custom/all"
           )
-          advance_process_time 1
+          advance_process_time(1)
           segment.finish
 
           assert_nil segment.transaction, "Did not expect segment to associated with a transaction"
@@ -216,7 +216,7 @@ module NewRelic
         end
 
         def test_start_external_request_segment
-          in_transaction "test_txn" do |txn|
+          in_transaction("test_txn") do |txn|
             segment = Tracer.start_external_request_segment(
               library: "Net::HTTP",
               uri: "http://site.com/endpoint",
@@ -228,7 +228,7 @@ module NewRelic
             assert_equal "http://site.com/endpoint", segment.uri.to_s
             assert_equal "GET", segment.procedure
 
-            advance_process_time 1
+            advance_process_time(1)
             segment.finish
             assert_equal Process.clock_gettime(Process::CLOCK_REALTIME), segment.end_time
           end
@@ -254,20 +254,20 @@ module NewRelic
         def test_children_time
           segment_a, segment_b, segment_c, segment_d = nil, nil, nil, nil
 
-          in_transaction "test" do
-            segment_a = NewRelic::Agent::Tracer.start_segment name: "metric a"
+          in_transaction("test") do
+            segment_a = NewRelic::Agent::Tracer.start_segment(name: "metric a")
             advance_process_time(0.001)
 
-            segment_b = NewRelic::Agent::Tracer.start_segment name: "metric b"
+            segment_b = NewRelic::Agent::Tracer.start_segment(name: "metric b")
             advance_process_time(0.002)
 
-            segment_c = NewRelic::Agent::Tracer.start_segment name: "metric c"
+            segment_c = NewRelic::Agent::Tracer.start_segment(name: "metric c")
             advance_process_time(0.003)
             segment_c.finish
 
             advance_process_time(0.001)
 
-            segment_d = NewRelic::Agent::Tracer.start_segment name: "metric d"
+            segment_d = NewRelic::Agent::Tracer.start_segment(name: "metric d")
             advance_process_time(0.002)
             segment_d.finish
 
@@ -285,7 +285,7 @@ module NewRelic
           limit = Agent.config[:'transaction_tracer.limit_segments']
           txn = in_transaction do
             (limit + 10).times do |n|
-              segment = NewRelic::Agent::Tracer.start_segment name: "MyCustom/segment#{n}"
+              segment = NewRelic::Agent::Tracer.start_segment(name: "MyCustom/segment#{n}")
               segment.finish
             end
           end
@@ -297,11 +297,11 @@ module NewRelic
             segment_a, segment_b, segment_c = nil, nil, nil
             in_transaction do
               advance_process_time(1)
-              segment_a = NewRelic::Agent::Tracer.start_segment name: 'metric_a'
+              segment_a = NewRelic::Agent::Tracer.start_segment(name: 'metric_a')
               advance_process_time(2)
-              segment_b = NewRelic::Agent::Tracer.start_segment name: 'metric_b'
+              segment_b = NewRelic::Agent::Tracer.start_segment(name: 'metric_b')
               advance_process_time(3)
-              segment_c = NewRelic::Agent::Tracer.start_segment name: 'metric_c'
+              segment_c = NewRelic::Agent::Tracer.start_segment(name: 'metric_c')
               advance_process_time(4)
               segment_c.finish
               segment_b.finish
@@ -321,11 +321,11 @@ module NewRelic
             segment_a, segment_b, segment_c = nil, nil, nil
             in_transaction do
               advance_process_time(1)
-              segment_a = NewRelic::Agent::Tracer.start_segment name: 'metric_a'
+              segment_a = NewRelic::Agent::Tracer.start_segment(name: 'metric_a')
               advance_process_time(2)
-              segment_b = NewRelic::Agent::Tracer.start_segment name: 'metric_b'
+              segment_b = NewRelic::Agent::Tracer.start_segment(name: 'metric_b')
               advance_process_time(3)
-              segment_c = NewRelic::Agent::Tracer.start_segment name: 'metric_c'
+              segment_c = NewRelic::Agent::Tracer.start_segment(name: 'metric_c')
               advance_process_time(4)
               segment_c.finish
               segment_b.finish
@@ -370,11 +370,11 @@ module NewRelic
           segment_a, segment_b, segment_c = nil, nil, nil
           in_transaction do
             advance_process_time(1)
-            segment_a = NewRelic::Agent::Tracer.start_segment name: 'metric_a'
+            segment_a = NewRelic::Agent::Tracer.start_segment(name: 'metric_a')
             advance_process_time(2)
-            segment_b = NewRelic::Agent::Tracer.start_segment name: 'metric_b'
+            segment_b = NewRelic::Agent::Tracer.start_segment(name: 'metric_b')
             advance_process_time(3)
-            segment_c = NewRelic::Agent::Tracer.start_segment name: 'metric_c'
+            segment_c = NewRelic::Agent::Tracer.start_segment(name: 'metric_c')
             advance_process_time(4)
             segment_c.finish
             segment_a.finish
@@ -399,9 +399,9 @@ module NewRelic
             :'transaction_tracer.limit_segments' => 100
           }
           with_config(config) do
-            in_transaction 'test_txn' do
+            in_transaction('test_txn') do
               110.times do |i|
-                segment = NewRelic::Agent::Tracer.start_segment name: "segment_#{i}"
+                segment = NewRelic::Agent::Tracer.start_segment(name: "segment_#{i}")
                 segment.finish
               end
             end
@@ -414,9 +414,9 @@ module NewRelic
         end
 
         def test_txn_not_recorded_when_tracing_is_disabled
-          with_config :'transaction_tracer.enabled' => false do
-            in_transaction 'dont_trace_this' do
-              segment = NewRelic::Agent::Tracer.start_segment name: 'seg'
+          with_config(:'transaction_tracer.enabled' => false) do
+            in_transaction('dont_trace_this') do
+              segment = NewRelic::Agent::Tracer.start_segment(name: 'seg')
               segment.finish
             end
           end
@@ -428,13 +428,13 @@ module NewRelic
           with_config(:'transaction_tracer.limit_segments' => 3) do
             in_transaction do |txn|
               expects_logging(:debug, includes("Segment limit"))
-              8.times { |i| NewRelic::Agent::Tracer.start_segment name: "segment_#{i}" }
+              8.times { |i| NewRelic::Agent::Tracer.start_segment(name: "segment_#{i}") }
             end
           end
         end
 
         def test_threshold_recorded_for_trace
-          with_config :'transaction_tracer.transaction_threshold' => 2.0 do
+          with_config(:'transaction_tracer.transaction_threshold' => 2.0) do
             in_transaction {}
             trace = last_transaction_trace
             assert_equal 2.0, trace.threshold
@@ -463,9 +463,9 @@ module NewRelic
         #      segment_b  segment_c
 
         def test_flexible_parenting_segment
-          in_transaction 'test_txn' do
-            segment_a = NewRelic::Agent::Tracer.start_segment name: 'segment_a'
-            segment_b = NewRelic::Agent::Tracer.start_segment name: 'segment_b'
+          in_transaction('test_txn') do
+            segment_a = NewRelic::Agent::Tracer.start_segment(name: 'segment_a')
+            segment_b = NewRelic::Agent::Tracer.start_segment(name: 'segment_b')
             segment_c = NewRelic::Agent::Tracer.start_segment(
               name: 'segment_a',
               parent: segment_a
@@ -480,9 +480,9 @@ module NewRelic
         end
 
         def test_flexible_parenting_datastore_segment
-          in_transaction 'test_txn' do
-            segment_a = NewRelic::Agent::Tracer.start_segment name: 'segment_a'
-            segment_b = NewRelic::Agent::Tracer.start_segment name: 'segment_b'
+          in_transaction('test_txn') do
+            segment_a = NewRelic::Agent::Tracer.start_segment(name: 'segment_a')
+            segment_b = NewRelic::Agent::Tracer.start_segment(name: 'segment_b')
             segment_c = NewRelic::Agent::Tracer.start_datastore_segment(
               product: "SQLite",
               operation: "Select",
@@ -499,9 +499,9 @@ module NewRelic
         end
 
         def test_flexible_parenting_external_request_segment
-          in_transaction 'test_txn' do
-            segment_a = NewRelic::Agent::Tracer.start_segment name: 'segment_a'
-            segment_b = NewRelic::Agent::Tracer.start_segment name: 'segment_b'
+          in_transaction('test_txn') do
+            segment_a = NewRelic::Agent::Tracer.start_segment(name: 'segment_a')
+            segment_b = NewRelic::Agent::Tracer.start_segment(name: 'segment_b')
             segment_c = NewRelic::Agent::Tracer.start_external_request_segment(
               library: "MyLib",
               uri: "https://blog.newrelic.com",
@@ -518,9 +518,9 @@ module NewRelic
         end
 
         def test_flexible_parenting_message_broker_segment
-          in_transaction 'test_txn' do
-            segment_a = NewRelic::Agent::Tracer.start_segment name: 'segment_a'
-            segment_b = NewRelic::Agent::Tracer.start_segment name: 'segment_b'
+          in_transaction('test_txn') do
+            segment_a = NewRelic::Agent::Tracer.start_segment(name: 'segment_a')
+            segment_b = NewRelic::Agent::Tracer.start_segment(name: 'segment_b')
             segment_c = NewRelic::Agent::Tracer.start_message_broker_segment(
               action: :produce,
               library: "RabbitMQ",
@@ -546,16 +546,16 @@ module NewRelic
         #      segment_b  segment_c     segment_e segment_f
 
         def test_parent_identifies_concurrent_children
-          in_transaction 'test_txn' do
-            segment_a = NewRelic::Agent::Tracer.start_segment name: 'segment_a'
-            segment_b = NewRelic::Agent::Tracer.start_segment name: 'segment_b'
+          in_transaction('test_txn') do
+            segment_a = NewRelic::Agent::Tracer.start_segment(name: 'segment_a')
+            segment_b = NewRelic::Agent::Tracer.start_segment(name: 'segment_b')
             segment_b.finish
-            segment_c = NewRelic::Agent::Tracer.start_segment name: 'segment_c'
+            segment_c = NewRelic::Agent::Tracer.start_segment(name: 'segment_c')
             segment_c.finish
             segment_a.finish
 
-            segment_d = NewRelic::Agent::Tracer.start_segment name: 'segment_d'
-            segment_e = NewRelic::Agent::Tracer.start_segment name: 'segment_e'
+            segment_d = NewRelic::Agent::Tracer.start_segment(name: 'segment_d')
+            segment_e = NewRelic::Agent::Tracer.start_segment(name: 'segment_e')
             segment_f = NewRelic::Agent::Tracer.start_segment(
               name: 'segment_f',
               parent: segment_d
@@ -588,33 +588,33 @@ module NewRelic
         def test_concurrent_durations
           segment_a, segment_b, segment_c, segment_d = nil, nil, nil, nil
 
-          in_transaction "test" do
-            segment_a = NewRelic::Agent::Tracer.start_segment name: "metric a"
-            advance_process_time 2
+          in_transaction("test") do
+            segment_a = NewRelic::Agent::Tracer.start_segment(name: "metric a")
+            advance_process_time(2)
 
-            segment_b = NewRelic::Agent::Tracer.start_segment name: "metric b"
-            advance_process_time 1
+            segment_b = NewRelic::Agent::Tracer.start_segment(name: "metric b")
+            advance_process_time(1)
 
             segment_c = NewRelic::Agent::Tracer.start_segment(
               name: "metric c",
               parent: segment_a
             )
 
-            advance_process_time 1
+            advance_process_time(1)
 
             segment_d = NewRelic::Agent::Tracer.start_segment(
               name: "metric d",
               parent: segment_a
             )
 
-            advance_process_time 1
+            advance_process_time(1)
             segment_b.finish
 
-            advance_process_time 1
+            advance_process_time(1)
             segment_c.finish
             segment_a.finish
 
-            advance_process_time 6
+            advance_process_time(6)
             segment_d.finish
           end
 
@@ -644,20 +644,20 @@ module NewRelic
         def test_child_segment_ends_after_parent_durations_correct
           segment_a, segment_b, segment_c = nil, nil, nil
 
-          in_transaction "test" do
-            segment_a = NewRelic::Agent::Tracer.start_segment name: "metric a"
-            advance_process_time 1
+          in_transaction("test") do
+            segment_a = NewRelic::Agent::Tracer.start_segment(name: "metric a")
+            advance_process_time(1)
 
-            segment_b = NewRelic::Agent::Tracer.start_segment name: "metric b"
-            advance_process_time 2
+            segment_b = NewRelic::Agent::Tracer.start_segment(name: "metric b")
+            advance_process_time(2)
 
             segment_b.finish
-            segment_c = NewRelic::Agent::Tracer.start_segment name: "metric c"
+            segment_c = NewRelic::Agent::Tracer.start_segment(name: "metric c")
 
-            advance_process_time 3
+            advance_process_time(3)
             segment_a.finish
 
-            advance_process_time 4
+            advance_process_time(4)
             segment_c.finish
           end
 
@@ -686,27 +686,27 @@ module NewRelic
         def test_durations_correct_with_sync_child_followed_by_concurrent_children
           segment_a, segment_b, segment_c, segment_d = nil, nil, nil, nil
 
-          in_transaction "test" do
-            segment_a = NewRelic::Agent::Tracer.start_segment name: "metric a"
-            advance_process_time 1
+          in_transaction("test") do
+            segment_a = NewRelic::Agent::Tracer.start_segment(name: "metric a")
+            advance_process_time(1)
 
-            segment_b = NewRelic::Agent::Tracer.start_segment name: "metric b"
-            advance_process_time 2
+            segment_b = NewRelic::Agent::Tracer.start_segment(name: "metric b")
+            advance_process_time(2)
             segment_b.finish
 
-            segment_c = NewRelic::Agent::Tracer.start_segment name: "metric c"
-            advance_process_time 1
+            segment_c = NewRelic::Agent::Tracer.start_segment(name: "metric c")
+            advance_process_time(1)
 
             segment_d = NewRelic::Agent::Tracer.start_segment(
               name: "metric d",
               parent: segment_a
             )
 
-            advance_process_time 2
+            advance_process_time(2)
             segment_c.finish
             segment_a.finish
 
-            advance_process_time 6
+            advance_process_time(6)
             segment_d.finish
           end
 
@@ -726,12 +726,12 @@ module NewRelic
         def test_transaction_detects_async_when_there_are_concurrent_children
           segment_a, segment_b, segment_c = nil, nil, nil
 
-          in_transaction "test" do |txn|
-            segment_a = NewRelic::Agent::Tracer.start_segment name: "metric a"
-            advance_process_time 2
+          in_transaction("test") do |txn|
+            segment_a = NewRelic::Agent::Tracer.start_segment(name: "metric a")
+            advance_process_time(2)
 
-            segment_b = NewRelic::Agent::Tracer.start_segment name: "metric b"
-            advance_process_time 1
+            segment_b = NewRelic::Agent::Tracer.start_segment(name: "metric b")
+            advance_process_time(1)
 
             refute txn.async?
 
@@ -742,12 +742,12 @@ module NewRelic
 
             assert txn.async?
 
-            advance_process_time 1
+            advance_process_time(1)
 
-            advance_process_time 1
+            advance_process_time(1)
             segment_b.finish
 
-            advance_process_time 1
+            advance_process_time(1)
             segment_c.finish
             segment_a.finish
           end
@@ -756,23 +756,23 @@ module NewRelic
         def test_transaction_detects_async_when_child_ends_after_parent
           segment_a, segment_b, segment_c = nil, nil, nil
 
-          in_transaction "test" do |txn|
-            segment_a = NewRelic::Agent::Tracer.start_segment name: "metric a"
-            advance_process_time 1
+          in_transaction("test") do |txn|
+            segment_a = NewRelic::Agent::Tracer.start_segment(name: "metric a")
+            advance_process_time(1)
 
-            segment_b = NewRelic::Agent::Tracer.start_segment name: "metric b"
-            advance_process_time 2
+            segment_b = NewRelic::Agent::Tracer.start_segment(name: "metric b")
+            advance_process_time(2)
 
             segment_b.finish
 
             refute txn.async?, "Expected transaction not to be asynchronous"
 
-            segment_c = NewRelic::Agent::Tracer.start_segment name: "metric c"
+            segment_c = NewRelic::Agent::Tracer.start_segment(name: "metric c")
 
-            advance_process_time 3
+            advance_process_time(3)
             segment_a.finish
 
-            advance_process_time 4
+            advance_process_time(4)
             segment_c.finish
 
             assert txn.async?, "Expected transaction to be asynchronous"
@@ -782,22 +782,22 @@ module NewRelic
         def test_transaction_records_exclusive_duration_millis_segment_param_when_transaction_async
           segment_a, segment_b, segment_c = nil, nil, nil
 
-          in_transaction "test" do
-            segment_a = NewRelic::Agent::Tracer.start_segment name: "metric a"
-            advance_process_time 2
+          in_transaction("test") do
+            segment_a = NewRelic::Agent::Tracer.start_segment(name: "metric a")
+            advance_process_time(2)
 
-            segment_b = NewRelic::Agent::Tracer.start_segment name: "metric b"
-            advance_process_time 1
+            segment_b = NewRelic::Agent::Tracer.start_segment(name: "metric b")
+            advance_process_time(1)
 
             segment_c = NewRelic::Agent::Tracer.start_segment(
               name: "metric c",
               parent: segment_a
             )
 
-            advance_process_time 2
+            advance_process_time(2)
             segment_b.finish
 
-            advance_process_time 1
+            advance_process_time(1)
             segment_c.finish
             segment_a.finish
           end
@@ -822,25 +822,25 @@ module NewRelic
         def test_total_time_metrics_async_sync_children_non_web
           segment_a, segment_b, segment_c, segment_d = nil, nil, nil, nil
 
-          transaction = in_transaction "test" do
-            segment_a = NewRelic::Agent::Tracer.start_segment name: "metric a"
-            advance_process_time 1
+          transaction = in_transaction("test") do
+            segment_a = NewRelic::Agent::Tracer.start_segment(name: "metric a")
+            advance_process_time(1)
 
-            segment_b = NewRelic::Agent::Tracer.start_segment name: "metric b"
-            advance_process_time 2
+            segment_b = NewRelic::Agent::Tracer.start_segment(name: "metric b")
+            advance_process_time(2)
             segment_b.finish
 
-            segment_c = NewRelic::Agent::Tracer.start_segment name: "metric c"
-            advance_process_time 1
+            segment_c = NewRelic::Agent::Tracer.start_segment(name: "metric c")
+            advance_process_time(1)
 
             segment_d = NewRelic::Agent::Tracer.start_segment(
               name: "metric d",
               parent: segment_a
             )
 
-            advance_process_time 2
+            advance_process_time(2)
             segment_c.finish
-            advance_process_time 1
+            advance_process_time(1)
 
             segment_d.finish
             segment_a.finish
@@ -868,25 +868,25 @@ module NewRelic
         def test_total_time_metrics_async_sync_children_web
           segment_a, segment_b, segment_c, segment_d = nil, nil, nil, nil
 
-          transaction = in_web_transaction "test" do
-            segment_a = NewRelic::Agent::Tracer.start_segment name: "metric a"
-            advance_process_time 1
+          transaction = in_web_transaction("test") do
+            segment_a = NewRelic::Agent::Tracer.start_segment(name: "metric a")
+            advance_process_time(1)
 
-            segment_b = NewRelic::Agent::Tracer.start_segment name: "metric b"
-            advance_process_time 2
+            segment_b = NewRelic::Agent::Tracer.start_segment(name: "metric b")
+            advance_process_time(2)
             segment_b.finish
 
-            segment_c = NewRelic::Agent::Tracer.start_segment name: "metric c"
-            advance_process_time 1
+            segment_c = NewRelic::Agent::Tracer.start_segment(name: "metric c")
+            advance_process_time(1)
 
             segment_d = NewRelic::Agent::Tracer.start_segment(
               name: "metric d",
               parent: segment_a
             )
 
-            advance_process_time 2
+            advance_process_time(2)
             segment_c.finish
-            advance_process_time 1
+            advance_process_time(1)
 
             segment_d.finish
             segment_a.finish
@@ -930,27 +930,27 @@ module NewRelic
         def test_times_accurate_when_child_finishes_after_parent
           segment_a, segment_b, segment_c, segment_d = nil, nil, nil, nil
 
-          txn = in_transaction "test" do
-            segment_a = NewRelic::Agent::Tracer.start_segment name: "metric a"
-            advance_process_time 1
+          txn = in_transaction("test") do
+            segment_a = NewRelic::Agent::Tracer.start_segment(name: "metric a")
+            advance_process_time(1)
 
-            segment_b = NewRelic::Agent::Tracer.start_segment name: "metric b"
-            advance_process_time 2
+            segment_b = NewRelic::Agent::Tracer.start_segment(name: "metric b")
+            advance_process_time(2)
             segment_b.finish
 
-            segment_c = NewRelic::Agent::Tracer.start_segment name: "metric c"
-            advance_process_time 1
+            segment_c = NewRelic::Agent::Tracer.start_segment(name: "metric c")
+            advance_process_time(1)
 
             segment_d = NewRelic::Agent::Tracer.start_segment(
               name: "metric d",
               parent: segment_a
             )
 
-            advance_process_time 2
+            advance_process_time(2)
             segment_c.finish
             segment_a.finish
 
-            advance_process_time 6
+            advance_process_time(6)
             segment_d.finish
           end
 
@@ -996,34 +996,34 @@ module NewRelic
         def test_times_accurate_when_child_finishes_after_parent_more_nesting
           segment_a, segment_b, segment_c, segment_d, segment_e = nil, nil, nil, nil, nil
 
-          txn = in_transaction "test" do
-            segment_a = NewRelic::Agent::Tracer.start_segment name: "metric a"
-            advance_process_time 1
+          txn = in_transaction("test") do
+            segment_a = NewRelic::Agent::Tracer.start_segment(name: "metric a")
+            advance_process_time(1)
 
-            segment_b = NewRelic::Agent::Tracer.start_segment name: "metric b"
+            segment_b = NewRelic::Agent::Tracer.start_segment(name: "metric b")
 
-            segment_c = NewRelic::Agent::Tracer.start_segment name: "metric c"
-            advance_process_time 2
+            segment_c = NewRelic::Agent::Tracer.start_segment(name: "metric c")
+            advance_process_time(2)
             segment_c.finish
 
-            segment_d = NewRelic::Agent::Tracer.start_segment name: "metric d"
-            advance_process_time 1
+            segment_d = NewRelic::Agent::Tracer.start_segment(name: "metric d")
+            advance_process_time(1)
 
             segment_e = NewRelic::Agent::Tracer.start_segment(
               name: "metric e",
               parent: segment_b
             )
 
-            advance_process_time 2
+            advance_process_time(2)
             segment_d.finish
 
-            advance_process_time 1
+            advance_process_time(1)
             segment_b.finish
 
-            advance_process_time 1
+            advance_process_time(1)
             segment_a.finish
 
-            advance_process_time 4
+            advance_process_time(4)
             segment_e.finish
           end
 

--- a/test/new_relic/agent/transaction_error_primitive_test.rb
+++ b/test/new_relic/agent/transaction_error_primitive_test.rb
@@ -32,19 +32,19 @@ module NewRelic
       end
 
       def test_event_includes_expected_errors
-        intrinsics, *_ = create_event :error_options => {
+        intrinsics, *_ = create_event(:error_options => {
           :expected => true
-        }
+        })
 
         assert intrinsics['error.expected']
       end
 
       def test_event_includes_synthetics
-        intrinsics, *_ = create_event :payload_options => {
+        intrinsics, *_ = create_event(:payload_options => {
           :synthetics_resource_id => 3,
           :synthetics_job_id => 4,
           :synthetics_monitor_id => 5
-        }
+        })
 
         assert_equal 3, intrinsics['nr.syntheticsResourceId']
         assert_equal 4, intrinsics['nr.syntheticsJobId']
@@ -53,12 +53,12 @@ module NewRelic
 
       def test_includes_mapped_metrics
         metrics = NewRelic::Agent::TransactionMetrics.new
-        metrics.record_unscoped 'Datastore/all', 10
-        metrics.record_unscoped 'GC/Transaction/all', 11
-        metrics.record_unscoped 'WebFrontend/QueueTime', 12
-        metrics.record_unscoped 'External/allWeb', 13
+        metrics.record_unscoped('Datastore/all', 10)
+        metrics.record_unscoped('GC/Transaction/all', 11)
+        metrics.record_unscoped('WebFrontend/QueueTime', 12)
+        metrics.record_unscoped('External/allWeb', 13)
 
-        intrinsics, *_ = create_event :payload_options => {:metrics => metrics}
+        intrinsics, *_ = create_event(:payload_options => {:metrics => metrics})
 
         assert_equal 10.0, intrinsics["databaseDuration"]
         assert_equal 1, intrinsics["databaseCallCount"]
@@ -69,7 +69,7 @@ module NewRelic
       end
 
       def test_includes_cat_attributes
-        intrinsics, *_ = create_event :payload_options => {:guid => "GUID", :referring_transaction_guid => "REFERRING_GUID"}
+        intrinsics, *_ = create_event(:payload_options => {:guid => "GUID", :referring_transaction_guid => "REFERRING_GUID"})
 
         assert_equal "GUID", intrinsics["nr.transactionGuid"]
         assert_equal "REFERRING_GUID", intrinsics["nr.referringTransactionGuid"]
@@ -79,28 +79,28 @@ module NewRelic
         attrs = {"user" => "Wes Mantooth", "channel" => 9}
 
         attributes = Attributes.new(NewRelic::Agent.instance.attribute_filter)
-        attributes.merge_custom_attributes attrs
+        attributes.merge_custom_attributes(attrs)
 
-        _, custom_attrs, _ = create_event :error_options => {:attributes => attributes}
+        _, custom_attrs, _ = create_event(:error_options => {:attributes => attributes})
 
         assert_equal attrs, custom_attrs
       end
 
       def test_includes_agent_attributes
         attributes = Attributes.new(NewRelic::Agent.instance.attribute_filter)
-        attributes.add_agent_attribute :'request.headers.referer', "http://blog.site/home", AttributeFilter::DST_ERROR_COLLECTOR
-        attributes.add_agent_attribute :'http.statusCode', 200, AttributeFilter::DST_ERROR_COLLECTOR
+        attributes.add_agent_attribute(:'request.headers.referer', "http://blog.site/home", AttributeFilter::DST_ERROR_COLLECTOR)
+        attributes.add_agent_attribute(:'http.statusCode', 200, AttributeFilter::DST_ERROR_COLLECTOR)
 
-        _, _, agent_attrs = create_event :error_options => {:attributes => attributes}
+        _, _, agent_attrs = create_event(:error_options => {:attributes => attributes})
 
         expected = {:"request.headers.referer" => "http://blog.site/home", :'http.statusCode' => 200}
         assert_equal expected, agent_attrs
       end
 
       def create_event options = {}
-        payload = generate_payload options[:payload_options] || {}
-        error = create_noticed_error options[:error_options] || {}
-        TransactionErrorPrimitive.create error, payload, @span_id
+        payload = generate_payload(options[:payload_options] || {})
+        error = create_noticed_error(options[:error_options] || {})
+        TransactionErrorPrimitive.create(error, payload, @span_id)
       end
 
       def generate_payload options = {}

--- a/test/new_relic/agent/transaction_event_aggregator_test.rb
+++ b/test/new_relic/agent/transaction_event_aggregator_test.rb
@@ -17,7 +17,7 @@ module NewRelic
       def setup
         nr_freeze_process_time
         events = NewRelic::Agent.instance.events
-        @event_aggregator = TransactionEventAggregator.new events
+        @event_aggregator = TransactionEventAggregator.new(events)
 
         @attributes = nil
       end
@@ -67,7 +67,7 @@ module NewRelic
       def test_block_is_not_executed_unless_buffer_admits_event
         event = nil
 
-        with_config :'transaction_events.max_samples_stored' => 5 do
+        with_config(:'transaction_events.max_samples_stored' => 5) do
           5.times { generate_request }
 
           payload = generate_payload
@@ -85,8 +85,8 @@ module NewRelic
       #
 
       def generate_request(name = 'Controller/whatever', options = {})
-        payload = generate_payload name, options
-        @event_aggregator.record event: TransactionEventPrimitive.create(payload)
+        payload = generate_payload(name, options)
+        @event_aggregator.record(event: TransactionEventPrimitive.create(payload))
       end
 
       def generate_payload(name = 'Controller/whatever', options = {})

--- a/test/new_relic/agent/transaction_event_recorder_test.rb
+++ b/test/new_relic/agent/transaction_event_recorder_test.rb
@@ -11,12 +11,12 @@ module NewRelic
     class TransactionEventRecorderTest < Minitest::Test
       def setup
         events = NewRelic::Agent.instance.events
-        @recorder = TransactionEventRecorder.new events
+        @recorder = TransactionEventRecorder.new(events)
         @attributes = nil
       end
 
       def test_synthetics_events_overflow_to_transaction_buffer
-        with_config :'synthetics.events_limit' => 10 do
+        with_config(:'synthetics.events_limit' => 10) do
           20.times do |i|
             generate_request("syn_#{i}", :synthetics_resource_id => 100)
           end
@@ -30,7 +30,7 @@ module NewRelic
       end
 
       def test_synthetics_events_timestamp_bumps_go_to_main_buffer
-        with_config :'synthetics.events_limit' => 10 do
+        with_config(:'synthetics.events_limit' => 10) do
           10.times do |i|
             generate_request("syn_#{i}", :timestamp => i + 10, :synthetics_resource_id => 100)
           end
@@ -47,9 +47,9 @@ module NewRelic
       end
 
       def test_normal_events_discarded_in_favor_sampled_events
-        with_config :'transaction_events.max_samples_stored' => 5 do
+        with_config(:'transaction_events.max_samples_stored' => 5) do
           5.times { generate_request }
-          5.times { |i| generate_request "sampled_#{i}", :priority => rand + 1 }
+          5.times { |i| generate_request("sampled_#{i}", :priority => rand + 1) }
 
           _, events = harvest_transaction_events!
 
@@ -60,8 +60,8 @@ module NewRelic
       end
 
       def test_sampled_events_not_discarded_in_favor_of_normal_events
-        with_config :'transaction_events.max_samples_stored' => 5 do
-          5.times { |i| generate_request "sampled_#{i}", :priority => rand + 1 }
+        with_config(:'transaction_events.max_samples_stored' => 5) do
+          5.times { |i| generate_request("sampled_#{i}", :priority => rand + 1) }
           5.times { generate_request }
 
           _, events = harvest_transaction_events!
@@ -83,7 +83,7 @@ module NewRelic
           :priority => options[:priority] || rand
         }.merge(options)
 
-        @recorder.record payload
+        @recorder.record(payload)
       end
 
       def attributes

--- a/test/new_relic/agent/transaction_sampler_test.rb
+++ b/test/new_relic/agent/transaction_sampler_test.rb
@@ -193,18 +193,18 @@ module NewRelic::Agent
     # generally usefully so
 
     def test_sample__gc_stats
-      GC.extend MockGCStats
+      GC.extend(MockGCStats)
       # These are effectively Garbage Collects, detected each time GC.time is
       # called by the transaction sampler.  One time value in seconds for each call.
       MockGCStats.mock_values = [0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0]
 
       with_config(:'transaction_tracer.transaction_threshold' => 0.0) do
-        in_transaction 'a' do
-          segment_b = Tracer.start_segment name: "b"
+        in_transaction('a') do
+          segment_b = Tracer.start_segment(name: "b")
           segment_b.finish
 
-          segment_c = Tracer.start_segment name: "c"
-          segment_d = Tracer.start_segment name: "d"
+          segment_c = Tracer.start_segment(name: "c")
+          segment_d = Tracer.start_segment(name: "d")
           segment_d.finish
           segment_c.finish
         end
@@ -223,30 +223,30 @@ module NewRelic::Agent
       nr_freeze_process_time
       with_config(:'transaction_tracer.transaction_threshold' => 0.0) do
         in_transaction do
-          s = Tracer.start_segment name: 'first'
-          advance_process_time 0.1
+          s = Tracer.start_segment(name: 'first')
+          advance_process_time(0.1)
           s.finish
         end
         in_transaction do
-          s = Tracer.start_segment name: 'second'
-          advance_process_time 0.1
-          s.finish
-        end
-
-        in_transaction do
-          s = Tracer.start_segment name: 'two_seconds'
-          advance_process_time 2
+          s = Tracer.start_segment(name: 'second')
+          advance_process_time(0.1)
           s.finish
         end
 
         in_transaction do
-          s = Tracer.start_segment name: 'fourth'
-          advance_process_time 0.1
+          s = Tracer.start_segment(name: 'two_seconds')
+          advance_process_time(2)
+          s.finish
+        end
+
+        in_transaction do
+          s = Tracer.start_segment(name: 'fourth')
+          advance_process_time(0.1)
           s.finish
         end
         in_transaction do
-          s = Tracer.start_segment name: 'fifth'
-          advance_process_time 0.1
+          s = Tracer.start_segment(name: 'fifth')
+          advance_process_time(0.1)
           s.finish
         end
 
@@ -257,8 +257,8 @@ module NewRelic::Agent
 
         # 1 second duration
         in_transaction do
-          s = Tracer.start_segment name: 'one_second'
-          advance_process_time 1
+          s = Tracer.start_segment(name: 'one_second')
+          advance_process_time(1)
           s.finish
         end
         @sampler.merge!([slowest])
@@ -267,8 +267,8 @@ module NewRelic::Agent
 
         # 1 second duration
         in_transaction do
-          s = Tracer.start_segment name: 'ten_seconds'
-          advance_process_time 10
+          s = Tracer.start_segment(name: 'ten_seconds')
+          advance_process_time(10)
           s.finish
         end
 

--- a/test/new_relic/agent/transaction_test.rb
+++ b/test/new_relic/agent/transaction_test.rb
@@ -512,13 +512,13 @@ module NewRelic::Agent
       nr_freeze_process_time
 
       with_config(:apdex_t => 1.0) do
-        in_web_transaction { advance_process_time 0.5 }
+        in_web_transaction { advance_process_time(0.5) }
         assert_equal('S', apdex)
 
-        in_web_transaction { advance_process_time 1.5 }
+        in_web_transaction { advance_process_time(1.5) }
         assert_equal('T', apdex)
 
-        in_web_transaction { advance_process_time 4.5 }
+        in_web_transaction { advance_process_time(4.5) }
         assert_equal('F', apdex)
       end
     end
@@ -532,7 +532,7 @@ module NewRelic::Agent
       nr_freeze_process_time
 
       with_config(:apdex_t => 1.0) do
-        in_background_transaction { advance_process_time 0.5 }
+        in_background_transaction { advance_process_time(0.5) }
         assert_nil apdex
       end
     end
@@ -549,13 +549,13 @@ module NewRelic::Agent
       key_transactions = {txn_name => 1.0}
 
       with_config(:apdex_t => 1.0, :web_transactions_apdex => key_transactions) do
-        in_background_transaction(txn_name) { advance_process_time 0.5 }
+        in_background_transaction(txn_name) { advance_process_time(0.5) }
         assert_equal('S', apdex)
 
-        in_background_transaction(txn_name) { advance_process_time 1.5 }
+        in_background_transaction(txn_name) { advance_process_time(1.5) }
         assert_equal('T', apdex)
 
-        in_background_transaction(txn_name) { advance_process_time 4.5 }
+        in_background_transaction(txn_name) { advance_process_time(4.5) }
         assert_equal('F', apdex)
       end
     end
@@ -951,10 +951,10 @@ module NewRelic::Agent
     end
 
     def with_java_classes_loaded
-      Transaction.class_variable_set :@@java_classes_loaded, true
+      Transaction.class_variable_set(:@@java_classes_loaded, true)
       yield
     ensure
-      Transaction.class_variable_set :@@java_classes_loaded, false
+      Transaction.class_variable_set(:@@java_classes_loaded, false)
     end
 
     def test_cpu_burn_normal
@@ -1185,7 +1185,7 @@ module NewRelic::Agent
 
     def test_doesnt_record_scoped_queue_time_metric
       t0 = nr_freeze_process_time
-      advance_process_time 10.0
+      advance_process_time(10.0)
       in_transaction('boo', :apdex_start_time => t0) do
         # nothing
       end
@@ -1484,7 +1484,7 @@ module NewRelic::Agent
 
     def test_error_recorded_predicate_true_when_error_recorded
       txn = in_transaction do |t|
-        t.notice_error StandardError.new "Sorry!"
+        t.notice_error(StandardError.new("Sorry!"))
       end
 
       assert txn.payload[:error], "Expected error to be recorded"
@@ -1495,9 +1495,9 @@ module NewRelic::Agent
         error.message == "Sorry!" ? nil : error
       end
 
-      with_ignore_error_filter filter do
+      with_ignore_error_filter(filter) do
         txn = in_transaction do |t|
-          t.notice_error StandardError.new "Sorry!"
+          t.notice_error(StandardError.new("Sorry!"))
         end
 
         refute txn.payload[:error], "Expected error to be apologetic"
@@ -1509,11 +1509,11 @@ module NewRelic::Agent
         error.message == "Sorry!" ? nil : error
       end
 
-      with_ignore_error_filter filter do
+      with_ignore_error_filter(filter) do
         txn = in_transaction do |t|
-          t.notice_error StandardError.new "Sorry!"
-          t.notice_error StandardError.new "Not Sorry!"
-          t.notice_error StandardError.new "Sorry!"
+          t.notice_error(StandardError.new("Sorry!"))
+          t.notice_error(StandardError.new("Not Sorry!"))
+          t.notice_error(StandardError.new("Sorry!"))
         end
 
         assert txn.payload[:error], "Expected error to be recorded"
@@ -1535,11 +1535,11 @@ module NewRelic::Agent
     end
 
     def test_set_transaction_name_for_nested_transactions
-      in_web_transaction "Controller/Framework/webby" do |t|
-        in_web_transaction "Controller/Framework/inner_1" do
-          in_web_transaction "Controller/Framework/inner_2" do
-            segment = Tracer.start_segment name: "Ruby/my_lib/my_meth"
-            NewRelic::Agent.set_transaction_name "RackFramework/action"
+      in_web_transaction("Controller/Framework/webby") do |t|
+        in_web_transaction("Controller/Framework/inner_1") do
+          in_web_transaction("Controller/Framework/inner_2") do
+            segment = Tracer.start_segment(name: "Ruby/my_lib/my_meth")
+            NewRelic::Agent.set_transaction_name("RackFramework/action")
             segment.finish
           end
         end

--- a/test/new_relic/agent/transaction_time_aggregator_test.rb
+++ b/test/new_relic/agent/transaction_time_aggregator_test.rb
@@ -58,17 +58,17 @@ class NewRelic::Agent::TransctionTimeAggregatorTest < Minitest::Test
     t0 = Process.clock_gettime(Process::CLOCK_REALTIME)
 
     worker = Thread.new do
-      ::NewRelic::Agent::TransactionTimeAggregator.transaction_start t0 + 27
-      ::NewRelic::Agent::TransactionTimeAggregator.transaction_stop t0 + 47
+      ::NewRelic::Agent::TransactionTimeAggregator.transaction_start(t0 + 27)
+      ::NewRelic::Agent::TransactionTimeAggregator.transaction_stop(t0 + 47)
     end
 
     # main thread:
-    ::NewRelic::Agent::TransactionTimeAggregator.transaction_start t0 + 15
-    ::NewRelic::Agent::TransactionTimeAggregator.transaction_stop t0 + 35
+    ::NewRelic::Agent::TransactionTimeAggregator.transaction_start(t0 + 15)
+    ::NewRelic::Agent::TransactionTimeAggregator.transaction_stop(t0 + 35)
 
     worker.join
 
-    busy_fraction = ::NewRelic::Agent::TransactionTimeAggregator.harvest! t0 + 60
+    busy_fraction = ::NewRelic::Agent::TransactionTimeAggregator.harvest!(t0 + 60)
     assert_equal 1.0 / 3.0, busy_fraction
   end
 
@@ -76,16 +76,16 @@ class NewRelic::Agent::TransctionTimeAggregatorTest < Minitest::Test
     t0 = Process.clock_gettime(Process::CLOCK_REALTIME)
 
     # main thread:
-    ::NewRelic::Agent::TransactionTimeAggregator.transaction_start t0 + 15
+    ::NewRelic::Agent::TransactionTimeAggregator.transaction_start(t0 + 15)
     starting_thread_id = Thread.current.object_id
 
     worker = Thread.new do
-      ::NewRelic::Agent::TransactionTimeAggregator.transaction_stop t0 + 35, starting_thread_id
+      ::NewRelic::Agent::TransactionTimeAggregator.transaction_stop(t0 + 35, starting_thread_id)
     end
 
     worker.join
 
-    busy_fraction = ::NewRelic::Agent::TransactionTimeAggregator.harvest! t0 + 60
+    busy_fraction = ::NewRelic::Agent::TransactionTimeAggregator.harvest!(t0 + 60)
     assert_equal 1.0 / 3.0, busy_fraction
   end
 
@@ -118,7 +118,7 @@ class NewRelic::Agent::TransctionTimeAggregatorTest < Minitest::Test
     t0 = Process.clock_gettime(Process::CLOCK_REALTIME)
     workers = 100.times.map do
       Thread.new do
-        ::NewRelic::Agent::TransactionTimeAggregator.transaction_start t0 + 15
+        ::NewRelic::Agent::TransactionTimeAggregator.transaction_start(t0 + 15)
         # thread dies before transaction completes
       end
     end

--- a/test/new_relic/agent/utilization/aws_test.rb
+++ b/test/new_relic/agent/utilization/aws_test.rb
@@ -21,7 +21,7 @@ module NewRelic
         # ---
 
         def test_generates_expected_collector_hash_for_valid_response
-          fixture = File.read File.join(aws_fixture_path, "valid.json")
+          fixture = File.read(File.join(aws_fixture_path, "valid.json"))
 
           mock_response = mock(code: '200', body: fixture)
           @vendor.stubs(:request_metadata).returns(mock_response)
@@ -37,7 +37,7 @@ module NewRelic
         end
 
         def test_fails_when_response_contains_invalid_chars
-          fixture = File.read File.join(aws_fixture_path, "invalid_chars.json")
+          fixture = File.read(File.join(aws_fixture_path, "invalid_chars.json"))
 
           mock_response = mock(code: '200', body: fixture)
           @vendor.stubs(:request_metadata).returns(mock_response)
@@ -47,7 +47,7 @@ module NewRelic
         end
 
         def test_fails_when_response_is_missing_required_value
-          fixture = File.read File.join(aws_fixture_path, "missing_value.json")
+          fixture = File.read(File.join(aws_fixture_path, "missing_value.json"))
 
           mock_response = mock(code: '200', body: fixture)
           @vendor.stubs(:request_metadata).returns(mock_response)
@@ -57,7 +57,7 @@ module NewRelic
         end
 
         def test_fails_based_on_response_code
-          fixture = File.read File.join(aws_fixture_path, "valid.json")
+          fixture = File.read(File.join(aws_fixture_path, "valid.json"))
 
           mock_response = stub(code: '404', body: fixture)
           @vendor.stubs(:request_metadata).returns(mock_response)
@@ -82,7 +82,7 @@ module NewRelic
         # ---
 
         load_cross_agent_test("utilization_vendor_specific/aws").each do |test_case|
-          test_case = symbolize_keys_in_object test_case
+          test_case = symbolize_keys_in_object(test_case)
 
           define_method("test_#{test_case[:testname]}".gsub(" ", "_")) do
             NewRelic::Agent::Utilization::AWS.stubs(:imds_token).returns('John Howe')
@@ -93,7 +93,7 @@ module NewRelic
             if uri_obj[:timeout]
               @vendor.stubs(:request_metadata).returns(nil)
             else
-              response = mock code: '200', body: ::JSON.dump(uri_obj[:response])
+              response = mock(code: '200', body: ::JSON.dump(uri_obj[:response]))
               @vendor.stubs(:request_metadata).returns(response)
             end
 

--- a/test/new_relic/agent/utilization/azure_test.rb
+++ b/test/new_relic/agent/utilization/azure_test.rb
@@ -21,7 +21,7 @@ module NewRelic
         # ---
 
         def test_generates_expected_collector_hash_for_valid_response
-          fixture = File.read File.join(azure_fixture_path, "valid.json")
+          fixture = File.read(File.join(azure_fixture_path, "valid.json"))
 
           stubbed_response = stub(code: '200', body: fixture)
           @vendor.stubs(:request_metadata).returns(stubbed_response)
@@ -38,7 +38,7 @@ module NewRelic
         end
 
         def test_fails_when_response_contains_invalid_chars
-          fixture = File.read File.join(azure_fixture_path, "invalid_chars.json")
+          fixture = File.read(File.join(azure_fixture_path, "invalid_chars.json"))
 
           stubbed_response = stub(code: '200', body: fixture)
           @vendor.stubs(:request_metadata).returns(stubbed_response)
@@ -48,7 +48,7 @@ module NewRelic
         end
 
         def test_fails_when_response_is_missing_required_value
-          fixture = File.read File.join(azure_fixture_path, "missing_value.json")
+          fixture = File.read(File.join(azure_fixture_path, "missing_value.json"))
 
           stubbed_response = stub(code: '200', body: fixture)
           @vendor.stubs(:request_metadata).returns(stubbed_response)
@@ -58,7 +58,7 @@ module NewRelic
         end
 
         def test_fails_based_on_response_code
-          fixture = File.read File.join(azure_fixture_path, "valid.json")
+          fixture = File.read(File.join(azure_fixture_path, "valid.json"))
 
           stubbed_response = stub(code: '404', body: fixture)
           @vendor.stubs(:request_metadata).returns(stubbed_response)
@@ -76,14 +76,14 @@ module NewRelic
         # ---
 
         load_cross_agent_test("utilization_vendor_specific/azure").each do |test_case|
-          test_case = symbolize_keys_in_object test_case
+          test_case = symbolize_keys_in_object(test_case)
 
           define_method("test_#{test_case[:testname]}".gsub(" ", "_")) do
             uri_obj = test_case[:uri][:'http://169.254.169.254/metadata/instance/compute?api-version=2017-03-01']
             if uri_obj[:timeout]
               @vendor.stubs(:request_metadata).returns(nil)
             else
-              response = mock code: '200', body: ::JSON.dump(uri_obj[:response])
+              response = mock(code: '200', body: ::JSON.dump(uri_obj[:response]))
               @vendor.stubs(:request_metadata).returns(response)
             end
 

--- a/test/new_relic/agent/utilization/gcp_test.rb
+++ b/test/new_relic/agent/utilization/gcp_test.rb
@@ -21,7 +21,7 @@ module NewRelic
         # ---
 
         def test_generates_expected_collector_hash_for_valid_response
-          fixture = File.read File.join(gcp_fixture_path, "valid.json")
+          fixture = File.read(File.join(gcp_fixture_path, "valid.json"))
 
           stubbed_response = stub(code: '200', body: fixture)
           @vendor.stubs(:request_metadata).returns(stubbed_response)
@@ -38,7 +38,7 @@ module NewRelic
         end
 
         def test_fails_when_response_contains_invalid_chars
-          fixture = File.read File.join(gcp_fixture_path, "invalid_chars.json")
+          fixture = File.read(File.join(gcp_fixture_path, "invalid_chars.json"))
 
           stubbed_response = stub(code: '200', body: fixture)
           @vendor.stubs(:request_metadata).returns(stubbed_response)
@@ -48,7 +48,7 @@ module NewRelic
         end
 
         def test_fails_when_response_is_missing_required_value
-          fixture = File.read File.join(gcp_fixture_path, "missing_value.json")
+          fixture = File.read(File.join(gcp_fixture_path, "missing_value.json"))
 
           stubbed_response = stub(code: '200', body: fixture)
           @vendor.stubs(:request_metadata).returns(stubbed_response)
@@ -58,7 +58,7 @@ module NewRelic
         end
 
         def test_fails_based_on_response_code
-          fixture = File.read File.join(gcp_fixture_path, "valid.json")
+          fixture = File.read(File.join(gcp_fixture_path, "valid.json"))
 
           stubbed_response = stub(code: '404', body: fixture)
           @vendor.stubs(:request_metadata).returns(stubbed_response)
@@ -76,14 +76,14 @@ module NewRelic
         # ---
 
         load_cross_agent_test("utilization_vendor_specific/gcp").each do |test_case|
-          test_case = symbolize_keys_in_object test_case
+          test_case = symbolize_keys_in_object(test_case)
 
           define_method("test_#{test_case[:testname]}".gsub(" ", "_")) do
             uri_obj = test_case[:uri][:'http://metadata.google.internal/computeMetadata/v1/instance/?recursive=true']
             if uri_obj[:timeout]
               @vendor.stubs(:request_metadata).returns(nil)
             else
-              response = mock code: '200', body: ::JSON.dump(uri_obj[:response])
+              response = mock(code: '200', body: ::JSON.dump(uri_obj[:response]))
               @vendor.stubs(:request_metadata).returns(response)
             end
 

--- a/test/new_relic/agent/utilization/pcf_test.rb
+++ b/test/new_relic/agent/utilization/pcf_test.rb
@@ -21,9 +21,9 @@ module NewRelic
         # ---
 
         def test_generate_expected_vendors_hash_when_expected_env_vars_present
-          with_pcf_env "CF_INSTANCE_GUID" => "fd326c0e-847e-47a1-65cc-45f6",
+          with_pcf_env("CF_INSTANCE_GUID" => "fd326c0e-847e-47a1-65cc-45f6",
             "CF_INSTANCE_IP" => "10.10.149.48",
-            "MEMORY_LIMIT"   => "1024m" do
+            "MEMORY_LIMIT"   => "1024m") do
             expected = {
               :cf_instance_guid => "fd326c0e-847e-47a1-65cc-45f6",
               :cf_instance_ip => "10.10.149.48",
@@ -36,16 +36,16 @@ module NewRelic
         end
 
         def test_fails_when_expected_value_has_invalid_chars
-          with_pcf_env "CF_INSTANCE_GUID" => "**fd326c0e-847e-47a1-65cc-45f6**",
+          with_pcf_env("CF_INSTANCE_GUID" => "**fd326c0e-847e-47a1-65cc-45f6**",
             "CF_INSTANCE_IP" => "10.10.149.48",
-            "MEMORY_LIMIT"   => "1024m" do
+            "MEMORY_LIMIT"   => "1024m") do
             refute @vendor.detect
           end
         end
 
         def test_fails_when_required_value_is_missing
-          with_pcf_env "CF_INSTANCE_GUID" => "fd326c0e-847e-47a1-65cc-45f6",
-            "CF_INSTANCE_IP" => "10.10.149.48" do
+          with_pcf_env("CF_INSTANCE_GUID" => "fd326c0e-847e-47a1-65cc-45f6",
+            "CF_INSTANCE_IP" => "10.10.149.48") do
             refute @vendor.detect
           end
         end
@@ -55,13 +55,13 @@ module NewRelic
         def with_pcf_env vars, &blk
           vars.each_pair { |k, v| ENV[k] = v }
           blk.call
-          vars.keys.each { |k| ENV.delete k }
+          vars.keys.each { |k| ENV.delete(k) }
         end
 
         # ---
 
         load_cross_agent_test("utilization_vendor_specific/pcf").each do |test_case|
-          test_case = symbolize_keys_in_object test_case
+          test_case = symbolize_keys_in_object(test_case)
 
           define_method("test_#{test_case[:testname]}".gsub(" ", "_")) do
             timeout = false

--- a/test/new_relic/agent_test.rb
+++ b/test/new_relic/agent_test.rb
@@ -361,9 +361,9 @@ module NewRelic
     def setup_linking_metadata_stubs app_names, hostname, entity_guid = nil
       NewRelic::Agent.config.reset_to_defaults
 
-      yaml_source = NewRelic::Agent::Configuration::YamlSource.new '', 'test'
+      yaml_source = NewRelic::Agent::Configuration::YamlSource.new('', 'test')
       yaml_source[:app_name] = app_names
-      NewRelic::Agent.config.replace_or_add_config yaml_source
+      NewRelic::Agent.config.replace_or_add_config(yaml_source)
 
       if entity_guid
         response_handler = NewRelic::Agent::Connect::ResponseHandler.new(Agent.instance, Agent.config)
@@ -374,7 +374,7 @@ module NewRelic
     end
 
     def test_linking_metadata_before_connect
-      setup_linking_metadata_stubs 'AppName', 'HostName'
+      setup_linking_metadata_stubs('AppName', 'HostName')
       expected = {
         'entity.name' => 'AppName',
         'entity.type' => 'SERVICE',
@@ -385,7 +385,7 @@ module NewRelic
     end
 
     def test_linking_metadata_after_connect
-      setup_linking_metadata_stubs 'AppName', 'HostName', 'EntityGUID'
+      setup_linking_metadata_stubs('AppName', 'HostName', 'EntityGUID')
 
       trace_id = nil
       span_id = nil
@@ -407,7 +407,7 @@ module NewRelic
     end
 
     def test_linking_metadata_no_transaction
-      setup_linking_metadata_stubs 'AppName', 'HostName', 'EntityGuid'
+      setup_linking_metadata_stubs('AppName', 'HostName', 'EntityGuid')
 
       expected = {
         'entity.name' => 'AppName',
@@ -483,12 +483,12 @@ module NewRelic
 
       loop do
         visited << a = stack.pop
-        if a.respond_to? :name
+        if a.respond_to?(:name)
           assert_equal a, Kernel.const_get(a.name)
         end
 
-        if a.respond_to? :constants
-          consts = (a.constants - DEPRECATED_CONSTANTS).map { |c| a.const_get c }.select do |c|
+        if a.respond_to?(:constants)
+          consts = (a.constants - DEPRECATED_CONSTANTS).map { |c| a.const_get(c) }.select do |c|
             if valid.include?(c.class) && !c.ancestors.include?(Minitest::Test)
               assert_instance_of String, c.name
               c.name.start_with?(a.name)
@@ -496,7 +496,7 @@ module NewRelic
               false
             end
           end
-          stack.concat (consts - visited)
+          stack.concat(consts - visited)
         end
 
         break if stack.empty?

--- a/test/new_relic/cli/commands/deployments_test.rb
+++ b/test/new_relic/cli/commands/deployments_test.rb
@@ -34,7 +34,7 @@ class NewRelic::Cli::DeploymentsTest < Minitest::Test
 
   def test_help
     begin
-      NewRelic::Cli::Deployments.new "-h"
+      NewRelic::Cli::Deployments.new("-h")
       fail "should have thrown"
     rescue NewRelic::Cli::Command::CommandFailure => c
       assert_match(/^Usage/, c.message)
@@ -44,7 +44,7 @@ class NewRelic::Cli::DeploymentsTest < Minitest::Test
 
   def test_bad_command
     assert_raises NewRelic::Cli::Command::CommandFailure do
-      NewRelic::Cli::Deployments.new ["-foo", "bar"]
+      NewRelic::Cli::Deployments.new(["-foo", "bar"])
     end
     @deployment = nil
   end

--- a/test/new_relic/collection_helper_test.rb
+++ b/test/new_relic/collection_helper_test.rb
@@ -25,7 +25,7 @@ class NewRelic::CollectionHelperTest < Minitest::Test
   end
 
   def test_array
-    new_array = normalize_params [1000] * 2000
+    new_array = normalize_params([1000] * 2000)
     assert_equal 128, new_array.size
     assert_equal '1000', new_array[0]
   end
@@ -46,7 +46,7 @@ class NewRelic::CollectionHelperTest < Minitest::Test
   class MyString < String; end
 
   def test_kind_of_string
-    s = MyString.new "This is a string"
+    s = MyString.new("This is a string")
     assert_equal "This is a string", s.to_s
     assert_equal MyString, s.class
     assert_equal String, s.to_s.class
@@ -96,13 +96,13 @@ class NewRelic::CollectionHelperTest < Minitest::Test
 
   def test_stringio
     # Verify StringIO works like this normally:
-    s = StringIO.new "start" + ("foo bar bat " * 1000)
+    s = StringIO.new("start" + ("foo bar bat " * 1000))
     val = nil
     s.each { |entry| val = entry; break }
     assert_match(/^startfoo bar/, val)
 
     # make sure stringios aren't affected by calling normalize_params:
-    s = StringIO.new "start" + ("foo bar bat " * 1000)
+    s = StringIO.new("start" + ("foo bar bat " * 1000))
     normalize_params({:foo => s.string})
     s.each { |entry| val = entry; break }
     assert_match(/^startfoo bar/, val)
@@ -112,7 +112,7 @@ class NewRelic::CollectionHelperTest < Minitest::Test
     include Enumerable
 
     def each
-      yield "1"
+      yield("1")
     end
   end
 

--- a/test/new_relic/common_aggregator_tests.rb
+++ b/test/new_relic/common_aggregator_tests.rb
@@ -62,7 +62,7 @@ module NewRelic
     end
 
     def test_respects_max_samples_stored
-      with_config aggregator.class.capacity_key => 5 do
+      with_config(aggregator.class.capacity_key => 5) do
         10.times { generate_event }
       end
 
@@ -95,9 +95,9 @@ module NewRelic
     end
 
     def test_lower_priority_events_discarded_in_favor_higher_priority_events
-      with_config aggregator.class.capacity_key => 5 do
-        5.times { |i| generate_event "totally_not_sampled_#{i}", :priority => rand }
-        5.times { |i| generate_event "sampled_#{i}", :priority => rand + 1 }
+      with_config(aggregator.class.capacity_key => 5) do
+        5.times { |i| generate_event("totally_not_sampled_#{i}", :priority => rand) }
+        5.times { |i| generate_event("sampled_#{i}", :priority => rand + 1) }
 
         _, events = aggregator.harvest!
 
@@ -108,9 +108,9 @@ module NewRelic
     end
 
     def test_higher_priority_events_not_discarded_in_favor_of_lower_priority_events
-      with_config aggregator.class.capacity_key => 5 do
-        5.times { |i| generate_event "sampled_#{i}", :priority => rand + 1 }
-        5.times { |i| generate_event "totally_not_sampled_#{i}", :priority => rand }
+      with_config(aggregator.class.capacity_key => 5) do
+        5.times { |i| generate_event("sampled_#{i}", :priority => rand + 1) }
+        5.times { |i| generate_event("totally_not_sampled_#{i}", :priority => rand) }
 
         _, events = aggregator.harvest!
 
@@ -131,8 +131,8 @@ module NewRelic
     end
 
     def test_sample_counts_are_correct_after_merge
-      with_config aggregator.class.capacity_key => 5 do
-        buffer = aggregator.instance_variable_get :@buffer
+      with_config(aggregator.class.capacity_key => 5) do
+        buffer = aggregator.instance_variable_get(:@buffer)
 
         4.times { generate_event }
         last_harvest = aggregator.harvest!
@@ -142,7 +142,7 @@ module NewRelic
         assert_equal 4, last_harvest[0][:events_seen]
 
         4.times { generate_event }
-        aggregator.merge! last_harvest
+        aggregator.merge!(last_harvest)
 
         reservoir_stats, samples = aggregator.harvest!
 
@@ -154,7 +154,7 @@ module NewRelic
     end
 
     def test_resets_limits_on_harvest
-      with_config aggregator.class.capacity_key => 100 do
+      with_config(aggregator.class.capacity_key => 100) do
         50.times { generate_event }
         events_before = last_events
         assert_equal 50, events_before.size

--- a/test/new_relic/control/instance_methods_test.rb
+++ b/test/new_relic/control/instance_methods_test.rb
@@ -63,10 +63,10 @@ class NewRelic::Control::InstanceMethodsTest < Minitest::Test
   end
 
   def refute_has_config(clazz)
-    refute NewRelic::Agent.config.config_classes_for_testing.include? clazz
+    refute NewRelic::Agent.config.config_classes_for_testing.include?(clazz)
   end
 
   def assert_has_config(clazz)
-    assert NewRelic::Agent.config.config_classes_for_testing.include? clazz
+    assert NewRelic::Agent.config.config_classes_for_testing.include?(clazz)
   end
 end

--- a/test/new_relic/control/instrumentation_test.rb
+++ b/test/new_relic/control/instrumentation_test.rb
@@ -22,7 +22,7 @@ class NewRelic::Control::InstrumentationTest < Minitest::Test
   def test_load_instrumentation_files_logs_errors_during_require
     @test_class.stubs(:require).raises('Instrumentation Test Error')
     expects_logging(:warn, includes("Error loading"), any_parameters)
-    @test_class.load_instrumentation_files '*'
+    @test_class.load_instrumentation_files('*')
   end
 
   def test_add_instrumentation_loads_the_instrumentation_files_if_instrumented

--- a/test/new_relic/dependency_detection_test.rb
+++ b/test/new_relic/dependency_detection_test.rb
@@ -31,7 +31,7 @@ class DependencyDetectionTest < Minitest::Test
     key = nil
 
     DependencyDetection.defer do
-      named :testing
+      named(:testing)
       executes { key = config_key }
     end
     DependencyDetection.detect!
@@ -43,8 +43,8 @@ class DependencyDetectionTest < Minitest::Test
     key = nil
 
     DependencyDetection.defer do
-      named :testing
-      configure_with :alternate
+      named(:testing)
+      configure_with(:alternate)
       executes { key = config_key }
     end
     DependencyDetection.detect!
@@ -83,7 +83,7 @@ class DependencyDetectionTest < Minitest::Test
     executed = false
 
     DependencyDetection.defer do
-      named :testing
+      named(:testing)
       executes { executed = true }
     end
     DependencyDetection.detect!
@@ -95,7 +95,7 @@ class DependencyDetectionTest < Minitest::Test
     executed = false
 
     DependencyDetection.defer do
-      named :testing
+      named(:testing)
       executes { executed = true }
     end
 
@@ -110,7 +110,7 @@ class DependencyDetectionTest < Minitest::Test
     executed = false
 
     DependencyDetection.defer do
-      named :testing
+      named(:testing)
       executes { executed = true }
     end
 
@@ -125,7 +125,7 @@ class DependencyDetectionTest < Minitest::Test
     setting = nil
 
     DependencyDetection.defer do
-      named :testing
+      named(:testing)
       executes { setting = config_value }
     end
     DependencyDetection.detect!
@@ -137,7 +137,7 @@ class DependencyDetectionTest < Minitest::Test
     executed = false
 
     dd = DependencyDetection.defer do
-      named :testing
+      named(:testing)
       executes { executed = true }
     end
 
@@ -174,7 +174,7 @@ class DependencyDetectionTest < Minitest::Test
     executed = false
 
     dd = DependencyDetection.defer do
-      named :testing
+      named(:testing)
       executes { executed = true }
     end
 
@@ -213,7 +213,7 @@ class DependencyDetectionTest < Minitest::Test
     executed = false
 
     dd = DependencyDetection.defer do
-      named :testing
+      named(:testing)
       executes { executed = true }
     end
 
@@ -239,7 +239,7 @@ class DependencyDetectionTest < Minitest::Test
     executed = false
 
     dd = DependencyDetection.defer do
-      named :testing
+      named(:testing)
       executes { executed = true }
     end
 
@@ -322,7 +322,7 @@ class DependencyDetectionTest < Minitest::Test
 
   def test_exception_during_depends_on_check_doesnt_propagate
     DependencyDetection.defer do
-      named :something_exceptional
+      named(:something_exceptional)
       depends_on { raise "Oops" }
     end
 
@@ -335,7 +335,7 @@ class DependencyDetectionTest < Minitest::Test
     ran_second_block = false
 
     DependencyDetection.defer do
-      named :something_exceptional
+      named(:something_exceptional)
       executes { raise "Ack!" }
       executes { ran_second_block = true }
     end
@@ -351,7 +351,7 @@ class DependencyDetectionTest < Minitest::Test
 
     2.times do
       DependencyDetection.defer do
-        named :foobar
+        named(:foobar)
         executes { run_count += 1 }
       end
     end

--- a/test/new_relic/environment_report_test.rb
+++ b/test/new_relic/environment_report_test.rb
@@ -51,7 +51,7 @@ class EnvironmentReportTest < Minitest::Test
 
   def test_it_knows_what_gems_are_in_the_environment
     assert(@report['Gems'].size > 5, "Expected at least 5 gems in #{@report['Gems'].inspect}")
-    rake = @report['Gems'].detect { |s| s.include? 'rake' }
+    rake = @report['Gems'].detect { |s| s.include?('rake') }
     assert_match(/^rake\([\d\.]+\)$/, rake)
   end
 

--- a/test/new_relic/fake_collector.rb
+++ b/test/new_relic/fake_collector.rb
@@ -124,13 +124,13 @@ module NewRelic
       uri = URI.parse(req.url)
       method = method_from_request(req)
 
-      if @mock.keys.include? method
+      if @mock.keys.include?(method)
         status, body = @mock[method].evaluate
         res.status = status
-        res.write ::JSON.dump(body)
+        res.write(::JSON.dump(body))
       else
         res.status = 500
-        res.write "Method not found"
+        res.write("Method not found")
       end
       run_id = uri.query =~ /run_id=(\d+)/ ? $1 : nil
       req.body.rewind

--- a/test/new_relic/fake_external_server.rb
+++ b/test/new_relic/fake_external_server.rb
@@ -30,7 +30,7 @@ module NewRelic
       res.status = req.params["status"].to_i if req.params["status"]
 
       in_transaction('test') do
-        res.write STATUS_MESSAGE
+        res.write(STATUS_MESSAGE)
       end
       res.finish
     end

--- a/test/new_relic/fake_server.rb
+++ b/test/new_relic/fake_server.rb
@@ -66,7 +66,7 @@ module NewRelic
       @started_options = build_webrick_options
 
       @server = WEBrick::HTTPServer.new(@started_options)
-      @server.mount String.new('/'), ::Rack::Handler.get(:webrick), app
+      @server.mount(String.new('/'), ::Rack::Handler.get(:webrick), app)
 
       @thread = Thread.new(&self.method(:run_server)).tap { |t| t.abort_on_exception = true }
     end

--- a/test/new_relic/framework_test.rb
+++ b/test/new_relic/framework_test.rb
@@ -18,7 +18,7 @@ class FrameworkTest < Minitest::Test
     NewRelic::Agent.reset_config
 
     # don't bomb out trying to load frameworks that don't exist.
-    NewRelic::Control.stubs(:new_instance).returns(stub :init_plugin => nil)
+    NewRelic::Control.stubs(:new_instance).returns(stub(:init_plugin => nil))
   end
 
   def teardown

--- a/test/new_relic/http_client_test_cases.rb
+++ b/test/new_relic/http_client_test_cases.rb
@@ -84,7 +84,7 @@ module HttpClientTestCases
   # This test is early warning an HTTP client's library
   # has made breaking changes on their Response objects
   def test_status_code_is_present
-    res = get_wrapped_response default_url
+    res = get_wrapped_response(default_url)
     assert_equal 200, res.status_code
   end
 
@@ -478,7 +478,7 @@ module HttpClientTestCases
     end
 
     last_node = find_last_transaction_node()
-    unless last_node.metric_name.start_with? "External"
+    unless last_node.metric_name.start_with?("External")
       refute last_node.params.key?(:uri)
     end
   end
@@ -561,7 +561,7 @@ module HttpClientTestCases
 
           in_transaction do |txn|
             txn_info = test_case['inboundPayload']
-            payload = NewRelic::Agent::CrossAppPayload.new 'someId', txn, txn_info
+            payload = NewRelic::Agent::CrossAppPayload.new('someId', txn, txn_info)
             txn.distributed_tracer.cross_app_payload = payload
             stub_transaction_guid(test_case['transactionGuid'])
             test_case['outboundRequests'].each do |req|
@@ -705,7 +705,7 @@ module HttpClientTestCases
   def simulate_server_error server_class, port
     server = server_class.new(port)
     server.run
-    get_response "http://localhost:#{port}"
+    get_response("http://localhost:#{port}")
   ensure
     server.stop
   end
@@ -716,7 +716,7 @@ module HttpClientTestCases
     in_transaction do |ext_txn|
       begin
         txn = ext_txn
-        response = simulate_server_error NewRelic::FakeForbiddenServer, 4403
+        response = simulate_server_error(NewRelic::FakeForbiddenServer, 4403)
       rescue StandardError => e
         # NOP
       end
@@ -734,7 +734,7 @@ module HttpClientTestCases
     in_transaction do |ext_txn|
       begin
         txn = ext_txn
-        response = simulate_server_error NewRelic::FakeInternalErrorServer, 5500
+        response = simulate_server_error(NewRelic::FakeInternalErrorServer, 5500)
       rescue StandardError => e
         # NOP
       end

--- a/test/new_relic/load_test.rb
+++ b/test/new_relic/load_test.rb
@@ -12,6 +12,6 @@ class LoadTest < Minitest::Test
     ::Resolv.expects(:getaddress).never
     ::IPSocket.expects(:getaddress).never
 
-    require_relative '../test_helper'
+    require_relative('../test_helper')
   end
 end

--- a/test/new_relic/marshalling_test_cases.rb
+++ b/test/new_relic/marshalling_test_cases.rb
@@ -197,7 +197,7 @@ module MarshallingTestCases
 
     def break_it
       NewRelic::Agent.set_transaction_name("break_it", :category => "TestTransaction")
-      NewRelic::Agent.notice_error StandardError.new("Sorry!")
+      NewRelic::Agent.notice_error(StandardError.new("Sorry!"))
       NewRelic::Agent::Tracer.current_span_id
     end
 

--- a/test/new_relic/multiverse_helpers.rb
+++ b/test/new_relic/multiverse_helpers.rb
@@ -232,7 +232,7 @@ module MultiverseHelpers
     raw_attributes = @js_data["atts"]
 
     if raw_attributes
-      attributes = ::JSON.load @instrumentor.obfuscator.deobfuscate(raw_attributes)
+      attributes = ::JSON.load(@instrumentor.obfuscator.deobfuscate(raw_attributes))
       @js_custom_attributes = attributes['u']
       @js_agent_attributes = attributes['a']
     end

--- a/test/new_relic/net_http_test_cases.rb
+++ b/test/new_relic/net_http_test_cases.rb
@@ -36,7 +36,7 @@ module NetHttpTestCases
   end
 
   def get_wrapped_response url
-    NewRelic::Agent::HTTPClients::NetHTTPResponse.new get_response url
+    NewRelic::Agent::HTTPClients::NetHTTPResponse.new(get_response(url))
   end
 
   def get_response_multi(url, n)
@@ -94,7 +94,7 @@ module NetHttpTestCases
     headers.each do |k, v|
       response[k] = v
     end
-    NewRelic::Agent::HTTPClients::NetHTTPResponse.new response
+    NewRelic::Agent::HTTPClients::NetHTTPResponse.new(response)
   end
 
   #
@@ -105,7 +105,7 @@ module NetHttpTestCases
     return if use_ssl?
 
     in_transaction do
-      Net::HTTP.get default_uri
+      Net::HTTP.get(default_uri)
     end
 
     assert_metrics_recorded([

--- a/test/new_relic/noticed_error_test.rb
+++ b/test/new_relic/noticed_error_test.rb
@@ -211,7 +211,7 @@ class NewRelic::Agent::NoticedErrorTest < Minitest::Test
   end
 
   def test_custom_attributes_sent_when_enabled
-    with_config :'error_collector.attributes.enabled' => true do
+    with_config(:'error_collector.attributes.enabled' => true) do
       attributes = NewRelic::Agent::Attributes.new(NewRelic::Agent.instance.attribute_filter)
       custom_attrs = {"name" => "Ron Burgundy", "channel" => 4}
       attributes.merge_custom_attributes(custom_attrs)
@@ -224,7 +224,7 @@ class NewRelic::Agent::NoticedErrorTest < Minitest::Test
   end
 
   def test_custom_attributes_not_sent_when_disabled
-    with_config :'error_collector.attributes.enabled' => false do
+    with_config(:'error_collector.attributes.enabled' => false) do
       attributes = NewRelic::Agent::Attributes.new(NewRelic::Agent.instance.attribute_filter)
       custom_attrs = {"name" => "Ron Burgundy", "channel" => 4}
       attributes.merge_custom_attributes(custom_attrs)
@@ -237,9 +237,9 @@ class NewRelic::Agent::NoticedErrorTest < Minitest::Test
   end
 
   def test_agent_attributes_sent_when_enabled
-    with_config :'error_collector.attributes.enabled' => true do
+    with_config(:'error_collector.attributes.enabled' => true) do
       attributes = NewRelic::Agent::Attributes.new(NewRelic::Agent.instance.attribute_filter)
-      attributes.add_agent_attribute :"request.headers.referer", "http://blog.site/home", NewRelic::Agent::AttributeFilter::DST_ALL
+      attributes.add_agent_attribute(:"request.headers.referer", "http://blog.site/home", NewRelic::Agent::AttributeFilter::DST_ALL)
 
       error = NewRelic::NoticedError.new(@path, Exception.new("O_o"))
       error.attributes = attributes
@@ -250,9 +250,9 @@ class NewRelic::Agent::NoticedErrorTest < Minitest::Test
   end
 
   def test_agent_attributes_not_sent_when_disabled
-    with_config :'error_collector.attributes.enabled' => false do
+    with_config(:'error_collector.attributes.enabled' => false) do
       attributes = NewRelic::Agent::Attributes.new(NewRelic::Agent.instance.attribute_filter)
-      attributes.add_agent_attribute :"request.headers.referer", "http://blog.site/home", NewRelic::Agent::AttributeFilter::DST_ALL
+      attributes.add_agent_attribute(:"request.headers.referer", "http://blog.site/home", NewRelic::Agent::AttributeFilter::DST_ALL)
 
       error = NewRelic::NoticedError.new(@path, Exception.new("O_o"))
       error.attributes = attributes

--- a/test/new_relic/rack/browser_monitoring_test.rb
+++ b/test/new_relic/rack/browser_monitoring_test.rb
@@ -110,7 +110,7 @@ if defined?(::Rack::Test)
 
     def test_should_not_inject_javascript_when_transaction_ignored
       with_config(:'rules.ignore_url_regexes' => ['^/ignore/path']) do
-        get '/ignore/path'
+        get('/ignore/path')
 
         app.stubs(:should_instrument?).returns(true)
         app.expects(:autoinstrument_source).never
@@ -118,7 +118,7 @@ if defined?(::Rack::Test)
     end
 
     def test_insert_header_should_mark_environment
-      get '/'
+      get('/')
       assert last_request.env.key?(NewRelic::Rack::BrowserMonitoring::ALREADY_INSTRUMENTED_KEY)
     end
 
@@ -160,7 +160,7 @@ if defined?(::Rack::Test)
       TestApp.next_response = Rack::Response.new("<html/>")
       TestApp.next_response.expects(:close)
 
-      get '/'
+      get('/')
 
       assert last_response.ok?
     end
@@ -170,7 +170,7 @@ if defined?(::Rack::Test)
       response.force_encoding(Encoding.find("US-ASCII"))
       TestApp.next_response = Rack::Response.new(response)
 
-      get '/'
+      get('/')
 
       assert last_response.ok?
     end
@@ -180,14 +180,14 @@ if defined?(::Rack::Test)
       TestApp.next_response.stubs(:respond_to?).with(:close).returns(false)
       TestApp.next_response.expects(:close).never
 
-      get '/'
+      get('/')
 
       assert last_response.ok?
     end
 
     def test_should_not_throw_exception_on_empty_reponse
       TestApp.doc = ''
-      get '/'
+      get('/')
 
       assert last_response.ok?
     end

--- a/test/nullverse/nullverse_helper.rb
+++ b/test/nullverse/nullverse_helper.rb
@@ -9,4 +9,4 @@ unless defined?(Minitest::Test)
   Minitest::Test = MiniTest::Unit::TestCase
 end
 
-$:.unshift File.expand_path('../../../lib', __FILE__)
+$:.unshift(File.expand_path('../../../lib', __FILE__))

--- a/test/performance/lib/performance/baseline_compare_reporter.rb
+++ b/test/performance/lib/performance/baseline_compare_reporter.rb
@@ -104,15 +104,15 @@ module Performance
       }
 
       table = Table.new(rows, @options) do
-        column :name
-        column :before, &(FormattingHelpers.method(:format_duration))
-        column :after, &(FormattingHelpers.method(:format_duration))
-        column :delta, &format_percent_delta
-        column :allocs_before
-        column :allocs_after
-        column :allocs_delta, &format_percent_delta
-        column :retained
-        column :retained_delta, &format_percent_delta
+        column(:name)
+        column(:before, &(FormattingHelpers.method(:format_duration)))
+        column(:after, &(FormattingHelpers.method(:format_duration)))
+        column(:delta, &format_percent_delta)
+        column(:allocs_before)
+        column(:allocs_after)
+        column(:allocs_delta, &format_percent_delta)
+        column(:retained)
+        column(:retained_delta, &format_percent_delta)
       end
 
       puts table.render

--- a/test/performance/lib/performance/result.rb
+++ b/test/performance/lib/performance/result.rb
@@ -89,7 +89,7 @@ module Performance
       hash['measurements'].each do |key, value|
         result.measurements[key.to_sym] = value
       end
-      result.tags.merge! hash['tags']
+      result.tags.merge!(hash['tags'])
       result.exception = hash['exception']
       result.elapsed = elapsed
       result.iterations = hash['iterations']

--- a/test/performance/script/mega-runner
+++ b/test/performance/script/mega-runner
@@ -26,7 +26,7 @@ runner_options = {
 }
 commits = commits_between(start_commit, stop_commit, repo_path)
 
-Performance.logger.info "Testing #{commits.size} commits"
+Performance.logger.info("Testing #{commits.size} commits")
 commits.each_with_index do |commit, i|
   checkout_commit(commit, repo_path)
   runner_options[:tags][:sequence_number] = i

--- a/test/performance/suites/active_record.rb
+++ b/test/performance/suites/active_record.rb
@@ -12,7 +12,7 @@ class ActiveRecordTest < Performance::TestCase
 
   def test_helper_by_name
     measure do
-      NewRelic::Agent::Instrumentation::ActiveRecordHelper.product_operation_collection_for NAME, SQL, ADAPTER
+      NewRelic::Agent::Instrumentation::ActiveRecordHelper.product_operation_collection_for(NAME, SQL, ADAPTER)
     end
   end
 
@@ -20,7 +20,7 @@ class ActiveRecordTest < Performance::TestCase
 
   def test_helper_by_sql
     measure do
-      NewRelic::Agent::Instrumentation::ActiveRecordHelper.product_operation_collection_for UNKNOWN_NAME, SQL, ADAPTER
+      NewRelic::Agent::Instrumentation::ActiveRecordHelper.product_operation_collection_for(UNKNOWN_NAME, SQL, ADAPTER)
     end
   end
 end

--- a/test/performance/suites/active_record_subscriber.rb
+++ b/test/performance/suites/active_record_subscriber.rb
@@ -48,7 +48,7 @@ unless defined?(ActiveSupport::Notifications::Event)
         end
 
         def parent_of?(event)
-          @children.include? event
+          @children.include?(event)
         end
       end
     end
@@ -68,7 +68,7 @@ class ActiveRecordSubscriberTest < Performance::TestCase
     }
 
     @subscriber = NewRelic::Agent::Instrumentation::ActiveRecordSubscriber.new
-    if @subscriber.respond_to? :active_record_config_for_event
+    if @subscriber.respond_to?(:active_record_config_for_event)
       @subscriber.class.send(:remove_method, :active_record_config_for_event)
       @subscriber.class.send(:define_method, :active_record_config_for_event) do |args|
         @config

--- a/test/performance/suites/datastores.rb
+++ b/test/performance/suites/datastores.rb
@@ -34,7 +34,7 @@ class DatastoresPerfTest < Performance::TestCase
 
     measure do
       in_transaction do
-        NewRelic::Agent::Datastores.wrap product, operation, collection do
+        NewRelic::Agent::Datastores.wrap(product, operation, collection) do
           FauxDB.query
         end
       end
@@ -51,10 +51,10 @@ class DatastoresPerfTest < Performance::TestCase
   end
 
   def test_segment_notice_sql
-    segment = NewRelic::Agent::Transaction::DatastoreSegment.new "MySQL", "select", "users"
+    segment = NewRelic::Agent::Transaction::DatastoreSegment.new("MySQL", "select", "users")
     conf = {:adapter => :mysql}
     measure do
-      segment._notice_sql SQL, conf
+      segment._notice_sql(SQL, conf)
     end
   end
 end

--- a/test/performance/suites/error_collector.rb
+++ b/test/performance/suites/error_collector.rb
@@ -11,8 +11,8 @@ class ErrorCollectorTests < Performance::TestCase
 
   def test_notice_error
     measure do
-      in_transaction :name => @txn_name do
-        NewRelic::Agent.notice_error StandardError.new @err_msg
+      in_transaction(:name => @txn_name) do
+        NewRelic::Agent.notice_error(StandardError.new(@err_msg))
       end
     end
   end
@@ -21,8 +21,8 @@ class ErrorCollectorTests < Performance::TestCase
     opts = {:custom_params => {:name => "Wes Mantooth", :channel => 9}}
 
     measure do
-      in_transaction :name => @txn_name do
-        NewRelic::Agent.notice_error StandardError.new(@err_msg), opts
+      in_transaction(:name => @txn_name) do
+        NewRelic::Agent.notice_error(StandardError.new(@err_msg), opts)
       end
     end
   end

--- a/test/performance/suites/external_segment.rb
+++ b/test/performance/suites/external_segment.rb
@@ -37,7 +37,7 @@ class ExternalSegment < Performance::TestCase
         Net::HTTP.get(TEST_URI)
       end
     end
-    stop_server io_server
+    stop_server(io_server)
   end
 
   def test_external_request_in_thread
@@ -48,20 +48,20 @@ class ExternalSegment < Performance::TestCase
         thread.join
       end
     end
-    stop_server io_server
+    stop_server(io_server)
   end
 
   def test_external_cat_request
     NewRelic::Agent.config.add_config_for_testing(CAT_CONFIG)
 
     io_server = start_server
-    reply_with_cat_headers io_server
+    reply_with_cat_headers(io_server)
     measure do
       in_transaction do
         Net::HTTP.get(TEST_URI)
       end
     end
-    stop_server io_server
+    stop_server(io_server)
   end
 
   def test_external_trace_context_request
@@ -73,7 +73,7 @@ class ExternalSegment < Performance::TestCase
         Net::HTTP.get(TEST_URI)
       end
     end
-    stop_server io_server
+    stop_server(io_server)
   end
 
   def test_external_trace_context_request_within_thread
@@ -86,7 +86,7 @@ class ExternalSegment < Performance::TestCase
         thread.join
       end
     end
-    stop_server io_server
+    stop_server(io_server)
   end
 
   SERVER_SCRIPT_PATH = File.expand_path('../../../script/external_server.rb', __FILE__)
@@ -116,7 +116,7 @@ class ExternalSegment < Performance::TestCase
   end
 
   def cat_response_headers
-    obfuscator = NewRelic::Agent::Obfuscator.new NewRelic::Agent.config[:encoding_key]
+    obfuscator = NewRelic::Agent::Obfuscator.new(NewRelic::Agent.config[:encoding_key])
     app_data = obfuscator.obfuscate(["1#1884", "txn-name", 2, 8, 0, 'BEC1BC64675138B9'].to_json) + "\n"
     {'X-NewRelic-App-Data' => app_data}
   end

--- a/test/performance/suites/logging.rb
+++ b/test/performance/suites/logging.rb
@@ -10,37 +10,37 @@ class LoggingTest < Performance::TestCase
 
   def test_decorating_logger
     io = StringIO.new
-    logger = NewRelic::Agent::Logging::DecoratingLogger.new io
+    logger = NewRelic::Agent::Logging::DecoratingLogger.new(io)
     measure do
-      logger.info EXAMPLE_MESSAGE
+      logger.info(EXAMPLE_MESSAGE)
     end
   end
 
   def test_logger_instrumentation
     io = StringIO.new
-    logger = ::Logger.new io
+    logger = ::Logger.new(io)
     measure do
-      logger.info EXAMPLE_MESSAGE
+      logger.info(EXAMPLE_MESSAGE)
     end
   end
 
   def test_local_log_decoration
     io = StringIO.new
-    logger = ::Logger.new io
+    logger = ::Logger.new(io)
     measure do
       with_config(:'application_logging.local_decorating.enabled' => true) do
-        logger.info EXAMPLE_MESSAGE
+        logger.info(EXAMPLE_MESSAGE)
       end
     end
   end
 
   def test_local_log_decoration_in_transaction
     io = StringIO.new
-    logger = ::Logger.new io
+    logger = ::Logger.new(io)
     measure do
       with_config(:'application_logging.local_decorating.enabled' => true) do
         in_transaction do
-          logger.info EXAMPLE_MESSAGE
+          logger.info(EXAMPLE_MESSAGE)
         end
       end
     end
@@ -48,10 +48,10 @@ class LoggingTest < Performance::TestCase
 
   def test_logger_instrumentation_in_transaction
     io = StringIO.new
-    logger = ::Logger.new io
+    logger = ::Logger.new(io)
     measure do
       in_transaction do
-        logger.info EXAMPLE_MESSAGE
+        logger.info(EXAMPLE_MESSAGE)
       end
     end
   end

--- a/test/performance/suites/rack_middleware.rb
+++ b/test/performance/suites/rack_middleware.rb
@@ -107,13 +107,13 @@ begin
       end
 
       @stack = Rack::Builder.new do
-        middlewares.each { |m| use m }
-        run TestApp.new
+        middlewares.each { |m| use(m) }
+        run(TestApp.new)
       end.to_app
 
       @stack_with_params = Rack::Builder.new do
-        middlewares.each { |m| use m }
-        run TestAppWithParams.new
+        middlewares.each { |m| use(m) }
+        run(TestAppWithParams.new)
       end.to_app
 
       @env = {

--- a/test/performance/suites/rules_engine.rb
+++ b/test/performance/suites/rules_engine.rb
@@ -28,9 +28,9 @@ class RulesEngineTests < Performance::TestCase
   def test_rules_engine_rename_transaction_rules
     measure do
       rules_engine = NewRelic::Agent::RulesEngine.create_transaction_rules(@basic_rule_specs)
-      rules_engine.rename "WebTransaction/Uri/one/two/seven/user/nine/account"
-      rules_engine.rename "WebTransaction/Custom/one/two/seven/user/nine/account"
-      rules_engine.rename "WebTransaction/Other/one/two/foo/bar"
+      rules_engine.rename("WebTransaction/Uri/one/two/seven/user/nine/account")
+      rules_engine.rename("WebTransaction/Custom/one/two/seven/user/nine/account")
+      rules_engine.rename("WebTransaction/Other/one/two/foo/bar")
     end
   end
 end

--- a/test/performance/suites/trace_context.rb
+++ b/test/performance/suites/trace_context.rb
@@ -32,9 +32,10 @@ class TraceContext < Performance::TestCase
     }
 
     measure do
-      NewRelic::Agent::DistributedTracing::TraceContext.parse \
+      NewRelic::Agent::DistributedTracing::TraceContext.parse( \
         carrier: carrier,
         trace_state_entry_key: "33@nr"
+      )
     end
   end
 
@@ -46,12 +47,13 @@ class TraceContext < Performance::TestCase
     trace_state = 'k1=asdf,k2=qwerty'
 
     measure do
-      NewRelic::Agent::DistributedTracing::TraceContext.insert \
+      NewRelic::Agent::DistributedTracing::TraceContext.insert( \
         carrier: carrier,
         trace_id: trace_id,
         parent_id: parent_id,
         trace_flags: trace_flags,
         trace_state: trace_state
+      )
     end
   end
 
@@ -60,10 +62,10 @@ class TraceContext < Performance::TestCase
 
     carrier = {}
 
-    with_config CONFIG do
+    with_config(CONFIG) do
       in_transaction do |txn|
         measure do
-          txn.distributed_tracer.insert_trace_context_header carrier: carrier
+          txn.distributed_tracer.insert_trace_context_header(carrier: carrier)
         end
       end
     end

--- a/test/script/external_server.rb
+++ b/test/script/external_server.rb
@@ -4,8 +4,8 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
-$:.unshift File.expand_path('../../../lib', __FILE__)
-$:.unshift File.expand_path('../..', __FILE__)
+$:.unshift(File.expand_path('../../../lib', __FILE__))
+$:.unshift(File.expand_path('../..', __FILE__))
 
 require 'newrelic_rpm'
 require 'agent_helper'
@@ -27,6 +27,6 @@ while message = JSON.parse(gets)
     server.stop
     exit(0)
   when "add_headers"
-    server.override_response_headers message["payload"]
+    server.override_response_headers(message["payload"])
   end
 end

--- a/test/simplecov_test_helper.rb
+++ b/test/simplecov_test_helper.rb
@@ -11,6 +11,6 @@ require 'simplecov' if RUBY_VERSION >= SIMPLECOV_MIN_RUBY_VERSION
 
 module SimpleCovHelper
   def self.command_name suite_name
-    SimpleCov.command_name suite_name if RUBY_VERSION >= '2.7.0'
+    SimpleCov.command_name(suite_name) if RUBY_VERSION >= '2.7.0'
   end
 end


### PR DESCRIPTION
# Overview

Using some exceptions for minitest methods and Ruby methods commonly called without parenthesis, apply the Style/MethodCallWithArgsParentheses cop to the codebase. 

Documentation for this cop: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/MethodCallWithArgsParentheses
