### PR TITLE
Update capitalization of SimpleCov

### DIFF
--- a/.github/actions/simplecov-report/README.md
+++ b/.github/actions/simplecov-report/README.md
@@ -1,4 +1,4 @@
-# Simplecov Report
+# SimpleCov Report
 
 A GitHub Action that reports SimpleCov coverage.
 
@@ -27,7 +27,7 @@ jobs:
       - name: Test
         run: bundle exec rspec
 
-      - name: Simplecov Report
+      - name: SimpleCov Report
         uses: aki77/simplecov-report-action@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/actions/simplecov-report/action.yml
+++ b/.github/actions/simplecov-report/action.yml
@@ -1,5 +1,5 @@
-name: "Simplecov Report"
-description: "Simplecov Report"
+name: "SimpleCov Report"
+description: "SimpleCov Report"
 author: aki77
 branding:
   icon: check-square

--- a/.github/actions/simplecov-report/dist/index.js
+++ b/.github/actions/simplecov-report/dist/index.js
@@ -6148,7 +6148,7 @@ function report(coveredPercent, failedThreshold, coveredPercentBranch, failedThr
             owner: github.context.repo.owner,
             repo: github.context.repo.repo,
             issue_number: pullRequestId,
-            body: `## Simplecov Report
+            body: `## SimpleCov Report
 ${summaryTable}
 `
         });
@@ -6235,8 +6235,8 @@ class OidcClient {
             const res = yield httpclient
                 .getJson(id_token_url)
                 .catch(error => {
-                throw new Error(`Failed to get ID Token. \n 
-        Error Code : ${error.statusCode}\n 
+                throw new Error(`Failed to get ID Token. \n
+        Error Code : ${error.statusCode}\n
         Error Message: ${error.result.message}`);
             });
             const id_token = (_a = res.result) === null || _a === void 0 ? void 0 : _a.value;
@@ -10211,7 +10211,7 @@ const lowercaseKeys = (obj) => Object.keys(obj).reduce((c, k) => ((c[k.toLowerCa
 /******/ },
 /******/ function(__webpack_require__) { // webpackRuntimeModules
 /******/ 	"use strict";
-/******/ 
+/******/
 /******/ 	/* webpack/runtime/make namespace object */
 /******/ 	!function() {
 /******/ 		// define __esModule on exports
@@ -10222,7 +10222,7 @@ const lowercaseKeys = (obj) => Object.keys(obj).reduce((c, k) => ((c[k.toLowerCa
 /******/ 			Object.defineProperty(exports, '__esModule', { value: true });
 /******/ 		};
 /******/ 	}();
-/******/ 	
+/******/
 /******/ 	/* webpack/runtime/define property getter */
 /******/ 	!function() {
 /******/ 		// define getter function for harmony exports
@@ -10233,6 +10233,6 @@ const lowercaseKeys = (obj) => Object.keys(obj).reduce((c, k) => ((c[k.toLowerCa
 /******/ 			}
 /******/ 		};
 /******/ 	}();
-/******/ 	
+/******/
 /******/ }
 );

--- a/.github/actions/simplecov-report/package.json
+++ b/.github/actions/simplecov-report/package.json
@@ -2,7 +2,7 @@
   "name": "simplecov-report",
   "version": "1.4.1",
   "private": true,
-  "description": "Simplecov Report",
+  "description": "SimpleCov Report",
   "main": "lib/main.js",
   "scripts": {
     "build": "tsc --allowSyntheticDefaultImports",

--- a/.github/actions/simplecov-report/src/report.ts
+++ b/.github/actions/simplecov-report/src/report.ts
@@ -21,7 +21,7 @@ export async function report(coveredPercent: number, failedThreshold: number, co
     owner: github.context.repo.owner,
     repo: github.context.repo.repo,
     issue_number: pullRequestId,
-    body: `## Simplecov Report
+    body: `## SimpleCov Report
 ${summaryTable}
 `
   })


### PR DESCRIPTION
# Overview

The gem's name is spelled with a capital 'C'. The action's comment used a lowercase 'C'. This brings our action into alignment with the maintainer's spelling.
