### PR TITLE
Execute @@after_run check only for Ruby >= 2.7

### DIFF
--- a/test/multiverse/lib/multiverse/suite.rb
+++ b/test/multiverse/lib/multiverse/suite.rb
@@ -538,10 +538,16 @@ module Multiverse
       end
 
       load(@after_file) if @after_file
-      begin
-        ::MiniTest.class_variable_get(:@@after_run).reverse_each(&:call)
-      rescue => e
-        puts "Error: #{e.inspect}"
+
+      if RUBY_VERSION >= '2.7.0'
+        # This is only used for SimpleCov at this time,
+        # an error will be raised on Ruby versions that do not run
+        # SimpleCov without this condition
+        begin
+          ::MiniTest.class_variable_get(:@@after_run).reverse_each(&:call)
+        rescue NameError => e
+          puts "NameError: #{e.inspect}"
+        end
       end
 
       if test_run


### PR DESCRIPTION
## Overview

This block was being run on versions of Ruby that do not generate SimpleCov coverage results, causing an error to be raised on the CI run. This if statement should prevent the errors from being raised.

Also, the rescue has been limited to NameError instead of globally rescuing any exception.