### PR TITLE
Avoid calling merge_or_append to speed up 

### DIFF
--- a/lib/new_relic/agent/range_extensions.rb
+++ b/lib/new_relic/agent/range_extensions.rb
@@ -12,26 +12,6 @@ module NewRelic
         r1.include?(r2.begin) || r2.include?(r1.begin)
       end
 
-      def merge(r1, r2)
-        return unless intersects?(r1, r2)
-        range_min = r1.begin < r2.begin ? r1.begin : r2.begin
-        range_max = r1.end > r2.end ? r1.end : r2.end
-        range_min..range_max
-      end
-
-      # Takes an array of ranges and a range which it will
-      # merge into an existing range if they intersect, otherwise
-      # it will append this range to the end the array.
-      def merge_or_append(range, ranges)
-        ranges.each_with_index do |r, i|
-          if merged = merge(r, range)
-            ranges[i] = merged
-            return ranges
-          end
-        end
-        ranges.push(range)
-      end
-
       # Computes the amount of overlap between range and an array of ranges.
       # For efficiency, it assumes that range intersects with each of the
       # ranges in the ranges array.

--- a/test/new_relic/agent/range_extensions_test.rb
+++ b/test/new_relic/agent/range_extensions_test.rb
@@ -17,26 +17,6 @@ module NewRelic
         refute RangeExtensions.intersects?((1...3), (3..5))
       end
 
-      def test_merge_merges_intersecting_ranges
-        merged = RangeExtensions.merge((1..5), (3..8))
-        assert_equal (1..8), merged
-      end
-
-      def test_merge_nil_for_disjoint_ranges
-        merged = RangeExtensions.merge((1...3), (3..5))
-        assert_nil merged
-      end
-
-      def test_merge_or_append_merges_intersecting_ranges
-        result = RangeExtensions.merge_or_append((3..8), [(1..5), (9..13)])
-        assert_equal [(1..8), (9..13)], result
-      end
-
-      def test_merge_or_append_appends_disjoint_ranges
-        result = RangeExtensions.merge_or_append((6..8), [(1..5), (9..13)])
-        assert_equal [(1..5), (9..13), (6..8)], result
-      end
-
       def test_compute_overlap
         result = RangeExtensions.compute_overlap(0..10, [-4..2, 6..7, 9..15])
         assert_equal 4, result

--- a/test/new_relic/agent/transaction/abstract_segment_test.rb
+++ b/test/new_relic/agent/transaction/abstract_segment_test.rb
@@ -259,6 +259,20 @@ module NewRelic
             assert_equal(segment.code_attributes, {})
           end
         end
+
+        class LazyMergeTimeRangesTest < Minitest::Test
+          def test_compacted
+            ranges = NewRelic::Agent::Transaction::AbstractSegment::LazyMergeTimeRanges.new
+            ranges.append(1.0..2.0)
+            assert_equal(ranges.compacted, [1.0..2.0])
+            ranges.append(3.0..4.0)
+            assert_equal(ranges.compacted, [1.0..2.0, 3.0..4.0])
+            ranges.append(3.5..4.5)
+            assert_equal(ranges.compacted, [1.0..2.0, 3.0..4.5]) # 3.5..4.5 is merged into 3.0..4.0
+            ranges.append(1.5..3.1)
+            assert_equal(ranges.compacted, [1.0..4.5]) # 1.5..3.1 joins 1.0..2.0 and 3.0..4.5, and results in a big range.
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

I've read them 👍 

# Overview

newrelic_rpm gets slow when `NewRelic::Agent::RangeExtensions.merge_or_append` is called so many times.

https://github.com/newrelic/newrelic-ruby-agent/issues/1264

`newrelic_rpm@8.9.0` slows the response, 446ms -> 33670ms. (See https://github.com/hkdnet/graphql-ruby-nr/tree/ccefc10dcae5a1ed90eaba4cc6f8ea3bcb6e38a4#result )
But the current patch slows the same response, 403ms -> 626ms. (See https://github.com/hkdnet/graphql-ruby-nr/tree/perf-test-for-lazy-merge#result )

Though the result is not stable (it depends on my machine's status), it shows a significant improvement.

Submitter Checklist:
- [x] Include a link to the related GitHub issue, if applicable
- [ ] Include a security review link, if applicable
    - I think we don't need it.

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
Github Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
