### PR TITLE
GHA: don't run SimpleCov on forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -326,7 +326,7 @@ jobs:
   simplecov:
     needs: [unit_tests, multiverse, infinite_tracing]
     runs-on: ubuntu-20.04
-    if: github.repository == 'newrelic/newrelic-ruby-agent'
+    if: github.repository_owner == 'newrelic'
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-ruby@v1


### PR DESCRIPTION
use a different conditional to rule out forks from performing SimpleCov
operations (which require write access to our artifact storage)

resolves #1278 