### PR TITLE
enable CLM by default

### DIFF
--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2016,7 +2016,8 @@ A map of error classes to a list of messages. When an error of one of the classe
           :public => true,
           :type => Boolean,
           :allowed_from_server => true,
-          :description => 'If `true`, the agent will report source code level metrics for traced methods.'
+          :description => "If `true`, the agent will report source code level metrics for traced methods.\nsee: " \
+                          'https://docs.newrelic.com/docs/apm/agents/ruby-agent/features/ruby-codestream-integration/'
         },
         :'instrumentation.active_support_logger' => {
           :default => instrumentation_value_from_boolean(:'application_logging.enabled'),

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2012,7 +2012,7 @@ A map of error classes to a list of messages. When an error of one of the classe
           :description => 'If `true`, the agent decorates logs with metadata to link to entities, hosts, traces, and spans.'
         },
         :'code_level_metrics.enabled' => {
-          :default => false,
+          :default => true,
           :public => true,
           :type => Boolean,
           :allowed_from_server => true,

--- a/newrelic.yml
+++ b/newrelic.yml
@@ -43,7 +43,8 @@ common: &default_settings
   # application_logging.local_decorating.enabled: false
 
   # If `true`, the agent will report source code level metrics for traced methods
-  # code_level_metrics.enabled: false
+  # see: https://docs.newrelic.com/docs/apm/agents/ruby-agent/features/ruby-codestream-integration/
+  # code_level_metrics.enabled: true
 
   # If true, enables transaction event sampling.
   # transaction_events.enabled: true

--- a/test/new_relic/agent/method_tracer_helpers_test.rb
+++ b/test/new_relic/agent/method_tracer_helpers_test.rb
@@ -105,4 +105,18 @@ class NewRelic::Agent::MethodTracerHelpersTest < Minitest::Test
         info)
     end
   end
+
+  def test_clm_memoization_hash_uses_frozen_keys_and_values
+    helped = Class.new do
+      include NewRelic::Agent::MethodTracerHelpers
+    end.new
+    with_config(:'code_level_metrics.enabled' => true) do
+      helped.code_information(::The::Example, :instance_method)
+      memoized = helped.instance_variable_get(:@code_information)
+      assert memoized
+      assert memoized.keys.size == 1
+      assert memoized.keys.first.frozen?
+      assert memoized.values.first.frozen?
+    end
+  end
 end


### PR DESCRIPTION
following the successes reported by a good number of opting-in adopters,
the decision has been made to enable code level metrics reporting in the
Ruby agent by default. users may still come up with feature requests for
additional CLM functionality or instrumented library coverage, but the
core functionality in place currently is thought to be stable and ready
for enabling by default.

resolves #1260