### PR TITLE
CI: treat Envfile files as Ruby

### DIFF
--- a/test/multiverse/suites/active_record/Envfile
+++ b/test/multiverse/suites/active_record/Envfile
@@ -1,3 +1,8 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
 # not testing the latest of activerecord in this suite because
 # mysql2 has issues with newer Rubies
 

--- a/test/multiverse/suites/active_record_pg/Envfile
+++ b/test/multiverse/suites/active_record_pg/Envfile
@@ -1,3 +1,8 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
 suite_condition('Skip AR for JRuby, initialization fails on GitHub Actions') do
   RUBY_PLATFORM != 'java'
 end

--- a/test/multiverse/suites/activemerchant/Envfile
+++ b/test/multiverse/suites/activemerchant/Envfile
@@ -1,3 +1,8 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
 ACTIVEMERCHANT_VERSIONS = [
   [nil, 3.0],
   ['1.121.0', 2.5, 3.0],

--- a/test/multiverse/suites/agent_only/Envfile
+++ b/test/multiverse/suites/agent_only/Envfile
@@ -1,3 +1,8 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
 gemfile <<-RB
   gem 'minitest', '4.7.5'
   gem 'rack', '< 2.1.0'

--- a/test/multiverse/suites/bare/Envfile
+++ b/test/multiverse/suites/bare/Envfile
@@ -1,3 +1,8 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
 gemfile <<-RB
   gem 'newrelic_rpm', :require => false, :path => File.expand_path('../../../../')
 RB

--- a/test/multiverse/suites/bunny/Envfile
+++ b/test/multiverse/suites/bunny/Envfile
@@ -1,3 +1,8 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
 suite_condition("bunny not supported for JRuby") do
   RUBY_PLATFORM != 'java'
 end

--- a/test/multiverse/suites/capistrano/Envfile
+++ b/test/multiverse/suites/capistrano/Envfile
@@ -1,3 +1,8 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
 suite_condition("Capistrano 3 flaky on JRuby") do
   RUBY_PLATFORM != 'java'
 end

--- a/test/multiverse/suites/capistrano2/Envfile
+++ b/test/multiverse/suites/capistrano2/Envfile
@@ -1,3 +1,8 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
 suite_condition("Capistrano testing is flaky on JRuby") do
   RUBY_PLATFORM != 'java'
 end

--- a/test/multiverse/suites/config_file_loading/Envfile
+++ b/test/multiverse/suites/config_file_loading/Envfile
@@ -1,3 +1,8 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
 omit_collector!
 
 PSYCH_VERSIONS = [

--- a/test/multiverse/suites/curb/Envfile
+++ b/test/multiverse/suites/curb/Envfile
@@ -1,3 +1,8 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
 suite_condition("Curb is not useful on JRuby") do
   RUBY_PLATFORM != 'java'
 end

--- a/test/multiverse/suites/datamapper/Envfile
+++ b/test/multiverse/suites/datamapper/Envfile
@@ -1,3 +1,8 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
 suite_condition("only test on < 2.4"){ RUBY_VERSION < '2.4.0' }
 
 adapter_gems = <<-RB
@@ -16,5 +21,3 @@ gemfile <<-RB
   gem 'addressable', :require => 'addressable/uri'
   #{adapter_gems}
 RB
-
-# vim: ft=ruby

--- a/test/multiverse/suites/deferred_instrumentation/Envfile
+++ b/test/multiverse/suites/deferred_instrumentation/Envfile
@@ -1,3 +1,8 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
 instrumentation_methods :chain, :prepend
 
 SINATRA_VERSIONS = [

--- a/test/multiverse/suites/delayed_job/Envfile
+++ b/test/multiverse/suites/delayed_job/Envfile
@@ -1,3 +1,8 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
 instrumentation_methods :chain, :prepend
 
 def sqlite
@@ -140,5 +145,3 @@ if RUBY_VERSION < '2.3.0'
     RB
   end
 end
-
-# vim: ft=ruby

--- a/test/multiverse/suites/excon/Envfile
+++ b/test/multiverse/suites/excon/Envfile
@@ -1,3 +1,8 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
 excon_versions = [
   nil,
   '0.56.0',

--- a/test/multiverse/suites/grape/Envfile
+++ b/test/multiverse/suites/grape/Envfile
@@ -1,3 +1,8 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
 instrumentation_methods :chain, :prepend
 
 GRAPE_VERSIONS = [

--- a/test/multiverse/suites/high_security/Envfile
+++ b/test/multiverse/suites/high_security/Envfile
@@ -1,3 +1,8 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
 gemfile <<-RB
   gem 'rack'
   #{ruby3_gem_webrick}

--- a/test/multiverse/suites/httpclient/Envfile
+++ b/test/multiverse/suites/httpclient/Envfile
@@ -1,3 +1,8 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
 instrumentation_methods :chain, :prepend
 HTTPCLIENT_VERSIONS = [
   [nil, 2.2],

--- a/test/multiverse/suites/httprb/Envfile
+++ b/test/multiverse/suites/httprb/Envfile
@@ -1,3 +1,8 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
 instrumentation_methods :chain, :prepend
 
 # NOTE, some versions of HTTP gem implements body with
@@ -28,5 +33,3 @@ def gem_list(httprb_version = nil)
 end
 
 create_gemfiles(HTTPRB_VERSIONS, gem_list)
-
-# vim: ft=ruby

--- a/test/multiverse/suites/infinite_tracing/Envfile
+++ b/test/multiverse/suites/infinite_tracing/Envfile
@@ -1,3 +1,8 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
 gemfile <<-RB
   gem 'newrelic-infinite_tracing', :path => '../../../../infinite_tracing'
 RB

--- a/test/multiverse/suites/json/Envfile
+++ b/test/multiverse/suites/json/Envfile
@@ -1,3 +1,8 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
 gemfile <<-RB
   gem 'rack'
   #{ruby3_gem_webrick}

--- a/test/multiverse/suites/logger/Envfile
+++ b/test/multiverse/suites/logger/Envfile
@@ -1,3 +1,8 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
 instrumentation_methods :chain, :prepend
 
 gemfile <<-RB

--- a/test/multiverse/suites/marshalling/Envfile
+++ b/test/multiverse/suites/marshalling/Envfile
@@ -1,3 +1,8 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
 gemfile <<-RB
   gem 'rack'
   #{ruby3_gem_webrick}

--- a/test/multiverse/suites/memcache/Envfile
+++ b/test/multiverse/suites/memcache/Envfile
@@ -1,3 +1,8 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
 require File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "..", "helpers", "docker"))
 
 if RUBY_VERSION >= '2.6.0'

--- a/test/multiverse/suites/mongo/Envfile
+++ b/test/multiverse/suites/mongo/Envfile
@@ -1,3 +1,8 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
 require File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "..", "helpers", "docker"))
 
 if RUBY_VERSION >= '2.6.0'
@@ -120,5 +125,3 @@ end
 after_suite do
   $mongo.stop
 end
-
-# vim: ft=ruby

--- a/test/multiverse/suites/net_http/Envfile
+++ b/test/multiverse/suites/net_http/Envfile
@@ -1,3 +1,8 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
 instrumentation_methods :chain, :prepend
 
 # Net::HTTP is included in Ruby's standard library

--- a/test/multiverse/suites/padrino/Envfile
+++ b/test/multiverse/suites/padrino/Envfile
@@ -1,3 +1,8 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
 instrumentation_methods :chain, :prepend
 
 gemfile <<-RB
@@ -6,5 +11,3 @@ gemfile <<-RB
   gem 'rack-test', '>= 0.8.0', :require => 'rack/test'
   gem 'webrick' if RUBY_VERSION >= '2.7.0'
 RB
-
-# vim: ft=ruby

--- a/test/multiverse/suites/rack/Envfile
+++ b/test/multiverse/suites/rack/Envfile
@@ -1,3 +1,8 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
 instrumentation_methods :chain, :prepend
 
 # The Rack suite also tests Puma::Rack::Builder

--- a/test/multiverse/suites/rails/Envfile
+++ b/test/multiverse/suites/rails/Envfile
@@ -1,3 +1,8 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
 # TODO: UNIT TESTS - Determine the root cause of our compatibility issues with
 #       rack-test 2+. If rack-test is not specified in Gemfile, the rum tests
 #       fail because the JS header is always included, even when not desired.

--- a/test/multiverse/suites/rails_prepend/Envfile
+++ b/test/multiverse/suites/rails_prepend/Envfile
@@ -1,3 +1,8 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
 RAILS_VERSIONS = [
   [nil, 2.7],
   ['7.0.0', 2.7],

--- a/test/multiverse/suites/rake/Envfile
+++ b/test/multiverse/suites/rake/Envfile
@@ -1,3 +1,7 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
 
 # NOTE:  Effective July, 2020, all the older versions of Rake prior to 12.3.3 are
 #        eliminated from the test suite due to security vulnerability.  Because of

--- a/test/multiverse/suites/redis/Envfile
+++ b/test/multiverse/suites/redis/Envfile
@@ -1,3 +1,8 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
 instrumentation_methods :chain, :prepend
 
 REDIS_VERSIONS = [

--- a/test/multiverse/suites/resque/Envfile
+++ b/test/multiverse/suites/resque/Envfile
@@ -1,3 +1,8 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
 RESQUE_VERSIONS = [
   [nil],
   ['2.2.0', 2.3],

--- a/test/multiverse/suites/sequel/Envfile
+++ b/test/multiverse/suites/sequel/Envfile
@@ -1,3 +1,8 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
 SEQUEL_VERSIONS = [
   [nil],
   ['5.58.0'],

--- a/test/multiverse/suites/sidekiq/Envfile
+++ b/test/multiverse/suites/sidekiq/Envfile
@@ -1,3 +1,8 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
 suite_condition("Sidekiq does not run on JRuby") do
   RUBY_PLATFORM != 'java'
 end

--- a/test/multiverse/suites/sinatra/Envfile
+++ b/test/multiverse/suites/sinatra/Envfile
@@ -1,3 +1,8 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
 instrumentation_methods :chain, :prepend
 
 SINATRA_VERSIONS = [
@@ -18,5 +23,3 @@ def gem_list(sinatra_version = nil)
 end
 
 create_gemfiles(SINATRA_VERSIONS, gem_list)
-
-# vim: ft=ruby

--- a/test/multiverse/suites/sinatra_agent_disabled/Envfile
+++ b/test/multiverse/suites/sinatra_agent_disabled/Envfile
@@ -1,3 +1,8 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
 SINATRA_VERSIONS = [
   [nil, 2.3],
   ['2.1.0', 2.3],
@@ -16,5 +21,3 @@ def gem_list(sinatra_version = nil)
 end
 
 create_gemfiles(SINATRA_VERSIONS, gem_list)
-
-# vim: ft=ruby

--- a/test/multiverse/suites/tilt/Envfile
+++ b/test/multiverse/suites/tilt/Envfile
@@ -1,3 +1,8 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
 instrumentation_methods :chain, :prepend
 
 TILT_VERSIONS = [

--- a/test/multiverse/suites/typhoeus/Envfile
+++ b/test/multiverse/suites/typhoeus/Envfile
@@ -1,3 +1,8 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
 instrumentation_methods :chain, :prepend
 
 TYPHOEUS_VERSIONS = [
@@ -17,4 +22,3 @@ def gem_list(typhoeus_version = nil)
 end
 
 create_gemfiles(TYPHOEUS_VERSIONS, gem_list)
-# vim: ft=ruby

--- a/test/multiverse/suites/unicorn/Envfile
+++ b/test/multiverse/suites/unicorn/Envfile
@@ -1,3 +1,8 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
 suite_condition("unicorn not supported for JRuby") do
   RUBY_PLATFORM != 'java'
 end
@@ -15,6 +20,3 @@ def gem_list(unicorn_version = nil)
     gem 'rack'
   RB
 end
-
-# vim: ft=ruby
-

--- a/test/multiverse/suites/yajl/Envfile
+++ b/test/multiverse/suites/yajl/Envfile
@@ -1,3 +1,8 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
 suite_condition("Yajl not supported for JRuby") do
   RUBY_PLATFORM != 'java'
 end
@@ -19,5 +24,3 @@ def gem_list(yajl_version = nil)
 end
 
 create_gemfiles(YAJL_VERSIONS, gem_list)
-
-# vim: ft=ruby

--- a/test/multiverse/test/suite_examples/one/a/Envfile
+++ b/test/multiverse/test/suite_examples/one/a/Envfile
@@ -1,3 +1,8 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
 gemfile <<-RUBY
   gem "timetrap"
 RUBY

--- a/test/multiverse/test/suite_examples/one/b/Envfile
+++ b/test/multiverse/test/suite_examples/one/b/Envfile
@@ -1,3 +1,8 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
 gemfile <<-RUBY
   gem "haml"
 RUBY

--- a/test/multiverse/test/suite_examples/three/a/Envfile
+++ b/test/multiverse/test/suite_examples/three/a/Envfile
@@ -1,2 +1,7 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
 gemfile "#noop"
 execute_mode 'spawn'

--- a/test/multiverse/test/suite_examples/three/b/Envfile
+++ b/test/multiverse/test/suite_examples/three/b/Envfile
@@ -1,2 +1,7 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
 gemfile "#noop"
 execute_mode 'fork'

--- a/test/multiverse/test/suite_examples/two/a/Envfile
+++ b/test/multiverse/test/suite_examples/two/a/Envfile
@@ -1,1 +1,6 @@
+# encoding: utf-8
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
 gemfile "#noop"


### PR DESCRIPTION
- give each `Envfile` file a standard Ruby file header, specifying utf-8
  encoding, the license info, and that string literals ought to be
  frozen
- remove the '# vim:' comments present on only some `Envfile` instances
  that would tell Vim to treat the file as a Ruby file. Vimmers can
  simply tell Vim that an 'Envfile' pattern encountered at buffer read
  time should trigger a 'set filetype=ruby' operation, like so:

```lua
-- 'Envfile' files are Ruby
local envfileGroup = vim.api.nvim_create_augroup('envfile', { clear = true })
vim.api.nvim_create_autocmd(
  { "Bufread" },
  { pattern = "Envfile", command = "set filetype=ruby", group = envfileGroup }
)
```