### PR TITLE
Don't modify frozen Logger instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # New Relic Ruby Agent Release Notes #
 
 
+  ## v8.10.0
+
+  * **Bugfix: Don't modify frozen Logger**
+
+    Previously the agent would modify each instance of the Logger class by adding a unique instance variable as part of the instrumentation. This could cause the error `FrozenError: can't modify frozen Logger` to be thrown if the Logger instance had been frozen. The agent will now check if the object is frozen before attempting to modify the object. Thanks to @mkcosta for bringing this issue to our attention.
+
+
+
   ## v8.9.0
   
   

--- a/lib/new_relic/agent/instrumentation/logger/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/logger/instrumentation.rb
@@ -15,18 +15,22 @@ module NewRelic
         # instrumentation installed yet. This lets us disable in AgentLogger
         # and AuditLogger without them having to know the inner details.
         def self.mark_skip_instrumenting(logger)
+          return if logger.frozen?
           logger.instance_variable_set(:@skip_instrumenting, true)
         end
 
         def self.clear_skip_instrumenting(logger)
+          return if logger.frozen?
           logger.instance_variable_set(:@skip_instrumenting, false)
         end
 
         def mark_skip_instrumenting
+          return if self.frozen?
           @skip_instrumenting = true
         end
 
         def clear_skip_instrumenting
+          return if self.frozen?
           @skip_instrumenting = false
         end
 

--- a/lib/new_relic/agent/instrumentation/logger/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/logger/instrumentation.rb
@@ -25,12 +25,12 @@ module NewRelic
         end
 
         def mark_skip_instrumenting
-          return if self.frozen?
+          return if frozen?
           @skip_instrumenting = true
         end
 
         def clear_skip_instrumenting
-          return if self.frozen?
+          return if frozen?
           @skip_instrumenting = false
         end
 

--- a/test/multiverse/suites/logger/logger_instrumentation_test.rb
+++ b/test/multiverse/suites/logger/logger_instrumentation_test.rb
@@ -174,6 +174,15 @@ class LoggerInstrumentationTest < Minitest::Test
     assert_metrics_recorded_exclusive([])
   end
 
+  def test_dont_modify_frozen_logger
+    @logger.freeze
+    @logger.mark_skip_instrumenting
+    @logger.clear_skip_instrumenting
+    NewRelic::Agent::Instrumentation::Logger.mark_skip_instrumenting(@logger)
+    NewRelic::Agent::Instrumentation::Logger.clear_skip_instrumenting(@logger)
+    assert !@logger.instance_variable_defined?(:@skip_instrumenting), "instance variable should not be defined"
+  end
+
   def assert_logging_instrumentation(level, count = 1)
     # We count on Logger calls but actually write metrics on harvest to
     # minimize impact in the hot path


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
This PR adds checks for if the logger is frozen before attempting to set/change the `@skip_instrumenting` instance variable. Since this variable is only used internally in the agent and we know those instances of Logger are not frozen, this shouldn't interfere with the purpose of this variable. 
closes #1288

Submitter Checklist:
- [ ] Include a link to the related GitHub issue, if applicable
- [ ] Include a security review link, if applicable

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
Github Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
