### PR TITLE
Bugfix for one line yaml config transaction_tracer.transaction_threshold: apdex_f

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,31 @@
 # New Relic Ruby Agent Release Notes #
 
 
+  ## v8.10.0
+
+  * **Bugfix: Error when setting the yaml configuration with `transaction_tracer.transaction_threshold: apdex_f`**
+    
+    Originally, the agent was only checking the `transaction_tracer.transaction_threshold` from the newrelic.yml correctly if it was on two lines. 
+
+    Example:
+
+    ```
+    # newrelic.yml
+    transaction_tracer:
+      transaction_threshold: apdex_f 
+    ```
+
+    When this was instead changed to be on one line, the agent was not able to correctly identify the value of apdex_f. 
+
+    Example:
+    ```
+    # newrelic.yml
+    transaction_tracer.transaction_threshold: apdex_f
+    ```
+    This would cause prevent transactions from finishing due to the error `ArgumentError: comparison of Float with String failed`. This has now been corrected and the agent is able to process newrelic.yml with a one line `transaction_tracer.transaction_threshold: apdex_f` correctly now. 
+    
+    Thank you to @oboxodo for bringing this to our attention.
+
   ## v8.9.0
   
   

--- a/lib/new_relic/agent/configuration/yaml_source.rb
+++ b/lib/new_relic/agent/configuration/yaml_source.rb
@@ -125,6 +125,8 @@ module NewRelic
               config['transaction_tracer']['transaction_threshold'].to_s =~ /apdex_f/i
             # when value is "apdex_f" remove the config and defer to default
             config['transaction_tracer'].delete('transaction_threshold')
+          elsif config['transaction_tracer.transaction_threshold'].to_s =~ /apdex_f/i
+            config.delete('transaction_tracer.transaction_threshold')
           end
         end
 

--- a/test/new_relic/agent/configuration/yaml_source_test.rb
+++ b/test/new_relic/agent/configuration/yaml_source_test.rb
@@ -122,6 +122,12 @@ module NewRelic::Agent::Configuration
       assert_includes source.failures.flatten.join(' '), 'yolo'
     end
 
+    def test_transaction_threshold_one_liner
+      config = {'transaction_tracer.transaction_threshold' => 'apdex_f'}
+      @source.send(:substitute_transaction_threshold, config)
+      assert config.empty?
+    end
+
     [1, 'no', 'off', 0, 'false', [], {}, 1.0, Time.now].each do |value|
       method_name = "test_booleanify_values_fails_with_value_#{value}"
       define_method(method_name) do


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
The agent was not correctly identifying the `apdex_f` value that is expected when setting `transaction_tracer.transaction_threshold` in the newrelic.yml if the config option was a one liner. The agent was only checking for the structure expecting it to be defined using two lines, like:
```
    transaction_tracer:
      transaction_threshold: apdex_f 
```
This PR fixes this issue to also check for the existence of a one liner and adds a test to make sure it is working.

closes https://github.com/newrelic/newrelic-ruby-agent/issues/1294
Submitter Checklist:
- [ ] Include a link to the related GitHub issue, if applicable
- [ ] Include a security review link, if applicable

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
Github Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
