### PR TITLE
Update gRPC instrumentation supportability_name

### DIFF
--- a/lib/new_relic/agent/instrumentation/grpc_client.rb
+++ b/lib/new_relic/agent/instrumentation/grpc_client.rb
@@ -14,10 +14,11 @@ DependencyDetection.defer do
   end
 
   executes do
+    supportability_name = 'GRPC::Client'
     if use_prepend?
-      prepend_instrument ::GRPC::ClientStub, ::NewRelic::Agent::Instrumentation::GRPC::Client::Prepend
+      prepend_instrument ::GRPC::ClientStub, ::NewRelic::Agent::Instrumentation::GRPC::Client::Prepend, supportability_name
     else
-      chain_instrument ::NewRelic::Agent::Instrumentation::GRPC::Client::Chain
+      chain_instrument ::NewRelic::Agent::Instrumentation::GRPC::Client::Chain, supportability_name
     end
   end
 end

--- a/lib/new_relic/agent/instrumentation/grpc_client.rb
+++ b/lib/new_relic/agent/instrumentation/grpc_client.rb
@@ -14,7 +14,7 @@ DependencyDetection.defer do
   end
 
   executes do
-    supportability_name = 'GRPC::Client'
+    supportability_name = 'gRPC_Client'
     if use_prepend?
       prepend_instrument ::GRPC::ClientStub, ::NewRelic::Agent::Instrumentation::GRPC::Client::Prepend, supportability_name
     else

--- a/lib/new_relic/agent/instrumentation/grpc_server.rb
+++ b/lib/new_relic/agent/instrumentation/grpc_server.rb
@@ -15,11 +15,12 @@ DependencyDetection.defer do
   end
 
   executes do
+    supportability_name = 'gRPC_Server'
     if use_prepend?
-      prepend_instrument ::GRPC::RpcServer, ::NewRelic::Agent::Instrumentation::GRPC::Server::RpcServerPrepend, 'GRPC::Server::RpcServer'
-      prepend_instrument ::GRPC::RpcDesc, ::NewRelic::Agent::Instrumentation::GRPC::Server::RpcDescPrepend, 'GRPC::Server::RpcDesc'
+      prepend_instrument ::GRPC::RpcServer, ::NewRelic::Agent::Instrumentation::GRPC::Server::RpcServerPrepend, supportability_name
+      prepend_instrument ::GRPC::RpcDesc, ::NewRelic::Agent::Instrumentation::GRPC::Server::RpcDescPrepend, supportability_name
     else
-      chain_instrument ::NewRelic::Agent::Instrumentation::GRPC::Server::Chain, 'GRPC::Server'
+      chain_instrument ::NewRelic::Agent::Instrumentation::GRPC::Server::Chain, supportability_name
     end
   end
 end

--- a/lib/new_relic/agent/instrumentation/grpc_server.rb
+++ b/lib/new_relic/agent/instrumentation/grpc_server.rb
@@ -16,10 +16,10 @@ DependencyDetection.defer do
 
   executes do
     if use_prepend?
-      prepend_instrument ::GRPC::RpcServer, ::NewRelic::Agent::Instrumentation::GRPC::Server::RpcServerPrepend
-      prepend_instrument ::GRPC::RpcDesc, ::NewRelic::Agent::Instrumentation::GRPC::Server::RpcDescPrepend
+      prepend_instrument ::GRPC::RpcServer, ::NewRelic::Agent::Instrumentation::GRPC::Server::RpcServerPrepend, 'GRPC::Server::RpcServer'
+      prepend_instrument ::GRPC::RpcDesc, ::NewRelic::Agent::Instrumentation::GRPC::Server::RpcDescPrepend, 'GRPC::Server::RpcDesc'
     else
-      chain_instrument ::NewRelic::Agent::Instrumentation::GRPC::Server::Chain
+      chain_instrument ::NewRelic::Agent::Instrumentation::GRPC::Server::Chain, 'GRPC::Server'
     end
   end
 end

--- a/test/new_relic/dependency_detection_test.rb
+++ b/test/new_relic/dependency_detection_test.rb
@@ -360,4 +360,15 @@ class DependencyDetectionTest < Minitest::Test
 
     assert_equal(1, run_count)
   end
+
+  def test_log_and_instrument_uses_supportability_name_when_provided
+    method = 'Stanislavski'
+    supportability_name = 'Magic::If'
+    log = with_array_logger do
+      DependencyDetection::Dependent.new.log_and_instrument(method, 'actor', supportability_name) { 'Given Circumstances' }
+    end
+    assert_metrics_recorded("Supportability/Instrumentation/#{supportability_name}/#{method}")
+    assert_log_contains(log, /#{supportability_name}/)
+    assert_log_contains(log, /#{method}/)
+  end
 end


### PR DESCRIPTION
# Overview
* Pass `supportability_name` argument to gRPC client instrumentation
* Pass `supportability_name` argument to gRPC server instrumentation
* Add test for DependencyDetection::Dependent#log_and_instrument to make sure the supportability_name is applied to the metric and log message when present.

Relates to #1303 

Submitter Checklist:
- [X] Include a link to the related GitHub issue, if applicable
- [ ] Include a security review link, if applicable

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
Github Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
