### PR TITLE
Revert perf minitest addition

### DIFF
--- a/test/performance/Gemfile
+++ b/test/performance/Gemfile
@@ -3,7 +3,6 @@ source 'https://rubygems.org'
 
 gem 'newrelic_rpm', :path => '../../..'
 
-gem 'minitest'
 gem 'mocha'
 gem 'pry'
 gem 'pry-nav'

--- a/test/performance/lib/performance/runner.rb
+++ b/test/performance/lib/performance/runner.rb
@@ -142,7 +142,7 @@ module Performance
       test_case_name = test_case.class.name
       test_identifier = "#{test_case_name}##{method}"
       runner_script = File.expand_path(File.join(File.dirname(__FILE__), '..', '..', 'script', 'runner'))
-      cmd = "#{runner_script} -T #{test_identifier} -j -q -I"
+      cmd = +"#{runner_script} -T #{test_identifier} -j -q -I"
       cmd << " -A #{@options[:agent_path]}"
       cmd << " -N #{@options[:iterations]}" if @options[:iterations]
       cmd << " -d #{@options[:duration]}" if @options[:duration]

--- a/test/performance/suites/trace_context.rb
+++ b/test/performance/suites/trace_context.rb
@@ -3,7 +3,6 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
-require 'minitest/autorun'
 require 'net/http'
 require 'new_relic/agent/distributed_tracing/trace_context'
 require 'new_relic/agent/transaction/trace_context'


### PR DESCRIPTION
This commit reverts the addition of minitest to performance tests. Additionally, prevents a string freeze.

_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
Describe the changes present in the pull request

Submitter Checklist:
- [ ] Include a link to the related GitHub issue, if applicable
- [ ] Include a security review link, if applicable

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
Github Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
