### PR TITLE
no stubs

### DIFF
--- a/test/new_relic/agent/monitors/trace_context_request_monitor_test.rb
+++ b/test/new_relic/agent/monitors/trace_context_request_monitor_test.rb
@@ -101,14 +101,9 @@ module NewRelic
 
       def build_parent_transaction_headers
         carrier = {}
-
-        # stubbing contexted allows trace_context_active? to pass
-        # which, in turn, allows us to insert a trace_context header here.
         parent_txn = in_transaction('referring_txn') do |txn|
-          Agent.instance.stub(:connected?, true) do
-            txn.sampled = true
-            txn.distributed_tracer.insert_trace_context_header(carrier, NewRelic::FORMAT_RACK)
-          end
+          txn.sampled = true
+          txn.distributed_tracer.insert_trace_context_header(carrier, NewRelic::FORMAT_RACK)
         end
         [parent_txn, carrier]
       end

--- a/test/performance/suites/trace_context.rb
+++ b/test/performance/suites/trace_context.rb
@@ -52,9 +52,7 @@ class TraceContext < Performance::TestCase
     with_config(CONFIG) do
       in_transaction do |txn|
         measure do
-          NewRelic::Agent.agent.stub(:connected?, true) do
-            txn.distributed_tracer.insert_trace_context_header(carrier: {})
-          end
+          txn.distributed_tracer.insert_trace_context_header(carrier: {})
         end
       end
     end


### PR DESCRIPTION
we need to revert #1149 because introducing MiniTest to the perf tests
causes issues. but we certainly don't want to go back to Mocha. so let's
just do without stubs entirely.

> ... A stub is a placeholder that thinks it's fly
> And is also known as a busta
> Always talkin' about how it'll respond
> And never does anything real
>
> ... So no, I don't need your code
> No, I don't want to trust you with mine and
> No, I don't want your return value
> No, I don't want none of your time and
>
> ... No, I don't want no stub
> A stub is a dummy that can't get no love from me
> Hangin' out on the unit test side
> Of the CI ride
> Trying to holla at me
> I don't want no stub
> A stub is a dummy that can't get no love from me
> Hanging' out on the unit test side
> Of the CI ride
> Trying to holla at me

![no-scrubs](https://user-images.githubusercontent.com/121392/182505646-e8eaa83e-8298-4fb3-99d8-2f671720248c.jpg)