### PR TITLE
Bugfix grpc instrumentation on ruby 2.5

### DIFF
--- a/lib/new_relic/agent/instrumentation/grpc/client/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/grpc/client/instrumentation.rb
@@ -20,7 +20,7 @@ module NewRelic
             segment = request_segment(method)
             request_wrapper = NewRelic::Agent::Instrumentation::GRPC::Client::RequestWrapper.new(@host)
             segment.add_request_headers(request_wrapper)
-            metadata.merge!(metadata, request_wrapper.instance_variable_get(:@newrelic_metadata))
+            metadata.merge!(request_wrapper.instance_variable_get(:@newrelic_metadata))
             grpc_message = nil
             grpc_status = 0
 


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
In ruby 2.5, [`merge!`](https://ruby-doc.org/core-2.5.9/Hash.html#method-i-merge-21) only accepts a single argument even though on [2.6+](https://ruby-doc.org/core-2.6.1/Hash.html#method-i-merge-21) multiple hashes can be passed in. 
Since the first argument being passed in was the same object that was calling `merge!`, I just removed it from being passed in as an argument since it was not needed. 


Submitter Checklist:
- [ ] Include a link to the related GitHub issue, if applicable
- [ ] Include a security review link, if applicable

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
Github Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
