### PR TITLE
Update GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: feature
+labels: feature request
 assignees: ''
 
 ---
@@ -20,5 +20,5 @@ A clear and concise description of any alternative solutions or features you've 
 Add any other context here.
 
 ### Priority
-Please help us better understand this feature request by choosing a priority from the following options: 
+Please help us better understand this feature request by choosing a priority from the following options:
 [Nice to Have, Really Want, Must Have, Blocker]

--- a/.github/ISSUE_TEMPLATE/story.md
+++ b/.github/ISSUE_TEMPLATE/story.md
@@ -1,28 +1,27 @@
 ---
 name: Story
-about: Story for a particular feature
+about: Issue describing development work to fulfill a feature request
 title: ''
 labels: ''
 assignees: ''
 priority: ''
 ---
-
-### Describe the story, please be clear on scope of the story.
-Please be concise with the scope for the story.
+### Description
+_What's the goal of this unit of work? What is included? What isn't included?_
 
 ### Acceptance Criteria
-Please outline the acceptance criteria
+_What tasks need to be accomplished to achieve the goal?_
+
+### Design Consideration/Limitations
+_Why is this the route we should take to achieve our goal?_
+_What can't be achieved within this story?_
 
 ### Dependencies
-- [ ] Dependencies on UI
-- [ ] Dependencies on Backend
-- [ ] Other dependencies ....
-
-### Describe Design Consideration/Limitations
-A clear and concise description of any alternative solutions or features you've considered.
+_Do any other teams or parts of the New Relic product need to be considered?_
+_Some common areas: UI, collector, documentation_
 
 ### Additional context
-Add any other context here.
+_What else should we know about this story that might not fit into the other categories?_
 
 ### Estimates
-Please provide initial t-shirt size
+_Please provide initial t-shirt size. S = 1-3 days,  M = 3-5 days (1 week), L = 1-2 weeks (1 sprint)_

--- a/.github/ISSUE_TEMPLATE/story.md
+++ b/.github/ISSUE_TEMPLATE/story.md
@@ -1,0 +1,28 @@
+---
+name: Story
+about: Story for a particular feature
+title: ''
+labels: ''
+assignees: ''
+priority: ''
+---
+
+### Describe the story, please be clear on scope of the story.
+Please be concise with the scope for the story.
+
+### Acceptance Criteria
+Please outline the acceptance criteria
+
+### Dependencies
+- [ ] Dependencies on UI
+- [ ] Dependencies on Backend
+- [ ] Other dependencies ....
+
+### Describe Design Consideration/Limitations
+A clear and concise description of any alternative solutions or features you've considered.
+
+### Additional context
+Add any other context here.
+
+### Estimates
+Please provide initial t-shirt size


### PR DESCRIPTION
# Overview
* Add a GitHub Issue template for the "Story" issue type, to be used for development work
* Update the label added when generating a Feature to be `feature request`

Relates to: #1285 
