### PR TITLE
CHANGELOG: v8.10.0 updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,17 @@
     | `instrumentation.grpc.host_denylist` | "" |  Provide a comma delimited list of host regex patterns (ex: "private.com$,exception.*") |
 
 
+  * **Code-level metrics functionality is enabled by default**
+
+    The code-level metrics functionality for the Ruby agent's [CodeStream integration](https://docs.newrelic.com/docs/apm/agents/ruby-agent/features/ruby-codestream-integration) is now enabled by default after we have received positive feedback and no open bugs for the past two releases.
+
+
   * **Performance: Rework timing range overlap calculations for multiple transaction segments**
 
     Many thanks to GitHub community members @bmulholland and @hkdnet. @bmulholland alerted us to [rmosolgo/graphql-ruby#3945](https://github.com/rmosolgo/graphql-ruby/issues/3945). That Issue essentially notes that the New Relic Ruby agent incurs a significant perfomance hit when the `graphql` RubyGem (which ships with New Relic Ruby agent support) is used with DataLoader to generate a high number of transactions. Then @hkdnet diagnosed the root cause in the Ruby agent and put together both a proof of concept fix and a full blown PR to resolve the problem. The agent keeps track multiple segments that are concurrently in play for a given transaction in order to merge the ones whose start and stop times intersect. The logic for doing this find-and-merge operation has been reworked to a) be deferred entirely until the transaction is ready to be recorded, and b) made more performant when it is needed. GraphQL DataLoader users and other users who generate lots of activity for monitoring within a short amount of time will hopefully see some good performance gains from these changes.
 
 
-  * **Performance: Make frozen string literals the default for the agent
+  * **Performance: Make frozen string literals the default for the agent**
 
     The Ruby `frozen_string_literal: true` magic source code comment has now been applied consistently across all Ruby files belonging to the agent. This can provide a performance boost, given that Ruby can rely on the strings remaining immutable. Previously only about a third of the agent's code was freezing string literals by default. Now that 100% of the code freezes string literals by default, we have internally observed some related performance gains through testing. We are hopeful that these will translate into some real world gains in production capacities.
 


### PR DESCRIPTION
* note that we flipped the code-level metrics default to on in v8.10.0
* bold markdown formatting fix