### PR TITLE
Remove duplicate rake multiverse runs

### DIFF
--- a/test/multiverse/suites/rake/Envfile
+++ b/test/multiverse/suites/rake/Envfile
@@ -30,28 +30,23 @@ instrumentation_methods :chain, :prepend
 
 RAKE_VERSIONS = [
   nil,
-  '13.0.0',
   '12.3.3'
 ]
 
 def gem_list(rake_version = nil)
   <<-RB
     gem 'rack'
-    gem 'rake'
-    #{ruby3_gem_webrick}
-  RB
-end
-
-create_gemfiles(RAKE_VERSIONS, gem_list)
-
-def gem_list(rake_version = nil)
-  <<-RB
-    gem 'rack'
     gem 'rake'#{rake_version}
     #{ruby3_gem_webrick}
-    gem 'rails'
-    gem 'minitest', '5.2.3'
   RB
 end
 
 create_gemfiles(RAKE_VERSIONS, gem_list)
+
+gemfile <<-RB
+  gem 'rack'
+  gem 'rake'
+  #{ruby3_gem_webrick}
+  gem 'rails'
+  gem 'minitest', '5.2.3'
+RB


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
I noticed that background_2 runs seemed to be taking even longer than normal so I looked into it and noticed there were 2 calls to `create_gemfiles` in the envfile, which was actually doubling the number of multiverse runs. This change brings it more in line with how the rake tests were being run before `create_gemfiles`. I didn't see an obvious way to have the rails and the no rails ones both being called by `create_gemfiles`, so I changed the rails rake test run to use the old style of `gemfile`, and kept the non rails runs using `create_gemfiles`. 
I also took out the 13.0.0 from the versions list because nil and that were running the same version every time, so I figure this would be better and we will still start using the newest version on any versions released in the future. 

Submitter Checklist:
- [ ] Include a link to the related GitHub issue, if applicable
- [ ] Include a security review link, if applicable

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
Github Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
