### PR TITLE
gRPC client: don't touch initialize

### DIFF
--- a/lib/new_relic/agent/instrumentation/grpc/client/chain.rb
+++ b/lib/new_relic/agent/instrumentation/grpc/client/chain.rb
@@ -13,14 +13,6 @@ module NewRelic::Agent::Instrumentation
           ::GRPC::ClientStub.class_eval do
             include NewRelic::Agent::Instrumentation::GRPC::Client
 
-            def initialize_with_newrelic_trace(*args)
-              @trace_with_newrelic = trace_with_newrelic?(args.first)
-              initialize_without_newrelic_trace(*args)
-            end
-
-            alias initialize_without_newrelic_trace initialize
-            alias initialize initialize_with_newrelic_trace
-
             def bidi_streamer_with_new_relic_trace(method, requests, marshal, unmarshal,
               deadline: nil,
               return_op: false,

--- a/lib/new_relic/agent/instrumentation/grpc/client/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/grpc/client/instrumentation.rb
@@ -70,16 +70,18 @@ module NewRelic
             "grpc://#{@host}/#{method}"
           end
 
-          def trace_with_newrelic?(host = nil)
-            return false if self.class.name.eql?('GRPC::InterceptorRegistry')
+          def interceptor?
+            self.class.name.eql?('GRPC::InterceptorRegistry')
+          end
 
-            do_trace = instance_variable_get(:@trace_with_newrelic)
-            return do_trace unless do_trace.nil? # check for nil, not falsey
+          def trace_with_newrelic?
+            return @trace_with_newrelic unless @trace_with_newrelic.nil? # check for nil, not false
 
-            host ||= @host
-            return false unless host && !host_denylisted?(host)
-
-            true
+            @trace_with_newrelic = if interceptor?
+              false
+            else
+              !host_denylisted?(@host)
+            end
           end
         end
       end

--- a/lib/new_relic/agent/instrumentation/grpc/client/prepend.rb
+++ b/lib/new_relic/agent/instrumentation/grpc/client/prepend.rb
@@ -13,11 +13,6 @@ module NewRelic
           module Prepend
             include NewRelic::Agent::Instrumentation::GRPC::Client
 
-            def initialize(*args)
-              @trace_with_newrelic = trace_with_newrelic?(args.first)
-              super(*args)
-            end
-
             def bidi_streamer(method, requests, marshal, unmarshal,
               deadline: nil,
               return_op: false,

--- a/lib/new_relic/agent/instrumentation/grpc/helper.rb
+++ b/lib/new_relic/agent/instrumentation/grpc/helper.rb
@@ -18,6 +18,8 @@ module NewRelic
           end
 
           def host_denylisted?(host)
+            return false unless host
+
             ignore_patterns.any? { |regex| host.match?(regex) }
           end
 


### PR DESCRIPTION
for the gRPC client instrumentation, we had been prepending/chaining
`initialize` calls to get at the host argument in order to apply our
gRPC host denylist behavior. when other libraries are themselves
bringing in the gRPC client library (via the `grpc` gem) and using their
own `initialize` chaining and `super` calls, we run the risk of passing
the wrong number of arguments to the `initialize` method in the chain
that we are handing things off to.

notably, this causes `google-ads-googleads` based apps to encounter
issues.

to address this, let's get out of the business of touching `initialize`
entirely, and source the host information from the gRPC client
instance's own `@host` ivar.

resolves #1337