### PR TITLE
Add coverage:clear task to remove coverage dirs

### DIFF
--- a/lib/tasks/coverage_report.rake
+++ b/lib/tasks/coverage_report.rake
@@ -18,4 +18,10 @@ namespace :coverage do
       SimpleCov.collate(Dir["lib/coverage_*/.resultset.json"])
     end
   end
+
+  desc "Removes all coverage_* directories"
+  task :clear do
+    require 'fileutils'
+    Dir["lib/coverage_*"].each { |dir| FileUtils.rm_rf(dir) }
+  end
 end


### PR DESCRIPTION
Every multiverse test run will accumulate new coverage directories. This task removes all directories in `lib` that begin with "coverage_"