### PR TITLE
Use SimpleFormatter for test runs

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -6,7 +6,8 @@ SimpleCov.command_name(random)
 SimpleCov.coverage_dir("coverage_#{random}")
 
 SimpleCov.start do
-  enable_coverage :branch
+  enable_coverage(:branch)
   SimpleCov.root(File.join(File.dirname(__FILE__), '/lib'))
-  track_files "**/*.rb"
+  track_files("**/*.rb")
+  formatter(SimpleCov::Formatter::SimpleFormatter)
 end


### PR DESCRIPTION
`SimpleCov::Formatter::SimpleFormatter` does not add a line about coverage
percentages at the end of every test run. It also does not create an HTML
output file. Instead, it only generates JSON files with the result
information and the last run data.

We don't use the HTML information very frequently for individual test runs, we can get that by running `coverage:report` if it's needed.