### PR TITLE
Update multiverse run message

### DIFF
--- a/test/multiverse/lib/multiverse/envfile.rb
+++ b/test/multiverse/lib/multiverse/envfile.rb
@@ -109,7 +109,7 @@ module Multiverse
     end
 
     def size
-      @gemfiles.size * permutations
+      @gemfiles.size
     end
 
     def add_version(version, twiddle_wakka = true)

--- a/test/multiverse/lib/multiverse/runner.rb
+++ b/test/multiverse/lib/multiverse/runner.rb
@@ -48,6 +48,7 @@ module Multiverse
 
     def run(filter = "", opts = {})
       execute_suites(filter, opts) do |suite|
+        puts yellow(suite.execution_message)
         suite.each_instrumentation_method do |method|
           suite.execute(method)
         end

--- a/test/multiverse/lib/multiverse/suite.rb
+++ b/test/multiverse/lib/multiverse/suite.rb
@@ -422,10 +422,6 @@ module Multiverse
       return unless check_environment_condition
       configure_instrumentation_method(instrumentation_method)
 
-      label = should_serialize? ? 'serial' : 'parallel'
-      env_count = filter_env ? 1 : environments.size
-      puts yellow("\nRunning #{directory.inspect} in #{env_count} environments in #{label}")
-
       environments.before.call if environments.before
       if should_serialize?
         execute_serial(instrumentation_method)
@@ -680,6 +676,16 @@ module Multiverse
 
     def exclude?(file)
       EXCLUDED_FILES.include?(File.basename(file))
+    end
+
+    def execution_message
+      label = should_serialize? ? 'serial' : 'parallel'
+      env_count = filter_env ? 1 : environments.size
+      env_plural = env_count > 1 ? 'environments' : 'environment'
+      opening = "\nRunning \"#{suite}\" suite in"
+      body = environments.instrumentation_permutations.map { |p| "#{env_count} #{p.upcase} #{env_plural}" }
+      ending = "in #{label}"
+      message = [opening, body.join(' and '), ending].join(' ')
     end
   end
 end


### PR DESCRIPTION
The message that read something like: 
```
Running "/Users/jbunch/git/public/newrelic-ruby-agent/test/multiverse/suites/grpc" in 2 environments in serial
``` 

was slightly misleading, as the `2 environments` would be from a single Envfile-produced Gemfile for both `chain` and `prepend` instrumentation permutations. It would also get re-printed when the next instrumentation permutation would be executed.
    
Now, the message reads something like:
```
Running "logger" suite in 1 CHAIN environment and 1 PREPEND environment in serial
```

and will only be printed at the top of the suite's run.