### PR TITLE
Use assert_nil for compatibility with Minitest 6

### DIFF
--- a/test/new_relic/agent/system_info_test.rb
+++ b/test/new_relic/agent/system_info_test.rb
@@ -216,8 +216,8 @@ class NewRelic::Agent::SystemInfoTest < Minitest::Test
     NewRelic::Agent::SystemInfo.stub(:sysctl_value, 1) do
       NewRelic::Agent::SystemInfo.processor_info_bsd
       info = NewRelic::Agent::SystemInfo.instance_variable_get(:@processor_info)
-      assert_equal nil, info[:num_physical_packages]
-      assert_equal nil, info[:num_physical_cores]
+      assert_nil info[:num_physical_packages]
+      assert_nil info[:num_physical_cores]
       assert_equal 1, info[:num_logical_processors]
     end
   end


### PR DESCRIPTION
# Overview
Addresses deprecation warning when running using Minitest 5.16.3: 

```
DEPRECATED: Use assert_nil if expecting nil from /Users/kreopelle/dev/newrelic-ruby-agent/test/new_relic/agent/system_info_test.rb:219. This will fail in Minitest 6.
DEPRECATED: Use assert_nil if expecting nil from /Users/kreopelle/dev/newrelic-ruby-agent/test/new_relic/agent/system_info_test.rb:220. This will fail in Minitest 6.
```

Submitter Checklist:
- [ ] Include a link to the related GitHub issue, if applicable
- [ ] Include a security review link, if applicable

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
Github Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
