### PR TITLE
CI: set the Mongo tag to v5

### DIFF
--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -1,12 +1,7 @@
 name: Scheduled Continuous Integration
 
 on:
-  push:
-    branches:
-      - main
-      - dev
-  schedule:
-    - cron:  '0 9 * * *'
+  pull_request:
 
 jobs:
   run_rubocop:
@@ -145,7 +140,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
       mongodb:
-        image: mongo
+        image: mongo:5.0.11
         ports:
           - 27017:27017
       rabbitmq:


### PR DESCRIPTION
with Mongo 6 out and causing issues with the older Rubies and older
Mongo gem versions, use 5 for now