### PR TITLE
Bump minitest to 5.3.3

### DIFF
--- a/newrelic_rpm.gemspec
+++ b/newrelic_rpm.gemspec
@@ -50,7 +50,7 @@ https://github.com/newrelic/newrelic-ruby-agent/
   s.add_development_dependency 'rake', '12.3.3'
   s.add_development_dependency 'rb-inotify', '0.9.10' # locked to support < Ruby 2.3 (and listen 3.0.8)
   s.add_development_dependency 'listen', '3.0.8' # locked to support < Ruby 2.3
-  s.add_development_dependency 'minitest', '4.7.5'
+  s.add_development_dependency 'minitest', '5.3.3'
   s.add_development_dependency 'minitest-stub-const', '0.6'
   s.add_development_dependency 'mocha', '~> 1.9.0'
   s.add_development_dependency 'yard'

--- a/test/environments/norails/Gemfile
+++ b/test/environments/norails/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 
 gem 'rake', '~> 12.3.3'
 
-gem 'minitest', '~> 4.7.5'
+gem 'minitest', '5.3.3'
 gem 'minitest-stub-const', '~> 0.6'
 gem 'mocha', '~> 1.9.0', :require => false
 gem 'rack', '>= 2.1.4'

--- a/test/environments/rails32/Gemfile
+++ b/test/environments/rails32/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 gem 'rails', '~> 3.2.0'
 gem 'i18n', '0.6.11'
 gem 'rake', '~> 12.3.3'
-gem 'minitest', '~> 4.7.5'
+gem 'minitest', '4.7.5' # Minitest ~> 4.2 required for Rails 3.2
 gem 'minitest-stub-const', '~> 0.6'
 gem 'mocha', '~> 1.9.0', :require => false
 gem 'rack', '< 2.0.0'

--- a/test/environments/rails40/Gemfile
+++ b/test/environments/rails40/Gemfile
@@ -4,22 +4,22 @@ source 'https://rubygems.org'
 gem 'rake', '~> 12.3.3'
 gem 'rails', '~> 4.0.0'
 
-gem 'minitest', '~> 4.7.5', :require => false
+gem 'minitest', '4.7.5', require: false # Minitest ~> 4.2 required for Rails 3.2
 gem 'minitest-stub-const', '~> 0.6', :require => false
-gem 'mocha', '~> 1.9.0', :require => false
+gem 'mocha', '~> 1.9.0', require: false
 gem 'rack-test'
 
 platforms :jruby do
-  gem "activerecord-jdbcmysql-adapter", "~>1.3.0"
-  gem "activerecord-jdbcsqlite3-adapter", "~>1.3.0"
-  gem "jruby-openssl"
+  gem 'activerecord-jdbcmysql-adapter', '~>1.3.0'
+  gem 'activerecord-jdbcsqlite3-adapter', '~>1.3.0'
+  gem 'jruby-openssl'
 end
 
 platforms :ruby, :rbx do
-  gem "mysql2", '~> 0.3.20'
+  gem 'mysql2', '~> 0.3.20'
   gem 'sqlite3', '~> 1.3.13'
 end
 
-gem "newrelic_rpm", :path => "../../.."
+gem 'newrelic_rpm', path: '../../..'
 
 gem 'pry', '~> 0.9.12'

--- a/test/multiverse/lib/multiverse/suite.rb
+++ b/test/multiverse/lib/multiverse/suite.rb
@@ -302,7 +302,7 @@ module Multiverse
       elsif RUBY_VERSION >= '2.4'
         '5.15.0'
       else
-        '4.7.5'
+        '5.3.3'
       end
     end
 

--- a/test/multiverse/suites/agent_only/Envfile
+++ b/test/multiverse/suites/agent_only/Envfile
@@ -4,7 +4,7 @@
 # frozen_string_literal: true
 
 gemfile <<-RB
-  gem 'minitest', '4.7.5'
+  gem 'minitest', '5.3.3'
   gem 'rack', '< 2.1.0'
   gem 'rack-test', '>= 0.8.0'
   #{ruby3_gem_webrick}

--- a/test/multiverse/suites/delayed_job/Envfile
+++ b/test/multiverse/suites/delayed_job/Envfile
@@ -54,7 +54,10 @@ gemfile <<-RB
   gem 'delayed_job', '~> 4.1.0'
   gem 'delayed_job_mongoid', '~> 2.3.0'
   gem 'i18n', '~> 0.7.0'
-  gem 'activesupport', '~> 3.2.22' if RUBY_VERSION >= '2.4.0' && RUBY_VERSION <= '2.6.0'
+  if RUBY_VERSION >= '2.4.0' && RUBY_VERSION <= '2.6.0'
+    gem 'minitest', '~> 4.7.5' # required for Rails < 4.1
+    gem 'activesupport', '~> 3.2.22'
+  end
   gem 'activesupport', '~> 6.0.0' if RUBY_VERSION > '2.6.0'
   #{boilerplate_gems}
 RB
@@ -63,6 +66,7 @@ if RUBY_VERSION < '2.4.0'
   gemfile <<-RB
     gem 'delayed_job', '~> 4.1.0'
     gem 'delayed_job_active_record', '~> 4.1.1'
+    gem 'minitest', '~> 4.7.5' # required for Rails < 4.1
     gem 'activerecord', '~> 3.2.19'
     gem 'i18n', '~> 0.6.11'
     #{boilerplate_gems}
@@ -102,7 +106,6 @@ if RUBY_VERSION < '2.4.0'
 else
   dj4_with_active_record = <<-DJ
     gem 'delayed_job', '~> 4.0.4'
-
     gem 'delayed_job_active_record', '= 4.0.2'
     #{boilerplate_gems}
   DJ
@@ -130,7 +133,8 @@ if RUBY_VERSION < '2.4.0'
   RB
 
   gemfile <<-RB
-    gem 'activerecord', '~>4.0.10'
+    gem 'activerecord', '~> 4.0.10'
+    gem 'minitest', '~> 4.7.5' # required for Rails < 4.1
     gem 'i18n', '~> 0.6.11'
     #{dj4_with_active_record}
   RB
@@ -140,6 +144,7 @@ if RUBY_VERSION < '2.3.0'
   [dj4_with_active_record, dj3_with_active_record].each do |dj|
     gemfile <<-RB
       gem 'activerecord', '~> 3.2.19'
+      gem 'minitest', '~> 4.7.5' # required for Rails < 4.1
       gem 'i18n', '~> 0.6.11'
       #{dj}
     RB

--- a/test/multiverse/suites/rails/Envfile
+++ b/test/multiverse/suites/rails/Envfile
@@ -19,7 +19,7 @@ RAILS_VERSIONS = [
   ['5.0.7', 2.2, 2.7],
   ['4.2.11', 2.2, 2.3],
   ['4.1.16', 2.2, 2.3],
-  ['4.0.13', 2.2, 2.3],
+  ['4.0.13', 2.2, 2.3]
 ]
 
 def haml_rails(rails_version = nil)
@@ -35,7 +35,6 @@ def haml_rails(rails_version = nil)
     "gem 'haml-rails', '~> 2.0'"
   end
 end
-
 
 def minitest_rails_version(rails_version = nil)
   if rails_version && rails_version.include?('4.0.13')
@@ -64,11 +63,13 @@ end
 create_gemfiles(RAILS_VERSIONS, gem_list)
 
 # TODO: MAJOR VERSION - Remove these two gemfiles.
+# Rails 3.2 requires minitest ~> 4.2
 if RUBY_VERSION < '2.4.0'
   gemfile <<-RB
     gem 'rails', '~> 3.2.0'
     gem 'i18n', '~> 0.6.11'
     gem 'haml', '4.0.2'   # Getting load issues with haml 4.0.3
+    gem 'minitest', '~> 4.7.5'
     gem 'minitest_tu_shim', :require => false
     #{pre2_rack_test}
   RB
@@ -78,6 +79,7 @@ if RUBY_VERSION < '2.4.0'
     gem 'i18n', '~> 0.6.11'
     gem 'sinatra', '~> 1.4.5'
     gem 'haml', '4.0.2'   # Getting load issues with haml 4.0.3
+    gem 'minitest', '~> 4.7.5'
     gem 'minitest_tu_shim', :require => false
     #{pre2_rack_test}
   RB


### PR DESCRIPTION
# Overview
With the exception of Rails 3.2- and Rails 4.0-related tests, our suites can successfully run on Minitest version 5.3.3. This gives us the opportunity to use Minitest 5.x related improvements and tools. 

Where Rails 3.2 and 4.0 are tested, version 4.7.5 has been preserved. 

Minitest 5.3.4 introduces a change that shuffles runnable objects before the test suite starts. This introduces some errors into our unit test suite, such as IO test failures. We'll work on jumping the 5.3.4 hurdles in another PR.

Submitter Checklist:
- [ ] Include a link to the related GitHub issue, if applicable
- [ ] Include a security review link, if applicable

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
Github Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
