### PR TITLE
CI: lock mongo tag to a known good v5 version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
       mongodb:
-        image: mongo
+        image: mongo:5.0.11
         ports:
           - 27017:27017
       rabbitmq:
@@ -273,7 +273,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
       mongodb:
-        image: mongo
+        image: mongo:5.0.11
         ports:
           - 27017:27017
       rabbitmq:

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -145,7 +145,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
       mongodb:
-        image: mongo
+        image: mongo:5.0.11
         ports:
           - 27017:27017
       rabbitmq:
@@ -278,7 +278,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
       mongodb:
-        image: mongo
+        image: mongo:5.0.11
         ports:
           - 27017:27017
       rabbitmq:


### PR DESCRIPTION
with mongo:latest now pointing to v6, we have some work to do to figure
out our compatibility stance on Mongo v6 given that some of our older
Ruby versions are failing CI checks with it. it's possible that the
failures are exclusively limited to very old versions of the mongo gem
that are no longer supported anyhow. Until we determine if that's the
case, let's lock the mongo image tag to v5.