### PR TITLE
CI: Use Ubuntu 22 for JRuby

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,7 +250,7 @@ jobs:
 
   jruby_multiverse:
     needs: run_rubocop
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     services:
       mysql:
         image: mysql:5.7
@@ -299,26 +299,39 @@ jobs:
       matrix:
         multiverse: [agent, background, background_2, database, frameworks, httpclients, httpclients_2, rails, rest]
     steps:
-      - uses: actions/checkout@v2
+      - name: Set the default Java version
+        run: sudo update-alternatives --set java ${JAVA_HOME_8_X64}/bin/java &&
+             sudo update-alternatives --set javac ${JAVA_HOME_8_X64}/bin/javac &&
+             java -version &&
+             javac -version
 
-      - name: Install Ruby jruby-9.3.7.0
+      - name: Check out the source code
+        uses: actions/checkout@v2
+
+      - name: Install JRuby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: jruby-9.3.7.0
+        env:
+          JAVA_HOME: ${{env.JAVA_HOME_8_X64}}
 
       - name: Bundle
         run: bundle install
+        env:
+          JAVA_HOME: ${{env.JAVA_HOME_8_X64}}
 
       - name: Run Multiverse Tests
         uses: nick-invision/retry@v1.0.0
         with:
           timeout_minutes: 60
-          max_attempts: 2
-          command: bundle exec rake test:multiverse[group=${{ matrix.multiverse }},verbose]
+          max_attempts: 1
+          # jruby -v yields info about which JVM version JRuby is using
+          command: jruby -v; bundle exec rake test:multiverse[group=${{ matrix.multiverse }},verbose]
         env:
           DB_PORT: ${{ job.services.mysql.ports[3306] }}
           SERIALIZE: 1
           JRUBY_OPTS: --dev
+          JAVA_HOME: ${{env.JAVA_HOME_8_X64}}
 
       - name: Annotate errors
         if: ${{ failure() }}

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -304,26 +304,38 @@ jobs:
       matrix:
         multiverse: [agent, background, background_2, database, frameworks, httpclients, httpclients_2, rails, rest]
     steps:
-      - uses: actions/checkout@v2
+      - name: Set the default Java version
+        run: sudo update-alternatives --set java ${JAVA_HOME_8_X64}/bin/java &&
+             sudo update-alternatives --set javac ${JAVA_HOME_8_X64}/bin/javac &&
+             java -version &&
+             javac -version
 
-      - name: Install Ruby jruby-9.3.7.0
+      - name: Check out the source code
+        uses: actions/checkout@v2
+
+      - name: Install JRuby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: jruby-9.3.7.0
+        env:
+          JAVA_HOME: ${{env.JAVA_HOME_8_X64}}
 
       - name: Bundle
         run: bundle install
+        env:
+          JAVA_HOME: ${{env.JAVA_HOME_8_X64}}
 
       - name: Run Multiverse Tests
         uses: nick-invision/retry@v1.0.0
         with:
           timeout_minutes: 60
-          max_attempts: 2
-          command:  bundle exec rake test:multiverse[group=${{ matrix.multiverse }},verbose]
+          max_attempts: 1
+          command:  jruby -v; bundle exec rake test:multiverse[group=${{ matrix.multiverse }},verbose]
         env:
           DB_PORT: ${{ job.services.mysql.ports[3306] }}
           SERIALIZE: 1
           JRUBY_OPTS: --dev
+          JAVA_HOME: ${{env.JAVA_HOME_8_X64}}
 
       - name: Annotate errors
         if: ${{ failure() }}

--- a/test/multiverse/suites/typhoeus/Envfile
+++ b/test/multiverse/suites/typhoeus/Envfile
@@ -7,7 +7,7 @@
 suite_condition("Typhoeus is skipped for JRuby with Ubuntu 22") do
   RUBY_PLATFORM != 'java' &&
     File.exist?('/etc/lsb-release') &&
-    File.read('/etc/lsb-release').match?('DISTRIB_RELEASE=22.04')
+    File.read('/etc/lsb-release') =~ /DISTRIB_RELEASE=22\.04/
 end
 
 instrumentation_methods :chain, :prepend

--- a/test/multiverse/suites/typhoeus/Envfile
+++ b/test/multiverse/suites/typhoeus/Envfile
@@ -3,6 +3,13 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
+# TODO: JRuby 9.3.7.0 crashes with Ubuntu 22 and JREs 8 and 11
+suite_condition("Typhoeus is skipped for JRuby with Ubuntu 22") do
+  RUBY_PLATFORM != 'java' &&
+    File.exist?('/etc/lsb-release') &&
+    File.read('/etc/lsb-release').match?('DISTRIB_RELEASE=22.04')
+end
+
 instrumentation_methods :chain, :prepend
 
 TYPHOEUS_VERSIONS = [


### PR DESCRIPTION
Use Ubuntu 22 for JRuby CI tests

- The GitHub Actions Ubuntu 22 image defaults to using JVM version 11.
  Our CI tests cause JRuby to crash with that default. Switch to JVM 8,
  which is preinstalled on the image and what we used with Ubuntu 18
- The Typhoeus multiverse suite still causes JRuby crashes. For now,
  disable them when the specific JRuby and Ubuntu 22 combination is
  present.
- Given that JRuby tests are permitted 60 minutes to run, don't bother
  retrying them on failure