### PR TITLE
CI: Use Ubuntu 22.04 LTS w/Ruby v3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,18 +5,18 @@ on:
 
 jobs:
   run_rubocop:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-ruby@v1
         with:
-          ruby-version: '2.7'
+          ruby-version: '3.1'
       - run: bundle
       - run: rubocop
 
   unit_tests:
     needs: run_rubocop
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     services:
       mysql:
         image: mysql:5.7
@@ -93,7 +93,7 @@ jobs:
 
   multiverse:
     needs: run_rubocop
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     services:
       mysql:
         image: mysql:5.7
@@ -212,7 +212,7 @@ jobs:
 
   infinite_tracing:
     needs: run_rubocop
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -339,13 +339,13 @@ jobs:
 
   simplecov:
     needs: [unit_tests, multiverse, infinite_tracing]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: github.repository_owner == 'newrelic'
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-ruby@v1
         with:
-          ruby-version: '2.7'
+          ruby-version: '3.1'
       - run: bundle
       - name: Download all workflow run artifacts
         uses: actions/download-artifact@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,4 @@
 name: PR Continuous Integration
-
 on:
   pull_request:
 
@@ -313,12 +312,12 @@ jobs:
         with:
           ruby-version: jruby-9.3.7.0
         env:
-          JAVA_HOME: ${{env.JAVA_HOME_8_X64}}
+          JAVA_HOME: /usr/lib/jvm/temurin-8-jdk-amd64
 
       - name: Bundle
         run: bundle install
         env:
-          JAVA_HOME: ${{env.JAVA_HOME_8_X64}}
+          JAVA_HOME: /usr/lib/jvm/temurin-8-jdk-amd64
 
       - name: Run Multiverse Tests
         uses: nick-invision/retry@v1.0.0
@@ -331,7 +330,7 @@ jobs:
           DB_PORT: ${{ job.services.mysql.ports[3306] }}
           SERIALIZE: 1
           JRUBY_OPTS: --dev
-          JAVA_HOME: ${{env.JAVA_HOME_8_X64}}
+          JAVA_HOME: /usr/lib/jvm/temurin-8-jdk-amd64
 
       - name: Annotate errors
         if: ${{ failure() }}

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -10,18 +10,18 @@ on:
 
 jobs:
   run_rubocop:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-ruby@v1
         with:
-          ruby-version: '2.7'
+          ruby-version: '3.1'
       - run: bundle
       - run: rubocop
 
   unit_tests:
     needs: run_rubocop
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     services:
       mysql:
         image: mysql:5.7
@@ -114,7 +114,7 @@ jobs:
 
   multiverse:
     needs: run_rubocop
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     services:
       mysql:
         image: mysql:5.7
@@ -224,7 +224,7 @@ jobs:
 
   infinite_tracing:
     needs: run_rubocop
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -62,7 +62,7 @@ jobs:
                 "rails": "norails,rails52,rails51,rails42,rails32"
               },
               "2.5.9": {
-                "rails": "norails,rails61,rails60,rails52,rails51,rails42,rails32"
+                "rails": "norails,rails61,rails60,rails52,rails51,rails42"
               },
               "2.6.10": {
                 "rails": "norails,rails61,rails60,rails52,rails51,rails42"
@@ -318,12 +318,12 @@ jobs:
         with:
           ruby-version: jruby-9.3.7.0
         env:
-          JAVA_HOME: ${{env.JAVA_HOME_8_X64}}
+          JAVA_HOME: /usr/lib/jvm/temurin-8-jdk-amd64
 
       - name: Bundle
         run: bundle install
         env:
-          JAVA_HOME: ${{env.JAVA_HOME_8_X64}}
+          JAVA_HOME: /usr/lib/jvm/temurin-8-jdk-amd64
 
       - name: Run Multiverse Tests
         uses: nick-invision/retry@v1.0.0
@@ -335,7 +335,7 @@ jobs:
           DB_PORT: ${{ job.services.mysql.ports[3306] }}
           SERIALIZE: 1
           JRUBY_OPTS: --dev
-          JAVA_HOME: ${{env.JAVA_HOME_8_X64}}
+          JAVA_HOME: /usr/lib/jvm/temurin-8-jdk-amd64
 
       - name: Annotate errors
         if: ${{ failure() }}

--- a/.github/workflows/gem_notifications.yml
+++ b/.github/workflows/gem_notifications.yml
@@ -6,11 +6,11 @@ on:
 
 jobs:
   gem_notifications:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: ruby/setup-ruby@v1.90.0
         with:
-          ruby-version: 2.7
+          ruby-version: 3.1
       - uses: actions/checkout@v2
       - run: gem install httparty
       - name: Check for outdated gems 
@@ -38,11 +38,11 @@ jobs:
             unicorn"
 
   cve_notifications:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: ruby/setup-ruby@v1.90.0
         with:
-          ruby-version: 2.7
+          ruby-version: 3.1
       - uses: actions/checkout@v2
       - run: gem install httparty
       - run: gem install feedjira

--- a/.github/workflows/scripts/setup_bundler
+++ b/.github/workflows/scripts/setup_bundler
@@ -4,18 +4,14 @@
 
 echo "DEBUG: RAILS_VERSION = $RAILS_VERSION"
 if [[ $RAILS_VERSION =~ .*"4".* ]]; then 
-  # Older rubies come with older Rubygems and we need 3.0.6 minimum to
-  # correctly install Bundler and do anything else within the multiverse test suite
-  # Ruby 2.2 and 2.3 need to use update_rubygems,
+  # Older rubies come with older Rubygems and we need 3.0.6 to
+  # correctly install Bundler 1.17 for the multiverse test suite
+  # Rubies < 2.3 need to use update_rubygems,
   # newer Rubies can use 'gem update --system'
-  if [[ $RUBY_VERSION = "2.2.10" || $RUBY_VERSION = "2.3.8" ]]; then
-    if [[ $RUBY_VERSION = "2.2.10" ]]; then
-      ru_version=2.7.11
-    else
-      ru_version=3.0.6
-    fi
-    echo "DEBUG: installing rubygems-update version $ru_version"
-    gem install rubygems-update:$ru_version
+  echo "DEBUG: RUBY_VERSION = $RUBY_VERSION"
+  if [[ $RUBY_VERSION = "2.2.10" ]]; then
+    echo "DEBUG: installing rubygems-update version 2.7.11"
+    gem install rubygems-update:2.7.11
     echo "DEBUG: running 'rubygems-update'"
     update_rubygems
   else

--- a/.github/workflows/scripts/setup_bundler
+++ b/.github/workflows/scripts/setup_bundler
@@ -20,7 +20,7 @@ if [[ $RAILS_VERSION =~ .*"4".* ]]; then
     update_rubygems
   else
     echo "DEBUG: running 'gem update --system --force'"
-    gem update --system --force
+    gem update --system 3.0.6 --force
   fi
   echo "DEBUG: obtaining pre-installed Bundler version"
   og_bundler=$(bundle --version | awk '{ print $3 }')

--- a/.github/workflows/scripts/setup_bundler
+++ b/.github/workflows/scripts/setup_bundler
@@ -2,22 +2,46 @@
 # This script sets up the bundler versions we need for our older unit tests
 # and sets up the bundler config for when we are using the older mysql version
 
+echo "DEBUG: RAILS_VERSION = $RAILS_VERSION"
 if [[ $RAILS_VERSION =~ .*"4".* ]]; then 
-  # Older rubies come with Ruby gems 2.5.x and we need 3.0.6 minimum to
+  # Older rubies come with older Rubygems and we need 3.0.6 minimum to
   # correctly install Bundler and do anything else within the multiverse test suite
-  gem update --system 3.0.6 --force
-  # need to use bundler <2 for all rails 4 and below tests
-  gem install --default bundler:1.17.3 --force
-  # add mysql specific config for bundler when we are using older mysql
-  bundle config --global build.mysql2 --with-mysql-config=/usr/local/mysql55/bin/mysql_config
-  gem list bundler
-  if [[ $RUBY_VERSION != "2.2.10" ]]; then 
-    # 2.2 does not install any 2+ bundler version, so nothing to uninstall
-    # but we do need to remove higher bundler versions for when we're running rails 4 tests
-    gem uninstall bundler
-    echo "did gem uninstall bundler"
+  # Ruby 2.2 and 2.3 need to use update_rubygems,
+  # newer Rubies can use 'gem update --system'
+  if [[ $RUBY_VERSION = "2.2.10" || $RUBY_VERSION = "2.3.8" ]]; then
+    if [[ $RUBY_VERSION = "2.2.10" ]]; then
+      ru_version=2.7.11
+    else
+      ru_version=3.0.6
+    fi
+    echo "DEBUG: installing rubygems-update version $ru_version"
+    gem install rubygems-update:$ru_version
+    echo "DEBUG: running 'rubygems-update'"
+    update_rubygems
+  else
+    echo "DEBUG: running 'gem update --system --force'"
+    gem update --system --force
   fi
-  echo "use bundler 1.17.3"
+  echo "DEBUG: obtaining pre-installed Bundler version"
+  og_bundler=$(bundle --version | awk '{ print $3 }')
+  echo "DEBUG: pre-installed Bundler version is $og_bundler"
+  if [[ "$og_bundler" != "1.17.3" ]]; then
+    # need to use bundler <2 for all rails 4 and below tests
+    echo "DEBUG: running 'gem install bundler'"
+    gem install --default bundler:1.17.3 --force
+    echo "DEBUG: running 'gem list bundler'"
+    gem list bundler
+    echo "DEBUG: RUBY_VERSION = $RUBY_VERSION"
+    if [[ $RUBY_VERSION != "2.2.10" ]]; then 
+      echo "DEBUG: running 'gem uninstall bundler'"
+      gem uninstall bundler
+      echo "DEBUG: running 'gem list bundler' again"
+      gem list bundler
+    fi
+  fi
+  # add mysql specific config for bundler when we are using older mysql
+  echo "DEBUG: running 'bundle config'"
+  bundle config --global build.mysql2 --with-mysql-config=/usr/local/mysql55/bin/mysql_config
 fi
-
+echo "DEBUG: running 'bundle install'"
 bundle install

--- a/.github/workflows/scripts/setup_bundler_multiverse
+++ b/.github/workflows/scripts/setup_bundler_multiverse
@@ -8,15 +8,10 @@ if [[ $RUBY_VERSION =~ 2.[^67] ]]; then
   # the multiverse test suite
   # NOTE that Ruby 2.2 and 2.3 need to use update_rubygems, while
   # newer Rubies can use 'gem update --system'
-  if [[ $RUBY_VERSION = "2.2.10" || $RUBY_VERSION = "2.3.8" ]]; then
-    echo "DEBUG: RUBY_VERSION = $RUBY_VERSION"
-    if [[ $RUBY_VERSION = "2.2.10" ]]; then
-      ru_version=2.7.11
-    else
-      ru_version=3.0.6
-    fi
-    echo "DEBUG: installing rubygems-update version $ru_version"
-    gem install rubygems-update:$ru_version
+  echo "DEBUG: RUBY_VERSION = $RUBY_VERSION"
+  if [[ $RUBY_VERSION = "2.2.10" ]]; then
+    echo "DEBUG: installing rubygems-update version 2.7.11"
+    gem install rubygems-update:2.7.11
     echo "DEBUG: running 'rubygems-update'"
     update_rubygems
   else

--- a/.github/workflows/scripts/setup_bundler_multiverse
+++ b/.github/workflows/scripts/setup_bundler_multiverse
@@ -3,37 +3,64 @@
 # and sets up the bundler config for when we are using the older mysql version
 
 if [[ $RUBY_VERSION =~ 2.[^67] ]]; then 
-  # Older rubies come with Ruby gems 2.5.x and we need 3.0.6 minimum to
+  # Older rubies come with older Rubygems and we need 3.0.6 minimum to
   # correctly install Bundler and do anything else within the multiverse test suite
-  gem update --system 3.0.6 --force
-  # need to use bundler <2 for all rails 4 and below tests
-  gem install --default bundler:1.17.3 --force
-  gem list bundler
-  if [[ $RUBY_VERSION != "2.2.10" ]]; then 
-    # 2.2 does not install any 2+ bundler version, so nothing to uninstall
-    # but we do need to remove higher bundler versions for when we're running rails 4 tests
-    gem uninstall bundler
-    echo "did gem uninstall bundler"
-  fi 
-  echo "use bundler 1.17.3"
+  # Ruby 2.2 and 2.3 need to use update_rubygems,
+  # newer Rubies can use 'gem update --system'
+  if [[ $RUBY_VERSION = "2.2.10" || $RUBY_VERSION = "2.3.8" ]]; then
+    echo "DEBUG: RUBY_VERSION = $RUBY_VERSION"
+    if [[ $RUBY_VERSION = "2.2.10" ]]; then
+      ru_version=2.7.11
+    else
+      ru_version=3.0.6
+    fi
+    echo "DEBUG: installing rubygems-update version $ru_version"
+    gem install rubygems-update:$ru_version
+    echo "DEBUG: running 'rubygems-update'"
+    update_rubygems
+  else
+    echo "DEBUG: running 'gem update --system --force'"
+    gem update --system --force
+  fi
+  echo "DEBUG: obtaining pre-installed Bundler version"
+  og_bundler=$(bundle --version | awk '{ print $3 }')
+  echo "DEBUG: pre-installed Bundler version is $og_bundler"
+  if [[ "$og_bundler" != "1.17.3" ]]; then
+    # need to use bundler <2 for all rails 4 and below tests
+    echo "DEBUG: running 'gem install bundler'"
+    gem install --default bundler:1.17.3 --force
+    echo "DEBUG: running 'gem list bundler'"
+    gem list bundler
+    echo "DEBUG: RUBY_VERSION = $RUBY_VERSION"
+    if [[ $RUBY_VERSION != "2.2.10" ]]; then 
+      echo "DEBUG: running 'gem uninstall bundler'"
+      gem uninstall bundler
+      echo "DEBUG: running 'gem list bundler' again"
+      gem list bundler
+    fi
+  fi
 fi
 
 # add mysql specific config for bundler when we are using older mysql
 if [[ $RUBY_VERSION =~ 2.[23] ]]; then  
+  echo "DEBUG: running 'bundle config'"
   bundle config --global build.mysql2 --with-mysql-config=/usr/local/mysql55/bin/mysql_config
   echo "set bundler to use mysql55 for mysql2"
 fi
 
 # for some reason, ruby 3.0 fails unless 3.1.0 is installed before it bundles for rails_prepend suite/rails 7
 if [[ $RUBY_VERSION =~ 3.0 ]]; then 
+  echo "DEBUG: running 'gem install digest'"
   gem install --default digest:3.1.0
   echo "installed digest 3.1.0"
 fi
 
 # for some reason, ruby 3.0+ fails unless strscan 3.0.4 is installed
 if [[ $RUBY_VERSION = 3.* ]]; then 
+  echo "DEBUG: running 'gem install strscran'"
   gem install --default strscan:3.0.4
   echo "installed strscan 3.0.4"
 fi
 
+echo "DEBUG: running 'bundle install'"
 bundle install

--- a/.github/workflows/scripts/setup_bundler_multiverse
+++ b/.github/workflows/scripts/setup_bundler_multiverse
@@ -3,9 +3,10 @@
 # and sets up the bundler config for when we are using the older mysql version
 
 if [[ $RUBY_VERSION =~ 2.[^67] ]]; then 
-  # Older rubies come with older Rubygems and we need 3.0.6 minimum to
-  # correctly install Bundler and do anything else within the multiverse test suite
-  # Ruby 2.2 and 2.3 need to use update_rubygems,
+  # Older rubies come with older Rubygems and we need 3.0.6 to
+  # correctly install Bundler 1.17.3 and do anything else within
+  # the multiverse test suite
+  # NOTE that Ruby 2.2 and 2.3 need to use update_rubygems, while
   # newer Rubies can use 'gem update --system'
   if [[ $RUBY_VERSION = "2.2.10" || $RUBY_VERSION = "2.3.8" ]]; then
     echo "DEBUG: RUBY_VERSION = $RUBY_VERSION"
@@ -20,7 +21,7 @@ if [[ $RUBY_VERSION =~ 2.[^67] ]]; then
     update_rubygems
   else
     echo "DEBUG: running 'gem update --system --force'"
-    gem update --system --force
+    gem update --system 3.0.6 --force
   fi
   echo "DEBUG: obtaining pre-installed Bundler version"
   og_bundler=$(bundle --version | awk '{ print $3 }')

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1466,7 +1466,7 @@ Style/MapToHash:
 
 Style/MethodCallWithArgsParentheses:
   Enabled: true
-  IgnoredMethods:
+  AllowedMethods:
     - puts
     - require
     - raise
@@ -1479,7 +1479,7 @@ Style/MethodCallWithArgsParentheses:
 
 Style/MethodCallWithoutArgsParentheses:
   Enabled: false
-  IgnoredMethods: []
+  AllowedMethods: []
 
 Style/MethodCalledOnDoEndBlock:
   Enabled: false

--- a/test/multiverse/suites/datamapper/Envfile
+++ b/test/multiverse/suites/datamapper/Envfile
@@ -3,7 +3,7 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
-suite_condition("only test on < 2.4"){ RUBY_VERSION < '2.4.0' }
+suite_condition("only test on 2.3") { RUBY_VERSION == '2.3.0' }
 
 adapter_gems = <<-RB
   gem 'dm-sqlite-adapter'

--- a/test/multiverse/suites/mongo/Envfile
+++ b/test/multiverse/suites/mongo/Envfile
@@ -38,6 +38,8 @@ MONGO_VERSIONS_OLDER_RUBIES = ['2.9.0',
 # The highest Mongo server version to test 1.x gems against
 MAX_SERVER_VERSION_FOR_1X_GEMS = 2.6
 
+CANNED_MONGO_VERSION = 5.0
+
 # * JRuby uses Mongo gem versions for v2.6.0+ Ruby only
 # * Newer CRubies use newer Mongo gem versions and older ones
 # * Older CRubies use older Mongo gem versions
@@ -58,8 +60,20 @@ def ruby_gte?(version)
   Gem::Version.new(RUBY_VERSION) >= Gem::Version.new(version)
 end
 
+def determine_mongo_version
+  return CANNED_MONGO_VERSION if docker?
+
+  mongo_path = ENV['PATH'].to_s.split(';').detect { |path| File.exist?(File.join(path, 'mongo')) }
+  return CANNED_MONGO_VERSION unless mongo_path
+
+  `#{mongo_path} --version`.scan(/version\sv([\d\.]+)/).join.to_f
+rescue => e
+  warn("Failed to determine a Mongo version: #{e.class}: #{e.message}")
+  CANNED_MONGO_VERSION
+end
+
 def installed_mongo_server_version
-  @mongo_server_version ||= docker? ? 5.0 : `mongo --version`.scan(/version\sv([\d\.]+)/).join.to_f
+  @installed_mongo_server_version ||= determine_mongo_version
 end
 
 mongo_versions.each do |mongo_version|

--- a/test/multiverse/suites/redis/Envfile
+++ b/test/multiverse/suites/redis/Envfile
@@ -6,7 +6,9 @@
 instrumentation_methods :chain, :prepend
 
 REDIS_VERSIONS = [
-  [nil, 2.4],
+  # TODO: add support for redis v5+, re-enable nil
+  # https://github.com/newrelic/newrelic-ruby-agent/issues/1361
+  # [nil, 2.4],
   ['4.7.1', 2.4],
   ['3.3.0']
 ]


### PR DESCRIPTION
updates to have our CI based entirely on Ubuntu 22, with Ruby v3.1 used
by default

- Update the CI Bundler setup scripts
  - Ruby 2.2 needs `update_rubygems`, not `gem update --system`
  - The setup-ruby action appears to leave us with the desired Bundler
    version already installed. Check the version and don't bother with
    installations and uninstallations if it exists
  - Add debugging statements everywhere
  - Don't attempt `bundle config` until the desired Bundler version is
    known to be present
- Stop testing Datamapper with Ruby 2.2, to avoid Ruby crashes
- Stop testing Rails 2.3 with Ruby 2.5 (Ruby 2.2, 2.3, and 2.4 will still test it)
- Update the Mongo suite to fall back to a default Mongo version if a
  `mongo` executable can't be found in `PATH`
- Don't test `redis` v5 yet

resolves #1112