### PR TITLE
CI: address warnings

### DIFF
--- a/newrelic_rpm.gemspec
+++ b/newrelic_rpm.gemspec
@@ -48,21 +48,14 @@ https://github.com/newrelic/newrelic-ruby-agent/
   s.require_paths = ["lib"]
   s.summary = "New Relic Ruby Agent"
   s.add_development_dependency 'rake', '12.3.3'
-  s.add_development_dependency 'rb-inotify', '0.9.10' # locked to support < Ruby 2.3 (and listen 3.0.8)
-  s.add_development_dependency 'listen', '3.0.8' # locked to support < Ruby 2.3
   s.add_development_dependency 'minitest', '5.3.3'
   s.add_development_dependency 'minitest-stub-const', '0.6'
-  s.add_development_dependency 'mocha', '~> 1.9.0'
+  s.add_development_dependency 'mocha', '~> 1.14.0'
   s.add_development_dependency 'yard'
-  s.add_development_dependency 'pry-nav', '~> 0.3.0'
-  s.add_development_dependency 'pry-stack_explorer', '~> 0.4.9'
-  s.add_development_dependency 'guard', '~> 2.16.0'
-  s.add_development_dependency 'guard-minitest', '~> 2.4.0'
+  s.add_development_dependency 'pry' unless ENV['CI']
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'rubocop'
   s.add_development_dependency 'rubocop-performance'
-  if RUBY_VERSION >= '2.7.0'
-    s.add_development_dependency 'simplecov'
-  end
+  s.add_development_dependency 'simplecov' if RUBY_VERSION >= '2.7.0'
   s.add_development_dependency 'httparty'
 end

--- a/test/agent_helper.rb
+++ b/test/agent_helper.rb
@@ -14,20 +14,6 @@ rescue LoadError
   # NOP -- Net::HTTP::STATUS_CODES was introduced in Ruby 2.5
 end
 
-module MiniTest
-  module Assertions
-    # The failure message is backwards.  This patch reverses the message
-    # Note: passing +msg+ caused two failure messages to be shown on failure
-    # and was more confusing than patching here.
-    def assert_match(matcher, obj, msg = nil)
-      msg = message(msg) { "Expected #{mu_pp(obj)} to match #{mu_pp(matcher)}" }
-      assert_respond_to matcher, :"=~"
-      matcher = Regexp.new(Regexp.escape(matcher)) if String === matcher
-      assert matcher =~ obj, msg
-    end
-  end
-end
-
 class ArrayLogDevice
   def initialize(array = [])
     @array = array
@@ -430,9 +416,9 @@ end
 # may be supplied.
 def with_segment(*args, &blk)
   segment = nil
-  txn = in_transaction(*args) do |txn|
-    segment = txn.current_segment
-    yield(segment, txn)
+  txn = in_transaction(*args) do |t|
+    segment = t.current_segment
+    yield(segment, t)
   end
   [segment, txn]
 end

--- a/test/helpers/ruby_rails_mappings.rb
+++ b/test/helpers/ruby_rails_mappings.rb
@@ -13,7 +13,7 @@ def ruby_rails_versions_hash
     map_yaml = ci['jobs']['unit_tests']['steps'].detect do |hash|
       hash.key?('with') && hash['with'].key?('map')
     end['with']['map']
-    versions = YAML.load(map_yaml)
+    YAML.load(map_yaml)
   end
 end
 

--- a/test/new_relic/agent/monitors/trace_context_request_monitor_test.rb
+++ b/test/new_relic/agent/monitors/trace_context_request_monitor_test.rb
@@ -42,7 +42,7 @@ module NewRelic
 
       def test_accepts_trace_context_with_trace_parent_and_no_trace_state
         carrier = {'HTTP_TRACEPARENT' => '00-12345678901234567890123456789012-1234567890123456-01'}
-        txn = in_transaction("receiving_txn") do |txn|
+        txn = in_transaction("receiving_txn") do
           @events.notify(:before_call, carrier)
         end
 
@@ -54,7 +54,7 @@ module NewRelic
           'HTTP_TRACEPARENT' => '00-12345678901234567890123456789012-1234567890123456-00',
           'HTTP_TRACESTATE' => ''
         }
-        txn = in_transaction("receiving_txn") do |txn|
+        txn = in_transaction("receiving_txn") do
           @events.notify(:before_call, carrier)
         end
 
@@ -66,7 +66,7 @@ module NewRelic
           'HTTP_TRACEPARENT' => '00-00000000000000000000000000000000-1234567890123456-00',
           'HTTP_TRACESTATE' => ''
         }
-        txn = in_transaction("receiving_txn") do |txn|
+        txn = in_transaction("receiving_txn") do
           @events.notify(:before_call, carrier)
         end
 

--- a/test/new_relic/agent/span_event_primitive_test.rb
+++ b/test/new_relic/agent/span_event_primitive_test.rb
@@ -75,8 +75,8 @@ module NewRelic
           root_span_event = nil
           root_segment = nil
 
-          txn = in_transaction do |txn|
-            root_segment = txn.current_segment
+          txn = in_transaction do |t|
+            root_segment = t.current_segment
           end
 
           root_span_event = SpanEventPrimitive.for_segment(root_segment)

--- a/test/new_relic/agent/transaction/segment_test.rb
+++ b/test/new_relic/agent/transaction/segment_test.rb
@@ -54,7 +54,7 @@ module NewRelic
         end
 
         def test_segment_with_no_error_does_not_produce_error_attributes
-          segment, _ = with_segment do |segment|
+          segment, _ = with_segment do
             # A perfectly fine walk through segmentland
           end
           refute segment.noticed_error_attributes

--- a/test/new_relic/license_test.rb
+++ b/test/new_relic/license_test.rb
@@ -20,8 +20,8 @@ class LicenseTest < Minitest::Test
   def test_all_files_have_license_header
     ruby_files.each do |file|
       lines = []
-      File.open(file, 'r') do |file|
-        file.each_line do |line|
+      File.open(file, 'r') do |f|
+        f.each_line do |line|
           break unless line.start_with?('#')
           lines << line
         end


### PR DESCRIPTION
- ActionControllerSubscriber instrumentation: don't attempt to grab @req
  unless it's known to exist
- gemspec: remove the unused listen, rb-inotify, pry-nav,
  pry-stack_explorer, guard, and guard-minitest. less surface area =
  fewer issues
- update mocha in the hopes of addressing warnings from v1.9
- replace the removed pry gems with pry itself, but only for local dev
- stop (redundantly?) monkeypatching MiniTest assert_match
- stop shadowing outer variables