### PR TITLE
CI: use vars for Ubuntu and Ruby versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,20 +2,24 @@ name: PR Continuous Integration
 on:
   pull_request:
 
+env:
+  UBUNTU_VERSION: ubuntu-22.04
+  RUBY_VERSION: 3.1
+
 jobs:
   run_rubocop:
-    runs-on: ubuntu-22.04
+    runs-on: $UBUNTU_VERSION
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.1'
+          ruby-version: $RUBY_VERSION
       - run: bundle
       - run: rubocop
 
   unit_tests:
     needs: run_rubocop
-    runs-on: ubuntu-22.04
+    runs-on: $UBUNTU_VERSION
     services:
       mysql:
         image: mysql:5.7
@@ -95,7 +99,7 @@ jobs:
 
   multiverse:
     needs: run_rubocop
-    runs-on: ubuntu-22.04
+    runs-on: $UBUNTU_VERSION
     services:
       mysql:
         image: mysql:5.7
@@ -217,7 +221,7 @@ jobs:
 
   infinite_tracing:
     needs: run_rubocop
-    runs-on: ubuntu-22.04
+    runs-on: $UBUNTU_VERSION
     strategy:
       fail-fast: false
       matrix:
@@ -255,7 +259,7 @@ jobs:
 
   jruby_multiverse:
     needs: run_rubocop
-    runs-on: ubuntu-22.04
+    runs-on: $UBUNTU_VERSION
     services:
       mysql:
         image: mysql:5.7
@@ -344,13 +348,13 @@ jobs:
 
   simplecov:
     needs: [unit_tests, multiverse, infinite_tracing]
-    runs-on: ubuntu-22.04
+    runs-on: $UBUNTU_VERSION
     if: github.repository_owner == 'newrelic'
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.1'
+          ruby-version: $RUBY_VERSION
       - run: bundle
       - name: Download all workflow run artifacts
         uses: actions/download-artifact@v3

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -8,20 +8,24 @@ on:
   schedule:
     - cron:  '0 9 * * *'
 
+env:
+  UBUNTU_VERSION: ubuntu-22.04
+  RUBY_VERSION: 3.1
+
 jobs:
   run_rubocop:
-    runs-on: ubuntu-22.04
+    runs-on: $UBUNTU_VERSION
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.1'
+          ruby-version: $RUBY_VERSION
       - run: bundle
       - run: rubocop
 
   unit_tests:
     needs: run_rubocop
-    runs-on: ubuntu-22.04
+    runs-on: $UBUNTU_VERSION
     services:
       mysql:
         image: mysql:5.7
@@ -117,7 +121,7 @@ jobs:
 
   multiverse:
     needs: run_rubocop
-    runs-on: ubuntu-22.04
+    runs-on: $UBUNTU_VERSION
     services:
       mysql:
         image: mysql:5.7
@@ -230,7 +234,7 @@ jobs:
 
   infinite_tracing:
     needs: run_rubocop
-    runs-on: ubuntu-22.04
+    runs-on: $UBUNTU_VERSION
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
DRY the CI YAMLs up a bit by placing the default OS and Ruby versions in
variables