### PR TITLE
Bugfix: thread tracing causes missing unscoped metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # New Relic Ruby Agent Release Notes #
 
 
+  ## v8.11.0
+
+
+  * **Bugfix: Missing unscoped metrics when instrumentation.thread.tracing is enabled**
+    
+    Previously, when `instrumentation.thread.tracing` was set to true, some puma applications encountered a bug where a varying number of unscoped metrics would be missing. The agent now will correctly store and send all unscoped metrics.
+    
+    Thank you to @texpert for providing details of their situation to help resolve the issue.
+  
+  
+
   ## v8.10.0
 
 

--- a/infinite_tracing/lib/infinite_tracing/worker.rb
+++ b/infinite_tracing/lib/infinite_tracing/worker.rb
@@ -52,7 +52,7 @@ module NewRelic::Agent
 
       def start_thread
         NewRelic::Agent.logger.debug("starting worker #{@name} thread...")
-        @worker_thread = Thread.new do
+        @worker_thread = NewRelic::Agent::Threading::AgentThread.create("infinite_tracing_worker") do
           catch(:exit) do
             begin
               @job.call

--- a/infinite_tracing/test/infinite_tracing/worker_test.rb
+++ b/infinite_tracing/test/infinite_tracing/worker_test.rb
@@ -25,6 +25,12 @@ module NewRelic::Agent::InfiniteTracing
       assert_metrics_recorded "Supportability/InfiniteTracing/Worker"
     end
 
+    def test_worker_uses_agentthread
+      NewRelic::Agent::Threading::AgentThread.expects(:create).returns(Thread.new {})
+      worker = Worker.new("simple") {}
+      worker.join
+    end
+
     def test_worker_handles_errors
       worker = Worker.new("error") do
         NewRelic::Agent.record_metric("Supportability/InfiniteTracing/Worker", 0.0)

--- a/lib/new_relic/agent/threading/agent_thread.rb
+++ b/lib/new_relic/agent/threading/agent_thread.rb
@@ -8,18 +8,18 @@ module NewRelic
     module Threading
       class AgentThread
         def self.create(label, &blk)
-          ::NewRelic::Agent.logger.debug("Creating New Relic thread: #{label}")
+          ::NewRelic::Agent.logger.debug("Creating AgentThread: #{label}")
           wrapped_blk = Proc.new do
             ::NewRelic::Agent.logger.warn("AgentThread created with current transaction #{::Thread.current[:newrelic_tracer_state].current_transaction.best_name}") if ::Thread.current[:newrelic_tracer_state] && ::Thread.current[:newrelic_tracer_state].current_transaction
             begin
               blk.call
             rescue => e
-              ::NewRelic::Agent.logger.error("Thread #{label} exited with error", e)
+              ::NewRelic::Agent.logger.error("AgentThread #{label} exited with error", e)
             rescue Exception => e
-              ::NewRelic::Agent.logger.error("Thread #{label} exited with exception. Re-raising in case of interrupt.", e)
+              ::NewRelic::Agent.logger.error("AgentThread #{label} exited with exception. Re-raising in case of interrupt.", e)
               raise
             ensure
-              ::NewRelic::Agent.logger.debug("Exiting New Relic thread: #{label}")
+              ::NewRelic::Agent.logger.debug("Exiting AgentThread: #{label}")
             end
           end
           thread = nil

--- a/lib/new_relic/agent/threading/agent_thread.rb
+++ b/lib/new_relic/agent/threading/agent_thread.rb
@@ -10,7 +10,10 @@ module NewRelic
         def self.create(label, &blk)
           ::NewRelic::Agent.logger.debug("Creating AgentThread: #{label}")
           wrapped_blk = Proc.new do
-            ::NewRelic::Agent.logger.warn("AgentThread created with current transaction #{::Thread.current[:newrelic_tracer_state].current_transaction.best_name}") if ::Thread.current[:newrelic_tracer_state] && ::Thread.current[:newrelic_tracer_state].current_transaction
+            if ::Thread.current[:newrelic_tracer_state] && Thread.current[:newrelic_tracer_state].current_transaction
+              txn = ::Thread.current[:newrelic_tracer_state].current_transaction
+              ::NewRelic::Agent.logger.warn("AgentThread created with current transaction #{txn.best_name}")
+            end
             begin
               blk.call
             rescue => e

--- a/lib/new_relic/agent/tracer.rb
+++ b/lib/new_relic/agent/tracer.rb
@@ -407,11 +407,13 @@ module NewRelic
         alias_method :tl_clear, :clear_state
 
         def thread_block_with_current_transaction(*args, &block)
-          current_txn = ::Thread.current[:newrelic_tracer_state].current_transaction if ::Thread.current[:newrelic_tracer_state]
+          current_txn = ::Thread.current[:newrelic_tracer_state].current_transaction if ::Thread.current[:newrelic_tracer_state] && ::Thread.current[:newrelic_tracer_state].is_execution_traced?
           Proc.new do
             begin
-              NewRelic::Agent::Tracer.state.current_transaction = current_txn
-              segment = NewRelic::Agent::Tracer.start_segment(name: "Ruby/Thread/#{::Thread.current.object_id}")
+              if current_txn
+                NewRelic::Agent::Tracer.state.current_transaction = current_txn
+                segment = NewRelic::Agent::Tracer.start_segment(name: "Ruby/Thread/#{::Thread.current.object_id}")
+              end
               block.call(*args) if block.respond_to?(:call)
             ensure
               segment.finish if segment

--- a/test/new_relic/agent/threading/agent_thread_test.rb
+++ b/test/new_relic/agent/threading/agent_thread_test.rb
@@ -157,6 +157,17 @@ module NewRelic::Agent::Threading
       assert_nil(bt)
     end
 
+    def test_agent_thread_creation_ignores_current_transaction
+      with_config(:'instrumentation.thread.tracing' => true) do
+        in_transaction do |txn|
+          t = AgentThread.create("label") do
+            refute ::Thread.current[:newrelic_tracer_state] && ::Thread.current[:newrelic_tracer_state].current_transaction, "Agent thread should not contain a current transaction"
+          end
+          t.join
+        end
+      end
+    end
+
     DONT_CARE = true
   end
 end


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
Missing unscoped metrics were found to be erroneously marked as an unscoped metric on a long running puma transaction that does not finish. This pr makes the following changes to prevent any unscoped metrics from being attached to transactions incorrectly. 
- All Threads created by the agent now use AgentThread (infinite tracing was not previously)
- AgentThread disables tracing when spawning threads
- When tracing threads
   -  the agent will no longer copy over the current_transaction if tracing is disabled
   - the agent will not attempt to create a segment if there is no current_transaction
- Added test that confirms any AgentThread spawned during the execution of a transaction will not be considered parto f the transaction


closes https://github.com/newrelic/newrelic-ruby-agent/issues/1238
closes https://github.com/newrelic/newrelic-ruby-agent/issues/1309


# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
