### PR TITLE
Set failedThreshold to 90

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -367,5 +367,5 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           resultPath: lib/coverage_results/.last_run.json
-          failedThreshold: 85
+          failedThreshold: 90
           failedThresholdBranch: 80


### PR DESCRIPTION
# Overview

We've had pretty consistent 92% coverage since the latest SimpleCov updates. Since we can expect that number, increase the threshold to 90% to ensure coverage does not drop too far.