### PR TITLE
RuboCop: stop permitting infinitely long lines

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -256,7 +256,9 @@ Layout/LineEndStringConcatenationIndentation:
   Enabled: false
 
 Layout/LineLength:
-  Enabled: false
+  # TODO: get this down to something closer to the 80 col ideal
+  #       we should be able to manage 120
+  Max: 576
 
 Layout/MultilineArrayBraceLayout:
   Enabled: true


### PR DESCRIPTION
Enforce a line length max with RuboCop, with a TODO to actually have the
value be reasonable in the future