### PR TITLE
Use HTMLFormatter in rake task

### DIFF
--- a/lib/tasks/coverage_report.rake
+++ b/lib/tasks/coverage_report.rake
@@ -13,10 +13,13 @@ namespace :coverage do
 
     if ENV['CI']
       SimpleCov.collate(Dir['*/coverage_*/.resultset.json']) do
+        formatter SimpleCov::Formatter::HTMLFormatter
         refuse_coverage_drop
       end
     else
-      SimpleCov.collate(Dir['lib/coverage_*/.resultset.json'])
+      SimpleCov.collate(Dir['lib/coverage_*/.resultset.json']) do
+        formatter SimpleCov::Formatter::HTMLFormatter
+      end
     end
 
     Dir['lib/coverage_{[!r][!e][!s][!u][!l][!t][!s]}*'].each { |dir| FileUtils.rm_rf(dir) }


### PR DESCRIPTION
# Overview

We use the SimpleFormatter by default for regular test runs. The HTML
format is most useful to use when we generate a collated report.
This PR will make sure HTML is created when the rake task is called.