### PR TITLE
Gabby: report only stable versions for 'previous'

### DIFF
--- a/.github/workflows/scripts/slack_gem_notifications/notifications_methods.rb
+++ b/.github/workflows/scripts/slack_gem_notifications/notifications_methods.rb
@@ -30,7 +30,15 @@ end
 # Gem entries are ordered by release date. The break limits versions to two versions: newest and previous.
 def gem_versions(gem_info)
   versions = gem_info.each_with_object([]) do |gem, arr|
-    arr << gem if gem['platform'] == 'ruby'
+    next unless gem['platform'] == 'ruby'
+
+    # for the "new" version (first one recored), report any and all types of
+    #   versions (stable, preview, rc, beta, etc.)
+    # for the "previous" version, record only the newest stable version
+    if arr.size == 0 || !gem['number'].match?(/(?:rc|beta|preview)/)
+      arr << gem
+    end
+
     break arr if arr.size == 2
   end
 end

--- a/.github/workflows/scripts/slack_gem_notifications/notifications_methods.rb
+++ b/.github/workflows/scripts/slack_gem_notifications/notifications_methods.rb
@@ -32,7 +32,7 @@ def gem_versions(gem_info)
   versions = gem_info.each_with_object([]) do |gem, arr|
     next unless gem['platform'] == 'ruby'
 
-    # for the "new" version (first one recored), report any and all types of
+    # for the "new" version (first one recorded), report any and all types of
     #   versions (stable, preview, rc, beta, etc.)
     # for the "previous" version, record only the newest stable version
     if arr.size == 0 || !gem['number'].match?(/(?:rc|beta|preview)/)

--- a/newrelic_rpm.gemspec
+++ b/newrelic_rpm.gemspec
@@ -47,7 +47,7 @@ https://github.com/newrelic/newrelic-ruby-agent/
   s.homepage = "https://github.com/newrelic/rpm"
   s.require_paths = ["lib"]
   s.summary = "New Relic Ruby Agent"
-  s.add_development_dependency 'feedjira', '3.2.1' # for Gabby
+  s.add_development_dependency 'feedjira', '3.2.1' unless ENV['CI'] # for Gabby
   s.add_development_dependency 'rake', '12.3.3'
   s.add_development_dependency 'minitest', '5.3.3'
   s.add_development_dependency 'minitest-stub-const', '0.6'
@@ -58,5 +58,5 @@ https://github.com/newrelic/newrelic-ruby-agent/
   s.add_development_dependency 'rubocop'
   s.add_development_dependency 'rubocop-performance'
   s.add_development_dependency 'simplecov' if RUBY_VERSION >= '2.7.0'
-  s.add_development_dependency 'httparty' # for perf tests and Gabby
+  s.add_development_dependency 'httparty' unless ENV['CI'] # for perf tests and Gabby
 end

--- a/newrelic_rpm.gemspec
+++ b/newrelic_rpm.gemspec
@@ -47,6 +47,7 @@ https://github.com/newrelic/newrelic-ruby-agent/
   s.homepage = "https://github.com/newrelic/rpm"
   s.require_paths = ["lib"]
   s.summary = "New Relic Ruby Agent"
+  s.add_development_dependency 'feedjira', '3.2.1' # for Gabby
   s.add_development_dependency 'rake', '12.3.3'
   s.add_development_dependency 'minitest', '5.3.3'
   s.add_development_dependency 'minitest-stub-const', '0.6'
@@ -57,5 +58,5 @@ https://github.com/newrelic/newrelic-ruby-agent/
   s.add_development_dependency 'rubocop'
   s.add_development_dependency 'rubocop-performance'
   s.add_development_dependency 'simplecov' if RUBY_VERSION >= '2.7.0'
-  s.add_development_dependency 'httparty'
+  s.add_development_dependency 'httparty' # for perf tests and Gabby
 end

--- a/test/new_relic/gem_notifications_tests.rb
+++ b/test/new_relic/gem_notifications_tests.rb
@@ -19,7 +19,9 @@ class GemNotifications < Minitest::Test
   end
 
   def http_get_response
-    [{"created_at" => "2001-07-18T16:15:29.083Z", "platform" => "ruby", "number" => "3.0.0"},
+    [{"created_at" => "2001-07-18T16:15:29.083Z", "platform" => "ruby", "number" => "4.0.0.preview"},
+      {"created_at" => "2001-07-18T16:15:29.083Z", "platform" => "ruby", "number" => "3.0.0.rc1"},
+      {"created_at" => "2001-07-18T16:15:29.083Z", "platform" => "ruby", "number" => "3.0.0"},
       {"created_at" => "1997-05-23T16:15:29.083Z", "platform" => "java", "number" => "2.0.0"},
       {"created_at" => "1993-06-11T16:15:29.083Z", "platform" => "ruby", "number" => "1.0.0"}]
   end
@@ -60,6 +62,16 @@ class GemNotifications < Minitest::Test
   def test_get_gem_info_max_size
     versions = gem_versions(http_get_response())
     assert_equal true, versions.size == 2
+  end
+
+  def test_newest_version_can_be_a_preview_or_rc_or_beta_release
+    versions = gem_versions(http_get_response())
+    assert_equal '4.0.0.preview', versions.first['number']
+  end
+
+  def test_previous_version_must_be_a_stable_release
+    versions = gem_versions(http_get_response())
+    assert_equal '3.0.0', versions.last['number']
   end
 
   def test_gem_updated_true


### PR DESCRIPTION
When Gabby notifies us about a new gem version that has recently become
available, it would be preferable to:

- mention rc1/beta/preview releases for the newly released version to
  give the team a heads up about development work being done on the gem
- only report stable versions for the previously released version.

This way, if a gem goes `v1.5 -> v2.0.preview -> v2.0.rc1 -> v2.0.rc2`
then the notifications will always tell us about the previous stable
version, not the previous beta version.

Currently, the notifications look like this:

- v1.5 to v2.0.preview
- v2.0.preview to v2.0.rc1
- v2.0.rc1 to v2.0.rc2

With the included changes, the notifications would instead read:

- v1.5 to v2.0.preview
- v1.5 to v2.0.rc1
- v1.5 to v2.0.rc2

This way we are notified of beta releases and don't have to manually
search for the previous stable version.