### PR TITLE
CI: for rake + rails, use rack v2

### DIFF
--- a/test/multiverse/suites/rake/Envfile
+++ b/test/multiverse/suites/rake/Envfile
@@ -44,7 +44,7 @@ end
 create_gemfiles(RAKE_VERSIONS, gem_list)
 
 gemfile <<-RB
-  gem 'rack'
+  gem 'rack', "~> #{RUBY_VERSION >= '2.3.0' ? '2.2.4' : '2.1.4.1'}"
   gem 'rake'
   #{ruby3_gem_webrick}
   gem 'rails'


### PR DESCRIPTION
when rake is tested with Rails, sprockets is brought in and has a `rack < 3` dependency. the multiverse suite helpers see the unpinned rack version and bring in `rackup`, which won't work with `rack < 3`.

lock rake + rails to rack v2 to let the multiverse suite helpers know to not bring in `rackup`.