### PR TITLE
Sqlite3 1.5.0 not compatible with ruby < 2.6

### DIFF
--- a/newrelic_rpm.gemspec
+++ b/newrelic_rpm.gemspec
@@ -47,7 +47,7 @@ https://github.com/newrelic/newrelic-ruby-agent/
   s.homepage = "https://github.com/newrelic/rpm"
   s.require_paths = ["lib"]
   s.summary = "New Relic Ruby Agent"
-  s.add_development_dependency 'feedjira', '3.2.1' unless ENV['CI'] # for Gabby
+  s.add_development_dependency 'feedjira', '3.2.1' unless ENV['CI']  || RUBY_VERSION < '2.5' # for Gabby
   s.add_development_dependency 'rake', '12.3.3'
   s.add_development_dependency 'minitest', '5.3.3'
   s.add_development_dependency 'minitest-stub-const', '0.6'

--- a/newrelic_rpm.gemspec
+++ b/newrelic_rpm.gemspec
@@ -47,7 +47,7 @@ https://github.com/newrelic/newrelic-ruby-agent/
   s.homepage = "https://github.com/newrelic/rpm"
   s.require_paths = ["lib"]
   s.summary = "New Relic Ruby Agent"
-  s.add_development_dependency 'feedjira', '3.2.1' unless ENV['CI']  || RUBY_VERSION < '2.5' # for Gabby
+  s.add_development_dependency 'feedjira', '3.2.1' unless ENV['CI'] || RUBY_VERSION < '2.5' # for Gabby
   s.add_development_dependency 'rake', '12.3.3'
   s.add_development_dependency 'minitest', '5.3.3'
   s.add_development_dependency 'minitest-stub-const', '0.6'

--- a/test/multiverse/suites/sequel/Envfile
+++ b/test/multiverse/suites/sequel/Envfile
@@ -13,7 +13,7 @@ def gem_list(sequel_version = nil)
   <<-RB
     gem 'newrelic_rpm', :require => false, :path => File.expand_path('../../../../')
     gem 'jdbc-sqlite3', '3.7.2', :platform => :jruby
-    gem 'sqlite3', :platform => :ruby
+    gem 'sqlite3',#{" '< 1.5.0'," if RUBY_VERSION < '2.6'} :platform => :ruby
     gem 'sequel'#{sequel_version}
   RB
 end


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
- Sqlite3 1.5.0 was released and has a minimum ruby version of 2.6, so we now pin the version on rubys < 2.6

Submitter Checklist:
- [ ] Include a link to the related GitHub issue, if applicable
- [ ] Include a security review link, if applicable

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
Github Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
