### PR TITLE
Ruby 3.2.0preview2

### DIFF
--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -1,12 +1,13 @@
 name: Scheduled Continuous Integration
 
 on:
-  push:
-    branches:
-      - main
-      - dev
-  schedule:
-    - cron:  '0 9 * * *'
+  pull_request:
+  # push:
+  #   branches:
+  #     - main
+  #     - dev
+  # schedule:
+  #   - cron:  '0 9 * * *'
 
 jobs:
   run_rubocop:
@@ -35,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: [2.2.10, 2.3.8, 2.4.10, 2.5.9, 2.6.10, 2.7.6, 3.0.4, 3.1.2, 3.2.0-preview1, jruby-9.3.7.0]
+        ruby-version: [2.2.10, 2.3.8, 2.4.10, 2.5.9, 2.6.10, 2.7.6, 3.0.4, 3.1.2, 3.2.0-preview2, jruby-9.3.7.0]
 
     steps:
       - name: Configure git
@@ -83,7 +84,7 @@ jobs:
               "3.1.2": {
                 "rails": "norails,rails61,rails70,railsedge"
               },
-              "3.2.0-preview1": {
+              "3.2.0-preview2": {
                 "rails": "norails,rails61,rails70,railsedge"
               },
               "jruby-9.3.7.0": {
@@ -177,7 +178,7 @@ jobs:
       fail-fast: false
       matrix:
         multiverse: [agent, background, background_2, database, frameworks, httpclients, httpclients_2, rails, rest]
-        ruby-version: [2.2.10, 2.3.8, 2.4.10, 2.5.9, 2.6.10, 2.7.6, 3.0.4, 3.1.2, 3.2.0-preview1]
+        ruby-version: [2.2.10, 2.3.8, 2.4.10, 2.5.9, 2.6.10, 2.7.6, 3.0.4, 3.1.2, 3.2.0-preview2]
     steps:
       - name: Configure git
         run: 'git config --global init.defaultBranch main'
@@ -240,7 +241,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: [2.5.9, 2.6.10, 2.7.6, 3.0.4, 3.1.2, 3.2.0-preview1]
+        ruby-version: [2.5.9, 2.6.10, 2.7.6, 3.0.4, 3.1.2, 3.2.0-preview2]
     steps:
       - name: Configure git
         run: 'git config --global init.defaultBranch main'

--- a/lib/new_relic/agent/samplers/vm_sampler.rb
+++ b/lib/new_relic/agent/samplers/vm_sampler.rb
@@ -19,6 +19,7 @@ module NewRelic
         MINOR_GC_METRIC = 'RubyVM/GC/minor_gc_count'.freeze
         METHOD_INVALIDATIONS_METRIC = 'RubyVM/CacheInvalidations/method'.freeze
         CONSTANT_INVALIDATIONS_METRIC = 'RubyVM/CacheInvalidations/constant'.freeze
+        CONSTANT_MISSES_METRIC = 'RubyVM/CacheMisses/constant'.freeze
 
         attr_reader :transaction_count
 
@@ -115,6 +116,7 @@ module NewRelic
           record_delta(snap, :minor_gc_count, MINOR_GC_METRIC, tcount)
           record_delta(snap, :method_cache_invalidations, METHOD_INVALIDATIONS_METRIC, tcount)
           record_delta(snap, :constant_cache_invalidations, CONSTANT_INVALIDATIONS_METRIC, tcount)
+          record_delta(snap, :constant_cache_misses, CONSTANT_MISSES_METRIC, tcount)
           record_heap_live_metric(snap)
           record_heap_free_metric(snap)
           record_thread_count_metric(snap)

--- a/lib/new_relic/agent/vm/mri_vm.rb
+++ b/lib/new_relic/agent/vm/mri_vm.rb
@@ -52,18 +52,18 @@ module NewRelic
           if supports?(:constant_cache_invalidations)
             snap.constant_cache_invalidations = gather_constant_cache_invalidations
           end
+
+          if supports?(:constant_cache_misses)
+            snap.constant_cache_misses = gather_constant_cache_misses
+          end
         end
 
         def gather_constant_cache_invalidations
-          # Ruby >= 3.2 uses :constant_cache
-          # see: https://github.com/ruby/ruby/pull/5433 and https://bugs.ruby-lang.org/issues/18589
-          # TODO: now that 3.2+ provides more granual cache invalidation data, should we report it instead of summing?
-          if RUBY_VERSION >= '3.2.0'
-            RubyVM.stat[:constant_cache].values.sum
-          # Ruby < 3.2 uses :global_constant_state
-          else
-            RubyVM.stat[:global_constant_state]
-          end
+          RubyVM.stat[RUBY_VERSION >= '3.2.0' ? :constant_cache_invalidations : :global_constant_state]
+        end
+
+        def gather_constant_cache_misses
+          RubyVM.stat[:constant_cache_misses]
         end
 
         def gather_thread_stats(snap)
@@ -84,6 +84,8 @@ module NewRelic
             RUBY_VERSION >= '2.1.0' && RUBY_VERSION < '3.0.0'
           when :constant_cache_invalidations
             RUBY_VERSION >= '2.1.0'
+          when :constant_cache_misses
+            RUBY_VERSION >= '3.2.0'
           else
             false
           end

--- a/lib/new_relic/agent/vm/snapshot.rb
+++ b/lib/new_relic/agent/vm/snapshot.rb
@@ -10,7 +10,7 @@ module NewRelic
         attr_accessor :gc_total_time, :gc_runs, :major_gc_count, :minor_gc_count,
           :total_allocated_object, :heap_live, :heap_free,
           :method_cache_invalidations, :constant_cache_invalidations,
-          :thread_count, :taken_at
+          :constant_cache_misses, :thread_count, :taken_at
 
         def initialize
           @taken_at = Process.clock_gettime(Process::CLOCK_REALTIME)

--- a/test/new_relic/agent/samplers/vm_sampler_test.rb
+++ b/test/new_relic/agent/samplers/vm_sampler_test.rb
@@ -22,7 +22,8 @@ module NewRelic
             :heap_live => 0,
             :heap_free => 0,
             :method_cache_invalidations => 0,
-            :constant_cache_invalidations => 0
+            :constant_cache_invalidations => 0,
+            :constant_cache_misses => 0
           )
           @sampler = VMSampler.new
           @sampler.setup_events(NewRelic::Agent.instance.events)
@@ -128,7 +129,8 @@ module NewRelic
         def test_poll_records_vm_cache_invalidations
           stub_snapshot(
             :method_cache_invalidations => 100,
-            :constant_cache_invalidations => 200
+            :constant_cache_invalidations => 200,
+            :constant_cache_misses => 175
           )
           generate_transactions(50)
           @sampler.poll
@@ -141,6 +143,10 @@ module NewRelic
             'RubyVM/CacheInvalidations/constant' => {
               :call_count => 50, # number of transactions
               :total_call_time => 200 # number of constant cache invalidations
+            }
+            'RubyVM/CacheMisses/constant' => {
+              :call_count => 50, # number of transactions
+              :total_call_time => 175 # number of constant cache misses
             }
           )
         end
@@ -187,6 +193,7 @@ module NewRelic
             :minor_gc_count => 10,
             :method_cache_invalidations => 10,
             :constant_cache_invalidations => 10
+            :constant_cache_misses => 10
           )
           @sampler.poll
 
@@ -209,6 +216,9 @@ module NewRelic
             },
             'RubyVM/CacheInvalidations/constant' => {
               :total_call_time => 10
+            },
+            'RubyVM/CacheMisses/constant' => {
+              :total_call_time => 10
             }
           }
 
@@ -224,6 +234,7 @@ module NewRelic
             :minor_gc_count => 20,
             :method_cache_invalidations => 20,
             :constant_cache_invalidations => 20
+            :constant_cache_misses => 20
           )
           @sampler.poll
 
@@ -242,6 +253,7 @@ module NewRelic
             :minor_gc_count => 10,
             :method_cache_invalidations => 10,
             :constant_cache_invalidations => 10,
+            :constant_cache_misses => 10,
             :taken_at => 10
           )
           generate_transactions(10)
@@ -255,6 +267,7 @@ module NewRelic
             :minor_gc_count => 20,
             :method_cache_invalidations => 20,
             :constant_cache_invalidations => 20,
+            :constant_cache_misses => 20,
             :taken_at => 20
           )
           generate_transactions(10)
@@ -284,6 +297,10 @@ module NewRelic
               :total_call_time => 20
             },
             'RubyVM/CacheInvalidations/constant' => {
+              :call_count => 20,
+              :total_call_time => 20
+            },
+            'RubyVM/CacheMisses/constant' => {
               :call_count => 20,
               :total_call_time => 20
             }

--- a/test/new_relic/agent/samplers/vm_sampler_test.rb
+++ b/test/new_relic/agent/samplers/vm_sampler_test.rb
@@ -143,7 +143,7 @@ module NewRelic
             'RubyVM/CacheInvalidations/constant' => {
               :call_count => 50, # number of transactions
               :total_call_time => 200 # number of constant cache invalidations
-            }
+            },
             'RubyVM/CacheMisses/constant' => {
               :call_count => 50, # number of transactions
               :total_call_time => 175 # number of constant cache misses
@@ -192,7 +192,7 @@ module NewRelic
             :major_gc_count => 10,
             :minor_gc_count => 10,
             :method_cache_invalidations => 10,
-            :constant_cache_invalidations => 10
+            :constant_cache_invalidations => 10,
             :constant_cache_misses => 10
           )
           @sampler.poll
@@ -233,7 +233,7 @@ module NewRelic
             :major_gc_count => 20,
             :minor_gc_count => 20,
             :method_cache_invalidations => 20,
-            :constant_cache_invalidations => 20
+            :constant_cache_invalidations => 20,
             :constant_cache_misses => 20
           )
           @sampler.poll

--- a/test/new_relic/agent/vm_test.rb
+++ b/test/new_relic/agent/vm_test.rb
@@ -27,6 +27,7 @@ class NewRelic::Agent::VMTestCase < Minitest::Test
     :heap_free,
     :method_cache_invalidations,
     :constant_cache_invalidations,
+    :constant_cache_misses,
     :thread_count
   ]
 


### PR DESCRIPTION
test against Ruby 3.2.0preview2 via CI

see
[changes](https://www.ruby-lang.org/en/news/2022/09/09/ruby-3-2-0-preview2-released/)