### PR TITLE
Fix Minitest/AssertEmpty Rubocop exclusions

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -15,19 +15,6 @@ Layout/EmptyLinesAroundBlockBody:
     - 'test/multiverse/suites/active_record/db/schema.rb'
     - 'test/multiverse/suites/active_record_pg/db/schema.rb'
 
-# Offense count: 15
-# This cop supports safe autocorrection (--autocorrect).
-Minitest/AssertEmpty:
-  Exclude:
-    - 'test/agent_helper.rb'
-    - 'test/multiverse/suites/rails/error_tracing_test.rb'
-    - 'test/new_relic/agent/configuration/default_source_test.rb'
-    - 'test/new_relic/agent/configuration/yaml_source_test.rb'
-    - 'test/new_relic/agent/external_test.rb'
-    - 'test/new_relic/agent/threading/backtrace_service_test.rb'
-    - 'test/new_relic/agent/threading/thread_profile_test.rb'
-    - 'test/new_relic/agent/transaction/slowest_sample_buffer_test.rb'
-
 # Offense count: 52
 # This cop supports safe autocorrection (--autocorrect).
 Minitest/AssertEmptyLiteral:

--- a/test/agent_helper.rb
+++ b/test/agent_helper.rb
@@ -111,7 +111,7 @@ end
 
 unless defined? assert_empty
   def assert_empty(collection, msg = nil)
-    assert collection.empty?, msg
+    assert_empty collection, msg
   end
 end
 
@@ -902,7 +902,7 @@ def assert_event_attributes(event, test_name, expected_attributes, non_expected_
   event_attrs.each do |name, actual_value|
     msg << "  #{name}: #{actual_value.inspect}\n"
   end
-  assert(incorrect_attributes.empty?, msg)
+  assert_empty(incorrect_attributes, msg)
 
   non_expected_attributes.each do |name|
     refute event_attrs[name], "Found value '#{event_attrs[name]}' for attribute '#{name}', but expected nothing in #{test_name}"

--- a/test/multiverse/suites/rails/error_tracing_test.rb
+++ b/test/multiverse/suites/rails/error_tracing_test.rb
@@ -205,13 +205,13 @@ class ErrorsWithoutSSCTest < ActionDispatch::IntegrationTest
 
   def test_should_not_notice_errors_from_ignored_action
     get('/error/ignored_action')
-    assert(errors.empty?,
+    assert_empty(errors,
       'Noticed an error that should have been ignored')
   end
 
   def test_should_not_notice_ignored_error_classes
     get('/error/ignored_error')
-    assert(errors.empty?,
+    assert_empty(errors,
       'Noticed an error that should have been ignored')
   end
 
@@ -232,7 +232,7 @@ class ErrorsWithoutSSCTest < ActionDispatch::IntegrationTest
       get('/error/controller_error')
     end
 
-    assert(errors.empty?,
+    assert_empty(errors,
       'Noticed an error that should have been ignored')
   end
 
@@ -240,7 +240,7 @@ class ErrorsWithoutSSCTest < ActionDispatch::IntegrationTest
     with_config(:'error_collector.ignore_status_codes' => '500') do
       get('/error/ignored_status_code')
 
-      assert(errors.empty?, 'Noticed an error that should have been ignored')
+      assert_empty(errors, 'Noticed an error that should have been ignored')
     end
   end
 
@@ -352,7 +352,7 @@ class ErrorsWithSSCTest < ErrorsWithoutSSCTest
   def test_should_ignore_server_ignored_errors
     get('/error/server_ignored_error')
 
-    assert(errors.empty?,
+    assert_empty(errors,
       'Noticed an error that should have been ignored' + errors.join(', '))
   end
 end

--- a/test/new_relic/agent/configuration/default_source_test.rb
+++ b/test/new_relic/agent/configuration/default_source_test.rb
@@ -223,8 +223,8 @@ module NewRelic::Agent::Configuration
         end
       end
 
-      assert unspecified_keys.empty?, "The following keys did not specify a value for :allowed_from_server: #{unspecified_keys.join(', ')}"
-      assert bad_value_keys.empty?, "The following keys had incorrect :allowed_from_server values (only true or false are allowed): #{bad_value_keys.join(', ')}"
+      assert_empty unspecified_keys, "The following keys did not specify a value for :allowed_from_server: #{unspecified_keys.join(', ')}"
+      assert_empty bad_value_keys, "The following keys had incorrect :allowed_from_server values (only true or false are allowed): #{bad_value_keys.join(', ')}"
     end
 
     def test_host_correct_when_license_key_matches_identifier

--- a/test/new_relic/agent/configuration/yaml_source_test.rb
+++ b/test/new_relic/agent/configuration/yaml_source_test.rb
@@ -125,7 +125,7 @@ module NewRelic::Agent::Configuration
     def test_transaction_threshold_one_liner
       config = {'transaction_tracer.transaction_threshold' => 'apdex_f'}
       @source.send(:substitute_transaction_threshold, config)
-      assert config.empty?
+      assert_empty config
     end
 
     [1, 'no', 'off', 0, 'false', [], {}, 1.0, Time.now].each do |value|

--- a/test/new_relic/agent/external_test.rb
+++ b/test/new_relic/agent/external_test.rb
@@ -72,7 +72,7 @@ module NewRelic
           }))
 
           l = with_array_logger { NewRelic::Agent::External.process_request_metadata(rmd) }
-          assert l.array.empty?, "process_request_metadata should not log errors without a current transaction"
+          assert_empty l.array, "process_request_metadata should not log errors without a current transaction"
 
           refute Tracer.current_transaction
         end
@@ -123,7 +123,7 @@ module NewRelic
 
           in_transaction do |txn|
             l = with_array_logger { NewRelic::Agent::External.process_request_metadata(rmd) }
-            assert l.array.empty?, "process_request_metadata should not log errors when cross app tracing is disabled"
+            assert_empty l.array, "process_request_metadata should not log errors when cross app tracing is disabled"
 
             refute txn.distributed_tracer.cross_app_payload
           end

--- a/test/new_relic/agent/threading/backtrace_service_test.rb
+++ b/test/new_relic/agent/threading/backtrace_service_test.rb
@@ -270,7 +270,7 @@ if NewRelic::Agent::Threading::BacktraceService.is_supported?
         @service.poll
 
         fake_transaction_finished('bar', 0, 1, thread)
-        assert @service.buffer.empty?
+        assert_empty @service.buffer
       end
 
       def test_on_transaction_finished_aggregates_backtraces_to_subscribed_profile

--- a/test/new_relic/agent/threading/thread_profile_test.rb
+++ b/test/new_relic/agent/threading/thread_profile_test.rb
@@ -202,7 +202,7 @@ if NewRelic::Agent::Threading::BacktraceService.is_supported?
 
       def test_empty
         profile = ThreadProfile.new
-        assert profile.empty?
+        assert_empty profile
       end
 
       def test_not_empty

--- a/test/new_relic/agent/transaction/slowest_sample_buffer_test.rb
+++ b/test/new_relic/agent/transaction/slowest_sample_buffer_test.rb
@@ -62,7 +62,7 @@ class NewRelic::Agent::Transaction
 
       @buffer.harvest_samples
 
-      assert(@buffer.samples.empty?)
+      assert_empty(@buffer.samples)
     end
   end
 end


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
For #1403

Submitter Checklist:
- [x] Include a link to the related GitHub issue, if applicable
- [ ] Include a security review link, if applicable

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
Github Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
