### PR TITLE
Stop SimpleCov on forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -373,7 +373,7 @@ jobs:
   simplecov:
     needs: [unit_tests, multiverse, infinite_tracing]
     runs-on: ubuntu-22.04
-    if: github.repository_owner == 'newrelic'
+    if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Configure git
         run: 'git config --global init.defaultBranch main'


### PR DESCRIPTION
SimpleCov is currently running on forks, making our CI fail when contributors make PRs. This commit tests a logic change to hopefully stop SimpleCov on forks.

_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
Describe the changes present in the pull request

Submitter Checklist:
- [ ] Include a link to the related GitHub issue, if applicable
- [ ] Include a security review link, if applicable

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
Github Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
