### PR TITLE
Resolve intermittent failure unexpected invocation: #<Mock:socket>.sync()

### DIFF
--- a/test/new_relic/agent/instrumentation/net_instrumentation_test.rb
+++ b/test/new_relic/agent/instrumentation/net_instrumentation_test.rb
@@ -26,10 +26,16 @@ class NewRelic::Agent::Instrumentation::NetInstrumentationTest < Minitest::Test
 
   def teardown
     NewRelic::Agent.shutdown
+    mocha_teardown
   end
 
   def test_scope_stack_integrity_maintained_on_request_failure
-    # This prevents intermittent failures and I don't know why it needs this now but it didn't before
+    # This is needed to prevent intermittent failures and I don't know why
+    # The error this prevents is unexpected invocation: #<Mock:socket>.sync()
+    # The error is caused by @socket being a mock
+    # If you add .sync to the mock in fixture_tcp_socket, the test seg faults instead of failing
+    # This was never needed previously and there were never any issues with it
+    # I have no idea.
     ::Net::Protocol.any_instance.stubs(:ssl_socket_connect)
 
     @socket.stubs(:write).raises('fake network error')

--- a/test/new_relic/agent/instrumentation/net_instrumentation_test.rb
+++ b/test/new_relic/agent/instrumentation/net_instrumentation_test.rb
@@ -29,6 +29,9 @@ class NewRelic::Agent::Instrumentation::NetInstrumentationTest < Minitest::Test
   end
 
   def test_scope_stack_integrity_maintained_on_request_failure
+    # This prevents intermittent failures and I don't know why it needs this now but it didn't before
+    ::Net::Protocol.any_instance.stubs(:ssl_socket_connect)
+
     @socket.stubs(:write).raises('fake network error')
     @socket.stubs(:write_nonblock).raises('fake network error')
     with_config(:"cross_application_tracer.enabled" => true) do


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
We started having intermittent failures caused by the mocking of socket in NetInstrumentationTest. 
```
NewRelic::Agent::Instrumentation::NetInstrumentationTest#test_scope_stack_integrity_maintained_on_request_failure [/opt/hostedtoolcache/Ruby/2.4.10/x64/lib/ruby/2.4.0/openssl/buffering.rb:44]:
unexpected invocation: #<Mock:socket>.sync()
```


Adding the method .sync to the mock resulted in seg faults instead of test failures, even when returning a variety of things from the sync method on the mock.  
```
/opt/hostedtoolcache/Ruby/2.5.9/x64/lib/ruby/2.5.0/net/protocol.rb:44: [BUG] Segmentation fault at 0x000056320000000f
ruby 2.5.9p229 (2021-04-05 revision 67939) [x86_64-linux]

-- Control frame information -----------------------------------------------
c:0033 p:---- s:0204 e:000203 CFUNC  :connect_nonblock
c:0032 p:0058 s:0199 e:000198 METHOD /opt/hostedtoolcache/Ruby/2.5.9/x64/lib/ruby/2.5.0/net/protocol.rb:44
c:0031 p:0603 s:0192 E:001928 METHOD /opt/hostedtoolcache/Ruby/2.5.9/x64/lib/ruby/2.5.0/net/http.rb:9[85]
....
```


Stubbing the method `::Net::Protocol#ssl_socket_connect` prevents the issue from happening. 
I have no idea why and I have no idea why this started happening suddenly last week after never happening once before.
¯\\_(ツ)_/¯

closes https://github.com/newrelic/newrelic-ruby-agent/issues/1405

Submitter Checklist:
- [ ] Include a link to the related GitHub issue, if applicable
- [ ] Include a security review link, if applicable

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
Github Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
