### PR TITLE
Address rubocop-minitest RefutePathExists errors

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -193,12 +193,6 @@ Minitest/RefuteIncludes:
     - 'test/new_relic/agent/configuration/manager_test.rb'
     - 'test/new_relic/control/instance_methods_test.rb'
 
-# Offense count: 3
-# This cop supports safe autocorrection (--autocorrect).
-Minitest/RefutePathExists:
-  Exclude:
-    - 'test/multiverse/suites/mongo/helpers/mongo_server_test.rb'
-
 # Offense count: 96
 # This cop supports safe autocorrection (--autocorrect).
 Minitest/RefutePredicate:

--- a/test/multiverse/suites/mongo/helpers/mongo_server_test.rb
+++ b/test/multiverse/suites/mongo/helpers/mongo_server_test.rb
@@ -45,7 +45,7 @@ class MongoServerTest < Test::Unit::TestCase
     path = @server.port_lock_path
     assert File.exist?(path)
     @server.release_port
-    refute File.exist?(path)
+    refute_path_exists(path)
   end
 
   def test_all_port_lock_files_returns_all_file_names
@@ -80,14 +80,14 @@ class MongoServerTest < Test::Unit::TestCase
     @server.start
     assert File.exist?(@server.port_lock_path)
     @server.stop
-    refute File.exist?(@server.port_lock_path)
+    refute_path_exists(@server.port_lock_path)
   end
 
   def test_stop_deletes_pid_file
     @server.start
     assert File.exist?(@server.pid_path)
     @server.stop
-    refute File.exist?(@server.pid_path)
+    refute_path_exists(@server.pid_path)
   end
 
   def test_pingable_returns_true_if_ping_is_ok


### PR DESCRIPTION
This commit addresses the rubcop-minitest RefutePathExists cop.

_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
Describe the changes present in the pull request

Submitter Checklist:
- [ ] Include a link to the related GitHub issue, if applicable
- [ ] Include a security review link, if applicable

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
Github Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
