### PR TITLE
Infinite Tracing: support batching and compression

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1476,14 +1476,16 @@ Style/MapToHash:
 Style/MethodCallWithArgsParentheses:
   Enabled: true
   AllowedMethods:
-    - puts
-    - require
-    - raise
-    - include
-    - fail
-    - print
     - add_dependency
     - add_development_dependency
+    - expect
+    - fail
+    - include
+    - print
+    - puts
+    - raise
+    - require
+    - stub
   AllowedPatterns: [^assert, ^refute]
 
 Style/MethodCallWithoutArgsParentheses:

--- a/infinite_tracing/lib/infinite_tracing/channel.rb
+++ b/infinite_tracing/lib/infinite_tracing/channel.rb
@@ -24,15 +24,6 @@ module NewRelic::Agent
         GRPC::Core::Channel.new(host_and_port, settings, credentials)
       end
 
-      # def apply_default_compression_level
-
-
-      #   require 'pry'
-      #   binding.pry
-
-      #   NewRelic::Agent.config[:'infinite_tracing.compression_level'] = DEFAULT_COMPRESSION_LEVEL
-      # end
-
       def channel_args
         return NewRelic::EMPTY_HASH unless compression_enabled?
 

--- a/infinite_tracing/lib/infinite_tracing/channel.rb
+++ b/infinite_tracing/lib/infinite_tracing/channel.rb
@@ -39,8 +39,8 @@ module NewRelic::Agent
       end
 
       def compression_options
-        { default_algorithm: :gzip,
-          default_level: compression_level }
+        {default_algorithm: :gzip,
+         default_level: compression_level}
       end
 
       def credentials

--- a/infinite_tracing/lib/infinite_tracing/client.rb
+++ b/infinite_tracing/lib/infinite_tracing/client.rb
@@ -148,7 +148,6 @@ module NewRelic::Agent
       def start_streaming(exponential_backoff = true)
         return if suspended?
 
-        @exponential_backoff = exponential_backoff
         Connection.instance.wait_for_agent_connect
         @lock.synchronize { response_handler(exponential_backoff) }
       end

--- a/infinite_tracing/lib/infinite_tracing/connection.rb
+++ b/infinite_tracing/lib/infinite_tracing/connection.rb
@@ -52,7 +52,7 @@ module NewRelic::Agent
         # so we're able to signal the client to restart when connectivity to the
         # server is disrupted.
         def record_span_batches(client, enumerator, exponential_backoff)
-          instance.record_span_batch(client, enumerator, exponential_backoff)
+          instance.record_span_batches(client, enumerator, exponential_backoff)
         end
 
         def metadata

--- a/infinite_tracing/test/infinite_tracing/channel_test.rb
+++ b/infinite_tracing/test/infinite_tracing/channel_test.rb
@@ -71,8 +71,7 @@ module NewRelic
 
         def test_invalid_compression_level
           channel = Channel.new
-          def channel.compression_level; :bogus; end
-          assert_raises(RuntimeError) { channel.validate_compression_level }
+          refute channel.valid_compression_level?(:bogus)
         end
 
         def test_channel_args_are_empty_if_compression_is_disabled

--- a/infinite_tracing/test/infinite_tracing/channel_test.rb
+++ b/infinite_tracing/test/infinite_tracing/channel_test.rb
@@ -56,6 +56,40 @@ module NewRelic
         ensure
           Config.unstub(:test_framework?)
         end
+
+        def test_compression_enabled_returns_true
+          with_config(remote_config.merge('infinite_tracing.compression_level': :high)) do
+            assert Channel.new.compression_enabled?
+          end
+        end
+
+        def test_compression_enabled_returns_false
+          with_config(remote_config.merge('infinite_tracing.compression_level': :none)) do
+            refute Channel.new.compression_enabled?
+          end
+        end
+
+        def test_invalid_compression_level
+          channel = Channel.new
+          def channel.compression_level; :bogus; end
+          assert_raises(RuntimeError) { channel.validate_compression_level }
+        end
+
+        def test_channel_args_are_empty_if_compression_is_disabled
+          with_config(remote_config.merge('infinite_tracing.compression_level': :none)) do
+            assert_equal Channel.new.channel_args, NewRelic::EMPTY_HASH
+          end
+        end
+
+        def test_channel_args_includes_compression_settings_if_compression_is_enabled
+          level = :low
+          expected_result = {'grpc.default_compression_level' => 1,
+                             'grpc.default_compression_algorithm' => 2,
+                             'grpc.compression_enabled_algorithms_bitset' => 7}
+          with_config(remote_config.merge('infinite_tracing.compression_level': level)) do
+            assert_equal Channel.new.channel_args, expected_result
+          end
+        end
       end
     end
   end

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2439,7 +2439,7 @@ A map of error classes to a list of messages. When an error of one of the classe
         },
         :'infinite_tracing.compression_level' => {
           :default => :none,
-          :public => true,
+          :public => false,
           :type => Symbol,
           :allowed_from_server => false,
           :external => :infinite_tracing,
@@ -2448,7 +2448,7 @@ A map of error classes to a list of messages. When an error of one of the classe
         },
         :'infinite_tracing.batching' => {
           :default => false,
-          :public => true,
+          :public => false,
           :type => Boolean,
           :allowed_from_server => false,
           :external => :infinite_tracing,

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2436,6 +2436,25 @@ A map of error classes to a list of messages. When an error of one of the classe
           :allowed_from_server => false,
           :external => :infinite_tracing,
           :description => "Configures the TCP/IP port for the Trace Observer Host"
+        },
+        :'infinite_tracing.compression_level' => {
+          :default => :none,
+          :public => true,
+          :type => Symbol,
+          :allowed_from_server => false,
+          :external => :infinite_tracing,
+          :description => "Configure the compression level for data sent to the Trace Observer\nMay be one of " \
+                          "[none|low|medium|high]\nBy default, compression is not used (level = none)"
+        },
+        :'infinite_tracing.batching' => {
+          :default => false,
+          :public => true,
+          :type => Boolean,
+          :allowed_from_server => false,
+          :external => :infinite_tracing,
+          :description => "If true, data sent to the Trace Observer will be batched instead of the default of each " \
+                          "span being sent individually"
+
         }
       }.freeze
     end

--- a/newrelic.yml
+++ b/newrelic.yml
@@ -301,6 +301,15 @@ common: &default_settings
   # Configures the TCP/IP port for the Trace Observer Host
   # infinite_tracing.trace_observer.port: 443
 
+  # Configure the compression level for data sent to the Trace Observer
+  # May be one of [none|low|medium|high]
+  # By default, compression is not used (level = none)
+  # infinite_tracing.compression_level: none
+
+  # If true, data sent to the Trace Observer will be batched instead of
+  # the default of each span being sent individually
+  # infinite_tracing.batching: false
+
   # Controls auto-instrumentation of bunny at start up.
   # May be one of [auto|prepend|chain|disabled].
   # instrumentation.bunny: auto


### PR DESCRIPTION
- Introduce a new `infinite_tracing.batching` config parameter with a boolean value defaulting to `false`. When `true`, Infinite Tracing's RecordSpanBatch RPC (previously existing but inaccessible) will be used to batch requests to the Trace Observer
- Introduce a new `infinite_tracing.compression_level` config parameter with a string value defaulting to `'none'`. When changed to a value of `'low'`, `'medium'`, or `'high'`, Infinite Tracing's gRPC client will use that compression level for outbound data.