### PR TITLE
Add condition to select MongoDB image to install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
       mongodb:
-        image: mongo:5.0.11
+        image: ${{ (matrix.ruby-version == '2.2.10' || matrix.ruby-version == '2.3.8' || matrix.ruby-version == '2.4.10') && 'mongo:5.0.11' || 'mongo:latest' }}
         ports:
           - 27017:27017
       rabbitmq:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
       mongodb:
-        image: ${{ (matrix.ruby-version == '2.2.10' || matrix.ruby-version == '2.3.8' || matrix.ruby-version == '2.4.10') && 'mongo:5.0.11' || 'mongo:latest' }}
+        image: ${{ contains(fromJson('["2.2.10", "2.3.8", "2.4.10"]'), matrix.ruby-version) && 'mongo:5.0.11' || 'mongo:latest' }}
         ports:
           - 27017:27017
       rabbitmq:

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -152,7 +152,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
       mongodb:
-        image: ${{ (matrix.ruby-version == '2.2.10' || matrix.ruby-version == '2.3.8' || matrix.ruby-version == '2.4.10') && 'mongo:5.0.11' || 'mongo:latest' }}
+        image: ${{ contains(fromJson('["2.2.10", "2.3.8", "2.4.10"]'), matrix.ruby-version) && 'mongo:5.0.11' || 'mongo:latest' }}
         ports:
           - 27017:27017
       rabbitmq:

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -152,7 +152,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
       mongodb:
-        image: mongo:5.0.11
+        image: ${{ (matrix.ruby-version == '2.2.10' || matrix.ruby-version == '2.3.8' || matrix.ruby-version == '2.4.10') && 'mongo:5.0.11' || 'mongo:latest' }}
         ports:
           - 27017:27017
       rabbitmq:


### PR DESCRIPTION
# Overview
* MongoDB v6 does not work on Ruby 2.4 and below
* We'd like to have newer Rubies continue to test on the latest MongoDB to help us know when there's breaking changes to our instrumentation
* This change conditionally installs a compatible mongo image based on the `matrix.ruby_version` value

Closes: #1351 

All Rubies tested with the database group in #1449 

Submitter Checklist:
- [X] Include a link to the related GitHub issue, if applicable
~~- [ ] Include a security review link, if applicable~~
