### PR TITLE
CI: remove file descriptor exhaustion tests

### DIFF
--- a/test/new_relic/agent/transaction/segment_test.rb
+++ b/test/new_relic/agent/transaction/segment_test.rb
@@ -271,29 +271,6 @@ module NewRelic
           assert_equal t, segment.start_time
         end
 
-        def test_generates_guid_when_running_out_of_file_descriptors
-          # SecureRandom.hex raises an exception when the ruby interpreter
-          # uses up all of its allotted file descriptors.
-          # See also: https://github.com/newrelic/newrelic-ruby-agent/issues/303
-          file_descriptors = []
-          begin
-            # Errno::EMFILE is raised when the system runs out of file
-            # descriptors
-            # If the segment constructor fails to create a random guid, the
-            # exception would be a RuntimeError
-            # When Docker Compose is used with this test file accessible via
-            # a volume, the error is Errno::EIO instead
-            assert_raises(Errno::EIO, Errno::EMFILE, Errno::ENFILE) do
-              while true
-                file_descriptors << IO.sysopen(__FILE__)
-                Segment.new("Test #{file_descriptors[-1]}")
-              end
-            end
-          ensure
-            file_descriptors.map { |fd| IO::new(fd).close }
-          end
-        end
-
         def test_adding_agent_attributes
           in_transaction do |txn|
             txn.add_agent_attribute(:foo, "bar", AttributeFilter::DST_ALL)


### PR DESCRIPTION
Using infinite loops to saturate Ruby ObjectSpace on every single CI run is not ideal.

Our guid generation logic used to be `SecureRandom` based, and used to run into issues when a systems resource limit was hit and access to `/dev/urandom` would fail.

When we
[switched](https://github.com/newrelic/newrelic-ruby-agent/commit/1294c5bb50640752378b9d9faa2f55ac3dd0dbcd) away from `SecureRandom`, a decision was made to test the new more fault tolerant guid generation logic by inducing the exhaustion of the host machine's file descriptors and proving that guid generation still works.

These tests are slow on modern cloud based devices with lots of resources, problematic when ran by multitasking devs locally, and simply do not provide us with value anymore. The `refute` lines inside the infinite loops also cause huge artificially inflated numbers of successful tests in the thousands.

Let's get rid of these.