### PR TITLE
some refactorings to satisfy ABC size limits

### DIFF
--- a/lib/new_relic/agent.rb
+++ b/lib/new_relic/agent.rb
@@ -580,14 +580,14 @@ module NewRelic
 
         segment = ::NewRelic::Agent::Tracer.current_segment
         if segment
-          add_new_segment_attributes(params, segement)
+          add_new_segment_attributes(params, segment)
         end
       else
         ::NewRelic::Agent.logger.warn("Bad argument passed to #add_custom_attributes. Expected Hash but got #{params.class}")
       end
     end
 
-    def add_new_segment_attributes(params, segement)
+    def add_new_segment_attributes(params, segment)
       # Make sure not to override existing segment-level custom attributes
       segment_custom_keys = segment.attributes.custom_attributes.keys.map(&:to_sym)
       segment.add_custom_attributes(params.reject { |k, _v| segment_custom_keys.include?(k.to_sym) })

--- a/lib/new_relic/agent/new_relic_service.rb
+++ b/lib/new_relic/agent/new_relic_service.rb
@@ -402,7 +402,7 @@ module NewRelic
       end
 
       def prep_request(opts)
-        headers = prep_headers
+        headers = prep_headers(opts)
         if Agent.config[:put_for_data_send]
           request = Net::HTTP::Put.new(opts[:uri], headers)
         else

--- a/lib/new_relic/agent/new_relic_service.rb
+++ b/lib/new_relic/agent/new_relic_service.rb
@@ -674,7 +674,7 @@ module NewRelic
         @collector = @configured_collector if method == :preconnect
       end
 
-      def invoke_remote_send_request(method, payload, data)
+      def invoke_remote_send_request(method, payload, data, encoding)
         uri = remote_method_uri(method)
         full_uri = "#{@collector}#{uri}"
 

--- a/lib/new_relic/agent/vm/mri_vm.rb
+++ b/lib/new_relic/agent/vm/mri_vm.rb
@@ -24,18 +24,32 @@ module NewRelic
         end
 
         def gather_gc_stats(snap)
-          if supports?(:gc_runs)
-            snap.gc_runs = GC.count
-          end
+          gather_gc_runs(snap) if supports?(:gc_runs)
+          gather_stats if GC.respond_to?(:stat)
+        end
 
-          if GC.respond_to?(:stat)
-            gc_stats = GC.stat
-            snap.total_allocated_object = gc_stats[:total_allocated_objects] || gc_stats[:total_allocated_object]
-            snap.major_gc_count = gc_stats[:major_gc_count]
-            snap.minor_gc_count = gc_stats[:minor_gc_count]
-            snap.heap_live = gc_stats[:heap_live_slots] || gc_stats[:heap_live_slot] || gc_stats[:heap_live_num]
-            snap.heap_free = gc_stats[:heap_free_slots] || gc_stats[:heap_free_slot] || gc_stats[:heap_free_num]
+        def gather_gc_runs(snap)
+          snap.gc_runs = GC.count
+        end
+
+        def gather_stats(snap)
+          snap.total_allocated_object = derive_from_gc_stats(%i[total_allocated_objects total_allocated_object])
+          snap.major_gc_count = derive_from_gc_stats(:major_gc_count)
+          snap.minor_gc_count = derive_from_gc_stats(:minor_gc_count)
+          snap.heap_live = derive_from_gc_stats(%i[heap_live_slots heap_live_slot heap_live_num])
+          snap.heap_free = derive_from_gc_stats(%i[heap_free_slots heap_free_slot heap_free_num])
+        end
+
+        def derive_from_gc_stats(keys)
+          Array(keys).each do |key|
+            value = gc_stats[key]
+            return value if value
           end
+          nil
+        end
+
+        def gc_stats
+          @gc_stats ||= GC.stat
         end
 
         def gather_gc_time(snap)

--- a/lib/new_relic/agent/vm/mri_vm.rb
+++ b/lib/new_relic/agent/vm/mri_vm.rb
@@ -25,37 +25,34 @@ module NewRelic
 
         def gather_gc_stats(snap)
           gather_gc_runs(snap) if supports?(:gc_runs)
-          gather_stats if GC.respond_to?(:stat)
+          gather_derived_stats(snap) if GC.respond_to?(:stat)
         end
 
         def gather_gc_runs(snap)
           snap.gc_runs = GC.count
         end
 
-        def gather_stats(snap)
-          snap.total_allocated_object = derive_from_gc_stats(%i[total_allocated_objects total_allocated_object])
-          snap.major_gc_count = derive_from_gc_stats(:major_gc_count)
-          snap.minor_gc_count = derive_from_gc_stats(:minor_gc_count)
-          snap.heap_live = derive_from_gc_stats(%i[heap_live_slots heap_live_slot heap_live_num])
-          snap.heap_free = derive_from_gc_stats(%i[heap_free_slots heap_free_slot heap_free_num])
+        def gather_derived_stats(snap)
+          stat = GC.stat
+          snap.total_allocated_object = derive_from_gc_stats(%i[total_allocated_objects total_allocated_object], stat)
+          snap.major_gc_count = derive_from_gc_stats(:major_gc_count, stat)
+          snap.minor_gc_count = derive_from_gc_stats(:minor_gc_count, stat)
+          snap.heap_live = derive_from_gc_stats(%i[heap_live_slots heap_live_slot heap_live_num], stat)
+          snap.heap_free = derive_from_gc_stats(%i[heap_free_slots heap_free_slot heap_free_num], stat)
         end
 
-        def derive_from_gc_stats(keys)
+        def derive_from_gc_stats(keys, stat)
           Array(keys).each do |key|
-            value = gc_stats[key]
+            value = stat[key]
             return value if value
           end
           nil
         end
 
-        def gc_stats
-          @gc_stats ||= GC.stat
-        end
-
         def gather_gc_time(snap)
-          if supports?(:gc_total_time)
-            snap.gc_total_time = NewRelic::Agent.instance.monotonic_gc_profiler.total_time_s
-          end
+          return unless supports?(:gc_total_time)
+
+          snap.gc_total_time = NewRelic::Agent.instance.monotonic_gc_profiler.total_time_s
         end
 
         def gather_ruby_vm_stats(snap)


### PR DESCRIPTION
refactorings with an aim of keeping the ABC size per method below the RuboCop default of 17