### PR TITLE
Haml 6.0 Release Fixes

### DIFF
--- a/test/multiverse/suites/rails_prepend/prepended_supportability_test.rb
+++ b/test/multiverse/suites/rails_prepend/prepended_supportability_test.rb
@@ -9,11 +9,12 @@ class PrependedSupportabilityMetricsTest < Minitest::Test
   include MultiverseHelpers
 
   def test_action_view_prepended_metrics
+    value_for_haml_version = Gem::Version.new(Haml::VERSION) >= Gem::Version.new('6.0.0') ? 1 : 2
     assert_metrics_recorded({
 
       # haml prepends a module on ActionView::Base
       #
-      "Supportability/PrependedModules/ActionView::Base" => metric_values_for(2),
+      "Supportability/PrependedModules/ActionView::Base" => metric_values_for(value_for_haml_version),
 
       "Supportability/PrependedModules/ActionView::Template" => metric_values_for(1),
       "Supportability/PrependedModules/ActionView::Renderer" => metric_values_for(1)

--- a/test/multiverse/suites/tilt/Envfile
+++ b/test/multiverse/suites/tilt/Envfile
@@ -10,10 +10,16 @@ TILT_VERSIONS = [
   ['1.4.1', 2.2, 2.7]
 ]
 
+def haml_version(tilt_version)
+  if tilt_version && (Gem::Version.new(tilt_version.match(/\d|\./)) < Gem::Version.new('2.0.0'))
+    add_version('5.2.2')
+  end
+end
+
 def gem_list(tilt_version = nil)
   <<-RB
     gem 'tilt'#{tilt_version}
-    gem 'haml'
+    gem 'haml'#{haml_version(tilt_version)}
     #{ruby3_gem_webrick}
   RB
 end

--- a/test/multiverse/suites/tilt/Envfile
+++ b/test/multiverse/suites/tilt/Envfile
@@ -11,7 +11,7 @@ TILT_VERSIONS = [
 ]
 
 def haml_version(tilt_version)
-  if tilt_version && (Gem::Version.new(tilt_version.match(/\d|\./)) < Gem::Version.new('2.0.0'))
+  if tilt_version && (Gem::Version.new(tilt_version.match(/^\d+/)) < Gem::Version.new('2.0.0'))
     add_version('5.2.2')
   end
 end

--- a/test/multiverse/suites/tilt/tilt_instrumentation_test.rb
+++ b/test/multiverse/suites/tilt/tilt_instrumentation_test.rb
@@ -17,7 +17,11 @@ class TiltInstrumentationTest < Minitest::Test
   end
 
   def haml_render_metric(filename = 'test.haml')
-    "View/Tilt::HamlTemplate/#{filename}/Rendering"
+    if Gem::Version.new(Haml::VERSION) >= Gem::Version.new('6.0.0')
+      "View/Haml::Template/#{filename}/Rendering"
+    else
+      "View/Tilt::HamlTemplate/#{filename}/Rendering"
+    end
   end
 
   ### Tilt::Template#render tests ###


### PR DESCRIPTION
# Overview

Many of our Rails tests as well as tests for other instrumented gems use Haml. With Haml's new release yesterday, a few areas that have unlocked Haml versions (some areas we control, some we seemingly don't) upgraded to version 6.0 when it was released September 21, 2022. Here's an overview of the changes made to our test suite to get things passing again.

* Use Haml::Template for Tilt metric name if Haml 6.0+
* Use Haml ~> 5.2.2 for testing with Tilt 1.4.1 (this version doesn't have a lock on accepted Haml versions, but seems incompatible with Haml 6.0)
* Create a conditional value for `rails_prepend` Action View metrics based on Haml version

Closes: #1456 

Submitter Checklist:
- [x] Include a link to the related GitHub issue, if applicable
- [ ] Include a security review link, if applicable

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
Github Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
