### PR TITLE
padrino tests: lock to sinatra < 3

### DIFF
--- a/test/multiverse/suites/padrino/Envfile
+++ b/test/multiverse/suites/padrino/Envfile
@@ -5,9 +5,11 @@
 
 instrumentation_methods :chain, :prepend
 
+# TODO: sinatra 3's CALLERS_TO_IGNORE array is frozen, causes issues
 gemfile <<-RB
   gem 'activesupport', '~> 3'
   gem 'padrino', '~> 0.15.1'
   gem 'rack-test', '>= 0.8.0', :require => 'rack/test'
+  gem 'sinatra', '< 3'
   gem 'webrick' if RUBY_VERSION >= '2.7.0'
 RB


### PR DESCRIPTION
sinatra v3 (released 2022-09-26) seems to have frozen the `CALLERS_TO_IGNORE` array, which padrino tries to concatenate onto

for now, stick with testing sinatra < 3 until there's a new padrino release