### PR TITLE
Enable RuboCop Performance linters

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -960,11 +960,7 @@ Performance/RegexpMatch:
 Performance/UnfreezeString:
   Enabled: false
 
-# Disabled until they can be focused on (no autocorrect)
-Performance/CollectionLiteralInLoop:
-  Enabled: false
-
-# Disabled until they can be focused on (no autocorrect)
+# TODO: Enable when time can be spent on it (no autocorrect)
 Performance/MethodObjectAsBlock:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -965,15 +965,8 @@ Performance/CollectionLiteralInLoop:
   Enabled: false
 
 # Disabled until they can be focused on (no autocorrect)
-Performance/Count:
-  Enabled: false
-
-# Disabled until they can be focused on (no autocorrect)
 Performance/MethodObjectAsBlock:
   Enabled: false
-
-Performance/TimesMap:
-  Enabled: true
 
 # Disabling for now
 Security/Eval:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -940,172 +940,40 @@ Naming/VariableName:
 Naming/VariableNumber:
   Enabled: false
 
-Performance/AncestorsInclude:
-  Enabled: false
-
-Performance/ArraySemiInfiniteRangeSlice:
-  Enabled: false
-
-Performance/BigDecimalWithNumericArgument:
-  Enabled: true
-
-# Disabled for support of older ruby versions
+# TODO: OLD RUBIES - Requires 2.7
 Performance/BindCall:
   Enabled: false
 
-# Disabling for now
-Performance/BlockGivenWithExplicitBlock:
-  Enabled: false
-
-# Disabling for now
-Performance/Caller:
-  Enabled: false
-
-Performance/CaseWhenSplat:
-  Enabled: false
-
-Performance/Casecmp:
-  Enabled: false
-
-Performance/ChainArrayAllocation:
-  Enabled: false
-
-Performance/CollectionLiteralInLoop:
-  Enabled: false
-
-Performance/CompareWithBlock:
-  Enabled: true
-
-Performance/ConcurrentMonotonicTime:
-  Enabled: true
-
-# Disabling for now
-Performance/ConstantRegexp:
-  Enabled: false
-
-# Disabling for now
-Performance/Count:
-  Enabled: false
-
+# TODO: OLD RUBIES - Requites 2.5
 Performance/DeletePrefix:
   Enabled: false
 
-Performance/DeleteSuffix:
-  Enabled: false
-
-# Disabling for now
-Performance/Detect:
-  Enabled: false
-
-# Disabling for now
-Performance/DoubleStartEndWith:
-  Enabled: false
-  # IncludeActiveSupportAliases: false
-
-Performance/EndWith:
-  Enabled: true
-
-Performance/FixedSize:
-  Enabled: true
-
-Performance/FlatMap:
-  Enabled: true
-  EnabledForFlattenWithoutParams: false
-
-# Disabling for now
-Performance/InefficientHashSearch:
-  Enabled: false
-  # Safe: false
-
-Performance/IoReadlines:
-  Enabled: false
-
+# TODO: OLD RUBIES - Requires 2.7
 Performance/MapCompact:
   Enabled: false
 
-Performance/MethodObjectAsBlock:
-  Enabled: false
-
-Performance/OpenStruct:
-  Enabled: false
-
-Performance/RangeInclude:
-  Enabled: true
-  Safe: false
-
-Performance/RedundantBlockCall:
-  Enabled: false
-
-Performance/RedundantEqualityComparisonBlock:
-  Enabled: false
-
-# Disabling for now
-Performance/RedundantMatch:
-  Enabled: false
-
-# Disabling for now
-Performance/RedundantMerge:
-  Enabled: false
-  # MaxKeyValuePairs: 2
-
-Performance/RedundantSortBlock:
-  Enabled: true
-
-Performance/RedundantSplitRegexpArgument:
-  Enabled: true
-
-Performance/RedundantStringChars:
-  Enabled: true
-
-# Disabling for now
+# TODO: OLD RUBIES - Requires 2.4
 Performance/RegexpMatch:
   Enabled: false
 
-# Disabling for now
-Performance/ReverseEach:
+# TODO: OLD RUBIES - Requires 2.3
+Performance/UnfreezeString:
   Enabled: false
 
-Performance/ReverseFirst:
-  Enabled: true
-
-Performance/SelectMap:
+# Disabled until they can be focused on (no autocorrect)
+Performance/CollectionLiteralInLoop:
   Enabled: false
 
-Performance/Size:
-  Enabled: true
-
-Performance/SortReverse:
-  Enabled: true
-
-Performance/Squeeze:
-  Enabled: true
-
-# Disabling for now
-Performance/StartWith:
+# Disabled until they can be focused on (no autocorrect)
+Performance/Count:
   Enabled: false
 
-Performance/StringIdentifierArgument:
-  Enabled: true
-
-Performance/StringInclude:
-  Enabled: false
-
-# Disabling for now
-Performance/StringReplacement:
-  Enabled: false
-
-Performance/Sum:
+# Disabled until they can be focused on (no autocorrect)
+Performance/MethodObjectAsBlock:
   Enabled: false
 
 Performance/TimesMap:
   Enabled: false
-
-# Disabling for now
-Performance/UnfreezeString:
-  Enabled: false
-
-Performance/UriDefaultParser:
-  Enabled: true
 
 # Disabling for now
 Security/Eval:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -952,16 +952,20 @@ Performance/DeletePrefix:
 Performance/MapCompact:
   Enabled: false
 
+# TODO: Enable when time can be spent on it (no autocorrect)
+Performance/MethodObjectAsBlock:
+  Enabled: false
+
 # TODO: OLD RUBIES - Requires 2.4
 Performance/RegexpMatch:
   Enabled: false
 
-# TODO: OLD RUBIES - Requires 2.3
-Performance/UnfreezeString:
+# TODO: OLD RUBIES - Requires 2.4
+Performance/Sum:
   Enabled: false
 
-# TODO: Enable when time can be spent on it (no autocorrect)
-Performance/MethodObjectAsBlock:
+# TODO: OLD RUBIES - Requires 2.3
+Performance/UnfreezeString:
   Enabled: false
 
 # Disabling for now

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -973,7 +973,7 @@ Performance/MethodObjectAsBlock:
   Enabled: false
 
 Performance/TimesMap:
-  Enabled: false
+  Enabled: true
 
 # Disabling for now
 Security/Eval:

--- a/bin/nrdebug
+++ b/bin/nrdebug
@@ -97,11 +97,11 @@ class LinuxProcessDataProvider < ProcessDataProvider
   end
 
   def procline
-    File.read(proc_path('cmdline')).gsub("\000", " ")
+    File.read(proc_path('cmdline')).tr("\000", " ")
   end
 
   def environment
-    File.read(proc_path('environ')).gsub("\000", "\n")
+    File.read(proc_path('environ')).tr("\000", "\n")
   end
 end
 
@@ -212,7 +212,7 @@ class ProcessReport
 
       section(f) do
         c_backtraces, ruby_backtraces = @target.gather_backtraces
-        if c_backtraces.match(/could not attach/i)
+        if c_backtraces =~ /could not attach/i
           fail("Failed to attach to target process. Please try again with sudo.")
         end
         section(f, "C Backtraces") { c_backtraces }

--- a/infinite_tracing/test/infinite_tracing/record_status_handler_test.rb
+++ b/infinite_tracing/test/infinite_tracing/record_status_handler_test.rb
@@ -24,7 +24,7 @@ module NewRelic::Agent::InfiniteTracing
     end
 
     def test_processes_multiple_items_and_stops
-      items = 5.times.map { |i| RecordStatus.new(messages_seen: i + 1) }
+      items = Array.new(5) { |i| RecordStatus.new(messages_seen: i + 1) }
       queue = EnumeratorQueue.new.preload(items)
 
       handler = build_handler(queue)

--- a/infinite_tracing/test/support/fake_trace_observer_helpers.rb
+++ b/infinite_tracing/test/support/fake_trace_observer_helpers.rb
@@ -13,7 +13,7 @@ if NewRelic::Agent::InfiniteTracing::Config.should_load?
       class EventListener
         def still_subscribed(event)
           return [] if @events[event].nil?
-          @events[event].select { |e| e.inspect =~ /infinite_tracing/ }
+          @events[event].select { |e| e.inspect.include?('infinite_tracing') }
         end
       end
 

--- a/infinite_tracing/test/support/fake_trace_observer_helpers.rb
+++ b/infinite_tracing/test/support/fake_trace_observer_helpers.rb
@@ -150,7 +150,7 @@ if NewRelic::Agent::InfiniteTracing::Config.should_load?
 
                     # If you want opportunity to do something after each segment
                     # is pushed, invoke this method with a block and do it.
-                    block.call(client, segments) if block_given?
+                    yield(client, segments) if block
 
                     # waits for the grpc mock server to handle any values it needs to
                     # important for tests that expect the mock server to break at a specific point

--- a/infinite_tracing/test/test_helper.rb
+++ b/infinite_tracing/test/test_helper.rb
@@ -39,7 +39,7 @@ Dir[File.expand_path('../support/*', __FILE__)].each { |f| require f }
 def timeout_cap(duration = 1.0)
   Timeout::timeout(duration) { yield }
 rescue Timeout::Error => error
-  raise Timeout::Error, "Unexpected timeout occurred after #{duration} seconds. #{error.backtrace.reject { |r| r =~ /gems\/minitest/ }.join("\n")}"
+  raise Timeout::Error, "Unexpected timeout occurred after #{duration} seconds. #{error.backtrace.reject { |r| r.include?('gems/minitest') }.join("\n")}"
 end
 
 def deferred_span(segment)
@@ -63,7 +63,7 @@ TRACE_POINT_ENABLED = false
 
 def trace
   @trace ||= TracePoint.new(:call, :b_call) do |tp|
-    next unless tp.defined_class.to_s =~ /InfiniteTracing/
+    next unless tp.defined_class.to_s.include?('InfiniteTracing')
     next unless [
       :record_spans,
       :record_span,

--- a/install.rb
+++ b/install.rb
@@ -3,7 +3,7 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
-if __FILE__ == $0 || $0 =~ /script\/plugin/ || File.basename($0) == 'rake'
+if __FILE__ == $0 || $0.include?('script/plugin') || File.basename($0) == 'rake'
   $LOAD_PATH << File.expand_path(File.join(File.dirname(__FILE__), 'lib'))
   require 'new_relic/cli/command'
   begin

--- a/lib/new_relic/agent/agent_logger.rb
+++ b/lib/new_relic/agent/agent_logger.rb
@@ -133,7 +133,7 @@ module NewRelic
       end
 
       def wants_stdout?
-        ::NewRelic::Agent.config[:log_file_path].upcase == "STDOUT"
+        ::NewRelic::Agent.config[:log_file_path].casecmp("STDOUT").zero?
       end
 
       def find_or_create_file_path(path_setting, root)

--- a/lib/new_relic/agent/agent_logger.rb
+++ b/lib/new_relic/agent/agent_logger.rb
@@ -86,7 +86,7 @@ module NewRelic
         if block
           return unless @log.send("#{level}?")
 
-          msgs = Array(block.call)
+          msgs = Array(yield)
         end
 
         msgs.flatten.each do |item|

--- a/lib/new_relic/agent/attribute_processing.rb
+++ b/lib/new_relic/agent/attribute_processing.rb
@@ -19,7 +19,7 @@ module NewRelic
         elsif prefix
           val = Coerce.scalar(object)
           if blk
-            blk.call(prefix, val)
+            yield(prefix, val)
           elsif !val.nil?
             result[prefix] = val
           end
@@ -32,7 +32,7 @@ module NewRelic
       def flatten_and_coerce_hash(hash, prefix, result, &blk)
         if hash.empty?
           if blk
-            blk.call(prefix, EMPTY_HASH_STRING_LITERAL)
+            yield(prefix, EMPTY_HASH_STRING_LITERAL)
           else
             result[prefix] = EMPTY_HASH_STRING_LITERAL
           end
@@ -47,7 +47,7 @@ module NewRelic
       def flatten_and_coerce_array(array, prefix, result, &blk)
         if array.empty?
           if blk
-            blk.call(prefix, EMPTY_ARRAY_STRING_LITERAL)
+            yield(prefix, EMPTY_ARRAY_STRING_LITERAL)
           else
             result[prefix] = EMPTY_ARRAY_STRING_LITERAL
           end

--- a/lib/new_relic/agent/audit_logger.rb
+++ b/lib/new_relic/agent/audit_logger.rb
@@ -95,7 +95,7 @@ module NewRelic
       end
 
       def wants_stdout?
-        ::NewRelic::Agent.config[:'audit_log.path'].upcase == "STDOUT"
+        ::NewRelic::Agent.config[:'audit_log.path'].casecmp("STDOUT").zero?
       end
 
       def create_log_formatter

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -48,7 +48,7 @@ module NewRelic
       # Marks the config option as deprecated in the documentation once generated.
       # Does not appear in logs.
       def self.deprecated_description(new_setting, description)
-        link_ref = new_setting.to_s.gsub(".", "-")
+        link_ref = new_setting.to_s.tr(".", "-")
         %{Please see: [#{new_setting}](docs/agents/ruby-agent/configuration/ruby-agent-configuration##{link_ref}). \n\n#{description}}
       end
 

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -158,7 +158,7 @@ module NewRelic
         def self.audit_log_path
           Proc.new {
             log_file_path = NewRelic::Agent.config[:log_file_path]
-            wants_stdout = (log_file_path.upcase == 'STDOUT')
+            wants_stdout = (log_file_path.casecmp('STDOUT').zero?)
             audit_log_dir = wants_stdout ? DEFAULT_LOG_DIR : log_file_path
 
             File.join(audit_log_dir, 'newrelic_audit.log')

--- a/lib/new_relic/agent/configuration/environment_source.rb
+++ b/lib/new_relic/agent/configuration/environment_source.rb
@@ -51,7 +51,7 @@ module NewRelic
 
         def set_log_file
           if ENV['NEW_RELIC_LOG']
-            if ENV['NEW_RELIC_LOG'].upcase == 'STDOUT'
+            if ENV['NEW_RELIC_LOG'].casecmp('STDOUT').zero?
               self[:log_file_path] = self[:log_file_name] = 'STDOUT'
             else
               self[:log_file_path] = File.dirname(ENV['NEW_RELIC_LOG'])

--- a/lib/new_relic/agent/configuration/environment_source.rb
+++ b/lib/new_relic/agent/configuration/environment_source.rb
@@ -44,7 +44,7 @@ module NewRelic
           config_setting = original_config_setting.to_s
 
           if config_setting.include?('.')
-            config_alias = config_setting.gsub(/\./, '_').to_sym
+            config_alias = config_setting.tr('.', '_').to_sym
             self.alias_map[config_alias] = original_config_setting
           end
         end

--- a/lib/new_relic/agent/configuration/manager.rb
+++ b/lib/new_relic/agent/configuration/manager.rb
@@ -156,7 +156,7 @@ module NewRelic
 
         def register_callback(key, &proc)
           @callbacks[key] << proc
-          proc.call(@cache[key])
+          yield(@cache[key])
         end
 
         def invoke_callbacks(direction, source)

--- a/lib/new_relic/agent/database.rb
+++ b/lib/new_relic/agent/database.rb
@@ -158,7 +158,7 @@ module NewRelic
           return connection if connection
 
           begin
-            @connections[config] = connector.call(config)
+            @connections[config] = yield(config)
           rescue => e
             ::NewRelic::Agent.logger.error("Caught exception trying to get connection to DB for explain.", e)
             nil

--- a/lib/new_relic/agent/error_filter.rb
+++ b/lib/new_relic/agent/error_filter.rb
@@ -81,7 +81,7 @@ module NewRelic
             @ignore_messages.update(errors)
             log_filter(:ignore_messages, errors)
           when String
-            if errors.match(/^[\d\,\-]+$/)
+            if errors =~ /^[\d\,\-]+$/
               @ignore_status_codes |= parse_status_codes(errors)
               log_filter(:ignore_status_codes, errors)
             else
@@ -105,7 +105,7 @@ module NewRelic
             @expected_messages.update(errors)
             log_filter(:expected_messages, errors)
           when String
-            if errors.match(/^[\d\,\-]+$/)
+            if errors =~ /^[\d\,\-]+$/
               @expected_status_codes |= parse_status_codes(errors)
               log_filter(:expected_status_codes, errors)
             else

--- a/lib/new_relic/agent/error_filter.rb
+++ b/lib/new_relic/agent/error_filter.rb
@@ -51,14 +51,14 @@ module NewRelic
 
       def ignore?(ex, status_code = nil)
         @ignore_classes.include?(ex.class.name) ||
-          (@ignore_messages.keys.include?(ex.class.name) &&
+          (@ignore_messages.key?(ex.class.name) &&
           @ignore_messages[ex.class.name].any? { |m| ex.message.include?(m) }) ||
           @ignore_status_codes.include?(status_code.to_i)
       end
 
       def expected?(ex, status_code = nil)
         @expected_classes.include?(ex.class.name) ||
-          (@expected_messages.keys.include?(ex.class.name) &&
+          (@expected_messages.key?(ex.class.name) &&
           @expected_messages[ex.class.name].any? { |m| ex.message.include?(m) }) ||
           @expected_status_codes.include?(status_code.to_i)
       end

--- a/lib/new_relic/agent/error_trace_aggregator.rb
+++ b/lib/new_relic/agent/error_trace_aggregator.rb
@@ -55,7 +55,7 @@ module NewRelic
       # checks the size of the error queue to make sure we are under
       # the maximum limit, and logs a warning if we are over the limit.
       def over_queue_limit?(message)
-        over_limit = (@errors.count { |err| err.is_internal } >= @capacity)
+        over_limit = (@errors.count { |err| !err.is_internal } >= @capacity)
         if over_limit
           ::NewRelic::Agent.logger.warn("The error reporting queue has reached #{@capacity}. The error detail for this and subsequent errors will not be transmitted to New Relic until the queued errors have been sent: #{message}")
         end

--- a/lib/new_relic/agent/error_trace_aggregator.rb
+++ b/lib/new_relic/agent/error_trace_aggregator.rb
@@ -55,7 +55,7 @@ module NewRelic
       # checks the size of the error queue to make sure we are under
       # the maximum limit, and logs a warning if we are over the limit.
       def over_queue_limit?(message)
-        over_limit = (@errors.reject { |err| err.is_internal }.length >= @capacity)
+        over_limit = (@errors.count { |err| err.is_internal } >= @capacity)
         if over_limit
           ::NewRelic::Agent.logger.warn("The error reporting queue has reached #{@capacity}. The error detail for this and subsequent errors will not be transmitted to New Relic until the queued errors have been sent: #{message}")
         end

--- a/lib/new_relic/agent/http_clients/http_rb_wrappers.rb
+++ b/lib/new_relic/agent/http_clients/http_rb_wrappers.rb
@@ -10,7 +10,7 @@ module NewRelic
     module HTTPClients
       class HTTPResponse < AbstractResponse
         def [](key)
-          _, value = @wrapped_response.headers.find { |k, _| key.downcase == k.downcase }
+          _, value = @wrapped_response.headers.find { |k, _| key.casecmp(k).zero? }
           value unless value.nil?
         end
 

--- a/lib/new_relic/agent/http_clients/httpclient_wrappers.rb
+++ b/lib/new_relic/agent/http_clients/httpclient_wrappers.rb
@@ -11,7 +11,7 @@ module NewRelic
       class HTTPClientResponse < AbstractResponse
         def [](key)
           @wrapped_response.headers.each do |k, v|
-            if key.downcase == k.downcase
+            if key.casecmp(k).zero?
               return v
             end
           end

--- a/lib/new_relic/agent/instrumentation/action_view_subscriber.rb
+++ b/lib/new_relic/agent/instrumentation/action_view_subscriber.rb
@@ -65,7 +65,7 @@ module NewRelic
 
         def metric_action(name)
           case name
-          when /#{RENDER_TEMPLATE_EVENT_NAME}$/ then 'Rendering'
+          when /#{RENDER_TEMPLATE_EVENT_NAME}$/o then 'Rendering'
           when RENDER_PARTIAL_EVENT_NAME then 'Partial'
           when RENDER_COLLECTION_EVENT_NAME then 'Partial'
           end

--- a/lib/new_relic/agent/instrumentation/active_merchant.rb
+++ b/lib/new_relic/agent/instrumentation/active_merchant.rb
@@ -25,7 +25,8 @@ DependencyDetection.defer do
       gateway.class_eval do
         implemented_methods = public_instance_methods(false).map(&:to_sym)
         gateway_name = self.name.split('::').last
-        [:authorize, :purchase, :credit, :void, :capture, :recurring, :store, :unstore, :update].each do |operation|
+        actions = [:authorize, :purchase, :credit, :void, :capture, :recurring, :store, :unstore, :update]
+        actions.each do |operation|
           if implemented_methods.include?(operation)
             add_method_tracer operation, [-> (*) { "ActiveMerchant/gateway/#{gateway_name}/#{operation}" },
               -> (*) { "ActiveMerchant/gateway/#{gateway_name}" },

--- a/lib/new_relic/agent/new_relic_service.rb
+++ b/lib/new_relic/agent/new_relic_service.rb
@@ -217,7 +217,7 @@ module NewRelic
       # represents 1 tcp connection which may transmit multiple HTTP requests
       # via keep-alive.
       def session(&block)
-        raise ArgumentError, "#{self.class}#shared_connection must be passed a block" unless block_given?
+        raise ArgumentError, "#{self.class}#shared_connection must be passed a block" unless block
 
         begin
           t0 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
@@ -237,13 +237,13 @@ module NewRelic
 
       def session_with_keepalive(&block)
         establish_shared_connection
-        block.call
+        yield
       end
 
       def session_without_keepalive(&block)
         begin
           establish_shared_connection
-          block.call
+          yield
         ensure
           close_shared_connection
         end

--- a/lib/new_relic/agent/obfuscator.rb
+++ b/lib/new_relic/agent/obfuscator.rb
@@ -24,7 +24,7 @@ module NewRelic
       end
 
       def obfuscate(text)
-        [encode(text)].pack(PACK_FORMAT).gsub(/\n/, '')
+        [encode(text)].pack(PACK_FORMAT).delete("\n")
       end
 
       def deobfuscate(text)

--- a/lib/new_relic/agent/priority_sampled_buffer.rb
+++ b/lib/new_relic/agent/priority_sampled_buffer.rb
@@ -35,13 +35,13 @@ module NewRelic
           priority ||= priority_for(event)
           if priority_for(@items[0]) < priority
             heapify_items_array
-            incoming = event || blk.call
+            incoming = event || yield
             @items[0] = incoming
             @items.fix(0)
             incoming
           end
         else
-          @items << (event || blk.call)
+          @items << (event || yield)
           @captured_lifetime += 1
           @items[-1]
         end

--- a/lib/new_relic/agent/samplers/memory_sampler.rb
+++ b/lib/new_relic/agent/samplers/memory_sampler.rb
@@ -20,7 +20,7 @@ module NewRelic
           # macos, linux, solaris
           if defined? JRuby
             @sampler = JavaHeapSampler.new
-          elsif platform =~ /linux/
+          elsif platform.include?('linux')
             @sampler = ProcStatus.new
             if !@sampler.can_run?
               ::NewRelic::Agent.logger.debug("Error attempting to use /proc/#{$$}/status file for reading memory. Using ps command instead.")
@@ -28,13 +28,13 @@ module NewRelic
             else
               ::NewRelic::Agent.logger.debug("Using /proc/#{$$}/status for reading process memory.")
             end
-          elsif platform =~ /darwin9/ # 10.5
+          elsif platform.include?('darwin9') # 10.5
             @sampler = ShellPS.new("ps -o rsz")
           elsif platform =~ /darwin(1|2)\d+/ # >= 10.6
             @sampler = ShellPS.new("ps -o rss")
-          elsif platform =~ /freebsd/
+          elsif platform.include?('freebsd')
             @sampler = ShellPS.new("ps -o rss")
-          elsif platform =~ /solaris/
+          elsif platform.include?('solaris')
             @sampler = ShellPS.new("/usr/bin/ps -o rss -p")
           end
 
@@ -47,7 +47,7 @@ module NewRelic
         end
 
         def self.platform
-          if RUBY_PLATFORM =~ /java/
+          if RUBY_PLATFORM.include?('java')
             begin
               NewRelic::Helper.run_command('uname -s').downcase
             rescue NewRelic::CommandRunFailedError, NewRelic::CommandExecutableNotFoundError

--- a/lib/new_relic/agent/system_info.rb
+++ b/lib/new_relic/agent/system_info.rb
@@ -129,7 +129,7 @@ module NewRelic
 
         num_physical_packages = cores.keys.map(&:first).uniq.size
         num_physical_cores = cores.size
-        num_logical_processors = cores.values.reduce(0, :+)
+        num_logical_processors = cores.values.sum
 
         if num_physical_cores == 0
           num_logical_processors = total_processors
@@ -174,7 +174,7 @@ module NewRelic
       end
 
       def self.docker_container_id
-        return unless ruby_os_identifier =~ /linux/
+        return unless ruby_os_identifier.include?('linux')
 
         cgroup_info = proc_try_read('/proc/self/cgroup')
         return unless cgroup_info

--- a/lib/new_relic/agent/system_info.rb
+++ b/lib/new_relic/agent/system_info.rb
@@ -129,7 +129,7 @@ module NewRelic
 
         num_physical_packages = cores.keys.map(&:first).uniq.size
         num_physical_cores = cores.size
-        num_logical_processors = cores.values.sum
+        num_logical_processors = cores.values.reduce(0, :+)
 
         if num_physical_cores == 0
           num_logical_processors = total_processors

--- a/lib/new_relic/agent/threading/agent_thread.rb
+++ b/lib/new_relic/agent/threading/agent_thread.rb
@@ -15,7 +15,7 @@ module NewRelic
               ::NewRelic::Agent.logger.warn("AgentThread created with current transaction #{txn.best_name}")
             end
             begin
-              blk.call
+              yield
             rescue => e
               ::NewRelic::Agent.logger.error("AgentThread #{label} exited with error", e)
             rescue Exception => e

--- a/lib/new_relic/agent/tracer.rb
+++ b/lib/new_relic/agent/tracer.rb
@@ -414,7 +414,7 @@ module NewRelic
                 NewRelic::Agent::Tracer.state.current_transaction = current_txn
                 segment = NewRelic::Agent::Tracer.start_segment(name: "Ruby/Thread/#{::Thread.current.object_id}")
               end
-              block.call(*args) if block.respond_to?(:call)
+              yield(*args) if block.respond_to?(:call)
             ensure
               segment.finish if segment
             end

--- a/lib/new_relic/agent/transaction.rb
+++ b/lib/new_relic/agent/transaction.rb
@@ -128,7 +128,7 @@ module NewRelic
       end
 
       def self.nested_transaction_name(name)
-        if name.start_with?(CONTROLLER_PREFIX) || name.start_with?(OTHER_TRANSACTION_PREFIX)
+        if name.start_with?(CONTROLLER_PREFIX, OTHER_TRANSACTION_PREFIX)
           "#{NESTED_TRANSACTION_PREFIX}#{name}"
         else
           name

--- a/lib/new_relic/agent/transaction/trace_node.rb
+++ b/lib/new_relic/agent/transaction/trace_node.rb
@@ -134,7 +134,7 @@ module NewRelic
         # call the provided block for this node and each
         # of the called nodes
         def each_node(&block)
-          block.call(self)
+          yield(self)
 
           if @children
             @children.each do |node|
@@ -146,7 +146,7 @@ module NewRelic
         # call the provided block for this node and each
         # of the called nodes while keeping track of nested nodes
         def each_node_with_nest_tracking(&block)
-          summary = block.call(self)
+          summary = yield(self)
           summary.current_nest_count += 1 if summary
 
           if @children

--- a/lib/new_relic/agent/utilization/vendor.rb
+++ b/lib/new_relic/agent/utilization/vendor.rb
@@ -74,7 +74,7 @@ module NewRelic
 
         def request_metadata
           processed_headers = headers
-          raise if processed_headers.values.include?(:error)
+          raise if processed_headers.value?(:error)
 
           Timeout.timeout(1) do
             response = nil

--- a/lib/new_relic/cli/command.rb
+++ b/lib/new_relic/cli/command.rb
@@ -72,7 +72,7 @@ module NewRelic
         extra = options.order!
         command = extra.shift
         # just make it a little easier on them
-        command = 'deployments' if command =~ /deploy/
+        command = 'deployments' if command.include?('deploy')
         if command.nil?
           STDERR.puts options
         elsif !@command_names.include?(command)

--- a/lib/new_relic/dependency_detection.rb
+++ b/lib/new_relic/dependency_detection.rb
@@ -140,7 +140,7 @@ module DependencyDetection
     end
 
     def depends_on(&block)
-      @dependencies << block if block_given?
+      @dependencies << block if block
     end
 
     def allowed_by_config?
@@ -206,11 +206,11 @@ module DependencyDetection
     end
 
     def executes(&block)
-      @executes << block if block_given?
+      @executes << block if block
     end
 
     def conflicts_with_prepend(&block)
-      @prepend_conflicts << block if block_given?
+      @prepend_conflicts << block if block
     end
 
     def use_prepend?

--- a/lib/new_relic/latest_changes.rb
+++ b/lib/new_relic/latest_changes.rb
@@ -31,8 +31,8 @@ EOS
 
       current_item = nil
       latest.each do |line|
-        if line.match(/^\s*\*.*/)
-          if line.match(/\(#{patch_level}\)/)
+        if line =~ /^\s*\*.*/
+          if line =~ /\(#{patch_level}\)/
             # Found a patch level item, so start tracking the lines!
             current_item = line
           else
@@ -53,7 +53,7 @@ EOS
       changes = []
       version_count = 0
       contents.each_line do |line|
-        if line.match(/##\s+v[\d.]+/)
+        if line =~ /##\s+v[\d.]+/
           version_count += 1
         end
         break if version_count >= 2

--- a/lib/new_relic/local_environment.rb
+++ b/lib/new_relic/local_environment.rb
@@ -183,7 +183,7 @@ module NewRelic
     end
 
     def check_for_litespeed
-      if caller.pop =~ /fcgi-bin\/RailsRunner\.rb/
+      if caller.pop.include?('fcgi-bin/RailsRunner.rb')
         @discovered_dispatcher = :litespeed
       end
     end

--- a/lib/new_relic/noticed_error.rb
+++ b/lib/new_relic/noticed_error.rb
@@ -135,10 +135,8 @@ class NewRelic::NoticedError
 
   def build_error_attributes
     @attributes_from_notice_error ||= {}
-    @attributes_from_notice_error.merge!({
-      ERROR_MESSAGE_KEY => string(message),
-      ERROR_CLASS_KEY => string(exception_class_name)
-    })
+    @attributes_from_notice_error[ERROR_MESSAGE_KEY] = string(message)
+    @attributes_from_notice_error[ERROR_CLASS_KEY] = string(exception_class_name)
 
     @attributes_from_notice_error[ERROR_EXPECTED_KEY] = true if expected
   end

--- a/lib/new_relic/supportability_helper.rb
+++ b/lib/new_relic/supportability_helper.rb
@@ -72,7 +72,7 @@ module NewRelic
     def valid_api_argument_class?(arg, name, klass)
       return true if arg.is_a?(klass)
 
-      caller_location = caller_locations.first.label
+      caller_location = caller_locations(1..1).first.label
 
       message = "Bad argument passed to ##{caller_location}. " \
         "Expected #{klass} for `#{name}` but got #{arg.class}"

--- a/lib/tasks/helpers/format.rb
+++ b/lib/tasks/helpers/format.rb
@@ -21,7 +21,7 @@ module Format
       key = key.to_s
       components = key.split(".")
 
-      if key.match(/^disable_/) # "disable_httpclient"
+      if key =~ /^disable_/ # "disable_httpclient"
         section_key = DISABLING
       elsif components.length >= 2 && !(components[1] == "attributes") # "analytics_events.enabled"
         section_key = components.first
@@ -99,7 +99,7 @@ module Format
 
   def format_env_var(key)
     return "None" if NON_ENV_CONFIGS.include?(key)
-    "NEW_RELIC_#{key.gsub(".", "_").upcase}"
+    "NEW_RELIC_#{key.tr(".", "_").upcase}"
   end
 
   def pluck(key, config_hash)

--- a/lib/tasks/helpers/prompt.rb
+++ b/lib/tasks/helpers/prompt.rb
@@ -16,7 +16,7 @@ module Prompt
     puts
     print "Do you wish to continue? ('y' to continue, return to cancel) [n] "
     continue = STDIN.gets.chomp
-    if continue.downcase.eql?('y')
+    if continue.casecmp('y').zero?
       system(command)
     else
       puts 'Cancelled'

--- a/lib/tasks/helpers/removers.rb
+++ b/lib/tasks/helpers/removers.rb
@@ -6,7 +6,7 @@
 module Removers
   def remove_local_multiverse_databases
     list_databases_command = %(echo "show databases" | mysql -u root)
-    databases = `#{list_databases_command}`.chomp!.split("\n").select { |s| s =~ /multiverse/ }
+    databases = `#{list_databases_command}`.chomp!.split("\n").select { |s| s.include?('multiverse') }
     databases.each do |database|
       puts "Dropping #{database}"
       `echo "drop database #{database}" | mysql -u root`

--- a/test/agent_helper.rb
+++ b/test/agent_helper.rb
@@ -275,7 +275,7 @@ def assert_metrics_recorded_exclusive(expected, options = {})
   expected_metrics = expected.keys.map { |s| metric_spec_from_specish(s) }
 
   unexpected_metrics = recorded_metrics - expected_metrics
-  unexpected_metrics.reject! { |m| m.name =~ /GC\/Transaction/ }
+  unexpected_metrics.reject! { |m| m.name.include?('GC/Transaction') }
 
   assert_equal(0, unexpected_metrics.size, "Found unexpected metrics: #{format_metric_spec_list(unexpected_metrics)}")
 end

--- a/test/agent_helper.rb
+++ b/test/agent_helper.rb
@@ -869,7 +869,7 @@ def load_cross_agent_test(name)
   data = File.read(test_file_path)
   data.gsub!('callCount', 'call_count')
   data = ::JSON.load(data)
-  data.each { |testcase| testcase['testname'].gsub!(' ', '_') if String === testcase['testname'] }
+  data.each { |testcase| testcase['testname'].tr!(' ', '_') if String === testcase['testname'] }
   data
 end
 

--- a/test/environments/lib/environments/runner.rb
+++ b/test/environments/lib/environments/runner.rb
@@ -66,7 +66,7 @@ module Environments
     # Ensures we bundle will recognize an explicit version number on command line
     def safe_explicit(version)
       return version if version.to_s == ""
-      test_version = `bundle #{version} --version` =~ /Could not find command/
+      test_version = `bundle #{version} --version`.include?('Could not find command')
       test_version ? "" : version
     end
 

--- a/test/helpers/config_scanning.rb
+++ b/test/helpers/config_scanning.rb
@@ -27,7 +27,7 @@ module NewRelic
             captures << line.scan(NAMED_DEPENDENCY_PATTERN).map(&method(:disable_name))
 
             captures.flatten.compact.each do |key|
-              default_keys.delete(key.gsub("'", "").to_sym)
+              default_keys.delete(key.delete("'").to_sym)
             end
             # Remove any config keys that are annotated with the 'dynamic_name' setting
             # This indicates that the names of these keys are constructed dynamically at

--- a/test/helpers/misc.rb
+++ b/test/helpers/misc.rb
@@ -113,7 +113,7 @@ end
 def wait_until_not_nil(give_up_after = 3, &block)
   total_tries = give_up_after * 10
   current_tries = 0
-  while block.call.nil? and current_tries < total_tries
+  while yield.nil? and current_tries < total_tries
     sleep(0.1)
     current_tries += 1
   end

--- a/test/multiverse/lib/multiverse/runner.rb
+++ b/test/multiverse/lib/multiverse/runner.rb
@@ -65,7 +65,7 @@ module Multiverse
       Dir.new(SUITES_DIRECTORY).entries.each do |dir|
         full_path = File.join(SUITES_DIRECTORY, dir)
 
-        next if dir =~ /\A\./
+        next if dir.start_with?('.')
         next unless passes_filter?(dir, filter)
         next unless File.exist?(File.join(full_path, "Envfile"))
 

--- a/test/multiverse/lib/multiverse/suite.rb
+++ b/test/multiverse/lib/multiverse/suite.rb
@@ -28,7 +28,7 @@ module Multiverse
     end
 
     def self.encode_options(decoded_opts)
-      Base64.encode64(Marshal.dump(decoded_opts)).gsub("\n", "")
+      Base64.encode64(Marshal.dump(decoded_opts)).delete("\n")
     end
 
     def self.decode_options(encoded_opts)

--- a/test/multiverse/lib/multiverse/suite.rb
+++ b/test/multiverse/lib/multiverse/suite.rb
@@ -136,7 +136,7 @@ module Multiverse
     # Ensures we bundle will recognize an explicit version number on command line
     def safe_explicit(version)
       return version if version.to_s == ""
-      test_version = `bundle #{version} --version` =~ /Could not find command/
+      test_version = `bundle #{version} --version`.include?('Could not find command')
       test_version ? "" : version
     end
 

--- a/test/multiverse/suites/active_record/config/database.rb
+++ b/test/multiverse/suites/active_record/config/database.rb
@@ -13,9 +13,9 @@ db_dir = File.expand_path('../../db', __FILE__)
 config_dir = File.expand_path(File.dirname(__FILE__))
 
 if defined?(ActiveRecord::VERSION)
-  ENV['DATABASE_NAME'] = "multiverse_activerecord_#{ActiveRecord::VERSION::STRING}_#{RUBY_VERSION}_#{RUBY_ENGINE}".gsub(".", "_")
+  ENV['DATABASE_NAME'] = "multiverse_activerecord_#{ActiveRecord::VERSION::STRING}_#{RUBY_VERSION}_#{RUBY_ENGINE}".tr(".", "_")
 else
-  ENV['DATABASE_NAME'] = "multiverse_activerecord_2_x_#{ENV["MULTIVERSE_ENV"]}_#{RUBY_VERSION}_#{RUBY_ENGINE}".gsub(".", "_")
+  ENV['DATABASE_NAME'] = "multiverse_activerecord_2_x_#{ENV["MULTIVERSE_ENV"]}_#{RUBY_VERSION}_#{RUBY_ENGINE}".tr(".", "_")
 end
 
 config_raw = File.read(File.join(config_dir, 'database.yml'))

--- a/test/multiverse/suites/active_record_pg/config/database.rb
+++ b/test/multiverse/suites/active_record_pg/config/database.rb
@@ -13,9 +13,9 @@ db_dir = File.expand_path('../../db', __FILE__)
 config_dir = File.expand_path(File.dirname(__FILE__))
 
 if defined?(ActiveRecord::VERSION)
-  ENV['DATABASE_NAME'] = "multiverse_activerecord_#{ActiveRecord::VERSION::STRING}_#{RUBY_VERSION}_#{RUBY_ENGINE}".gsub(".", "_")
+  ENV['DATABASE_NAME'] = "multiverse_activerecord_#{ActiveRecord::VERSION::STRING}_#{RUBY_VERSION}_#{RUBY_ENGINE}".tr(".", "_")
 else
-  ENV['DATABASE_NAME'] = "multiverse_activerecord_2_x_#{ENV["MULTIVERSE_ENV"]}_#{RUBY_VERSION}_#{RUBY_ENGINE}".gsub(".", "_")
+  ENV['DATABASE_NAME'] = "multiverse_activerecord_2_x_#{ENV["MULTIVERSE_ENV"]}_#{RUBY_VERSION}_#{RUBY_ENGINE}".tr(".", "_")
 end
 
 config_raw = File.read(File.join(config_dir, 'database.yml'))

--- a/test/multiverse/suites/bunny/bunny_test.rb
+++ b/test/multiverse/suites/bunny/bunny_test.rb
@@ -356,7 +356,7 @@ class BunnyTest < Minitest::Test
     queue_name = temp ? "" : random_string
     queue = @chan.queue(queue_name, exclusive: exclusive)
 
-    yield(queue) if block_given?
+    yield(queue) if block
 
     @chan.queue(queue.name).purge
   end

--- a/test/multiverse/suites/capistrano/config/deploy.rb
+++ b/test/multiverse/suites/capistrano/config/deploy.rb
@@ -8,7 +8,7 @@ set :application, 'test'
 # Since Capistrano 3 doesn't allow settings direct from command-line, add any
 # settings we want to conditionally toggle from tests in the following manner.
 ENV.keys.each do |key|
-  if key.match(/NEWRELIC_CAPISTRANO_/)
+  if key =~ /NEWRELIC_CAPISTRANO_/
     name = key.gsub('NEWRELIC_CAPISTRANO_', '').downcase
     set "newrelic_#{name}".to_sym, ENV[key]
   end

--- a/test/multiverse/suites/capistrano/config/deploy.rb
+++ b/test/multiverse/suites/capistrano/config/deploy.rb
@@ -8,7 +8,7 @@ set :application, 'test'
 # Since Capistrano 3 doesn't allow settings direct from command-line, add any
 # settings we want to conditionally toggle from tests in the following manner.
 ENV.keys.each do |key|
-  if key =~ /NEWRELIC_CAPISTRANO_/
+  if key.include?('NEWRELIC_CAPISTRANO_')
     name = key.gsub('NEWRELIC_CAPISTRANO_', '').downcase
     set "newrelic_#{name}".to_sym, ENV[key]
   end

--- a/test/multiverse/suites/mongo/helpers/mongo_operation_tests.rb
+++ b/test/multiverse/suites/mongo/helpers/mongo_operation_tests.rb
@@ -465,7 +465,7 @@ module MongoOperationTests
     node = find_last_transaction_node
     statement = node.params[:statement]
 
-    refute statement.keys.include?(:documents), "Noticed NoSQL should not include documents: #{statement}"
+    refute statement.key?(:documents), "Noticed NoSQL should not include documents: #{statement}"
   end
 
   def test_noticed_nosql_does_not_contain_selector_values
@@ -545,6 +545,6 @@ module MongoOperationTests
 
   def statement_metric(action)
     metrics = build_test_metrics(action)
-    metrics.select { |m| m.start_with?("Datastore/statement") }.first
+    metrics.find { |m| m.start_with?("Datastore/statement") }
   end
 end

--- a/test/multiverse/suites/mongo/helpers/mongo_replica_set.rb
+++ b/test/multiverse/suites/mongo/helpers/mongo_replica_set.rb
@@ -93,6 +93,6 @@ class MongoReplicaSet
     return nil unless running?
     self.servers.first.client['admin'].command({'replSetInitiate' => config})
   rescue Mongo::OperationFailure => e
-    raise e unless e.message =~ /already initialized/
+    raise e unless e.message.include?('already initialized')
   end
 end

--- a/test/multiverse/suites/mongo/helpers/mongo_replica_set.rb
+++ b/test/multiverse/suites/mongo/helpers/mongo_replica_set.rb
@@ -93,6 +93,6 @@ class MongoReplicaSet
     return nil unless running?
     self.servers.first.client['admin'].command({'replSetInitiate' => config})
   rescue Mongo::OperationFailure => e
-    raise e unless e.message.match(/already initialized/)
+    raise e unless e.message =~ /already initialized/
   end
 end

--- a/test/multiverse/suites/mongo/mongo2_instrumentation_test.rb
+++ b/test/multiverse/suites/mongo/mongo2_instrumentation_test.rb
@@ -510,7 +510,7 @@ if NewRelic::Agent::Datastores::Mongo.is_supported_version? &&
             node = find_last_transaction_node
             statement = node.params[:statement]
 
-            refute statement.keys.include?(:documents), "Noticed NoSQL should not include documents: #{statement}"
+            refute statement.key?(:documents), "Noticed NoSQL should not include documents: #{statement}"
           end
 
           def test_noticed_nosql_does_not_contain_selector_values
@@ -570,7 +570,7 @@ if NewRelic::Agent::Datastores::Mongo.is_supported_version? &&
 
           def statement_metric(action)
             metrics = build_test_metrics(action, true)
-            metrics.select { |m| m.start_with?("Datastore/statement") }.first
+            metrics.find { |m| m.start_with?("Datastore/statement") }
           end
 
           def assert_mongo_operation(expected_value, query)

--- a/test/multiverse/suites/rails/middlewares.rb
+++ b/test/multiverse/suites/rails/middlewares.rb
@@ -12,9 +12,9 @@ class ErrorMiddleware
 
   def call(env)
     path = ::Rack::Request.new(env).path_info
-    raise "middleware error" if path =~ /\/middleware_error\/before/
+    raise "middleware error" if path.include?('/middleware_error/before')
     result = @app.call(env)
-    raise "middleware error" if path =~ /\/middleware_error\/after/
+    raise "middleware error" if path.include?('/middleware_error/after')
     result
   end
 end

--- a/test/multiverse/suites/rails/middlewares.rb
+++ b/test/multiverse/suites/rails/middlewares.rb
@@ -12,9 +12,9 @@ class ErrorMiddleware
 
   def call(env)
     path = ::Rack::Request.new(env).path_info
-    raise "middleware error" if path.match(/\/middleware_error\/before/)
+    raise "middleware error" if path =~ /\/middleware_error\/before/
     result = @app.call(env)
-    raise "middleware error" if path.match(/\/middleware_error\/after/)
+    raise "middleware error" if path =~ /\/middleware_error\/after/
     result
   end
 end

--- a/test/multiverse/suites/rails/view_instrumentation_test.rb
+++ b/test/multiverse/suites/rails/view_instrumentation_test.rb
@@ -86,6 +86,7 @@ end
 
 class ViewInstrumentationTest < ActionDispatch::IntegrationTest
   include MultiverseHelpers
+  RENDERING_OPTIONS = [:js_render, :xml_render, :proc_render, :json_render]
 
   setup_and_teardown_agent do
     # ActiveSupport testing keeps blowing away my subscribers on
@@ -186,8 +187,6 @@ class ViewInstrumentationTest < ActionDispatch::IntegrationTest
       sample = last_transaction_trace
       assert find_node_with_name(sample, "View/foos/_foo.html.haml/Partial")
     end
-
-    RENDERING_OPTIONS = [:js_render, :xml_render, :proc_render, :json_render]
 
     RENDERING_OPTIONS.each do |action|
       define_method("test_should_not_instrument_rendering_of_#{action}") do

--- a/test/multiverse/suites/rails/view_instrumentation_test.rb
+++ b/test/multiverse/suites/rails/view_instrumentation_test.rb
@@ -187,7 +187,9 @@ class ViewInstrumentationTest < ActionDispatch::IntegrationTest
       assert find_node_with_name(sample, "View/foos/_foo.html.haml/Partial")
     end
 
-    [:js_render, :xml_render, :proc_render, :json_render].each do |action|
+    RENDERING_OPTIONS = [:js_render, :xml_render, :proc_render, :json_render]
+
+    RENDERING_OPTIONS.each do |action|
       define_method("test_should_not_instrument_rendering_of_#{action}") do
         get "/views/#{action}"
         sample = last_transaction_trace

--- a/test/multiverse/suites/sinatra/ignoring_test.rb
+++ b/test/multiverse/suites/sinatra/ignoring_test.rb
@@ -60,11 +60,11 @@ class SinatraTestCase < Minitest::Test
   end
 
   def assert_enduser_ignored(response)
-    refute_match(/#{JS_AGENT_LOADER}/, response.body)
+    refute_match(/#{JS_AGENT_LOADER}/o, response.body)
   end
 
   def refute_enduser_ignored(response)
-    assert_match(/#{JS_AGENT_LOADER}/, response.body)
+    assert_match(/#{JS_AGENT_LOADER}/o, response.body)
   end
 
   # Keep Test::Unit happy by specifying at least one test method here

--- a/test/new_relic/agent/agent_test.rb
+++ b/test/new_relic/agent/agent_test.rb
@@ -547,7 +547,7 @@ module NewRelic
             @agent.start
           end
         end
-        logmsg = logdev.array.first.gsub(/\n/, '')
+        logmsg = logdev.array.first.delete("\n")
 
         assert !@agent.started?, "agent was started"
         assert_match(/No application name configured/i, logmsg)

--- a/test/new_relic/agent/configuration/default_source_test.rb
+++ b/test/new_relic/agent/configuration/default_source_test.rb
@@ -218,7 +218,9 @@ module NewRelic::Agent::Configuration
           unspecified_keys << key
         end
 
-        if ![true, false].include?(spec[:allowed_from_server])
+        booleans = [true, false]
+
+        if !booleans.include?(spec[:allowed_from_server])
           bad_value_keys << key
         end
       end

--- a/test/new_relic/agent/configuration/orphan_configuration_test.rb
+++ b/test/new_relic/agent/configuration/orphan_configuration_test.rb
@@ -20,7 +20,7 @@ class OrphanedConfigTest < Minitest::Test
         next unless config_match
 
         config_keys = config_match.captures.map do |key|
-          key.gsub("'", "").to_sym
+          key.delete("'").to_sym
         end
 
         config_keys.each do |key|

--- a/test/new_relic/agent/datastores/redis_test.rb
+++ b/test/new_relic/agent/datastores/redis_test.rb
@@ -85,7 +85,7 @@ class NewRelic::Agent::Datastores::RedisTest < Minitest::Test
   end
 
   def test_format_pipeline_commands_truncates_long_commands
-    pipeline = NewRelic::Agent::Datastores::Redis::MAXIMUM_COMMAND_LENGTH.times.map do
+    pipeline = Array.new(NewRelic::Agent::Datastores::Redis::MAXIMUM_COMMAND_LENGTH) do
       [:set, "0123456789"]
     end
 

--- a/test/new_relic/agent/external_test.rb
+++ b/test/new_relic/agent/external_test.rb
@@ -89,7 +89,7 @@ module NewRelic
           in_transaction do |txn|
             l = with_array_logger { NewRelic::Agent::External.process_request_metadata(rmd) }
             refute_empty l.array, "process_request_metadata should log error on invalid ID"
-            assert l.array.first =~ %r{invalid/non-trusted ID}
+            assert_includes l.array.first, 'invalid/non-trusted ID'
 
             refute txn.distributed_tracer.cross_app_payload
           end
@@ -107,7 +107,7 @@ module NewRelic
           in_transaction do |txn|
             l = with_array_logger { NewRelic::Agent::External.process_request_metadata(rmd) }
             refute_empty l.array, "process_request_metadata should log error on invalid ID"
-            assert l.array.first =~ %r{invalid/non-trusted ID}
+            assert_includes l.array.first, 'invalid/non-trusted ID'
 
             refute txn.distributed_tracer.cross_app_payload
           end

--- a/test/new_relic/agent/instrumentation/middleware_proxy_test.rb
+++ b/test/new_relic/agent/instrumentation/middleware_proxy_test.rb
@@ -41,7 +41,7 @@ class NewRelic::Agent::Instrumentation::MiddlewareProxyTest < Minitest::Test
 
       def initialize(*args, &blk)
         @initialize_args = args
-        blk.call
+        yield
       end
     end
 

--- a/test/new_relic/agent/javascript_instrumentor_test.rb
+++ b/test/new_relic/agent/javascript_instrumentor_test.rb
@@ -330,7 +330,7 @@ class NewRelic::Agent::JavascriptInstrumentorTest < Minitest::Test
   end
 
   def pack(text)
-    [text].pack("m0").gsub("\n", "")
+    [text].pack("m0").delete("\n")
   end
 
   def unpack_to_object(text)

--- a/test/new_relic/agent/messaging_test.rb
+++ b/test/new_relic/agent/messaging_test.rb
@@ -179,7 +179,7 @@ module NewRelic
         transaction_event = last_transaction_event
         assert Array === transaction_event, "expected Array, actual: #{transaction_event.class}"
         assert_equal 3, transaction_event.length, "expected Array of 3 elements, actual: #{transaction_event.length}"
-        assert transaction_event.all? { |e| Hash === e }, "expected Array of 3 hashes, actual: [#{transaction_event.map(&:class).join(',')}]"
+        assert transaction_event.all?(Hash), "expected Array of 3 hashes, actual: [#{transaction_event.map(&:class).join(',')}]"
         assert transaction_event[2].key?(:'message.routingKey'), "expected transaction event attributes to have key :'message.routingKey', actual: #{transaction_event[2].keys.join(',')}"
         assert_equal "red", transaction_event[2][:'message.routingKey']
 

--- a/test/new_relic/agent/messaging_test.rb
+++ b/test/new_relic/agent/messaging_test.rb
@@ -179,7 +179,9 @@ module NewRelic
         transaction_event = last_transaction_event
         assert Array === transaction_event, "expected Array, actual: #{transaction_event.class}"
         assert_equal 3, transaction_event.length, "expected Array of 3 elements, actual: #{transaction_event.length}"
-        assert transaction_event.all?(Hash), "expected Array of 3 hashes, actual: [#{transaction_event.map(&:class).join(',')}]"
+        # rubocop:disable Performance/RedundantEqualityComparisonBlock
+        assert transaction_event.all? { |e| Hash === e }, "expected Array of 3 hashes, actual: [#{transaction_event.map(&:class).join(',')}]"
+        # rubocop:enable Performance/RedundantEqualityComparisonBlock
         assert transaction_event[2].key?(:'message.routingKey'), "expected transaction event attributes to have key :'message.routingKey', actual: #{transaction_event[2].keys.join(',')}"
         assert_equal "red", transaction_event[2][:'message.routingKey']
 

--- a/test/new_relic/agent/obfuscator_test.rb
+++ b/test/new_relic/agent/obfuscator_test.rb
@@ -71,6 +71,6 @@ class NewRelic::Agent::ObfuscatorTest < Minitest::Test
     assert_equal(expected, output)
 
     unoutput = obfuscator.obfuscate(Base64.decode64(output))
-    assert_equal Base64.encode64(text).gsub("\n", ''), unoutput
+    assert_equal Base64.encode64(text).delete("\n"), unoutput
   end
 end

--- a/test/new_relic/agent/pipe_service_test.rb
+++ b/test/new_relic/agent/pipe_service_test.rb
@@ -152,7 +152,7 @@ class PipeServiceTest < Minitest::Test
     data = {}
     while payload = pipe.read
       endpoint, data_for_endpoint = Marshal.load(payload)
-      data.merge!(endpoint => data_for_endpoint)
+      data[endpoint] = data_for_endpoint
     end
     data
   end

--- a/test/new_relic/agent/samplers/memory_sampler_test.rb
+++ b/test/new_relic/agent/samplers/memory_sampler_test.rb
@@ -23,7 +23,7 @@ class NewRelic::Agent::Samplers::MemorySamplerTest < Minitest::Test
   end
 
   def test_memory__linux
-    return if RUBY_PLATFORM =~ /darwin/
+    return if RUBY_PLATFORM.include?('darwin')
     NewRelic::Agent::Samplers::MemorySampler.any_instance.stubs(:platform).returns('linux')
     stub_sampler_get_memory
     s = NewRelic::Agent::Samplers::MemorySampler.new

--- a/test/new_relic/agent/system_info_test.rb
+++ b/test/new_relic/agent/system_info_test.rb
@@ -47,7 +47,7 @@ class NewRelic::Agent::SystemInfoTest < Minitest::Test
           assert_equal num_logical_processors, info[:num_logical_processors]
         end
       end
-    elsif File.basename(file) =~ /malformed/
+    elsif File.basename(file).include?('malformed')
       define_method("test_#{File.basename(file)}") do
         cpuinfo = File.read(file)
         info = @sysinfo.parse_cpuinfo(cpuinfo)

--- a/test/new_relic/agent/threading/agent_thread_test.rb
+++ b/test/new_relic/agent/threading/agent_thread_test.rb
@@ -124,7 +124,7 @@ module NewRelic::Agent::Threading
         report_on_exception_original_value = Thread.report_on_exception
         Thread.report_on_exception = false
       end
-      blk.call
+      yield
       if Thread.respond_to?(:report_on_exception)
         Thread.report_on_exception = report_on_exception_original_value
       end

--- a/test/new_relic/agent/threading/fake_thread.rb
+++ b/test/new_relic/agent/threading/fake_thread.rb
@@ -8,7 +8,7 @@ class FakeThread
 
   def initialize(locals = {}, &block)
     @locals = locals
-    yield if block_given?
+    yield if block
   end
 
   def self.current

--- a/test/new_relic/agent/tracer_state_test.rb
+++ b/test/new_relic/agent/tracer_state_test.rb
@@ -57,7 +57,8 @@ module NewRelic::Agent
 
       variables.each do |ivar|
         value = state.instance_variable_get(ivar)
-        assert [0, nil, false, []].include?(value),
+        empties = [0, nil, false, []]
+        assert empties.include?(value),
           "Expected #{ivar} to reset, but was #{value}"
       end
     end

--- a/test/new_relic/agent/transaction/external_request_segment_test.rb
+++ b/test/new_relic/agent/transaction/external_request_segment_test.rb
@@ -696,7 +696,7 @@ module NewRelic::Agent
               segment = external_request_segment { |s| s.process_response_metadata(rmd); s }
             end
             refute_empty l.array, "process_response_metadata should log error on invalid ID"
-            assert l.array.first =~ %r{invalid/non-trusted ID}
+            assert_includes l.array.first, 'invalid/non-trusted ID'
 
             assert_equal 'External/example.com/foo/get', segment.name
           end
@@ -722,7 +722,7 @@ module NewRelic::Agent
               segment = external_request_segment { |s| s.process_response_metadata(rmd); s }
             end
             refute_empty l.array, "process_response_metadata should log error on invalid ID"
-            assert l.array.first =~ %r{invalid/non-trusted ID}
+            assert_includes l.array.first, 'invalid/non-trusted ID'
 
             assert_equal 'External/example.com/foo/get', segment.name
           end

--- a/test/new_relic/agent/transaction_time_aggregator_test.rb
+++ b/test/new_relic/agent/transaction_time_aggregator_test.rb
@@ -116,7 +116,7 @@ class NewRelic::Agent::TransctionTimeAggregatorTest < Minitest::Test
     stats = NewRelic::Agent::TransactionTimeAggregator.instance_variable_get(:@stats)
 
     t0 = Process.clock_gettime(Process::CLOCK_REALTIME)
-    workers = 100.times.map do
+    workers = Array.new(100) do
       Thread.new do
         ::NewRelic::Agent::TransactionTimeAggregator.transaction_start(t0 + 15)
         # thread dies before transaction completes

--- a/test/new_relic/agent/utilization/aws_test.rb
+++ b/test/new_relic/agent/utilization/aws_test.rb
@@ -84,7 +84,7 @@ module NewRelic
         load_cross_agent_test("utilization_vendor_specific/aws").each do |test_case|
           test_case = symbolize_keys_in_object(test_case)
 
-          define_method("test_#{test_case[:testname]}".gsub(" ", "_")) do
+          define_method("test_#{test_case[:testname]}".tr(" ", "_")) do
             NewRelic::Agent::Utilization::AWS.stubs(:imds_token).returns('John Howe')
             uri_obj_key = test_case[:uri].keys.detect do |key|
               key =~ %r{http://169.254.169.254/(?:2016-09-02|latest)/dynamic/instance-identity/document}

--- a/test/new_relic/agent/utilization/azure_test.rb
+++ b/test/new_relic/agent/utilization/azure_test.rb
@@ -78,7 +78,7 @@ module NewRelic
         load_cross_agent_test("utilization_vendor_specific/azure").each do |test_case|
           test_case = symbolize_keys_in_object(test_case)
 
-          define_method("test_#{test_case[:testname]}".gsub(" ", "_")) do
+          define_method("test_#{test_case[:testname]}".tr(" ", "_")) do
             uri_obj = test_case[:uri][:'http://169.254.169.254/metadata/instance/compute?api-version=2017-03-01']
             if uri_obj[:timeout]
               @vendor.stubs(:request_metadata).returns(nil)

--- a/test/new_relic/agent/utilization/gcp_test.rb
+++ b/test/new_relic/agent/utilization/gcp_test.rb
@@ -78,7 +78,7 @@ module NewRelic
         load_cross_agent_test("utilization_vendor_specific/gcp").each do |test_case|
           test_case = symbolize_keys_in_object(test_case)
 
-          define_method("test_#{test_case[:testname]}".gsub(" ", "_")) do
+          define_method("test_#{test_case[:testname]}".tr(" ", "_")) do
             uri_obj = test_case[:uri][:'http://metadata.google.internal/computeMetadata/v1/instance/?recursive=true']
             if uri_obj[:timeout]
               @vendor.stubs(:request_metadata).returns(nil)

--- a/test/new_relic/agent/utilization/pcf_test.rb
+++ b/test/new_relic/agent/utilization/pcf_test.rb
@@ -54,7 +54,7 @@ module NewRelic
 
         def with_pcf_env(vars, &blk)
           vars.each_pair { |k, v| ENV[k] = v }
-          blk.call
+          yield
           vars.keys.each { |k| ENV.delete(k) }
         end
 
@@ -63,7 +63,7 @@ module NewRelic
         load_cross_agent_test("utilization_vendor_specific/pcf").each do |test_case|
           test_case = symbolize_keys_in_object(test_case)
 
-          define_method("test_#{test_case[:testname]}".gsub(" ", "_")) do
+          define_method("test_#{test_case[:testname]}".tr(" ", "_")) do
             timeout = false
             pcf_env = test_case[:env_vars].reduce({}) do |h, (k, v)|
               h[k.to_s] = v[:response] if v[:response]

--- a/test/new_relic/agent/utilization_data_test.rb
+++ b/test/new_relic/agent/utilization_data_test.rb
@@ -327,7 +327,7 @@ module NewRelic::Agent
 
     def with_pcf_env(vars, &blk)
       vars.each_pair { |k, v| ENV[k] = v }
-      blk.call
+      yield
       vars.keys.each { |k| ENV.delete(k) }
     end
 

--- a/test/new_relic/agent/utilization_data_test.rb
+++ b/test/new_relic/agent/utilization_data_test.rb
@@ -349,7 +349,7 @@ module NewRelic::Agent
 
         # additionally, boot_id will be picked up on linux/inside docker containers. so let's
         # add the local boot_id to the expected hash on linux.
-        if RbConfig::CONFIG['host_os'] =~ /linux/
+        if RbConfig::CONFIG['host_os'].include?('linux')
           refute test_case[:expected_output_json][:boot_id]
           test_case[:expected_output_json][:boot_id] = NewRelic::Agent::SystemInfo.proc_try_read('/proc/sys/kernel/random/boot_id').chomp
         end

--- a/test/new_relic/fake_collector.rb
+++ b/test/new_relic/fake_collector.rb
@@ -124,7 +124,7 @@ module NewRelic
       uri = URI.parse(req.url)
       method = method_from_request(req)
 
-      if @mock.keys.include?(method)
+      if @mock.key?(method)
         status, body = @mock[method].evaluate
         res.status = status
         res.write(::JSON.dump(body))

--- a/test/new_relic/framework_test.rb
+++ b/test/new_relic/framework_test.rb
@@ -37,7 +37,9 @@ class FrameworkTest < Minitest::Test
 
     # does the path match "rails\d" (ex: rails7) or "railsedge"?
     if ENV['BUNDLE_GEMFILE'] =~ /rails(?:\d|edge)/
-      assert_truthy NewRelic::Agent.config[:framework].include?('rails')
+      # rubocop:disable Performance/StringInclude
+      assert_truthy NewRelic::Agent.config[:framework].match(/rails/)
+      # rubocop:enable Performance/StringInclude
     else
       assert_equal :sinatra, NewRelic::Agent.config[:framework]
     end

--- a/test/new_relic/framework_test.rb
+++ b/test/new_relic/framework_test.rb
@@ -36,7 +36,7 @@ class FrameworkTest < Minitest::Test
     end
 
     # does the path match "rails\d" (ex: rails7) or "railsedge"?
-    if ENV['BUNDLE_GEMFILE'].match(/rails(?:\d|edge)/)
+    if ENV['BUNDLE_GEMFILE'] =~ /rails(?:\d|edge)/
       assert_truthy NewRelic::Agent.config[:framework].match(/rails/)
     else
       assert_equal :sinatra, NewRelic::Agent.config[:framework]

--- a/test/new_relic/framework_test.rb
+++ b/test/new_relic/framework_test.rb
@@ -37,7 +37,7 @@ class FrameworkTest < Minitest::Test
 
     # does the path match "rails\d" (ex: rails7) or "railsedge"?
     if ENV['BUNDLE_GEMFILE'] =~ /rails(?:\d|edge)/
-      assert_truthy NewRelic::Agent.config[:framework].match(/rails/)
+      assert_truthy NewRelic::Agent.config[:framework].include?('rails')
     else
       assert_equal :sinatra, NewRelic::Agent.config[:framework]
     end

--- a/test/new_relic/http_client_test_cases.rb
+++ b/test/new_relic/http_client_test_cases.rb
@@ -633,7 +633,7 @@ module HttpClientTestCases
   end
 
   def http_header_name_to_rack_key(name)
-    "HTTP_" + name.upcase.gsub('-', '_')
+    "HTTP_" + name.upcase.tr('-', '_')
   end
 
   def make_app_data_payload(*args)

--- a/test/new_relic/http_client_test_cases.rb
+++ b/test/new_relic/http_client_test_cases.rb
@@ -295,7 +295,7 @@ module HttpClientTestCases
 
   def test_agent_doesnt_add_a_request_header_to_outgoing_requests_if_xp_disabled
     in_transaction { get_response }
-    assert_equal false, server.requests.last.keys.any? { |k| k =~ /NEWRELIC_ID/ }
+    assert_equal false, server.requests.last.keys.any? { |k| k.include?('NEWRELIC_ID') }
   end
 
   def test_agent_doesnt_add_a_request_header_if_empty_cross_process_id
@@ -303,7 +303,7 @@ module HttpClientTestCases
       :'distributed_tracing.enabled' => false,
       :cross_process_id => "") do
       in_transaction { get_response }
-      assert_equal false, server.requests.last.keys.any? { |k| k =~ /NEWRELIC_ID/ }
+      assert_equal false, server.requests.last.keys.any? { |k| k.include?('NEWRELIC_ID') }
     end
   end
 
@@ -314,7 +314,7 @@ module HttpClientTestCases
       :encoding_key => ""
     ) do
       in_transaction { get_response }
-      assert_equal false, server.requests.last.keys.any? { |k| k =~ /NEWRELIC_ID/ }
+      assert_equal false, server.requests.last.keys.any? { |k| k.include?('NEWRELIC_ID') }
     end
   end
 

--- a/test/new_relic/marshalling_test_cases.rb
+++ b/test/new_relic/marshalling_test_cases.rb
@@ -207,10 +207,10 @@ module MarshallingTestCases
   def with_around_hook(&blk)
     if respond_to?(:around_each)
       around_each do
-        blk.call
+        yield
       end
     else
-      blk.call
+      yield
     end
 
     if respond_to?(:after_each)

--- a/test/new_relic/multiverse_helpers.rb
+++ b/test/new_relic/multiverse_helpers.rb
@@ -51,7 +51,7 @@ module MultiverseHelpers
     # Give caller a shot to setup before we start
     # Don't just yield, as that won't necessarily have the intended receiver
     # (the test case instance itself)
-    self.instance_exec($collector, &block) if block_given? && self.respond_to?(:instance_exec)
+    self.instance_exec($collector, &block) if block && self.respond_to?(:instance_exec)
 
     # It's important that this be called after the instance_exec above, so that
     # test cases have the chance to change settings on the fake collector first
@@ -93,7 +93,7 @@ module MultiverseHelpers
 
   def run_agent(options = {}, &block)
     setup_agent(options)
-    yield if block_given?
+    yield if block
     teardown_agent
   end
 

--- a/test/new_relic/rack/browser_monitoring_test.rb
+++ b/test/new_relic/rack/browser_monitoring_test.rb
@@ -133,7 +133,7 @@ if defined?(::Rack::Test)
     RUM_PLACEHOLDER = "EXPECTED_RUM_LOADER_LOCATION"
 
     source_files.each do |source_file|
-      source_filename = File.basename(source_file).gsub(".", "_")
+      source_filename = File.basename(source_file).tr(".", "_")
       instrumented_html = File.read(source_file)
       uninstrumented_html = instrumented_html.gsub(RUM_PLACEHOLDER, '')
 

--- a/test/performance/lib/performance/runner.rb
+++ b/test/performance/lib/performance/runner.rb
@@ -70,7 +70,7 @@ module Performance
         end
       end
       test_case.on(:after_each) do |test, test_name, result|
-        instrumentors.reverse.each { |i| i.after(test, test_name) }
+        instrumentors.reverse_each { |i| i.after(test, test_name) }
         instrumentors.each do |i|
           result.measurements.merge!(i.results)
           result.artifacts.concat(i.artifacts)

--- a/test/performance/suites/agent_attributes.rb
+++ b/test/performance/suites/agent_attributes.rb
@@ -45,8 +45,8 @@ class AgentAttributesTests < Performance::TestCase
   end
 
   def test_with_tons_o_rules
-    with_config(:'attributes.include' => 100.times.map { fake_guid(32) },
-      :'attributes.exclude' => 100.times.map { fake_guid(32) }) do
+    with_config(:'attributes.include' => Array.new(100) { fake_guid(32) },
+      :'attributes.exclude' => Array.new(100) { fake_guid(32) }) do
       @filter = NewRelic::Agent::AttributeFilter.new(NewRelic::Agent.config)
 
       measure do

--- a/test/performance/suites/marshalling.rb
+++ b/test/performance/suites/marshalling.rb
@@ -61,7 +61,7 @@ class Marshalling < Performance::TestCase
   def each_string(object, &blk)
     case object
     when String
-      blk.call(object)
+      yield(object)
     when Array
       object.map! { |x| each_string(x, &blk) }
     when Hash

--- a/test/performance/suites/marshalling.rb
+++ b/test/performance/suites/marshalling.rb
@@ -74,7 +74,7 @@ class Marshalling < Performance::TestCase
   BYTE_ALPHABET = (0..255).to_a.freeze
 
   def generate_random_string(length)
-    length.times.map { BYTE_ALPHABET.sample }.pack('C*')
+    Array.new(length) { BYTE_ALPHABET.sample }.pack('C*')
   end
 
   def convert_strings_to_binary(object)

--- a/test/performance/suites/thread_profiling.rb
+++ b/test/performance/suites/thread_profiling.rb
@@ -60,7 +60,7 @@ class ThreadProfiling < Performance::TestCase
     @threads.each(&:join)
     mocha_teardown
   rescue Exception => e
-    if e.message =~ /Deadlock/
+    if e.message.include?('Deadlock')
       Thread.list.select(&:alive?).each do |t|
         STDERR.puts "*" * 80
         STDERR.puts "Live thread: #{t.inspect}"


### PR DESCRIPTION
# Overview

This PR turns on RuboCop Performance linters that are compatible with the Rubies we support and represent a very small amount of effort to resolve. Linters incompatible with the Rubies we support have been marked with TODOs and the minimum supported Ruby version.

Submitter Checklist:
- [ ] Include a link to the related GitHub issue, if applicable
- [ ] Include a security review link, if applicable

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
Github Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
