### PR TITLE
CI: add a 'method' filter

### DIFF
--- a/test/multiverse/README.md
+++ b/test/multiverse/README.md
@@ -106,6 +106,9 @@ You can pass these additional parameters to the test:multiverse rake task to con
 - `name=` only tests with names matching string will be executed
 - `env=` only the Nth environment will be executed (may be specified multiple times)
 - `file=` only tests in specified file will be executed
+    NOTE: the given string will be fuzzily matched against relative paths below the suite name
+          ex: "file=instrumentation" to match `test/multiverse/suites/redis/redis_instrumentation_test.rb`
+- `method=` only tests for the specified method ("chain" or "prepend") will be executed
 - `debug` environments for each suite will be executed in serial rather than parallel (the default), and the pry gem will be automatically included, so that you can use it to help debug tests.
 
 ```

--- a/test/multiverse/lib/multiverse/runner.rb
+++ b/test/multiverse/lib/multiverse/runner.rb
@@ -49,6 +49,10 @@ module Multiverse
       execute_suites(filter, opts) do |suite|
         puts yellow(suite.execution_message)
         suite.each_instrumentation_method do |method|
+          if opts.key?(:method) && method != opts[:method]
+            puts "Skipping method '#{method}' while focusing only on '#{opts[:method]}'"
+            next
+          end
           suite.execute(method)
         end
       end


### PR DESCRIPTION
when performing multiverse tests, one can now specify a 'method' filter

ex: `bundle exec rake test:multiverse[rake,method=prepend]`