### PR TITLE
CI: skip MiniTest v5 syntax under MiniTest v4

### DIFF
--- a/test/multiverse/suites/rack/rack_builder_test.rb
+++ b/test/multiverse/suites/rack/rack_builder_test.rb
@@ -87,8 +87,7 @@ class RackBuilderTest < Minitest::Test
   end
 
   def test_run_with_tracing
-    # TODO: OLD RUBIES - RUBY_VERSION < 2.3
-    skip 'Requires Ruby 2.3+' unless RUBY_VERSION >= '2.3.0'
+    skip 'Requires MiniTest v5+' unless MiniTest::Unit::VERSION > '5.0'
 
     instance = TestBuilderClass.new
     app = :the_app
@@ -109,8 +108,7 @@ class RackBuilderTest < Minitest::Test
   end
 
   def test_use_with_tracing
-    # TODO: OLD RUBIES - RUBY_VERSION < 2.3
-    skip 'Requires Ruby 2.3+' unless RUBY_VERSION >= '2.3.0'
+    skip 'Requires MiniTest v5+' unless MiniTest::Unit::VERSION > '5.0'
 
     instance = TestBuilderClass.new
     def instance.middleware_instrumentation_enabled?; true; end
@@ -135,8 +133,7 @@ class RackBuilderTest < Minitest::Test
   end
 
   def test_generate_traced_map
-    # TODO: OLD RUBIES - RUBY_VERSION < 2.3
-    skip 'Requires Ruby 2.3+' unless RUBY_VERSION >= '2.3.0'
+    skip 'Requires MiniTest v5+' unless MiniTest::Unit::VERSION > '5.0'
 
     url = :url
     handler = 'handler'

--- a/test/multiverse/suites/rake/instrumentation_test.rb
+++ b/test/multiverse/suites/rake/instrumentation_test.rb
@@ -15,6 +15,8 @@ class RakeInstrumentationTest < Minitest::Test
   class ErrorClass < StandardError; end
 
   def test_invoke_with_newrelic_tracing_happy_path
+    skip 'Requires MiniTest v5+' unless MiniTest::Unit::VERSION > '5.0'
+
     instance = TesterClass.new
     instance_mock = MiniTest::Mock.new
     with_config('rake.connect_timeout': instance.timeout) do
@@ -35,6 +37,8 @@ class RakeInstrumentationTest < Minitest::Test
   end
 
   def test_invoke_with_newrelic_tracing_when_tracing_is_disabled
+    skip 'Requires MiniTest v5+' unless MiniTest::Unit::VERSION > '5.0'
+
     instance = TesterClass.new
     NewRelic::Agent::Instrumentation::Rake.stub :should_trace?, false, [instance.name] do
       # make absolutely sure the .config call is not being made
@@ -46,6 +50,8 @@ class RakeInstrumentationTest < Minitest::Test
   end
 
   def test_invoke_with_tracing_with_exception
+    skip 'Requires MiniTest v5+' unless MiniTest::Unit::VERSION > '5.0'
+
     instance = TesterClass.new
     NewRelic::Agent::Instrumentation::Rake.stub :should_trace?, true, [instance.name] do
       error = RuntimeError.new('expected')
@@ -62,12 +68,16 @@ class RakeInstrumentationTest < Minitest::Test
   end
 
   def test_we_should_install_if_newrelic_rake_is_absent
+    skip 'Requires MiniTest v5+' unless MiniTest::Unit::VERSION > '5.0'
+
     NewRelic::LanguageSupport.stub :bundled_gem?, false, 'newrelic-rake' do
       assert NewRelic::Agent::Instrumentation::Rake.should_install?
     end
   end
 
   def test_we_should_not_install_if_newrelic_rake_is_present
+    skip 'Requires MiniTest v5+' unless MiniTest::Unit::VERSION > '5.0'
+
     NewRelic::LanguageSupport.stub :bundled_gem?, true, 'newrelic-rake' do
       refute NewRelic::Agent::Instrumentation::Rake.should_install?
     end
@@ -86,6 +96,8 @@ class RakeInstrumentationTest < Minitest::Test
   end
 
   def test_a_task_is_monkeypatched_for_executation_instrumentation
+    skip 'Requires MiniTest v5+' unless MiniTest::Unit::VERSION > '5.0'
+
     name = 'Call the Ships to Port'
     task = OpenStruct.new
     task.name = name
@@ -190,6 +202,8 @@ class RakeInstrumentationTest < Minitest::Test
   end
 
   def test_record_attributes_without_named_args
+    skip 'Requires MiniTest v5+' unless MiniTest::Unit::VERSION > '5.0'
+
     top_level_tasks = %w[James Meowth]
     named_args = []
     task = OpenStruct.new(application: OpenStruct.new(top_level_tasks: top_level_tasks),


### PR DESCRIPTION
until we figure out how to get the entirety of our CI suite into the year 2013, skip the use of MiniTest's v5's 3 argument `stub` method when running tests under old MiniTest versions