### PR TITLE
Enable rubocop style/commentannotation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1098,9 +1098,6 @@ Style/CommandLiteral:
   # EnforcedStyle: mixed
   # AllowInnerBackticks: false
 
-Style/CommentAnnotation:
-  Enabled: false
-
 Style/CommentedKeyword:
   Enabled: false
 

--- a/lib/new_relic/agent/instrumentation/memcache.rb
+++ b/lib/new_relic/agent/instrumentation/memcache.rb
@@ -2,8 +2,8 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
-# NOTE: there are multiple implementations of the MemCache client in Ruby,
-# each with slightly different API's and semantics.
+# NOTE: there are multiple implementations of the Memcached client in Ruby,
+# each with slightly different APIs and semantics.
 # See:
 #     http://www.deveiate.org/code/Ruby-MemCache/ (Gem: Ruby-MemCache)
 #     http://seattlerb.rubyforge.org/memcache-client/ (Gem: memcache-client)

--- a/lib/new_relic/agent/instrumentation/memcache.rb
+++ b/lib/new_relic/agent/instrumentation/memcache.rb
@@ -2,7 +2,7 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
-# NOTE there are multiple implementations of the MemCache client in Ruby,
+# NOTE: there are multiple implementations of the MemCache client in Ruby,
 # each with slightly different API's and semantics.
 # See:
 #     http://www.deveiate.org/code/Ruby-MemCache/ (Gem: Ruby-MemCache)

--- a/lib/new_relic/agent/new_relic_service.rb
+++ b/lib/new_relic/agent/new_relic_service.rb
@@ -643,7 +643,7 @@ module NewRelic
       # that may cause corrupt compression if there is a problem.
       def user_agent
         if defined?(::RUBY_VERSION) && defined?(::RUBY_PLATFORM)
-          ruby_description = "(ruby #{::RUBY_VERSION} #{::RUBY_PLATFORM}) " # note the trailing space!
+          ruby_description = "(ruby #{::RUBY_VERSION} #{::RUBY_PLATFORM}) " # NOTE: the trailing space!
         end
         zlib_version = "zlib/#{Zlib.zlib_version}" if defined?(::Zlib) && Zlib.respond_to?(:zlib_version)
         "NewRelic-RubyAgent/#{NewRelic::VERSION::STRING} #{ruby_description}#{zlib_version}"

--- a/lib/new_relic/collection_helper.rb
+++ b/lib/new_relic/collection_helper.rb
@@ -11,7 +11,7 @@ module NewRelic
     def normalize_params(params)
       case params
         when Hash
-          # optimize for empty hash since that is often what this is called with.
+          # Optimize for empty hash since that is often what this is called with.
           return params if params.empty?
           new_params = {}
           params.each do |key, value|

--- a/test/new_relic/agent/tracer_test.rb
+++ b/test/new_relic/agent/tracer_test.rb
@@ -174,7 +174,7 @@ module NewRelic
             category: :middleware
           )
 
-          # todo: Implement current_segment on Tracer
+          # TODO: Implement current_segment on Tracer
           assert_equal finishable, Tracer.current_transaction.current_segment
 
           finishable.finish

--- a/test/new_relic/agent/transaction_test.rb
+++ b/test/new_relic/agent/transaction_test.rb
@@ -30,7 +30,7 @@ module NewRelic::Agent
       end
     end
 
-    # note: technically this shouldn't happen if the request we are dealing with is
+    # NOTE: technically this shouldn't happen if the request we are dealing with is
     # a Rack::Request (or subclass such as ActionDispatch::Request or the old
     # ActionController::AbstractRequest)
     def test_request_with_path_with_query_string

--- a/test/performance/suites/active_record_subscriber.rb
+++ b/test/performance/suites/active_record_subscriber.rb
@@ -4,7 +4,7 @@
 
 require 'new_relic/agent/instrumentation/active_record_subscriber'
 
-# Note: This test was cobbled together from the AR Subscriber Unit Test and
+# NOTE: This test was cobbled together from the AR Subscriber Unit Test and
 # by cut & paste of ActiveSupport::Notifcations::Event from Rails source.
 # This test is here because it's useful, not because it's well written.
 # If you have a desire to improve this test, do it!


### PR DESCRIPTION
Enable rubocop's `style/commentannotation` and address errors. Documentation on this cop [lives here](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/CommentAnnotation) and is enabled `true` by default.

Closes #998

_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
Describe the changes present in the pull request

Submitter Checklist:
- [ ] Include a link to the related GitHub issue, if applicable
- [ ] Include a security review link, if applicable

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
Github Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
