### PR TITLE
Address Minitest/AssertEmptyLiteral

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -20,11 +20,6 @@ Layout/EmptyLinesAroundBlockBody:
 Metrics/AbcSize:
   Max: 82
 
-# Offense count: 52
-# This cop supports safe autocorrection (--autocorrect).
-Minitest/AssertEmptyLiteral:
-  Enabled: false
-
 # Offense count: 13
 # This cop supports safe autocorrection (--autocorrect).
 Minitest/AssertEqual:

--- a/test/agent_helper.rb
+++ b/test/agent_helper.rb
@@ -314,7 +314,7 @@ def assert_metrics_not_recorded(not_expected)
       found_but_not_expected << spec
     end
   end
-  assert_equal([], found_but_not_expected, "Found unexpected metrics: #{format_metric_spec_list(found_but_not_expected)}")
+  assert_empty(found_but_not_expected, "Found unexpected metrics: #{format_metric_spec_list(found_but_not_expected)}")
 end
 
 alias :refute_metrics_recorded :assert_metrics_not_recorded
@@ -325,8 +325,7 @@ def assert_no_metrics_match(regex)
     matching_metrics << metric if metric.match(regex)
   end
 
-  assert_equal(
-    [],
+  assert_empty(
     matching_metrics,
     "Found unexpected metrics:\n" + matching_metrics.map { |m| "  '#{m}'" }.join("\n") + "\n\n"
   )

--- a/test/multiverse/suites/agent_only/error_events_test.rb
+++ b/test/multiverse/suites/agent_only/error_events_test.rb
@@ -113,7 +113,7 @@ class ErrorEventsTest < Minitest::Test
 
     _, custom_attributes, _ = last_error_event
 
-    assert_equal({}, custom_attributes)
+    assert_empty(custom_attributes)
   end
 
   def test_error_events_outside_txn_abide_by_custom_attributes_config
@@ -125,7 +125,7 @@ class ErrorEventsTest < Minitest::Test
 
     _, custom_attributes, _ = last_error_event
 
-    assert_equal({}, custom_attributes)
+    assert_empty(custom_attributes)
   end
 
   def generate_errors(num_errors = 1, options = {})

--- a/test/multiverse/suites/agent_only/transaction_events_test.rb
+++ b/test/multiverse/suites/agent_only/transaction_events_test.rb
@@ -40,7 +40,7 @@ class TransactionEventsTest < Minitest::Test
 
     _, custom_attributes, _ = last_transaction_event
 
-    assert_equal({}, custom_attributes)
+    assert_empty(custom_attributes)
   end
 
   def last_transaction_event

--- a/test/multiverse/suites/rails/parameter_capture_test.rb
+++ b/test/multiverse/suites/rails/parameter_capture_test.rb
@@ -43,7 +43,7 @@ class ParameterCaptureTest < ActionDispatch::IntegrationTest
     with_config(:capture_params => false) do
       get('/parameter_capture/transaction?other=1234&secret=4567')
     end
-    assert_equal({}, last_transaction_trace_request_params)
+    assert_empty(last_transaction_trace_request_params)
   end
 
   def test_uri_on_traced_errors_never_contains_query_string_without_capture_params
@@ -147,7 +147,7 @@ class ParameterCaptureTest < ActionDispatch::IntegrationTest
       get('/middleware_error/before?other=1234&secret=4567')
     end
 
-    assert_equal({}, last_transaction_trace_request_params)
+    assert_empty(last_transaction_trace_request_params)
   end
 
   def test_no_params_captured_on_error_when_bails_before_rails_even_when_enabled
@@ -161,7 +161,7 @@ class ParameterCaptureTest < ActionDispatch::IntegrationTest
     with_config(:capture_params => true) do
       get('/middleware_error/before?other=1234&secret=4567')
     end
-    assert_equal({}, last_transaction_trace_request_params)
+    assert_empty(last_transaction_trace_request_params)
   end
 
   def test_uri_on_tt_should_not_contain_query_string_with_capture_params_off

--- a/test/multiverse/suites/sequel/sequel_plugin_test.rb
+++ b/test/multiverse/suites/sequel/sequel_plugin_test.rb
@@ -192,7 +192,7 @@ if Sequel.const_defined?(:MAJOR) &&
           model_class[11]
         end
         assert_match %r{select \* from `posts` where `id` = 11}i, node.params[:sql]
-        assert_equal([], node.params[:explain_plan], "Should not capture explain plan with single-threaded connection pool")
+        assert_empty(node.params[:explain_plan], "Should not capture explain plan with single-threaded connection pool")
       end
     end
 

--- a/test/new_relic/agent/agent/connect_test.rb
+++ b/test/new_relic/agent/agent/connect_test.rb
@@ -213,7 +213,7 @@ class NewRelic::Agent::Agent::ConnectTest < Minitest::Test
 
   def test_environment_for_connect_negative
     with_config(:send_environment_info => false) do
-      assert_equal [], environment_for_connect
+      assert_empty(environment_for_connect)
     end
   end
 

--- a/test/new_relic/agent/attribute_processing_test.rb
+++ b/test/new_relic/agent/attribute_processing_test.rb
@@ -124,9 +124,7 @@ class AttributeProcessingTest < Minitest::Test
   end
 
   def test_flatten_and_coerce_turns_nan_or_infinity_into_null_and_then_dropped
-    assert_equal(
-      {
-      },
+    assert_empty(
       NewRelic::Agent::AttributeProcessing.flatten_and_coerce(
         {
           'nan' => Float::NAN,

--- a/test/new_relic/agent/commands/agent_command_router_test.rb
+++ b/test/new_relic/agent/commands/agent_command_router_test.rb
@@ -117,14 +117,14 @@ class AgentCommandRouterTest < Minitest::Test
 
     def test_harvest_not_started
       result = agent_commands.harvest!
-      assert_equal([], result)
+      assert_empty(result)
     end
 
     def test_harvest_with_profile_in_progress
       start_profile('duration' => 1.0)
 
       result = agent_commands.harvest!
-      assert_equal([], result)
+      assert_empty(result)
     end
 
     def test_harvest_with_profile_completed

--- a/test/new_relic/agent/configuration/manager_test.rb
+++ b/test/new_relic/agent/configuration/manager_test.rb
@@ -409,7 +409,7 @@ module NewRelic::Agent::Configuration
       @manager.stubs(:transform_from_default).returns(bomb)
 
       with_config(:'rules.ignore_url_regexes' => 'boom') do
-        assert_equal [], @manager.fetch(:'rules.ignore_url_regexes')
+        assert_empty(@manager.fetch(:'rules.ignore_url_regexes'))
       end
     end
 

--- a/test/new_relic/agent/configuration/security_policy_source_test.rb
+++ b/test/new_relic/agent/configuration/security_policy_source_test.rb
@@ -70,13 +70,13 @@ module NewRelic
             :'transaction_segments.attributes.include'   => ['sql_statement']) do
             source = SecurityPolicySource.new(policies)
 
-            assert_equal [], source[:'attributes.include']
-            assert_equal [], source[:'transaction_tracer.attributes.include']
-            assert_equal [], source[:'transaction_events.attributes.include']
-            assert_equal [], source[:'error_collector.attributes.include']
-            assert_equal [], source[:'browser_monitoring.attributes.include']
-            assert_equal [], source[:'span_events.attributes.include']
-            assert_equal [], source[:'transaction_segments.attributes.include']
+            assert_empty(source[:'attributes.include'])
+            assert_empty(source[:'transaction_tracer.attributes.include'])
+            assert_empty(source[:'transaction_events.attributes.include'])
+            assert_empty(source[:'error_collector.attributes.include'])
+            assert_empty(source[:'browser_monitoring.attributes.include'])
+            assert_empty(source[:'span_events.attributes.include'])
+            assert_empty(source[:'transaction_segments.attributes.include'])
           end
         end
 

--- a/test/new_relic/agent/connect/request_builder_test.rb
+++ b/test/new_relic/agent/connect/request_builder_test.rb
@@ -27,7 +27,7 @@ class NewRelic::Agent::Agent::RequestBuilderTest < Minitest::Test
 
   def test_sanitize_environment_report_cannot_be_serialized
     @service.stubs(:valid_to_marshal?).returns(false)
-    assert_equal [], @request_builder.sanitize_environment_report(['not empty'])
+    assert_empty(@request_builder.sanitize_environment_report(['not empty']))
   end
 
   def test_connect_settings

--- a/test/new_relic/agent/database_test.rb
+++ b/test/new_relic/agent/database_test.rb
@@ -298,7 +298,7 @@ class NewRelic::Agent::DatabaseTest < Minitest::Test
 
   def test_explain_sql_non_select
     statement = NewRelic::Agent::Database::Statement.new('foo', mock('config'), mock('explainer'))
-    assert_equal([], NewRelic::Agent::Database.explain_sql(statement))
+    assert_empty(NewRelic::Agent::Database.explain_sql(statement))
   end
 
   def test_dont_collect_explain_for_truncated_query
@@ -307,7 +307,7 @@ class NewRelic::Agent::DatabaseTest < Minitest::Test
     statement = NewRelic::Agent::Database::Statement.new(sql, config, mock('explainer'))
 
     expects_logging(:debug, 'Unable to collect explain plan for truncated query.')
-    assert_equal [], NewRelic::Agent::Database.explain_sql(statement)
+    assert_empty(NewRelic::Agent::Database.explain_sql(statement))
   end
 
   def test_dont_collect_explain_for_parameterized_query
@@ -316,7 +316,7 @@ class NewRelic::Agent::DatabaseTest < Minitest::Test
     statement = NewRelic::Agent::Database::Statement.new(sql, config, mock('explainer'))
 
     expects_logging(:debug, 'Unable to collect explain plan for parameter-less parameterized query.')
-    assert_equal [], NewRelic::Agent::Database.explain_sql(statement)
+    assert_empty NewRelic::Agent::Database.explain_sql(statement)
   end
 
   def test_do_collect_explain_for_parameter_looking_literal
@@ -349,7 +349,7 @@ class NewRelic::Agent::DatabaseTest < Minitest::Test
     statement = NewRelic::Agent::Database::Statement.new(sql, config, mock('explainer'))
 
     expects_logging(:debug, "Not collecting explain plan because an unknown connection adapter ('dorkdb') was used.")
-    assert_equal [], NewRelic::Agent::Database.explain_sql(statement)
+    assert_empty NewRelic::Agent::Database.explain_sql(statement)
   end
 
   def test_dont_collect_explain_for_multiple_queries
@@ -358,7 +358,7 @@ class NewRelic::Agent::DatabaseTest < Minitest::Test
     statement = NewRelic::Agent::Database::Statement.new(sql, config, mock('explainer'))
 
     expects_logging(:debug, 'Unable to collect explain plan for multiple queries.')
-    assert_equal [], NewRelic::Agent::Database.explain_sql(statement)
+    assert_empty NewRelic::Agent::Database.explain_sql(statement)
   end
 
   def test_explain_sql_no_connection_config
@@ -378,7 +378,7 @@ class NewRelic::Agent::DatabaseTest < Minitest::Test
     explainer = lambda { |statement| nil }
     statement = NewRelic::Agent::Database::Statement.new('SELECT', config, explainer)
 
-    assert_equal([], NewRelic::Agent::Database.explain_sql(statement))
+    assert_empty(NewRelic::Agent::Database.explain_sql(statement))
   end
 
   # See SqlObfuscationTest, which uses cross agent tests for the basic SQL

--- a/test/new_relic/agent/heap_test.rb
+++ b/test/new_relic/agent/heap_test.rb
@@ -44,7 +44,7 @@ module NewRelic
         end
 
         assert_equal [1, 4, 5, 7, 12, 30], ordered_items
-        assert_equal [], heap.to_a
+        assert_empty(heap.to_a)
       end
 
       def test_fix_bubbles_up_large_heap
@@ -61,7 +61,7 @@ module NewRelic
         end
 
         assert_equal (0..100).to_a - [replaced_value], ordered_items
-        assert_equal [], heap.to_a
+        assert_empty heap.to_a
       end
 
       def test_fix_bubbles_down
@@ -77,7 +77,7 @@ module NewRelic
         end
 
         assert_equal [4, 5, 7, 12, 30, 50], ordered_items
-        assert_equal [], heap.to_a
+        assert_empty heap.to_a
       end
 
       def test_fix_bubbles_down_large_heap
@@ -93,7 +93,7 @@ module NewRelic
         end
 
         assert_equal (2..101).to_a, ordered_items
-        assert_equal [], heap.to_a
+        assert_empty heap.to_a
       end
 
       def test_fix_leaves_item_if_heap_rule_satisfied
@@ -111,7 +111,7 @@ module NewRelic
         end
 
         assert_equal [4, 5, 7, 9, 12, 30], ordered_items
-        assert_equal [], heap.to_a
+        assert_empty heap.to_a
       end
 
       def test_items_are_popped_in_ascending_order
@@ -124,7 +124,7 @@ module NewRelic
         end
 
         assert_equal [4, 5, 7, 8, 12, 30], ordered_items
-        assert_equal [], heap.to_a
+        assert_empty heap.to_a
       end
 
       def test_items_are_popped_in_ascending_order_with_priority_function
@@ -155,7 +155,7 @@ module NewRelic
         ]
 
         assert_equal expected, ordered_items
-        assert_equal [], heap.to_a
+        assert_empty heap.to_a
       end
 
       def test_large_heap_even_number_of_items
@@ -167,7 +167,7 @@ module NewRelic
         end
 
         assert_equal (0..100).to_a, output
-        assert_equal [], heap.to_a
+        assert_empty heap.to_a
       end
 
       def test_large_heap_odd_number_of_items
@@ -179,7 +179,7 @@ module NewRelic
         end
 
         assert_equal (0..101).to_a, output
-        assert_equal [], heap.to_a
+        assert_empty heap.to_a
       end
     end
   end

--- a/test/new_relic/agent/method_visibility_test.rb
+++ b/test/new_relic/agent/method_visibility_test.rb
@@ -83,7 +83,7 @@ class MethodVisibilityTest < Minitest::Test
   end
 
   def test_tracing_non_public_methods_doesnt_add_public_methods
-    assert_equal [], ObjectWithTracers.public_instance_methods - ObjectWithInstrumentation.public_instance_methods
+    assert_empty(ObjectWithTracers.public_instance_methods - ObjectWithInstrumentation.public_instance_methods)
   end
 
   # FIXME: Currently including MethodTracer and ControllerInstrumentation

--- a/test/new_relic/agent/new_relic_service_test.rb
+++ b/test/new_relic/agent/new_relic_service_test.rb
@@ -64,7 +64,7 @@ class NewRelicServiceTest < Minitest::Test
     assert(block_ran)
 
     assert_equal([:start, :finish], handle1.calls)
-    assert_equal([], handle2.calls)
+    assert_empty(handle2.calls)
   end
 
   def test_multiple_http_handles_are_used_outside_session_block
@@ -135,7 +135,7 @@ class NewRelicServiceTest < Minitest::Test
 
     assert_equal([:start, :request, :finish], conn0.calls)
     assert_equal([:start, :request, :request, :request], conn1.calls)
-    assert_equal([], conn2.calls)
+    assert_empty(conn2.calls)
   end
 
   def test_repeated_connection_failures
@@ -198,7 +198,7 @@ class NewRelicServiceTest < Minitest::Test
 
     assert_equal([:request], conn0.calls)
     assert_equal([:request], conn1.calls)
-    assert_equal([], conn2.calls)
+    assert_empty(conn2.calls)
   end
 
   def test_no_default_cert_file_path
@@ -512,7 +512,7 @@ class NewRelicServiceTest < Minitest::Test
   def test_agent_command_results
     @http_handle.respond_to(:agent_command_results, {})
     response = @service.agent_command_results({'1' => {}})
-    assert_equal({}, response)
+    assert_empty(response)
   end
 
   def test_request_timeout

--- a/test/new_relic/agent/priority_sampled_buffer_test.rb
+++ b/test/new_relic/agent/priority_sampled_buffer_test.rb
@@ -60,7 +60,7 @@ module NewRelic::Agent
       100.times { |i| buffer.append(event: create_event(priority: i)) }
       buffer.reset!
       assert_equal(0, buffer.size)
-      assert_equal([], buffer.to_a)
+      assert_empty(buffer.to_a)
     end
 
     def test_to_a_returns_copy_of_items_array
@@ -83,7 +83,7 @@ module NewRelic::Agent
 
       buffer.reset!
 
-      assert_equal([], buffer.to_a)
+      assert_empty(buffer.to_a)
     end
 
     def test_buffer_full_works_properly

--- a/test/new_relic/agent/transaction/trace_node_test.rb
+++ b/test/new_relic/agent/transaction/trace_node_test.rb
@@ -136,7 +136,7 @@ class NewRelic::Agent::Transaction::TraceNodeTest < Minitest::Test
 
   def test_children_default
     s = NewRelic::Agent::Transaction::TraceNode.new('Custom/test/metric', Process.clock_gettime(Process::CLOCK_REALTIME))
-    assert_equal([], s.children)
+    assert_empty(s.children)
   end
 
   def test_children_with_nodes
@@ -216,7 +216,7 @@ class NewRelic::Agent::Transaction::TraceNodeTest < Minitest::Test
   def test_params
     s = NewRelic::Agent::Transaction::TraceNode.new('Custom/test/metric', Process.clock_gettime(Process::CLOCK_REALTIME))
 
-    assert_equal({}, s.params)
+    assert_empty(s.params)
 
     # should otherwise take the value from the @params var
     s.instance_eval { @params = {:foo => 'correct'} }

--- a/test/new_relic/agent/transaction/tracing_test.rb
+++ b/test/new_relic/agent/transaction/tracing_test.rb
@@ -351,7 +351,7 @@ module NewRelic
 
             expected_sql = "SELECT * FROM sandwiches WHERE bread = 'challah'"
             deepest_node = find_last_transaction_node(last_sample)
-            assert_equal([], deepest_node.children)
+            assert_empty(deepest_node.children)
             assert_equal(expected_sql, deepest_node[:sql].sql)
           end
         end

--- a/test/new_relic/agent/transaction_sampler_test.rb
+++ b/test/new_relic/agent/transaction_sampler_test.rb
@@ -99,7 +99,7 @@ module NewRelic::Agent
 
     def test_harvest_when_disabled
       with_config(:'transaction_tracer.enabled' => false) do
-        assert_equal([], @sampler.harvest!)
+        assert_empty(@sampler.harvest!)
       end
     end
 
@@ -109,14 +109,14 @@ module NewRelic::Agent
         @last_sample = 'a sample'
       end
 
-      assert_equal([], @sampler.harvest!)
+      assert_empty(@sampler.harvest!)
 
       # make sure the samples have been cleared
       assert_nil(@sampler.instance_variable_get(:@last_sample))
     end
 
     def test_harvest_no_data
-      assert_equal([], @sampler.harvest!)
+      assert_empty(@sampler.harvest!)
     end
 
     def test_add_samples_holds_onto_previous_result

--- a/test/new_relic/noticed_error_test.rb
+++ b/test/new_relic/noticed_error_test.rb
@@ -231,7 +231,7 @@ class NewRelic::Agent::NoticedErrorTest < Minitest::Test
       error = NewRelic::NoticedError.new(@path, Exception.new("O_o"))
       error.attributes = attributes
 
-      assert_equal({}, error.custom_attributes)
+      assert_empty(error.custom_attributes)
     end
   end
 
@@ -256,7 +256,7 @@ class NewRelic::Agent::NoticedErrorTest < Minitest::Test
       error = NewRelic::NoticedError.new(@path, Exception.new("O_o"))
       error.attributes = attributes
 
-      assert_equal({}, error.agent_attributes)
+      assert_empty(error.agent_attributes)
     end
   end
 


### PR DESCRIPTION
Address Minitest/AssertEmptyLiteral
- Remove from `rubocop_todo`
- Resolve offenses