### PR TITLE
Address Minitest/AssertEqual

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -20,18 +20,6 @@ Layout/EmptyLinesAroundBlockBody:
 Metrics/AbcSize:
   Max: 82
 
-# Offense count: 13
-# This cop supports safe autocorrection (--autocorrect).
-Minitest/AssertEqual:
-  Exclude:
-    - 'test/multiverse/suites/config_file_loading/config_file_loading_test.rb'
-    - 'test/new_relic/agent/configuration/default_source_test.rb'
-    - 'test/new_relic/agent/error_trace_aggregator_test.rb'
-    - 'test/new_relic/agent/method_tracer_helpers_test.rb'
-    - 'test/new_relic/agent/method_tracer_test.rb'
-    - 'test/new_relic/agent/transaction_sampler_test.rb'
-    - 'test/new_relic/metric_data_test.rb'
-
 # Offense count: 145
 # This cop supports safe autocorrection (--autocorrect).
 Minitest/AssertInDelta:

--- a/test/multiverse/suites/config_file_loading/config_file_loading_test.rb
+++ b/test/multiverse/suites/config_file_loading/config_file_loading_test.rb
@@ -79,7 +79,7 @@ bazbangbarn:
 
   def assert_config_read_from(path, manual_config_options = {})
     setup_config(path, manual_config_options)
-    assert NewRelic::Agent.config[:foo] == "success!!", "Failed to read yaml config from #{path.inspect[0..100]}\n\n#{NewRelic::Agent.config.inspect[0..100]}"
+    assert_equal("success!!", NewRelic::Agent.config[:foo], "Failed to read yaml config from #{path.inspect[0..100]}\n\n#{NewRelic::Agent.config.inspect[0..100]}")
   end
 
   def assert_config_not_read_from(path)

--- a/test/new_relic/agent/configuration/default_source_test.rb
+++ b/test/new_relic/agent/configuration/default_source_test.rb
@@ -174,7 +174,7 @@ module NewRelic::Agent::Configuration
           result = NewRelic::Agent.config[key]
 
           message = "Expected #{key} to convert comma delimited string into array.\nExpected: #{expected.inspect}, Result: #{result.inspect}\n"
-          assert expected == result, message
+          assert_equal(expected, result, message)
         end
 
         key = "#{type}attributes.include".to_sym
@@ -197,7 +197,7 @@ module NewRelic::Agent::Configuration
           result = NewRelic::Agent.config[key]
 
           message = "Expected #{key} not to modify settings from YAML array.\nExpected: #{expected.inspect}, Result: #{result.inspect}\n"
-          assert expected == result, message
+          assert_equal expected, result, message
         end
 
         key = "#{type}attributes.include".to_sym

--- a/test/new_relic/agent/error_trace_aggregator_test.rb
+++ b/test/new_relic/agent/error_trace_aggregator_test.rb
@@ -139,7 +139,7 @@ module NewRelic
         end
 
         errors = error_trace_aggregator.harvest!
-        assert_equal(errors.length, max_q_length)
+        assert_equal(max_q_length, errors.length)
         errors.each_index do |i|
           error = errors.shift
           actual = error.to_collector_array.last["userAttributes"]["x"]

--- a/test/new_relic/agent/error_trace_aggregator_test.rb
+++ b/test/new_relic/agent/error_trace_aggregator_test.rb
@@ -139,7 +139,7 @@ module NewRelic
         end
 
         errors = error_trace_aggregator.harvest!
-        assert errors.length == max_q_length
+        assert_equal(errors.length, max_q_length)
         errors.each_index do |i|
           error = errors.shift
           actual = error.to_collector_array.last["userAttributes"]["x"]

--- a/test/new_relic/agent/method_tracer_helpers_test.rb
+++ b/test/new_relic/agent/method_tracer_helpers_test.rb
@@ -113,7 +113,7 @@ class NewRelic::Agent::MethodTracerHelpersTest < Minitest::Test
       helped.code_information(::The::Example, :instance_method)
       memoized = helped.instance_variable_get(:@code_information)
       assert memoized
-      assert memoized.keys.size == 1
+      assert_equal(1, memoized.keys.size)
       assert memoized.keys.first.frozen?
       assert memoized.values.first.frozen?
     end

--- a/test/new_relic/agent/method_tracer_test.rb
+++ b/test/new_relic/agent/method_tracer_test.rb
@@ -497,16 +497,16 @@ class NewRelic::Agent::MethodTracerTest < Minitest::Test
   # test methods to be traced
   def method_to_be_traced(x, y, z, is_traced, expected_metric)
     advance_process_time(0.05)
-    assert x == 1
-    assert y == 2
-    assert z == 3
+    assert_equal(1, x)
+    assert_equal(2, y)
+    assert_equal(3, z)
   end
 
   def method_with_block(x, y, z, is_traced, expected_metric, &block)
     advance_process_time(0.05)
-    assert x == 1
-    assert y == 2
-    assert z == 3
+    assert_equal(1, x)
+    assert_equal(2, y)
+    assert_equal(3, z)
     yield
   end
 

--- a/test/new_relic/agent/transaction_sampler_test.rb
+++ b/test/new_relic/agent/transaction_sampler_test.rb
@@ -262,8 +262,7 @@ module NewRelic::Agent
         end
         @sampler.merge!([slowest])
         not_as_slow = @sampler.harvest![0]
-        assert_equal(not_as_slow, slowest)
-        assert("Should re-harvest the same transaction since it should be slower than the new transaction - expected #{slowest.inspect} but got #{not_as_slow.inspect}")
+        assert_equal(not_as_slow, slowest, "Should re-harvest the same transaction since it should be slower than the new transaction - expected #{slowest.inspect} but got #{not_as_slow.inspect}")
 
         # 1 second duration
         in_transaction do

--- a/test/new_relic/agent/transaction_sampler_test.rb
+++ b/test/new_relic/agent/transaction_sampler_test.rb
@@ -262,7 +262,8 @@ module NewRelic::Agent
         end
         @sampler.merge!([slowest])
         not_as_slow = @sampler.harvest![0]
-        assert((not_as_slow == slowest), "Should re-harvest the same transaction since it should be slower than the new transaction - expected #{slowest.inspect} but got #{not_as_slow.inspect}")
+        assert_equal(not_as_slow, slowest)
+        assert("Should re-harvest the same transaction since it should be slower than the new transaction - expected #{slowest.inspect} but got #{not_as_slow.inspect}")
 
         # 1 second duration
         in_transaction do

--- a/test/new_relic/metric_data_test.rb
+++ b/test/new_relic/metric_data_test.rb
@@ -84,7 +84,7 @@ class NewRelic::MetricDataTest < Minitest::Test
     stats = mock('stats')
     md1 = NewRelic::MetricData.new(spec, stats)
     expected = [spec, stats].hash
-    assert(expected == md1.hash, "expected #{expected} to equal #{md1.hash}")
+    assert_equal(expected, md1.hash, "expected #{expected} to equal #{md1.hash}")
   end
 
   if {}.respond_to?(:to_json)


### PR DESCRIPTION
Fix `assert_equal` errors and remove from `rubocop_todo` file.

_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
Describe the changes present in the pull request

Submitter Checklist:
- [ ] Include a link to the related GitHub issue, if applicable
- [ ] Include a security review link, if applicable

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
Github Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
