### PR TITLE
Address Minitest/AssertIncludes offenses

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -25,26 +25,6 @@ Metrics/AbcSize:
 Minitest/AssertInDelta:
   Enabled: false
 
-# Offense count: 22
-# This cop supports safe autocorrection (--autocorrect).
-Minitest/AssertIncludes:
-  Exclude:
-    - 'test/agent_helper.rb'
-    - 'test/multiverse/suites/rails/active_support_logger_test.rb'
-    - 'test/multiverse/suites/sequel/sequel_plugin_test.rb'
-    - 'test/multiverse/suites/sinatra_agent_disabled/shim_test.rb'
-    - 'test/new_relic/agent/audit_logger_test.rb'
-    - 'test/new_relic/agent/configuration/manager_test.rb'
-    - 'test/new_relic/agent/configuration/orphan_configuration_test.rb'
-    - 'test/new_relic/agent/error_trace_aggregator_test.rb'
-    - 'test/new_relic/agent/javascript_instrumentor_test.rb'
-    - 'test/new_relic/agent/method_visibility_test.rb'
-    - 'test/new_relic/agent/sampler_test.rb'
-    - 'test/new_relic/agent/tracer_state_test.rb'
-    - 'test/new_relic/control/instance_methods_test.rb'
-    - 'test/new_relic/environment_report_test.rb'
-    - 'test/new_relic/metric_data_test.rb'
-
 # Offense count: 4
 # This cop supports safe autocorrection (--autocorrect).
 Minitest/AssertKindOf:

--- a/test/agent_helper.rb
+++ b/test/agent_helper.rb
@@ -131,7 +131,7 @@ def assert_audit_log_contains(audit_log_contents, needle)
   regex = /[:"]/
   needle = needle.gsub(regex, '')
   haystack = audit_log_contents.gsub(regex, '')
-  assert(haystack.include?(needle), "Expected log to contain '#{needle}'")
+  assert_includes(haystack, needle, "Expected log to contain '#{needle}'")
 end
 
 # Because we don't generate a strictly machine-readable representation of

--- a/test/multiverse/suites/rails/active_support_logger_test.rb
+++ b/test/multiverse/suites/rails/active_support_logger_test.rb
@@ -30,8 +30,8 @@ if defined?(ActiveSupport::Logger)
 
       @logger.add(Logger::DEBUG, message)
 
-      assert @output.string.include?(message)
-      assert @broadcasted_output.string.include?(message)
+      assert_includes(@output.string, message)
+      assert_includes(@broadcasted_output.string, message)
 
       # LogEventAggregator sees the log only once
       assert_equal 1, @aggregator.instance_variable_get(:@seen)

--- a/test/multiverse/suites/sequel/sequel_plugin_test.rb
+++ b/test/multiverse/suites/sequel/sequel_plugin_test.rb
@@ -220,7 +220,7 @@ if Sequel.const_defined?(:MAJOR) &&
         expected_metric_name = "Datastore/statement/#{product_name}/Post/all"
         recorded_metric_names = NewRelic::Agent.agent.sql_sampler.sql_traces.values.map(&:database_metric_name)
 
-        assert recorded_metric_names.include?(expected_metric_name)
+        assert_includes(recorded_metric_names, expected_metric_name)
       end
     end
   end

--- a/test/multiverse/suites/sinatra_agent_disabled/shim_test.rb
+++ b/test/multiverse/suites/sinatra_agent_disabled/shim_test.rb
@@ -23,8 +23,8 @@ class SinatraAgentDisabledTestCase < Minitest::Test
     assert MiddlewareApp.respond_to?(:newrelic_ignore_enduser), "Class method newrelic_ignore_enduser not defined"
 
     # instance method shims
-    assert MiddlewareApp.instance_methods.include?(:new_relic_trace_controller_action), "Instance method new_relic_trace_controller_action not defined"
-    assert MiddlewareApp.instance_methods.include?(:perform_action_with_newrelic_trace), "Instance method perform_action_with_newrelic_trace not defined"
+    assert_includes(MiddlewareApp.instance_methods, :new_relic_trace_controller_action, "Instance method new_relic_trace_controller_action not defined")
+    assert_includes(MiddlewareApp.instance_methods, :perform_action_with_newrelic_trace, "Instance method perform_action_with_newrelic_trace not defined")
   end
 
   def test_shims_exist_when_agent_enabled_false

--- a/test/new_relic/agent/audit_logger_test.rb
+++ b/test/new_relic/agent/audit_logger_test.rb
@@ -39,7 +39,7 @@ class AuditLoggerTest < Minitest::Test
 
   def assert_log_contains_string(str)
     log_body = read_log_body
-    assert(log_body.include?(str), "Expected log to contain string '#{str}'\nLog body was: #{log_body}")
+    assert_includes(log_body, str, "Expected log to contain string '#{str}'\nLog body was: #{log_body}")
   end
 
   def read_log_body

--- a/test/new_relic/agent/configuration/manager_test.rb
+++ b/test/new_relic/agent/configuration/manager_test.rb
@@ -293,8 +293,8 @@ module NewRelic::Agent::Configuration
     end
 
     def test_config_is_correctly_initialized
-      assert @manager.config_classes_for_testing.include?(EnvironmentSource)
-      assert @manager.config_classes_for_testing.include?(DefaultSource)
+      assert_includes(@manager.config_classes_for_testing, EnvironmentSource)
+      assert_includes(@manager.config_classes_for_testing, DefaultSource)
       refute @manager.config_classes_for_testing.include?(ManualSource)
       refute @manager.config_classes_for_testing.include?(ServerSource)
       refute @manager.config_classes_for_testing.include?(YamlSource)
@@ -306,7 +306,7 @@ module NewRelic::Agent::Configuration
       refute @manager.config_classes_for_testing.include?(SecurityPolicySource)
       security_policy_source = SecurityPolicySource.new({'record_sql' => {'enabled' => false}})
       @manager.replace_or_add_config(security_policy_source)
-      assert @manager.config_classes_for_testing.include?(SecurityPolicySource)
+      assert_includes(@manager.config_classes_for_testing, SecurityPolicySource)
     end
 
     load_cross_agent_test("labels").each do |testcase|

--- a/test/new_relic/agent/configuration/orphan_configuration_test.rb
+++ b/test/new_relic/agent/configuration/orphan_configuration_test.rb
@@ -24,7 +24,7 @@ class OrphanedConfigTest < Minitest::Test
 
         config_keys.each do |key|
           msg = "#{file}:#{index} - Configuration key #{key} is not described in default_source.rb.\n"
-          assert @default_keys.include?(key), msg
+          assert_includes(@default_keys, key, msg)
         end
       end
     end

--- a/test/new_relic/agent/error_trace_aggregator_test.rb
+++ b/test/new_relic/agent/error_trace_aggregator_test.rb
@@ -243,8 +243,8 @@ module NewRelic
         errors = error_trace_aggregator.harvest!
         err = errors.first
 
-        assert err.message.include?(exception.message)
-        assert err.message.include?("Ruby agent internal error")
+        assert_includes(err.message, exception.message)
+        assert_includes(err.message, "Ruby agent internal error")
       end
 
       def test_errors_not_noticed_when_disabled

--- a/test/new_relic/agent/javascript_instrumentor_test.rb
+++ b/test/new_relic/agent/javascript_instrumentor_test.rb
@@ -311,7 +311,7 @@ class NewRelic::Agent::JavascriptInstrumentorTest < Minitest::Test
   end
 
   def assert_has_text(snippet, footer)
-    assert(footer.include?(snippet), "Expected footer to include snippet: #{snippet}, but instead was #{footer}")
+    assert_includes(footer, snippet, "Expected footer to include snippet: #{snippet}, but instead was #{footer}")
   end
 
   def assert_attributes_are(expected)

--- a/test/new_relic/agent/method_visibility_test.rb
+++ b/test/new_relic/agent/method_visibility_test.rb
@@ -74,11 +74,11 @@ class MethodVisibilityTest < Minitest::Test
 
   %w[ public private protected ].each do |visibility|
     define_method "test_should_preserve_visibility_of_#{visibility}_traced_method" do
-      assert @instance.send("#{visibility}_methods").map { |s| s.to_sym }.include?(:"#{visibility}_method!"), "Method #{visibility}_method should be #{visibility}"
+      assert_includes(@instance.send("#{visibility}_methods").map { |s| s.to_sym }, :"#{visibility}_method!", "Method #{visibility}_method should be #{visibility}")
     end
 
     define_method "test_should_preserve_visibility_of_#{visibility}_traced_transaction" do
-      assert @instance.send("#{visibility}_methods").map { |s| s.to_sym }.include?(:"#{visibility}_transaction!"), "Transcation #{visibility}_transaction should be #{visibility}"
+      assert_includes(@instance.send("#{visibility}_methods").map { |s| s.to_sym }, :"#{visibility}_transaction!", "Transcation #{visibility}_transaction should be #{visibility}")
     end
   end
 

--- a/test/new_relic/agent/sampler_test.rb
+++ b/test/new_relic/agent/sampler_test.rb
@@ -20,7 +20,7 @@ class NewRelic::Agent::SamplerTest < Minitest::Test
   def test_inherited_should_append_subclasses_to_sampler_classes
     test_class = Class.new(NewRelic::Agent::Sampler)
     sampler_classes = NewRelic::Agent::Sampler.instance_variable_get(:@sampler_classes)
-    assert(sampler_classes.include?(test_class), "Sampler classes (#{sampler_classes.inspect}) does not include #{test_class.inspect}")
+    assert_includes(sampler_classes, test_class, "Sampler classes (#{sampler_classes.inspect}) does not include #{test_class.inspect}")
     # cleanup the sampler created above
     NewRelic::Agent::Sampler.instance_eval { @sampler_classes.delete(test_class) }
   end
@@ -28,7 +28,7 @@ class NewRelic::Agent::SamplerTest < Minitest::Test
   def test_sampler_classes_should_be_an_array
     sampler_classes = NewRelic::Agent::Sampler.instance_variable_get(:@sampler_classes)
     assert(sampler_classes.is_a?(Array), 'Sampler classes should be saved as an array')
-    assert(sampler_classes.include?(NewRelic::Agent::Samplers::CpuSampler), 'Sampler classes should include the CPU sampler')
+    assert_includes(sampler_classes, NewRelic::Agent::Samplers::CpuSampler, 'Sampler classes should include the CPU sampler')
   end
 
   def test_enabled_should_return_true_if_name_unknown

--- a/test/new_relic/agent/tracer_state_test.rb
+++ b/test/new_relic/agent/tracer_state_test.rb
@@ -57,8 +57,7 @@ module NewRelic::Agent
       variables.each do |ivar|
         value = state.instance_variable_get(ivar)
         empties = [0, nil, false, []]
-        assert empties.include?(value),
-          "Expected #{ivar} to reset, but was #{value}"
+        assert_includes(empties, value, "Expected #{ivar} to reset, but was #{value}")
       end
     end
   end

--- a/test/new_relic/control/instance_methods_test.rb
+++ b/test/new_relic/control/instance_methods_test.rb
@@ -66,6 +66,6 @@ class NewRelic::Control::InstanceMethodsTest < Minitest::Test
   end
 
   def assert_has_config(clazz)
-    assert NewRelic::Agent.config.config_classes_for_testing.include?(clazz)
+    assert_includes(NewRelic::Agent.config.config_classes_for_testing, clazz)
   end
 end

--- a/test/new_relic/environment_report_test.rb
+++ b/test/new_relic/environment_report_test.rb
@@ -19,7 +19,7 @@ class EnvironmentReportTest < Minitest::Test
     ::NewRelic::EnvironmentReport.report_on("something") { "awesome" }
     data = Array(::NewRelic::EnvironmentReport.new)
     expected = ["something", "awesome"]
-    assert data.include?(expected), "expected to find #{expected} in #{data.inspect}"
+    assert_includes(data, expected, "expected to find #{expected} in #{data.inspect}")
   end
 
   def test_register_a_value_to_report_on

--- a/test/new_relic/metric_data_test.rb
+++ b/test/new_relic/metric_data_test.rb
@@ -91,7 +91,7 @@ class NewRelic::MetricDataTest < Minitest::Test
     def test_to_json
       md = NewRelic::MetricData.new(NewRelic::MetricSpec.new('Custom/test/method', ''), NewRelic::Agent::Stats.new)
       json = md.to_json
-      assert(json.include?('"Custom/test/method"'), "should include the metric spec in the json")
+      assert_includes(json, '"Custom/test/method"', "should include the metric spec in the json")
     end
 
   else


### PR DESCRIPTION
Address `Minitest/AssertIncludes` offenses and remove from `rubocop_todo`