### PR TITLE
Address Minitest/AssertKindOf

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -27,14 +27,6 @@ Minitest/AssertInDelta:
 
 # Offense count: 4
 # This cop supports safe autocorrection (--autocorrect).
-Minitest/AssertKindOf:
-  Exclude:
-    - 'test/new_relic/agent/agent_test.rb'
-    - 'test/new_relic/agent/pipe_channel_manager_test.rb'
-    - 'test/new_relic/agent_test.rb'
-
-# Offense count: 4
-# This cop supports safe autocorrection (--autocorrect).
 Minitest/AssertNil:
   Exclude:
     - 'test/multiverse/suites/agent_only/log_events_test.rb'

--- a/test/new_relic/agent/agent_test.rb
+++ b/test/new_relic/agent/agent_test.rb
@@ -35,7 +35,7 @@ module NewRelic
           @agent.after_fork(:report_to_channel => 123)
         end
 
-        assert(@agent.service.kind_of?(NewRelic::Agent::PipeService),
+        assert_kind_of(NewRelic::Agent::PipeService, @agent.service,
           'Agent should use PipeService when directed to report to pipe channel')
         NewRelic::Agent::PipeService.any_instance.expects(:shutdown).never
         assert_equal 123, @agent.service.channel_id

--- a/test/new_relic/agent/pipe_channel_manager_test.rb
+++ b/test/new_relic/agent/pipe_channel_manager_test.rb
@@ -35,8 +35,8 @@ class NewRelic::Agent::PipeChannelManagerTest < Minitest::Test
     NewRelic::Agent::PipeChannelManager.register_report_channel(1)
     pipe = NewRelic::Agent::PipeChannelManager.channels[1]
 
-    assert pipe.out.kind_of?(IO)
-    assert pipe.in.kind_of?(IO)
+    assert_kind_of(IO, pipe.out)
+    assert_kind_of(IO, pipe.in)
 
     NewRelic::Agent::PipeChannelManager.listener.close_all_pipes
   end

--- a/test/new_relic/agent_test.rb
+++ b/test/new_relic/agent_test.rb
@@ -159,23 +159,27 @@ module NewRelic
 
     def test_is_execution_traced_empty
       NewRelic::Agent::Tracer.state.untraced = []
-      assert_equal(true, NewRelic::Agent.tl_is_execution_traced?, 'should be true since the thread local is an empty array')
+      assert_equal(true, NewRelic::Agent.tl_is_execution_traced?,
+        'should be true since the thread local is an empty array')
     end
 
     def test_is_execution_traced_false
       NewRelic::Agent::Tracer.state.untraced = [true, false]
-      assert_equal(false, NewRelic::Agent.tl_is_execution_traced?, 'should be false since the thread local stack has the last element false')
+      assert_equal(false, NewRelic::Agent.tl_is_execution_traced?,
+        'should be false since the thread local stack has the last element false')
     end
 
     def test_instance
       NewRelic::Agent.manual_start
-      assert_equal(NewRelic::Agent.agent, NewRelic::Agent.instance, "should return the same agent for both identical methods")
+      assert_equal(NewRelic::Agent.agent, NewRelic::Agent.instance,
+        "should return the same agent for both identical methods")
       NewRelic::Agent.shutdown
     end
 
     def test_register_report_channel
       NewRelic::Agent.register_report_channel(:channel_id)
-      assert_kind_of(NewRelic::Agent::PipeChannelManager::Pipe, NewRelic::Agent::PipeChannelManager.channels[:channel_id])
+      assert_kind_of(NewRelic::Agent::PipeChannelManager::Pipe, 
+        NewRelic::Agent::PipeChannelManager.channels[:channel_id])
       NewRelic::Agent::PipeChannelManager.listener.close_all_pipes
     end
 

--- a/test/new_relic/agent_test.rb
+++ b/test/new_relic/agent_test.rb
@@ -175,8 +175,7 @@ module NewRelic
 
     def test_register_report_channel
       NewRelic::Agent.register_report_channel(:channel_id)
-      assert NewRelic::Agent::PipeChannelManager.channels[:channel_id] \
-        .kind_of?(NewRelic::Agent::PipeChannelManager::Pipe)
+      assert_kind_of(NewRelic::Agent::PipeChannelManager::Pipe, NewRelic::Agent::PipeChannelManager.channels[:channel_id])
       NewRelic::Agent::PipeChannelManager.listener.close_all_pipes
     end
 

--- a/test/new_relic/agent_test.rb
+++ b/test/new_relic/agent_test.rb
@@ -178,7 +178,7 @@ module NewRelic
 
     def test_register_report_channel
       NewRelic::Agent.register_report_channel(:channel_id)
-      assert_kind_of(NewRelic::Agent::PipeChannelManager::Pipe, 
+      assert_kind_of(NewRelic::Agent::PipeChannelManager::Pipe,
         NewRelic::Agent::PipeChannelManager.channels[:channel_id])
       NewRelic::Agent::PipeChannelManager.listener.close_all_pipes
     end


### PR DESCRIPTION
Address `Minitest/AssertKindOf` and remove from `rubocop_todo`