### PR TITLE
Address rubocop Minitest/RefuteEqual

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -125,16 +125,6 @@ Minitest/LiteralAsActualArgument:
 Minitest/MultipleAssertions:
   Max: 28
 
-# Offense count: 9
-# This cop supports safe autocorrection (--autocorrect).
-Minitest/RefuteEqual:
-  Exclude:
-    - 'test/agent_helper.rb'
-    - 'test/multiverse/suites/config_file_loading/config_file_loading_test.rb'
-    - 'test/new_relic/agent/agent_test.rb'
-    - 'test/new_relic/agent/configuration/manager_test.rb'
-    - 'test/new_relic/marshalling_test_cases.rb'
-
 # Offense count: 121
 # This cop supports safe autocorrection (--autocorrect).
 Minitest/RefuteFalse:

--- a/test/multiverse/suites/config_file_loading/config_file_loading_test.rb
+++ b/test/multiverse/suites/config_file_loading/config_file_loading_test.rb
@@ -85,8 +85,8 @@ bazbangbarn:
 
   def assert_config_not_read_from(path)
     setup_config(path)
-    refute_equal(NewRelic::Agent.config[:foo], "success!!",
-      "Read yaml config from #{path.inspect}\n\n#{NewRelic::Agent.config.inspect}")
+    refute_equal NewRelic::Agent.config[:foo], "success!!",
+      "Read yaml config from #{path.inspect}\n\n#{NewRelic::Agent.config.inspect}"
   end
 
   def test_config_loads_from_config_newrelic_yml

--- a/test/multiverse/suites/config_file_loading/config_file_loading_test.rb
+++ b/test/multiverse/suites/config_file_loading/config_file_loading_test.rb
@@ -79,12 +79,14 @@ bazbangbarn:
 
   def assert_config_read_from(path, manual_config_options = {})
     setup_config(path, manual_config_options)
-    assert_equal("success!!", NewRelic::Agent.config[:foo], "Failed to read yaml config from #{path.inspect[0..100]}\n\n#{NewRelic::Agent.config.inspect[0..100]}")
+    assert_equal("success!!", NewRelic::Agent.config[:foo],
+      "Failed to read yaml config from #{path.inspect[0..100]}\n\n#{NewRelic::Agent.config.inspect[0..100]}")
   end
 
   def assert_config_not_read_from(path)
     setup_config(path)
-    assert NewRelic::Agent.config[:foo] != "success!!", "Read yaml config from #{path.inspect}\n\n#{NewRelic::Agent.config.inspect}"
+    refute_equal(NewRelic::Agent.config[:foo], "success!!",
+      "Read yaml config from #{path.inspect}\n\n#{NewRelic::Agent.config.inspect}")
   end
 
   def test_config_loads_from_config_newrelic_yml

--- a/test/new_relic/agent/agent_test.rb
+++ b/test/new_relic/agent/agent_test.rb
@@ -78,7 +78,7 @@ module NewRelic
 
           @agent.after_fork(:report_to_channel => 123)
 
-          assert old_engine != @agent.stats_engine, "Still got our old engine around!"
+          refute_equal(old_engine, @agent.stats_engine, "Still got our old engine around!")
         end
       end
 

--- a/test/new_relic/agent/agent_test.rb
+++ b/test/new_relic/agent/agent_test.rb
@@ -78,7 +78,7 @@ module NewRelic
 
           @agent.after_fork(:report_to_channel => 123)
 
-          refute_equal(old_engine, @agent.stats_engine, "Still got our old engine around!")
+          refute_equal old_engine, @agent.stats_engine, "Still got our old engine around!"
         end
       end
 

--- a/test/new_relic/agent/configuration/manager_test.rb
+++ b/test/new_relic/agent/configuration/manager_test.rb
@@ -216,7 +216,7 @@ module NewRelic::Agent::Configuration
         actual = value
       end
       @manager.add_config_for_testing(:test => proc { "value" })
-      assert actual.class != Proc, 'Callback returned Proc'
+      refute_equal(actual.class, Proc, 'Callback returned Proc')
     end
 
     def test_callback_not_called_if_no_change

--- a/test/new_relic/agent/configuration/manager_test.rb
+++ b/test/new_relic/agent/configuration/manager_test.rb
@@ -216,7 +216,7 @@ module NewRelic::Agent::Configuration
         actual = value
       end
       @manager.add_config_for_testing(:test => proc { "value" })
-      refute_equal(actual.class, Proc, 'Callback returned Proc')
+      refute_equal actual.class, Proc, 'Callback returned Proc'
     end
 
     def test_callback_not_called_if_no_change


### PR DESCRIPTION
Address `Minitest/RefuteEqual` offenses and remove from `rubocop_todo`