### PR TITLE
Address Minitest/AssertTruthy

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -58,26 +58,6 @@ Minitest/AssertRespondTo:
     - 'test/new_relic/collection_helper_test.rb'
     - 'test/new_relic/data_container_tests.rb'
 
-# Offense count: 35
-# This cop supports safe autocorrection (--autocorrect).
-Minitest/AssertTruthy:
-  Exclude:
-    - 'test/multiverse/suites/agent_only/error_events_test.rb'
-    - 'test/multiverse/suites/rack/puma_rack_urlmap_test.rb'
-    - 'test/multiverse/suites/sequel/sequel_safety_test.rb'
-    - 'test/new_relic/agent/commands/thread_profiler_session_test.rb'
-    - 'test/new_relic/agent/configuration/environment_source_test.rb'
-    - 'test/new_relic/agent/configuration/manager_test.rb'
-    - 'test/new_relic/agent/configuration/security_policy_source_test.rb'
-    - 'test/new_relic/agent/configuration/yaml_source_test.rb'
-    - 'test/new_relic/agent/distributed_tracing/distributed_trace_payload_test.rb'
-    - 'test/new_relic/agent/distributed_tracing/trace_context_payload_test.rb'
-    - 'test/new_relic/agent/priority_sampled_buffer_test.rb'
-    - 'test/new_relic/agent/transaction/distributed_tracing_test.rb'
-    - 'test/new_relic/agent_test.rb'
-    - 'test/new_relic/gem_notifications_tests.rb'
-    - 'test/new_relic/language_support_test.rb'
-
 # Offense count: 24
 Minitest/AssertWithExpectedArgument:
   Exclude:

--- a/test/multiverse/suites/agent_only/error_events_test.rb
+++ b/test/multiverse/suites/agent_only/error_events_test.rb
@@ -31,7 +31,7 @@ class ErrorEventsTest < Minitest::Test
 
     intrinsics, _, _ = last_error_event
 
-    assert_equal true, intrinsics["error.expected"]
+    assert intrinsics["error.expected"]
   end
 
   def test_records_supportability_metrics

--- a/test/multiverse/suites/rack/puma_rack_urlmap_test.rb
+++ b/test/multiverse/suites/rack/puma_rack_urlmap_test.rb
@@ -20,7 +20,7 @@ if NewRelic::Agent::Instrumentation::RackHelpers.puma_rack_version_supported?
         # confirm basic mapping functionality still works as expected
         assert_equal v, result
         # confirm that we've enhanced the mapping experience
-        assert_equal true, env['newrelic.transaction_started']
+        assert env['newrelic.transaction_started']
       end
     end
   end

--- a/test/multiverse/suites/sequel/sequel_safety_test.rb
+++ b/test/multiverse/suites/sequel/sequel_safety_test.rb
@@ -22,7 +22,7 @@ class SequelSafetyTest < Minitest::Test
       require 'newrelic_rpm'
 
       DB.transaction do
-        assert_equal(true, DB.in_transaction?)
+        assert DB.in_transaction?
       end
     end
   end

--- a/test/new_relic/agent/commands/thread_profiler_session_test.rb
+++ b/test/new_relic/agent/commands/thread_profiler_session_test.rb
@@ -143,7 +143,7 @@ else
 
     def test_handle_start_command_starts_running
       @profiler.handle_start_command(start_command)
-      assert_equal true, @profiler.running?
+      assert @profiler.running?
     end
 
     def test_config_can_disable_running

--- a/test/new_relic/agent/configuration/environment_source_test.rb
+++ b/test/new_relic/agent/configuration/environment_source_test.rb
@@ -127,7 +127,7 @@ module NewRelic::Agent::Configuration
     def test_set_key_by_type_uses_the_default_type
       ENV['NEW_RELIC_TEST'] = 'true'
       @environment_source.set_key_by_type(:enabled, 'NEW_RELIC_TEST')
-      assert_equal true, @environment_source[:enabled]
+      assert @environment_source[:enabled]
     end
 
     def test_set_key_by_type_converts_comma_lists_to_array
@@ -204,7 +204,7 @@ module NewRelic::Agent::Configuration
 
     def assert_applied_boolean(env_var, config_var)
       ENV[env_var] = 'true'
-      assert_equal true, EnvironmentSource.new[config_var.to_sym]
+      assert EnvironmentSource.new[config_var.to_sym]
       ENV.delete(env_var)
     end
   end

--- a/test/new_relic/agent/configuration/manager_test.rb
+++ b/test/new_relic/agent/configuration/manager_test.rb
@@ -238,7 +238,7 @@ module NewRelic::Agent::Configuration
       refute @manager.finished_configuring?
 
       @manager.replace_or_add_config(ServerSource.new({}))
-      assert_equal true, @manager.finished_configuring?
+      assert @manager.finished_configuring?
     end
 
     def test_notifies_finished_configuring
@@ -246,7 +246,7 @@ module NewRelic::Agent::Configuration
       NewRelic::Agent.instance.events.subscribe(:initial_configuration_complete) { called = true }
       @manager.replace_or_add_config(ServerSource.new({}))
 
-      assert_equal true, called
+      assert called
     end
 
     def test_doesnt_notify_unless_finished

--- a/test/new_relic/agent/configuration/security_policy_source_test.rb
+++ b/test/new_relic/agent/configuration/security_policy_source_test.rb
@@ -20,7 +20,7 @@ module NewRelic
 
             assert_equal 'obfuscated', source[:'transaction_tracer.record_sql']
             assert_equal 'obfuscated', source[:'slow_sql.record_sql']
-            assert_equal true, source[:'mongo.obfuscate_queries']
+            assert source[:'mongo.obfuscate_queries']
           end
         end
 

--- a/test/new_relic/agent/configuration/yaml_source_test.rb
+++ b/test/new_relic/agent/configuration/yaml_source_test.rb
@@ -32,10 +32,10 @@ module NewRelic::Agent::Configuration
     end
 
     def test_config_booleans
-      assert_equal true, @source[:tval]
+      assert @source[:tval]
       refute @source[:fval]
       assert_nil @source[:not_in_yaml_val]
-      assert_equal true, @source[:yval]
+      assert @source[:yval]
       assert_equal 'sure', @source[:sval]
     end
 

--- a/test/new_relic/agent/distributed_tracing/distributed_trace_payload_test.rb
+++ b/test/new_relic/agent/distributed_tracing/distributed_trace_payload_test.rb
@@ -93,7 +93,7 @@ module NewRelic::Agent
       NewRelic::Agent.instance.adaptive_sampler.stubs(:sampled?).returns(true)
       in_transaction("test_txn2") do |txn|
         payload = DistributedTracePayload.for_transaction(txn)
-        assert_equal true, payload.sampled
+        assert payload.sampled
       end
     end
 
@@ -118,7 +118,7 @@ module NewRelic::Agent
       assert_equal referring_transaction.initial_segment.guid, payload.id
       assert_equal referring_transaction.guid, payload.transaction_id
       assert_equal referring_transaction.trace_id, payload.trace_id
-      assert_equal true, payload.sampled?
+      assert payload.sampled?
       assert_equal referring_transaction.priority, payload.priority
       assert_equal created_at.round, payload.timestamp
     end
@@ -144,7 +144,7 @@ module NewRelic::Agent
       assert_equal referring_transaction.initial_segment.guid, payload.id
       assert_equal referring_transaction.guid, payload.transaction_id
       assert_equal referring_transaction.trace_id, payload.trace_id
-      assert_equal true, payload.sampled?
+      assert payload.sampled?
       assert_equal referring_transaction.priority, payload.priority
       assert_equal created_at.round, payload.timestamp
     end

--- a/test/new_relic/agent/distributed_tracing/trace_context_payload_test.rb
+++ b/test/new_relic/agent/distributed_tracing/trace_context_payload_test.rb
@@ -61,7 +61,7 @@ module NewRelic
         assert_equal "6789", payload.parent_app_id
         assert_equal "f85f42fd82a4cf1d", payload.id
         assert_equal "164d3b4b0d09cb05", payload.transaction_id
-        assert_equal true, payload.sampled
+        assert payload.sampled
         assert_equal 0.123, payload.priority
       end
 
@@ -94,7 +94,7 @@ module NewRelic
         assert_equal "6789", payload.parent_app_id
         assert_equal "f85f42fd82a4cf1d", payload.id
         assert_equal "164d3b4b0d09cb05", payload.transaction_id
-        assert_equal true, payload.sampled
+        assert payload.sampled
         assert_equal 0.123, payload.priority
       end
 

--- a/test/new_relic/agent/priority_sampled_buffer_test.rb
+++ b/test/new_relic/agent/priority_sampled_buffer_test.rb
@@ -96,7 +96,7 @@ module NewRelic::Agent
 
       4.times do |i|
         buffer.append(event: create_event(priority: i))
-        assert_equal(true, buffer.full?, "#PrioritySampledBuffer#append should return true once buffer is full")
+        assert(buffer.full?, "#PrioritySampledBuffer#append should return true once buffer is full")
       end
     end
 

--- a/test/new_relic/agent/transaction/distributed_tracing_test.rb
+++ b/test/new_relic/agent/transaction/distributed_tracing_test.rb
@@ -260,7 +260,7 @@ module NewRelic
           assert_equal inbound_payload.trace_id, child_intrinsics["traceId"]
           assert_equal inbound_payload.id, child_intrinsics["parentSpanId"]
           assert_equal child_transaction.guid, child_intrinsics["guid"]
-          assert_equal true, child_intrinsics["sampled"]
+          assert child_intrinsics["sampled"]
 
           assert child_intrinsics["parentId"]
           assert_equal parent_transaction.guid, child_intrinsics["parentId"]
@@ -351,7 +351,7 @@ module NewRelic
           assert_equal inbound_payload.transaction_id, referring_transaction.guid
           assert_equal transaction.guid, intrinsics["guid"]
           assert_equal inbound_payload.trace_id, intrinsics["traceId"]
-          assert_equal true, intrinsics["sampled"]
+          assert intrinsics["sampled"]
           assert intrinsics["parentId"], "Child should be linked to parent transaction"
           assert_equal inbound_payload.transaction_id, intrinsics["parentId"]
         end
@@ -382,8 +382,8 @@ module NewRelic
 
           intrinsics, _, _ = last_transaction_event
 
-          assert_equal true, transaction.sampled?
-          assert_equal true, intrinsics["sampled"]
+          assert transaction.sampled?
+          assert intrinsics["sampled"]
         end
 
         def test_sampled_flag_added_to_intrinsics_without_distributed_trace_when_true
@@ -396,9 +396,9 @@ module NewRelic
           txn_intrinsics, _, _ = last_transaction_event
           err_intrinsics, _, _ = last_error_event
 
-          assert_equal true, transaction.sampled?
-          assert_equal true, txn_intrinsics["sampled"]
-          assert_equal true, err_intrinsics["sampled"]
+          assert transaction.sampled?
+          assert txn_intrinsics["sampled"]
+          assert err_intrinsics["sampled"]
         end
 
         def test_sampled_flag_added_to_intrinsics_without_distributed_trace_when_false
@@ -558,7 +558,7 @@ module NewRelic
           in_transaction('test_txn') do |txn|
             txn.distributed_tracer.accept_distributed_trace_payload(payload.text)
 
-            assert_equal true, txn.sampled?
+            assert txn.sampled?
             assert_equal payload.priority, txn.priority
           end
         end

--- a/test/new_relic/agent_test.rb
+++ b/test/new_relic/agent_test.rb
@@ -134,12 +134,12 @@ module NewRelic
 
     def test_is_sql_recorded_true
       NewRelic::Agent::Tracer.state.record_sql = true
-      assert_equal(true, NewRelic::Agent.tl_is_sql_recorded?, 'should be true since the thread local is set')
+      assert(NewRelic::Agent.tl_is_sql_recorded?, 'should be true since the thread local is set')
     end
 
     def test_is_sql_recorded_blank
       NewRelic::Agent::Tracer.state.record_sql = nil
-      assert_equal(true, NewRelic::Agent.tl_is_sql_recorded?, 'should be true since the thread local is not set')
+      assert(NewRelic::Agent.tl_is_sql_recorded?, 'should be true since the thread local is not set')
     end
 
     def test_is_sql_recorded_false
@@ -149,17 +149,17 @@ module NewRelic
 
     def test_is_execution_traced_true
       NewRelic::Agent::Tracer.state.untraced = [true, true]
-      assert_equal(true, NewRelic::Agent.tl_is_execution_traced?, 'should be true since the thread local is set')
+      assert(NewRelic::Agent.tl_is_execution_traced?, 'should be true since the thread local is set')
     end
 
     def test_is_execution_traced_blank
       NewRelic::Agent::Tracer.state.untraced = nil
-      assert_equal(true, NewRelic::Agent.tl_is_execution_traced?, 'should be true since the thread local is not set')
+      assert(NewRelic::Agent.tl_is_execution_traced?, 'should be true since the thread local is not set')
     end
 
     def test_is_execution_traced_empty
       NewRelic::Agent::Tracer.state.untraced = []
-      assert_equal(true, NewRelic::Agent.tl_is_execution_traced?,
+      assert(NewRelic::Agent.tl_is_execution_traced?,
         'should be true since the thread local is an empty array')
     end
 

--- a/test/new_relic/language_support_test.rb
+++ b/test/new_relic/language_support_test.rb
@@ -44,12 +44,12 @@ class NewRelic::LanguageSupportTest < Minitest::Test
 
     def test_gc_profiler_enabled
       ::GC::Profiler.stubs(:enabled?).returns(true)
-      assert_equal true, NewRelic::LanguageSupport.gc_profiler_enabled?
+      assert NewRelic::LanguageSupport.gc_profiler_enabled?
     end
 
     def test_gc_profiler_enabled_when_response_is_only_truthy
       ::GC::Profiler.stubs(:enabled?).returns(0)
-      assert_equal true, NewRelic::LanguageSupport.gc_profiler_enabled?
+      assert NewRelic::LanguageSupport.gc_profiler_enabled?
     end
 
     def test_gc_profiler_enabled_when_config_is_disabled


### PR DESCRIPTION
Address `Minitest/AssertTruthy` and remove from `rubocop_todo`