### PR TITLE
Address Minitest/LiteralAsActualArgument

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -99,26 +99,6 @@ Minitest/DuplicateTestRun:
     - 'test/multiverse/suites/rails/error_tracing_test.rb'
     - 'test/multiverse/suites/sinatra/ignoring_test.rb'
 
-# Offense count: 38
-# This cop supports safe autocorrection (--autocorrect).
-Minitest/LiteralAsActualArgument:
-  Exclude:
-    - 'test/multiverse/suites/rails/active_support_logger_test.rb'
-    - 'test/new_relic/agent/configuration/environment_source_test.rb'
-    - 'test/new_relic/agent/connect/request_builder_test.rb'
-    - 'test/new_relic/agent/error_trace_aggregator_test.rb'
-    - 'test/new_relic/agent/instrumentation/controller_instrumentation_test.rb'
-    - 'test/new_relic/agent/new_relic_service_test.rb'
-    - 'test/new_relic/agent/samplers/cpu_sampler_test.rb'
-    - 'test/new_relic/agent/samplers/memory_sampler_test.rb'
-    - 'test/new_relic/agent/stats_test.rb'
-    - 'test/new_relic/agent/transaction/abstract_segment_test.rb'
-    - 'test/new_relic/agent/transaction/datastore_segment_test.rb'
-    - 'test/new_relic/agent/transaction_sampler_test.rb'
-    - 'test/new_relic/gem_notifications_tests.rb'
-    - 'test/new_relic/marshalling_test_cases.rb'
-    - 'test/new_relic/noticed_error_test.rb'
-
 # Offense count: 260
 Minitest/MultipleAssertions:
   Max: 28

--- a/test/multiverse/suites/rails/active_support_logger_test.rb
+++ b/test/multiverse/suites/rails/active_support_logger_test.rb
@@ -35,7 +35,7 @@ if defined?(ActiveSupport::Logger)
 
       # LogEventAggregator sees the log only once
       assert_equal 1, @aggregator.instance_variable_get(:@seen)
-      assert_equal @aggregator.instance_variable_get(:@seen_by_severity), {"DEBUG" => 1}
+      assert_equal({"DEBUG" => 1}, @aggregator.instance_variable_get(:@seen_by_severity))
     end
   end
 end

--- a/test/new_relic/agent/configuration/environment_source_test.rb
+++ b/test/new_relic/agent/configuration/environment_source_test.rb
@@ -121,7 +121,7 @@ module NewRelic::Agent::Configuration
     def test_set_value_from_environment_variable
       ENV['NEW_RELIC_LICENSE_KEY'] = 'super rad'
       @environment_source.set_value_from_environment_variable('NEW_RELIC_LICENSE_KEY')
-      assert_equal @environment_source[:license_key], 'super rad'
+      assert_equal 'super rad', @environment_source[:license_key]
     end
 
     def test_set_key_by_type_uses_the_default_type

--- a/test/new_relic/agent/connect/request_builder_test.rb
+++ b/test/new_relic/agent/connect/request_builder_test.rb
@@ -49,7 +49,7 @@ class NewRelic::Agent::Agent::RequestBuilderTest < Minitest::Test
 
       settings = @request_builder.connect_payload
 
-      assert_equal settings[:identifier], "ruby:lo-calhost:a,b,c"
+      assert_equal "ruby:lo-calhost:a,b,c", settings[:identifier]
     end
   end
 

--- a/test/new_relic/agent/error_trace_aggregator_test.rb
+++ b/test/new_relic/agent/error_trace_aggregator_test.rb
@@ -39,7 +39,7 @@ module NewRelic
 
         errors = error_trace_aggregator.harvest!
 
-        assert_equal errors.length, 1
+        assert_equal 1, errors.length
 
         err = errors.first
         assert_equal 'message', err.message

--- a/test/new_relic/agent/instrumentation/controller_instrumentation_test.rb
+++ b/test/new_relic/agent/instrumentation/controller_instrumentation_test.rb
@@ -227,19 +227,19 @@ module NewRelic::Agent::Instrumentation
 
     def test_transaction_namer_determines_prefix
       in_transaction do |txn|
-        assert_equal @txn_namer.prefix_for_category(txn, :controller), 'Controller/'
-        assert_equal @txn_namer.prefix_for_category(txn, :web), 'Controller/'
-        assert_equal @txn_namer.prefix_for_category(txn, :task), 'OtherTransaction/Background/'
-        assert_equal @txn_namer.prefix_for_category(txn, :background), 'OtherTransaction/Background/'
-        assert_equal @txn_namer.prefix_for_category(txn, :rack), 'Controller/Rack/'
-        assert_equal @txn_namer.prefix_for_category(txn, :sinatra), 'Controller/Sinatra/'
-        assert_equal @txn_namer.prefix_for_category(txn, :uri), 'Controller/'
-        assert_equal @txn_namer.prefix_for_category(txn, :middleware), 'Middleware/Rack/'
-        assert_equal @txn_namer.prefix_for_category(txn, :grape), 'Controller/Grape/'
-        assert_equal @txn_namer.prefix_for_category(txn, :rake), 'OtherTransaction/Rake/'
-        assert_equal @txn_namer.prefix_for_category(txn, :action_cable), 'Controller/ActionCable/'
-        assert_equal @txn_namer.prefix_for_category(txn, :message), 'OtherTransaction/Message/'
-        assert_equal @txn_namer.prefix_for_category(txn, :foo), 'foo/'
+        assert_equal 'Controller/', @txn_namer.prefix_for_category(txn, :controller)
+        assert_equal 'Controller/', @txn_namer.prefix_for_category(txn, :web)
+        assert_equal 'OtherTransaction/Background/', @txn_namer.prefix_for_category(txn, :task)
+        assert_equal 'OtherTransaction/Background/', @txn_namer.prefix_for_category(txn, :background)
+        assert_equal 'Controller/Rack/', @txn_namer.prefix_for_category(txn, :rack)
+        assert_equal 'Controller/Sinatra/', @txn_namer.prefix_for_category(txn, :sinatra)
+        assert_equal 'Controller/', @txn_namer.prefix_for_category(txn, :uri)
+        assert_equal 'Middleware/Rack/', @txn_namer.prefix_for_category(txn, :middleware)
+        assert_equal 'Controller/Grape/', @txn_namer.prefix_for_category(txn, :grape)
+        assert_equal 'OtherTransaction/Rake/', @txn_namer.prefix_for_category(txn, :rake)
+        assert_equal 'Controller/ActionCable/', @txn_namer.prefix_for_category(txn, :action_cable)
+        assert_equal 'OtherTransaction/Message/', @txn_namer.prefix_for_category(txn, :message)
+        assert_equal 'foo/', @txn_namer.prefix_for_category(txn, :foo)
       end
     end
 

--- a/test/new_relic/agent/new_relic_service_test.rb
+++ b/test/new_relic/agent/new_relic_service_test.rb
@@ -317,7 +317,7 @@ class NewRelicServiceTest < Minitest::Test
     @http_handle.respond_to(:preconnect, preconnect_response_for_policies('localhost', policies))
 
     with_config(:security_policies_token => 'please-check-these-policies') do
-      assert_equal @service.preconnect['redirect_host'], 'localhost'
+      assert_equal 'localhost', @service.preconnect['redirect_host']
     end
   end
 

--- a/test/new_relic/agent/samplers/cpu_sampler_test.rb
+++ b/test/new_relic/agent/samplers/cpu_sampler_test.rb
@@ -36,11 +36,11 @@ class NewRelic::Agent::Samplers::CpuSamplerTest < Minitest::Test
   #
 
   def assert_supported_on_platform
-    assert_equal NewRelic::Agent::Samplers::CpuSampler.supported_on_this_platform?, true, "should be supported on this platform"
+    assert NewRelic::Agent::Samplers::CpuSampler.supported_on_this_platform?, "should be supported on this platform"
   end
 
   def refute_supported_on_platform
-    assert_equal NewRelic::Agent::Samplers::CpuSampler.supported_on_this_platform?, false, "should not be supported on this platform"
+    refute NewRelic::Agent::Samplers::CpuSampler.supported_on_this_platform?, "should not be supported on this platform"
   end
 
   def set_jruby_version_constant(string)

--- a/test/new_relic/agent/samplers/memory_sampler_test.rb
+++ b/test/new_relic/agent/samplers/memory_sampler_test.rb
@@ -70,7 +70,7 @@ class NewRelic::Agent::Samplers::MemorySamplerTest < Minitest::Test
     NewRelic::Helper.stubs('run_command').with('uname -s').raises(NewRelic::CommandRunFailedError)
     NewRelic::Agent::Samplers::MemorySampler.stub_const(:RUBY_PLATFORM, 'java') do
       platform = NewRelic::Agent::Samplers::MemorySampler.platform
-      assert_equal platform, 'unknown'
+      assert_equal 'unknown', platform
     end
   end
 

--- a/test/new_relic/agent/stats_test.rb
+++ b/test/new_relic/agent/stats_test.rb
@@ -50,7 +50,7 @@ class NewRelic::Agent::StatsTest < Minitest::Test
     stats = NewRelic::Agent::Stats.new
     validate(stats: stats, count: 0, total: 0, min: 0, max: 0)
 
-    assert_equal stats.call_count, 0
+    assert_equal 0, stats.call_count
     stats.trace_call(10)
     stats.trace_call(20)
     stats.trace_call(30)

--- a/test/new_relic/agent/transaction/abstract_segment_test.rb
+++ b/test/new_relic/agent/transaction/abstract_segment_test.rb
@@ -257,14 +257,14 @@ module NewRelic
 
         def test_code_level_metrics_attributes_are_empty_if_the_metrics_are_empty
           with_segment do |segment|
-            assert_equal(segment.code_attributes, {})
+            assert_empty segment.code_attributes
           end
         end
 
         def test_code_level_metrics_are_all_or_nothing
           with_segment do |segment|
             segment.code_information = clm_info.reject { |key| key == :namespace }
-            assert_equal(segment.code_attributes, {})
+            assert_empty(segment.code_attributes)
           end
         end
 

--- a/test/new_relic/agent/transaction/datastore_segment_test.rb
+++ b/test/new_relic/agent/transaction/datastore_segment_test.rb
@@ -517,7 +517,7 @@ module NewRelic
           sample = last_transaction_trace
           node = find_node_with_name(sample, segment.name)
 
-          assert_equal node.params[:database_name], "pizza_cube"
+          assert_equal "pizza_cube", node.params[:database_name]
         end
 
         def test_does_not_add_database_name_segment_parameter_when_disabled
@@ -552,10 +552,10 @@ module NewRelic
             Agent.instance.sql_sampler.expects(:notice_sql_statement) do |statement, name, duration|
               assert_equal segment.sql_statement.sql, statement.sql_statement
               assert_equal segment.name, name
-              assert_equal duration, 2.0
+              assert_equal(2.0, duration)
             end
             segment.finish
-            assert_equal segment.params[:sql].sql, "select * from blogs"
+            assert_equal("select * from blogs", segment.params[:sql].sql)
           end
         end
 
@@ -625,7 +625,7 @@ module NewRelic
             )
             segment.notice_sql("select * from blogs where " + ("something is nothing" * 16_384))
             segment.finish
-            assert_equal segment.params[:sql].sql.length, 16_384
+            assert_equal(16_384, segment.params[:sql].sql.length)
           end
         end
 
@@ -641,10 +641,10 @@ module NewRelic
             Agent.instance.sql_sampler.expects(:notice_sql_statement) do |statement, name, duration|
               assert_equal segment.sql_statement.sql, statement.sql_statement
               assert_equal segment.name, name
-              assert_equal duration, 2.0
+              assert_equal(2.0, duration)
             end
             segment.finish
-            assert_equal segment.params[:sql].sql, "select * from blogs"
+            assert_equal("select * from blogs", segment.params[:sql].sql)
           end
         end
 

--- a/test/new_relic/agent/transaction_sampler_test.rb
+++ b/test/new_relic/agent/transaction_sampler_test.rb
@@ -274,7 +274,7 @@ module NewRelic::Agent
         @sampler.merge!([slowest])
         new_slowest = @sampler.harvest![0]
         assert((new_slowest != slowest), "Should not harvest the same trace since the new one should be slower")
-        assert_equal(new_slowest.duration.round, 10, "Slowest duration must be = 10, but was: #{new_slowest.duration.inspect}")
+        assert_equal(10, new_slowest.duration.round, "Slowest duration must be = 10, but was: #{new_slowest.duration.inspect}")
       end
       nr_unfreeze_process_time
     end

--- a/test/new_relic/marshalling_test_cases.rb
+++ b/test/new_relic/marshalling_test_cases.rb
@@ -70,7 +70,7 @@ module MarshallingTestCases
     assert_equal "TestTransaction/do_it", event[0]["name"]
     assert_equal 0.0, event[0]["duration"]
     refute event[0]["error"]
-    assert_equal event[0]["parent.transportType"], "Unknown"
+    assert_equal "Unknown", event[0]["parent.transportType"]
     refute_nil event[0]['guid']
     refute_nil event[0]["traceId"]
 
@@ -147,10 +147,10 @@ module MarshallingTestCases
 
     assert_equal 12, event[0].size
 
-    assert_equal event[1], {}
-    assert_equal event[2], {}
+    assert_empty(event[1])
+    assert_empty(event[2])
 
-    assert_equal event.size, 3
+    assert_equal(3, event.size)
   end
 
   def test_sends_log_events

--- a/test/new_relic/noticed_error_test.rb
+++ b/test/new_relic/noticed_error_test.rb
@@ -184,7 +184,7 @@ class NewRelic::Agent::NoticedErrorTest < Minitest::Test
     e = Exception.new('Buffy FOREVER')
     e.stubs(:original_exception).returns(nil)
     error = NewRelic::NoticedError.new(@path, e, @time)
-    assert_equal(error.message.to_s, 'Buffy FOREVER')
+    assert_equal('Buffy FOREVER', error.message.to_s)
   end
 
   if defined?(Rails::VERSION::MAJOR) && Rails::VERSION::MAJOR < 5
@@ -192,7 +192,7 @@ class NewRelic::Agent::NoticedErrorTest < Minitest::Test
       orig = FooError.new
       e = mock('exception', original_exception: orig)
       error = NewRelic::NoticedError.new(@path, e, @time)
-      assert_equal(error.exception_class_name, 'FooError')
+      assert_equal('FooError', error.exception_class_name)
     end
   end
 


### PR DESCRIPTION
Address  rubocop `Minitest/LiteralAsActualArgument` and remove from `rubocop_todo`