### PR TITLE
Rubocop refactor review revisions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1796,9 +1796,6 @@ Style/WhileUntilDo:
 Style/WhileUntilModifier:
   Enabled: false
 
-Style/WordArray:
-  Enabled: false
-
 # Disabling for now
 Style/YodaCondition:
   Enabled: false

--- a/infinite_tracing/newrelic-infinite_tracing.gemspec
+++ b/infinite_tracing/newrelic-infinite_tracing.gemspec
@@ -68,7 +68,7 @@ Gem or plugin, hosted on https://github.com/newrelic/newrelic-ruby-agent/
   s.files = file_list
 
   s.homepage = "https://github.com/newrelic/newrelic-ruby-agent/tree/main/infinite_tracing"
-  s.require_paths = ["lib", "infinite_tracing"]
+  s.require_paths = %w[lib infinite_tracing]
   s.summary = "New Relic Infinite Tracing for the Ruby agent"
 
   s.add_dependency 'newrelic_rpm', NewRelic::VERSION::STRING

--- a/lib/new_relic/agent/attribute_filter.rb
+++ b/lib/new_relic/agent/attribute_filter.rb
@@ -129,7 +129,7 @@ module NewRelic
       end
 
       def prep_datastore_rules(config)
-        build_rule(['host', 'port_path_or_id'], DST_TRANSACTION_SEGMENTS, config[:'datastore_tracer.instance_reporting.enabled'])
+        build_rule(%w[host port_path_or_id], DST_TRANSACTION_SEGMENTS, config[:'datastore_tracer.instance_reporting.enabled'])
         build_rule(['database_name'], DST_TRANSACTION_SEGMENTS, config[:'datastore_tracer.database_name_reporting.enabled'])
       end
 

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -1931,7 +1931,7 @@ A map of error classes to a list of messages. When an error of one of the classe
           :description => 'If `true`, the agent uses Heroku dyno names as the hostname.'
         },
         :'heroku.dyno_name_prefixes_to_shorten' => {
-          :default => ['scheduler', 'run'],
+          :default => %w[scheduler run],
           :public => true,
           :type => Array,
           :allowed_from_server => false,

--- a/lib/new_relic/agent/configuration/yaml_source.rb
+++ b/lib/new_relic/agent/configuration/yaml_source.rb
@@ -13,7 +13,7 @@ module NewRelic
 
         # These are configuration options that have a value of a Hash
         # This is used in YamlSource#dot_flattened prevent flattening these values
-        CONFIG_WITH_HASH_VALUE = ['expected_messages', 'ignore_messages']
+        CONFIG_WITH_HASH_VALUE = %w[expected_messages ignore_messages]
 
         def initialize(path, env)
           @path = path

--- a/lib/new_relic/agent/database.rb
+++ b/lib/new_relic/agent/database.rb
@@ -118,18 +118,18 @@ module NewRelic
         return statement.explain || []
       end
 
-      KNOWN_OPERATIONS = [
-        'alter',
-        'select',
-        'update',
-        'delete',
-        'insert',
-        'create',
-        'show',
-        'set',
-        'exec',
-        'execute',
-        'call'
+      KNOWN_OPERATIONS = %w[
+        alter
+        select
+        update
+        delete
+        insert
+        create
+        show
+        set
+        exec
+        execute
+        call
       ]
       OTHER_OPERATION = 'other'.freeze
       SQL_COMMENT_REGEX = Regexp.new('/\*.*?\*/', Regexp::MULTILINE).freeze

--- a/lib/new_relic/agent/datastores/mongo/event_formatter.rb
+++ b/lib/new_relic/agent/datastores/mongo/event_formatter.rb
@@ -10,10 +10,10 @@ module NewRelic
       module Mongo
         module EventFormatter
           # Keys that will get their values replaced with '?'.
-          OBFUSCATE_KEYS = ['filter', 'query', 'pipeline'].freeze
+          OBFUSCATE_KEYS = %w[filter query pipeline].freeze
 
           # Keys that will get completely removed from the statement.
-          DENYLISTED_KEYS = ['deletes', 'documents', 'updates'].freeze
+          DENYLISTED_KEYS = %w[deletes documents updates].freeze
 
           def self.format(command_name, database_name, command)
             return nil unless NewRelic::Agent.config[:'mongo.capture_queries']

--- a/lib/new_relic/agent/utilization/azure.rb
+++ b/lib/new_relic/agent/utilization/azure.rb
@@ -9,7 +9,7 @@ module NewRelic
         vendor_name "azure"
         endpoint "http://169.254.169.254/metadata/instance/compute?api-version=2017-03-01"
         headers "Metadata" => "true"
-        keys ["vmId", "name", "vmSize", "location"]
+        keys %w[vmId name vmSize location]
         key_transforms :to_sym
       end
     end

--- a/lib/new_relic/agent/utilization/gcp.rb
+++ b/lib/new_relic/agent/utilization/gcp.rb
@@ -11,7 +11,7 @@ module NewRelic
         vendor_name "gcp"
         endpoint "http://metadata.google.internal/computeMetadata/v1/instance/?recursive=true"
         headers "Metadata-Flavor" => "Google"
-        keys ["id", "machineType", "name", "zone"]
+        keys %w[id machineType name zone]
         key_transforms :to_sym
 
         MACH_TYPE = 'machineType'.freeze

--- a/lib/new_relic/agent/utilization/pcf.rb
+++ b/lib/new_relic/agent/utilization/pcf.rb
@@ -9,7 +9,7 @@ module NewRelic
     module Utilization
       class PCF < Vendor
         vendor_name "pcf"
-        keys ["CF_INSTANCE_GUID", "CF_INSTANCE_IP", "MEMORY_LIMIT"]
+        keys %w[CF_INSTANCE_GUID CF_INSTANCE_IP MEMORY_LIMIT]
         key_transforms [:downcase, :to_sym]
 
         def detect

--- a/lib/new_relic/control/private_instance_methods.rb
+++ b/lib/new_relic/control/private_instance_methods.rb
@@ -2,12 +2,14 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
-# require 'new_relic/agent/agent_logger'
-# require 'new_relic/agent/memory_logger'
+require 'new_relic/agent/memory_logger'
+require 'new_relic/agent/agent_logger'
 
 module NewRelic
   class Control
     module PrivateInstanceMethods
+      private
+
       def configure_high_security
         if security_settings_valid? && Agent.config[:high_security]
           Agent.logger.info("Installing high security configuration based on local configuration")

--- a/lib/tasks/instrumentation_generator/instrumentation.thor
+++ b/lib/tasks/instrumentation_generator/instrumentation.thor
@@ -57,7 +57,7 @@ class Instrumentation < Thor
   private
 
   def create_instrumentation_files(base_path)
-    ['chain', 'instrumentation', 'prepend'].each do |file|
+    %w[chain instrumentation prepend].each do |file|
       template("templates/#{file}.tt", "#{base_path}/#{file}.rb")
     end
 

--- a/newrelic_rpm.gemspec
+++ b/newrelic_rpm.gemspec
@@ -21,7 +21,7 @@ Gem or plugin, hosted on
 https://github.com/newrelic/newrelic-ruby-agent/
   EOS
   s.email = "support@newrelic.com"
-  s.executables = ["newrelic_cmd", "newrelic", "nrdebug"]
+  s.executables = %w[newrelic_cmd newrelic nrdebug]
   s.extra_rdoc_files = [
     "CHANGELOG.md",
     "LICENSE",

--- a/test/multiverse/lib/multiverse/runner.rb
+++ b/test/multiverse/lib/multiverse/runner.rb
@@ -98,14 +98,14 @@ module Multiverse
     end
 
     GROUPS = {
-      "agent" => ["agent_only", "bare", "config_file_loading", "deferred_instrumentation", "high_security", "no_json", "json", "marshalling", "yajl"],
-      "background" => ["delayed_job", "sidekiq", "resque"],
+      "agent" => %w[agent_only bare config_file_loading deferred_instrumentation high_security no_json json marshalling yajl],
+      "background" => %w[delayed_job sidekiq resque],
       "background_2" => ["rake"],
-      "database" => ["datamapper", "mongo", "redis", "sequel"],
-      "rails" => ["active_record", "active_record_pg", "rails", "rails_prepend", "activemerchant"],
-      "frameworks" => ["sinatra", "padrino", "grape"],
-      "httpclients" => ["curb", "excon", "httpclient"],
-      "httpclients_2" => ["typhoeus", "net_http", "httprb"],
+      "database" => %w[datamapper mongo redis sequel],
+      "rails" => %w[active_record active_record_pg rails rails_prepend activemerchant],
+      "frameworks" => %w[sinatra padrino grape],
+      "httpclients" => %w[curb excon httpclient],
+      "httpclients_2" => %w[typhoeus net_http httprb],
       "infinite_tracing" => ["infinite_tracing"],
 
       "rest" => [] # Specially handled below

--- a/test/multiverse/suites/active_record/active_record_test.rb
+++ b/test/multiverse/suites/active_record/active_record_test.rb
@@ -627,7 +627,7 @@ class ActiveRecordInstrumentationTest < Minitest::Test
   end
 
   def assert_activerecord_metrics(model, operation, stats = {})
-    operation = operation_for(operation) if ['create', 'delete'].include?(operation)
+    operation = operation_for(operation) if %w[create delete].include?(operation)
 
     assert_metrics_recorded({
       "Datastore/statement/#{current_product}/#{model}/#{operation}" => stats,

--- a/test/multiverse/suites/active_record_pg/active_record_test.rb
+++ b/test/multiverse/suites/active_record_pg/active_record_test.rb
@@ -617,7 +617,7 @@ class ActiveRecordInstrumentationTest < Minitest::Test
   end
 
   def assert_activerecord_metrics(model, operation, stats = {})
-    operation = operation_for(operation) if ['create', 'delete'].include?(operation)
+    operation = operation_for(operation) if %w[create delete].include?(operation)
 
     assert_metrics_recorded({
       "Datastore/statement/#{current_product}/#{model}/#{operation}" => stats,

--- a/test/multiverse/suites/agent_only/rename_rule_test.rb
+++ b/test/multiverse/suites/agent_only/rename_rule_test.rb
@@ -11,7 +11,7 @@ class RenameRuleTest < Minitest::Test
       {'match_expression' => 'Nothing', 'replacement' => 'Something'}
     ]
     segment_terms_rules = [
-      {'prefix' => 'other/qux', 'terms' => ['Nothing', 'one', 'two']}
+      {'prefix' => 'other/qux', 'terms' => %w[Nothing one two]}
     ]
     collector.stub('connect', {
       'agent_run_id' => 666,

--- a/test/multiverse/suites/grape/grape_versioning_test_api.rb
+++ b/test/multiverse/suites/grape/grape_versioning_test_api.rb
@@ -47,7 +47,7 @@ unless ::Grape::VERSION == '0.1.5'
     class ApiV4 < Grape::API
       # version from http accept header is not supported in older versions of grape
       if Gem::Version.new(Grape::VERSION) >= Gem::Version.new('0.16.0')
-        version ['v4', 'v5'], :using => :accept_version_header
+        version %w[v4 v5], :using => :accept_version_header
       end
 
       format :json

--- a/test/multiverse/suites/rails/activejob_test.rb
+++ b/test/multiverse/suites/rails/activejob_test.rb
@@ -165,7 +165,7 @@ if Rails::VERSION::STRING >= "4.2.0"
 
     def test_doesnt_interfere_with_params_on_job
       MyJobWithParams.perform_later("1", "2")
-      assert_equal(["1", "2"], MyJobWithParams.last_params)
+      assert_equal(%w[1 2], MyJobWithParams.last_params)
     end
 
     def test_captures_errors

--- a/test/multiverse/suites/rails/request_statistics_test.rb
+++ b/test/multiverse/suites/rails/request_statistics_test.rb
@@ -141,7 +141,7 @@ class RequestStatsTest < ActionDispatch::IntegrationTest
       assert_encoding 'utf-8', sample['name']
       assert_equal 'Transaction', sample['type']
 
-      ['blue', 'bar', 'bad'].each do |key|
+      %w[blue bar bad].each do |key|
         assert_not_includes(sample, key)
       end
 

--- a/test/multiverse/suites/rails/view_instrumentation_test.rb
+++ b/test/multiverse/suites/rails/view_instrumentation_test.rb
@@ -98,7 +98,7 @@ class ViewInstrumentationTest < ActionDispatch::IntegrationTest
     end
   end
 
-  (ViewsController.action_methods - ['raise_render', 'collection_render', 'haml_render']).each do |method|
+  (ViewsController.action_methods - %w[raise_render collection_render haml_render]).each do |method|
     define_method("test_sanity_#{method}") do
       get "/views/#{method}"
       assert_equal 200, status

--- a/test/multiverse/suites/redis/redis_instrumentation_test.rb
+++ b/test/multiverse/suites/redis/redis_instrumentation_test.rb
@@ -366,12 +366,12 @@ if NewRelic::Agent::Datastores::Redis.is_supported_version?
       assert_equal 'bar', @redis.get('foo')
       assert_equal 1, @redis.del('foo')
 
-      assert_equal ['OK', 'OK'], @redis.multi { @redis.set('foo', 'bar'); @redis.set('baz', 'bat') }
-      assert_equal ['bar', 'bat'], @redis.multi { @redis.get('foo'); @redis.get('baz') }
+      assert_equal %w[OK OK], @redis.multi { @redis.set('foo', 'bar'); @redis.set('baz', 'bat') }
+      assert_equal %w[bar bat], @redis.multi { @redis.get('foo'); @redis.get('baz') }
       assert_equal 2, @redis.del('foo', 'baz')
 
-      assert_equal ['OK', 'OK'], @redis.pipelined { @redis.set('foo', 'bar'); @redis.set('baz', 'bat') }
-      assert_equal ['bar', 'bat'], @redis.pipelined { @redis.get('foo'); @redis.get('baz') }
+      assert_equal %w[OK OK], @redis.pipelined { @redis.set('foo', 'bar'); @redis.set('baz', 'bat') }
+      assert_equal %w[bar bat], @redis.pipelined { @redis.get('foo'); @redis.get('baz') }
       assert_equal 2, @redis.del('foo', 'baz')
     end
 

--- a/test/new_relic/agent/agent_logger_test.rb
+++ b/test/new_relic/agent/agent_logger_test.rb
@@ -221,7 +221,7 @@ class AgentLoggerTest < Minitest::Test
     logger = create_basic_logger
 
     e = Exception.new("howdy")
-    e.set_backtrace(["wiggle", "wobble", "topple"])
+    e.set_backtrace(%w[wiggle wobble topple])
 
     logger.log_exception(:info, e)
 
@@ -233,7 +233,7 @@ class AgentLoggerTest < Minitest::Test
     logger = create_basic_logger
 
     e = Exception.new("howdy")
-    e.set_backtrace(["wiggle", "wobble", "topple"])
+    e.set_backtrace(%w[wiggle wobble topple])
 
     logger.log_exception(:warn, e, :info)
 

--- a/test/new_relic/agent/agent_test.rb
+++ b/test/new_relic/agent/agent_test.rb
@@ -554,7 +554,7 @@ module NewRelic
 
       def test_harvest_from_container
         container = mock
-        harvested_items = ['foo', 'bar', 'baz']
+        harvested_items = %w[foo bar baz]
         container.expects(:harvest!).returns(harvested_items)
         items = @agent.send(:harvest_from_container, container, 'digglewumpus')
         assert_equal(harvested_items, items)
@@ -702,7 +702,7 @@ module NewRelic
       end
 
       def test_log_ignore_url_regexes
-        with_config(:rules => {:ignore_url_regexes => ['foo', 'bar', 'baz']}) do
+        with_config(:rules => {:ignore_url_regexes => %w[foo bar baz]}) do
           expects_logging(:info, includes("/foo/, /bar/, /baz/"))
           @agent.log_ignore_url_regexes
         end

--- a/test/new_relic/agent/attribute_filter_test.rb
+++ b/test/new_relic/agent/attribute_filter_test.rb
@@ -80,7 +80,7 @@ module NewRelic::Agent
         filter = AttributeFilter.new(NewRelic::Agent.config)
         result = filter.apply('request.parameters.muggle', AttributeFilter::DST_NONE)
 
-        assert_destinations ['transaction_tracer', 'error_collector'], result
+        assert_destinations %w[transaction_tracer error_collector], result
       end
     end
 
@@ -98,7 +98,7 @@ module NewRelic::Agent
         filter = AttributeFilter.new(NewRelic::Agent.config)
         result = filter.apply('job.resque.args.*', AttributeFilter::DST_NONE)
 
-        assert_destinations ['transaction_tracer', 'error_collector'], result
+        assert_destinations %w[transaction_tracer error_collector], result
       end
     end
 
@@ -116,7 +116,7 @@ module NewRelic::Agent
         filter = AttributeFilter.new(NewRelic::Agent.config)
         result = filter.apply('job.sidekiq.args.*', AttributeFilter::DST_NONE)
 
-        assert_destinations ['transaction_tracer', 'error_collector'], result
+        assert_destinations %w[transaction_tracer error_collector], result
       end
     end
 
@@ -217,12 +217,12 @@ module NewRelic::Agent
 
         result = filter.apply('request.headers.contentType', AttributeFilter::DST_ALL)
 
-        expected_destinations = [
-          'transaction_events',
-          'transaction_tracer',
-          'error_collector',
-          'span_events',
-          'transaction_segments'
+        expected_destinations = %w[
+          transaction_events
+          transaction_tracer
+          error_collector
+          span_events
+          transaction_segments
         ]
 
         assert_destinations expected_destinations, result

--- a/test/new_relic/agent/attribute_processing_test.rb
+++ b/test/new_relic/agent/attribute_processing_test.rb
@@ -49,7 +49,7 @@ class AttributeProcessingTest < Minitest::Test
   end
 
   def test_prefix_optional_for_flatten_and_coerce
-    params = {:foo => {:bar => ["v1", "v2"]}}
+    params = {:foo => {:bar => %w[v1 v2]}}
 
     expected = {
       "foo.bar.0" => "v1",
@@ -62,7 +62,7 @@ class AttributeProcessingTest < Minitest::Test
   end
 
   def test_prefix_optional_for_flatten_and_coerce_with_initial_array_argument
-    params = [:foo => {:bar => ["v1", "v2"]}]
+    params = [:foo => {:bar => %w[v1 v2]}]
 
     expected = {
       "0.foo.bar.0" => "v1",
@@ -141,7 +141,7 @@ class AttributeProcessingTest < Minitest::Test
   end
 
   def test_flatten_and_coerce_calls_a_block_key_and_value_when_provided
-    params = {:foo => {:bar => ["qux", "quux"]}}
+    params = {:foo => {:bar => %w[qux quux]}}
     yielded = {}
 
     NewRelic::Agent::AttributeProcessing.flatten_and_coerce(params) { |k, v| yielded[k] = v }

--- a/test/new_relic/agent/collector_response_code_test.rb
+++ b/test/new_relic/agent/collector_response_code_test.rb
@@ -10,7 +10,7 @@ module NewRelic
     class CollectorResponseCodeTest < Minitest::Test
       def setup
         @agent = NewRelic::Agent::Agent.new
-        @errors = ["e1", "e2"]
+        @errors = %w[e1 e2]
       end
 
       def stub_service(response)

--- a/test/new_relic/agent/configuration/default_source_test.rb
+++ b/test/new_relic/agent/configuration/default_source_test.rb
@@ -98,7 +98,7 @@ module NewRelic::Agent::Configuration
 
     def test_convert_to_list
       result = DefaultSource.convert_to_list("Foo,Bar,Baz")
-      assert_equal ['Foo', 'Bar', 'Baz'], result
+      assert_equal %w[Foo Bar Baz], result
     end
 
     def test_convert_to_list_returns_original_argument_given_array
@@ -170,7 +170,7 @@ module NewRelic::Agent::Configuration
         key = "#{type}attributes.exclude".to_sym
 
         with_config(key => 'foo,bar,baz') do
-          expected = ["foo", "bar", "baz"]
+          expected = %w[foo bar baz]
           result = NewRelic::Agent.config[key]
 
           message = "Expected #{key} to convert comma delimited string into array.\nExpected: #{expected.inspect}, Result: #{result.inspect}\n"
@@ -180,7 +180,7 @@ module NewRelic::Agent::Configuration
         key = "#{type}attributes.include".to_sym
 
         with_config(key => 'foo,bar,baz') do
-          assert_equal ["foo", "bar", "baz"], NewRelic::Agent.config[key]
+          assert_equal %w[foo bar baz], NewRelic::Agent.config[key]
         end
       end
     end
@@ -192,8 +192,8 @@ module NewRelic::Agent::Configuration
       types.each do |type|
         key = "#{type}attributes.exclude".to_sym
 
-        with_config(key => ['foo', 'bar', 'baz']) do
-          expected = ["foo", "bar", "baz"]
+        with_config(key => %w[foo bar baz]) do
+          expected = %w[foo bar baz]
           result = NewRelic::Agent.config[key]
 
           message = "Expected #{key} not to modify settings from YAML array.\nExpected: #{expected.inspect}, Result: #{result.inspect}\n"
@@ -203,7 +203,7 @@ module NewRelic::Agent::Configuration
         key = "#{type}attributes.include".to_sym
 
         with_config(key => 'foo,bar,baz') do
-          assert_equal ["foo", "bar", "baz"], NewRelic::Agent.config[key]
+          assert_equal %w[foo bar baz], NewRelic::Agent.config[key]
         end
       end
     end

--- a/test/new_relic/agent/configuration/environment_source_test.rb
+++ b/test/new_relic/agent/configuration/environment_source_test.rb
@@ -133,13 +133,13 @@ module NewRelic::Agent::Configuration
     def test_set_key_by_type_converts_comma_lists_to_array
       ENV['NEW_RELIC_ATTRIBUTES_INCLUDE'] = 'hi,bye'
       @environment_source.set_key_by_type(:'attributes.include', 'NEW_RELIC_ATTRIBUTES_INCLUDE')
-      assert_equal ['hi', 'bye'], @environment_source[:'attributes.include']
+      assert_equal %w[hi bye], @environment_source[:'attributes.include']
     end
 
     def test_set_key_by_type_converts_comma_lists_with_spaces_to_array
       ENV['NEW_RELIC_ATTRIBUTES_INCLUDE'] = 'hi, bye'
       @environment_source.set_key_by_type(:'attributes.include', 'NEW_RELIC_ATTRIBUTES_INCLUDE')
-      assert_equal ['hi', 'bye'], @environment_source[:'attributes.include']
+      assert_equal %w[hi bye], @environment_source[:'attributes.include']
     end
 
     def test_set_key_with_new_relic_prefix

--- a/test/new_relic/agent/database_test.rb
+++ b/test/new_relic/agent/database_test.rb
@@ -54,7 +54,7 @@ class NewRelic::Agent::DatabaseTest < Minitest::Test
     config = {:adapter => 'mysql2'}
     sql = 'SELECT * FROM spells where id=1'
 
-    columns = ["id", "select_type", "table", "type", "possible_keys", "key", "key_len", "ref", "rows", "Extra"]
+    columns = %w[id select_type table type possible_keys key key_len ref rows Extra]
     rows = [["1", "SIMPLE", "spells", "const", "PRIMARY", "PRIMARY", "4", "const", "1", ""]]
     activerecord_result = ::ActiveRecord::Result.new(columns, rows)
     explainer = lambda { |statement| activerecord_result }
@@ -108,8 +108,8 @@ class NewRelic::Agent::DatabaseTest < Minitest::Test
 
     statement = NewRelic::Agent::Database::Statement.new(sql, config, explainer)
     result = NewRelic::Agent::Database.explain_sql(statement)
-    expected_result = [["select_type", "key_len", "table", "id", "possible_keys", "type",
-      "Extra", "rows", "ref", "key"],
+    expected_result = [%w[select_type key_len table id possible_keys type
+      Extra rows ref key],
       [["SIMPLE", nil, "blogs", "1", nil, "ALL", "", "2", nil, nil]]]
 
     assert_equal(expected_result[0].sort, result[0].sort, "Headers don't match")
@@ -142,7 +142,7 @@ class NewRelic::Agent::DatabaseTest < Minitest::Test
     config = {:adapter => 'mysql2'}
     sql = 'SELECT foo'
 
-    plan_fields = ["select_type", "key_len", "table", "id", "possible_keys", "type", "Extra", "rows", "ref", "key"]
+    plan_fields = %w[select_type key_len table id possible_keys type Extra rows ref key]
     plan_row = ["SIMPLE", nil, "blogs", "1", nil, "ALL", "", "2", nil, nil]
     explainer_result = mock('explain plan')
     explainer_result.expects(:fields).returns(plan_fields)
@@ -151,8 +151,8 @@ class NewRelic::Agent::DatabaseTest < Minitest::Test
 
     statement = NewRelic::Agent::Database::Statement.new(sql, config, explainer)
     result = NewRelic::Agent::Database.explain_sql(statement)
-    expected_result = [["select_type", "key_len", "table", "id", "possible_keys", "type",
-      "Extra", "rows", "ref", "key"],
+    expected_result = [%w[select_type key_len table id possible_keys type
+      Extra rows ref key],
       [["SIMPLE", nil, "blogs", "1", nil, "ALL", "", "2", nil, nil]]]
 
     assert_equal(expected_result[0].sort, result[0].sort, "Headers don't match")

--- a/test/new_relic/agent/datastores/metric_helper_test.rb
+++ b/test/new_relic/agent/datastores/metric_helper_test.rb
@@ -181,7 +181,7 @@ module NewRelic
         in_transaction do
           NewRelic::Agent.with_database_metric_name("Model", "new_method") do
             result = Datastores::MetricHelper.product_operation_collection_for("MoreSpecificDB", "original_method", nil, @product)
-            expected = ["MoreSpecificDB", "new_method", "Model"]
+            expected = %w[MoreSpecificDB new_method Model]
             assert_equal expected, result
           end
         end

--- a/test/new_relic/agent/distributed_tracing/trace_context_header_data_test.rb
+++ b/test/new_relic/agent/distributed_tracing/trace_context_header_data_test.rb
@@ -10,7 +10,7 @@ module NewRelic
       class TraceContext
         class TraceContextHeaderDataTest < Minitest::Test
           def test_tracestate_built_from_array
-            other_entries = ['one', 'two']
+            other_entries = %w[one two]
             header_data = HeaderData.new('traceparent', 'tracestate_entry', other_entries, 0, '')
 
             assert_nil header_data.instance_variable_get(:@trace_state)

--- a/test/new_relic/agent/encoding_normalizer_test.rb
+++ b/test/new_relic/agent/encoding_normalizer_test.rb
@@ -10,7 +10,7 @@ class EncodingNormalizerTest < Minitest::Test
 
   def test_normalize_object_converts_symbol_values_to_strings
     result = EncodingNormalizer.normalize_object([:foo, :bar])
-    assert_equal(['foo', 'bar'], result)
+    assert_equal(%w[foo bar], result)
   end
 
   def test_normalize_object_converts_symbols_in_hash_to_strings

--- a/test/new_relic/agent/error_collector_test.rb
+++ b/test/new_relic/agent/error_collector_test.rb
@@ -264,20 +264,20 @@ module NewRelic::Agent
 
       def test_trace_truncated_with_config
         with_config(:'error_collector.max_backtrace_frames' => 2) do
-          trace = @error_collector.truncate_trace(['error1', 'error2', 'error3', 'error4'])
+          trace = @error_collector.truncate_trace(%w[error1 error2 error3 error4])
           assert_equal ['error1', '<truncated 2 additional frames>', 'error4'], trace
         end
       end
 
       def test_trace_truncated_with_nil_config
         with_config(:'error_collector.max_backtrace_frames' => nil) do
-          trace = @error_collector.truncate_trace(['error1', 'error2', 'error3', 'error4'])
+          trace = @error_collector.truncate_trace(%w[error1 error2 error3 error4])
           assert_equal 4, trace.length
         end
       end
 
       def test_short_trace_not_truncated
-        trace = @error_collector.truncate_trace(['error', 'error', 'error'], 6)
+        trace = @error_collector.truncate_trace(%w[error error error], 6)
         assert_equal 3, trace.length
       end
 
@@ -287,12 +287,12 @@ module NewRelic::Agent
       end
 
       def test_keeps_correct_frames_if_keep_frames_is_even
-        trace = @error_collector.truncate_trace(['error1', 'error2', 'error3', 'error4'], 2)
+        trace = @error_collector.truncate_trace(%w[error1 error2 error3 error4], 2)
         assert_equal ['error1', '<truncated 2 additional frames>', 'error4'], trace
       end
 
       def test_keeps_correct_frames_if_keep_frames_is_odd
-        trace = @error_collector.truncate_trace(['error1', 'error2', 'error3', 'error4'], 3)
+        trace = @error_collector.truncate_trace(%w[error1 error2 error3 error4], 3)
         assert_equal ['error1', 'error2', '<truncated 1 additional frames>', 'error4'], trace
       end
 

--- a/test/new_relic/agent/error_filter_test.rb
+++ b/test/new_relic/agent/error_filter_test.rb
@@ -18,7 +18,7 @@ module NewRelic::Agent
       end
 
       def test_ignore_classes
-        with_config(:'error_collector.ignore_classes' => ['TestExceptionA', 'TestExceptionC']) do
+        with_config(:'error_collector.ignore_classes' => %w[TestExceptionA TestExceptionC]) do
           @error_filter.load_all
           assert @error_filter.ignore?(TestExceptionA.new)
           refute @error_filter.ignore?(TestExceptionB.new)
@@ -108,7 +108,7 @@ module NewRelic::Agent
       end
 
       def test_expected_classes
-        with_config(:'error_collector.expected_classes' => ['TestExceptionA', 'TestExceptionC']) do
+        with_config(:'error_collector.expected_classes' => %w[TestExceptionA TestExceptionC]) do
           @error_filter.load_all
           assert @error_filter.expected?(TestExceptionA.new)
           refute @error_filter.expected?(TestExceptionB.new)
@@ -152,7 +152,7 @@ module NewRelic::Agent
         @error_filter.reset
         refute @error_filter.expected?(TestExceptionA.new)
 
-        @error_filter.expect('401,405-409', ['500', '505-509'])
+        @error_filter.expect('401,405-409', %w[500 505-509])
         assert @error_filter.expected?(TestExceptionA.new, 401)
         assert @error_filter.expected?(TestExceptionA.new, 407)
         assert @error_filter.expected?(TestExceptionA.new, 500)

--- a/test/new_relic/agent/error_trace_aggregator_test.rb
+++ b/test/new_relic/agent/error_trace_aggregator_test.rb
@@ -86,7 +86,7 @@ module NewRelic
       def test_supported_param_types
         types = [[1, '1'],
           [1.1, '1.1'],
-          ['hi', 'hi'],
+          %w[hi hi],
           [:hi, 'hi'],
           [StandardError.new("test"), "#<StandardError>"],
           [TestClass.new, "#<NewRelic::Agent::ErrorTraceAggregatorTest::TestClass>"]]
@@ -195,7 +195,7 @@ module NewRelic
       end
 
       def test_notice_agent_error_uses_exception_backtrace_if_present
-        trace = ["boo", "yeah", "error"]
+        trace = %w[boo yeah error]
         exception = DifficultToDebugAgentError.new
         exception.set_backtrace(trace)
         error_trace_aggregator.notice_agent_error(exception)

--- a/test/new_relic/agent/instrumentation/instance_identification_test.rb
+++ b/test/new_relic/agent/instrumentation/instance_identification_test.rb
@@ -112,7 +112,7 @@ module NewRelic
             end
           end
 
-          SUPPORTED_PRODUCTS = ["Postgres", "MySQL"]
+          SUPPORTED_PRODUCTS = %w[Postgres MySQL]
 
           load_cross_agent_test('datastores/datastore_instances').each do |test|
             next unless SUPPORTED_PRODUCTS.include?(test['product'])

--- a/test/new_relic/agent/method_tracer/instance_methods/trace_execution_scoped_test.rb
+++ b/test/new_relic/agent/method_tracer/instance_methods/trace_execution_scoped_test.rb
@@ -20,14 +20,14 @@ class NewRelic::Agent::MethodTracer::TraceExecutionScopedTest < Minitest::Test
 
   def test_metric_recording_in_non_nested_transaction
     in_transaction('outer') do
-      trace_execution_scoped(['foo', 'bar']) do
+      trace_execution_scoped(%w[foo bar]) do
         # erm
       end
     end
 
     expected_values = {:call_count => 1}
     assert_metrics_recorded_exclusive(
-      ['foo', 'outer'] => expected_values,
+      %w[foo outer] => expected_values,
       'foo' => expected_values,
       'bar' => expected_values,
       'outer' => expected_values,
@@ -43,7 +43,7 @@ class NewRelic::Agent::MethodTracer::TraceExecutionScopedTest < Minitest::Test
   def test_metric_recording_in_nested_transactions
     in_transaction('Controller/outer_txn') do
       in_transaction('Controller/inner_txn') do
-        trace_execution_scoped(['foo', 'bar']) do
+        trace_execution_scoped(%w[foo bar]) do
           # erm
         end
       end
@@ -90,7 +90,7 @@ class NewRelic::Agent::MethodTracer::TraceExecutionScopedTest < Minitest::Test
 
   def test_metric_recording_inside_transaction
     in_transaction('outer') do
-      trace_execution_scoped(['foo', 'bar']) do
+      trace_execution_scoped(%w[foo bar]) do
         # erm
       end
     end
@@ -99,7 +99,7 @@ class NewRelic::Agent::MethodTracer::TraceExecutionScopedTest < Minitest::Test
     assert_metrics_recorded_exclusive(
       'outer' => expected_values,
       'foo' => expected_values,
-      ['foo', 'outer'] => expected_values,
+      %w[foo outer] => expected_values,
       'bar' => expected_values,
       'Supportability/API/trace_execution_scoped' => expected_values,
       'OtherTransactionTotalTime' => expected_values,
@@ -114,7 +114,7 @@ class NewRelic::Agent::MethodTracer::TraceExecutionScopedTest < Minitest::Test
     options = {:metric => false, :scoped_metric => false}
 
     in_transaction('outer') do
-      trace_execution_scoped(['foo', 'bar'], options) do
+      trace_execution_scoped(%w[foo bar], options) do
         # erm
       end
     end
@@ -151,7 +151,7 @@ class NewRelic::Agent::MethodTracer::TraceExecutionScopedTest < Minitest::Test
         :total_call_time => 20,
         :total_exclusive_time => 10
       },
-      ['parent', 'txn'] => {
+      %w[parent txn] => {
         :call_count => 1,
         :total_call_time => 20,
         :total_exclusive_time => 10
@@ -161,7 +161,7 @@ class NewRelic::Agent::MethodTracer::TraceExecutionScopedTest < Minitest::Test
         :total_call_time => 10,
         :total_exclusive_time => 10
       },
-      ['child', 'txn'] => {
+      %w[child txn] => {
         :call_count => 1,
         :total_call_time => 10,
         :total_exclusive_time => 10
@@ -201,7 +201,7 @@ class NewRelic::Agent::MethodTracer::TraceExecutionScopedTest < Minitest::Test
   end
 
   def test_trace_execution_scope_runs_passed_block_and_returns_its_value
-    value = trace_execution_scoped(['metric', 'array'], {}) do
+    value = trace_execution_scoped(%w[metric array], {}) do
       1172
     end
     assert_equal 1172, value, 'should return the contents of the block'
@@ -209,7 +209,7 @@ class NewRelic::Agent::MethodTracer::TraceExecutionScopedTest < Minitest::Test
 
   def test_trace_execution_scoped_does_not_swallow_errors
     assert_raises(RuntimeError) do
-      trace_execution_scoped(['metric', 'array'], {}) do
+      trace_execution_scoped(%w[metric array], {}) do
         raise 'raising a test error'
       end
     end

--- a/test/new_relic/agent/method_tracer_test.rb
+++ b/test/new_relic/agent/method_tracer_test.rb
@@ -295,7 +295,7 @@ class NewRelic::Agent::MethodTracerTest < Minitest::Test
       method_c1
     end
 
-    assert_metrics_recorded(['c1', 'c3'])
+    assert_metrics_recorded(%w[c1 c3])
     assert_metrics_not_recorded('c2')
   end
 
@@ -431,7 +431,7 @@ class NewRelic::Agent::MethodTracerTest < Minitest::Test
     end
 
     assert_metrics_recorded({
-      ["YY", "test_txn"] => {:call_count => 1}
+      %w[YY test_txn] => {:call_count => 1}
     })
   end
 
@@ -442,7 +442,7 @@ class NewRelic::Agent::MethodTracerTest < Minitest::Test
     end
 
     assert_metrics_recorded([
-      ['XX', 'test_txn'],
+      %w[XX test_txn],
       'YY',
       'ZZ'
     ])
@@ -460,9 +460,9 @@ class NewRelic::Agent::MethodTracerTest < Minitest::Test
 
     added_methods = host_instance_methods - plain_instance_methods
 
-    public_api_methods = [
-      'trace_execution_unscoped',
-      'trace_execution_scoped'
+    public_api_methods = %w[
+      trace_execution_unscoped
+      trace_execution_scoped
     ]
 
     assert_equal(public_api_methods.sort, added_methods.map(&:to_s).sort)
@@ -486,7 +486,7 @@ class NewRelic::Agent::MethodTracerTest < Minitest::Test
       method_to_be_traced(1, 2, 3, false, 'X')
     end
 
-    assert_metrics_not_recorded ['X', 'test_txn']
+    assert_metrics_not_recorded %w[X test_txn]
   end
 
   def check_time(t1, t2)

--- a/test/new_relic/agent/new_relic_service_test.rb
+++ b/test/new_relic/agent/new_relic_service_test.rb
@@ -590,7 +590,7 @@ class NewRelicServiceTest < Minitest::Test
   def test_supportability_metrics_for_endpoint_response_time
     NewRelic::Agent.drop_buffered_data
 
-    payload = ['eggs', 'spam']
+    payload = %w[eggs spam]
     @http_handle.respond_to(:foobar, 'foobar')
     @service.send(:invoke_remote, :foobar, payload)
 
@@ -616,7 +616,7 @@ class NewRelicServiceTest < Minitest::Test
 
   def test_json_marshaller_handles_responses_from_collector
     marshaller = NewRelic::Agent::NewRelicService::JsonMarshaller.new
-    assert_equal ['beep', 'boop'], marshaller.load('{"return_value": ["beep","boop"]}')
+    assert_equal %w[beep boop], marshaller.load('{"return_value": ["beep","boop"]}')
   end
 
   def test_json_marshaller_returns_nil_on_empty_response_from_collector
@@ -815,7 +815,7 @@ class NewRelicServiceTest < Minitest::Test
   def test_supportability_metrics_with_item_count
     NewRelic::Agent.drop_buffered_data
 
-    payload = ['eggs', 'spam']
+    payload = %w[eggs spam]
     @http_handle.respond_to(:foobar, 'foobar')
     @service.send(:invoke_remote, :foobar, payload, :item_count => 12)
 
@@ -875,7 +875,7 @@ class NewRelicServiceTest < Minitest::Test
   def test_supportability_metrics_without_item_count
     NewRelic::Agent.drop_buffered_data
 
-    payload = ['eggs', 'spam']
+    payload = %w[eggs spam]
     @http_handle.respond_to(:foobar, 'foobar')
     @service.send(:invoke_remote, :foobar, payload)
 
@@ -898,7 +898,7 @@ class NewRelicServiceTest < Minitest::Test
   def test_supportability_metrics_with_serialization_failure
     NewRelic::Agent.drop_buffered_data
 
-    payload = ['eggs', 'spam']
+    payload = %w[eggs spam]
     @http_handle.respond_to(:foobar, 'foobar')
     @service.marshaller.stubs(:dump).raises(StandardError.new)
 

--- a/test/new_relic/agent/sql_sampler_test.rb
+++ b/test/new_relic/agent/sql_sampler_test.rb
@@ -184,13 +184,13 @@ class NewRelic::Agent::SqlSamplerTest < Minitest::Test
     @sampler.save_slow_sql(data)
     sql_traces = @sampler.harvest!.sort_by(&:total_call_time).reverse
 
-    assert_equal(["header0", "header1", "header2"],
+    assert_equal(%w[header0 header1 header2],
       sql_traces[0].params[:explain_plan][0].sort)
-    assert_equal(["header0", "header1", "header2"],
+    assert_equal(%w[header0 header1 header2],
       sql_traces[1].params[:explain_plan][0].sort)
-    assert_equal(["foo0", "foo1", "foo2"],
+    assert_equal(%w[foo0 foo1 foo2],
       sql_traces[0].params[:explain_plan][1][0].sort)
-    assert_equal(["bar0", "bar1", "bar2"],
+    assert_equal(%w[bar0 bar1 bar2],
       sql_traces[1].params[:explain_plan][1][0].sort)
   end
 

--- a/test/new_relic/agent/stats_engine_test.rb
+++ b/test/new_relic/agent/stats_engine_test.rb
@@ -37,11 +37,11 @@ class NewRelic::Agent::StatsEngineTest < Minitest::Test
 
   def test_record_unscoped_metrics_records_to_transaction_stats_if_in_txn
     in_transaction do
-      @engine.tl_record_unscoped_metrics(['a', 'b'], 20, 10)
+      @engine.tl_record_unscoped_metrics(%w[a b], 20, 10)
 
       # txn is still active, so metrics should not be merged into global
       # stats hash yet
-      assert_metrics_not_recorded(['a', 'b'])
+      assert_metrics_not_recorded(%w[a b])
     end
 
     expected = {
@@ -56,7 +56,7 @@ class NewRelic::Agent::StatsEngineTest < Minitest::Test
   end
 
   def test_record_unscoped_metrics_records_to_global_metrics_if_no_txn
-    @engine.tl_record_unscoped_metrics(['a', 'b'], 20, 10)
+    @engine.tl_record_unscoped_metrics(%w[a b], 20, 10)
     expected = {
       :call_count => 1,
       :total_call_time => 20,
@@ -135,7 +135,7 @@ class NewRelic::Agent::StatsEngineTest < Minitest::Test
     }
     assert_metrics_recorded(
       'a' => expected,
-      ['a', 'txn'] => expected
+      %w[a txn] => expected
     )
   end
 
@@ -150,15 +150,15 @@ class NewRelic::Agent::StatsEngineTest < Minitest::Test
     expected = {:total_call_time => 42, :call_count => 99}
     assert_metrics_recorded(
       'a' => expected,
-      ['a', 'txn'] => expected,
+      %w[a txn] => expected,
       'b' => expected
     )
   end
 
   def test_record_scoped_and_unscoped_metrics_records_multiple_unscoped_metrics
     in_transaction('txn') do
-      @engine.tl_record_scoped_and_unscoped_metrics('a', ['b', 'c'], 20, 10)
-      assert_metrics_not_recorded(['a', 'b', 'c'])
+      @engine.tl_record_scoped_and_unscoped_metrics('a', %w[b c], 20, 10)
+      assert_metrics_not_recorded(%w[a b c])
     end
 
     expected = {
@@ -168,13 +168,13 @@ class NewRelic::Agent::StatsEngineTest < Minitest::Test
     }
     assert_metrics_recorded(
       'a' => expected,
-      ['a', 'txn'] => expected,
+      %w[a txn] => expected,
       'b' => expected,
       'c' => expected
     )
     assert_metrics_not_recorded([
-      ['b', 'txn'],
-      ['c', 'txn']
+      %w[b txn],
+      %w[c txn]
     ])
   end
 
@@ -201,8 +201,8 @@ class NewRelic::Agent::StatsEngineTest < Minitest::Test
     assert_metrics_recorded(
       'm1' => expected,
       'm2' => expected,
-      ['m1', 'txn'] => expected,
-      ['m2', 'txn'] => expected,
+      %w[m1 txn] => expected,
+      %w[m2 txn] => expected,
       'm3' => expected,
       'm4' => expected
     )
@@ -231,8 +231,8 @@ class NewRelic::Agent::StatsEngineTest < Minitest::Test
     assert_metrics_recorded(
       'm1' => expected,
       'm2' => expected,
-      ['m1', 'txn'] => expected,
-      ['m2', 'txn'] => expected,
+      %w[m1 txn] => expected,
+      %w[m2 txn] => expected,
       'm3' => expected,
       'm4' => expected
     )
@@ -365,7 +365,7 @@ class NewRelic::Agent::StatsEngineTest < Minitest::Test
       @engine.tl_record_unscoped_metrics('foo', 42)
     end
     assert_metrics_recorded('foo' => {:call_count => 1, :total_call_time => 42})
-    assert_metrics_not_recorded([['foo', 'scopey']])
+    assert_metrics_not_recorded([%w[foo scopey]])
   end
 
   def test_record_supportability_metric_count_records_counts_only

--- a/test/new_relic/agent/transaction/distributed_tracing_test.rb
+++ b/test/new_relic/agent/transaction/distributed_tracing_test.rb
@@ -295,7 +295,7 @@ module NewRelic
 
           intrinsics = txn.attributes.intrinsic_attributes_for(NewRelic::Agent::AttributeFilter::DST_TRANSACTION_TRACER)
 
-          expected_keys = ['guid', 'traceId', 'sampled']
+          expected_keys = %w[guid traceId sampled]
 
           expected_keys.each do |key|
             assert intrinsics.key?(key), "Expected to find #{key} as an intrinsic, but did not"

--- a/test/new_relic/agent/transaction/tracing_test.rb
+++ b/test/new_relic/agent/transaction/tracing_test.rb
@@ -331,7 +331,7 @@ module NewRelic
               segment_a.finish
             end
 
-            assert_metrics_recorded ['metric_a', 'metric_b', 'metric_c']
+            assert_metrics_recorded %w[metric_a metric_b metric_c]
           end
         end
 

--- a/test/new_relic/agent/transaction_metrics_test.rb
+++ b/test/new_relic/agent/transaction_metrics_test.rb
@@ -21,8 +21,8 @@ class TransactionMetricsTest < Minitest::Test
   end
 
   def test_record_scoped_and_unscoped_should_take_multiple_metrics
-    @metrics.record_scoped_and_unscoped(['foo', 'bar'], 42, 12)
-    assert_scoped_metrics(@metrics, ['foo', 'bar'], {
+    @metrics.record_scoped_and_unscoped(%w[foo bar], 42, 12)
+    assert_scoped_metrics(@metrics, %w[foo bar], {
       :call_count => 1,
       :total_call_time => 42,
       :total_exclusive_time => 12
@@ -55,8 +55,8 @@ class TransactionMetricsTest < Minitest::Test
   end
 
   def test_record_unscoped_should_take_multiple_metrics
-    @metrics.record_unscoped(['foo', 'bar'], 42, 12)
-    assert_unscoped_metrics(@metrics, ['foo', 'bar'], {
+    @metrics.record_unscoped(%w[foo bar], 42, 12)
+    assert_unscoped_metrics(@metrics, %w[foo bar], {
       :call_count => 1,
       :total_call_time => 42,
       :total_exclusive_time => 12

--- a/test/new_relic/agent/utilization/vendor_test.rb
+++ b/test/new_relic/agent/utilization/vendor_test.rb
@@ -13,7 +13,7 @@ module NewRelic
           vendor_name "example"
           endpoint "http://169.254.169.254/metadata"
           headers "meta" => "yes"
-          keys ["vm_type", "vm_id", "vm_zone"]
+          keys %w[vm_type vm_id vm_zone]
           key_transforms :to_sym
         end
 

--- a/test/new_relic/environment_report_test.rb
+++ b/test/new_relic/environment_report_test.rb
@@ -18,7 +18,7 @@ class EnvironmentReportTest < Minitest::Test
   def test_converts_to_array
     ::NewRelic::EnvironmentReport.report_on("something") { "awesome" }
     data = Array(::NewRelic::EnvironmentReport.new)
-    expected = ["something", "awesome"]
+    expected = %w[something awesome]
     assert_includes(data, expected, "expected to find #{expected} in #{data.inspect}")
   end
 

--- a/test/performance/script/baselines
+++ b/test/performance/script/baselines
@@ -91,7 +91,7 @@ ga_gem_versions.each do |version|
   gem.extract!
   options = {
     :agent_path => gem.extracted_path,
-    :reporter_classes => ["ConsoleReporter", "HakoReporter"],
+    :reporter_classes => %w[ConsoleReporter HakoReporter],
     :tags => {
       :series => 'baseline',
       :newrelic_rpm_git_sha => gem.git_sha

--- a/test/performance/suites/redis.rb
+++ b/test/performance/suites/redis.rb
@@ -19,7 +19,7 @@ class RedisTest < Performance::TestCase
 
   def test_args
     with_config(:'transaction_tracer.record_redis_arguments' => true) do
-      commands = ["argumentative", "commands", "get", "called", "a", "bunch"]
+      commands = %w[argumentative commands get called a bunch]
       measure do
         NewRelic::Agent::Datastores::Redis.format_command(commands)
       end

--- a/test/performance/suites/rules_engine.rb
+++ b/test/performance/suites/rules_engine.rb
@@ -8,11 +8,11 @@ class RulesEngineTests < Performance::TestCase
       "transaction_segment_terms": [
         {
           "prefix": "WebTransaction/Custom",
-          "terms": ["one", "two", "three"]
+          "terms": %w[one two three]
         },
         {
           "prefix": "WebTransaction/Uri",
-          "terms": ["seven", "eight", "nine"]
+          "terms": %w[seven eight nine]
         }
       ]
     }

--- a/test/performance/suites/trace_execution_scoped.rb
+++ b/test/performance/suites/trace_execution_scoped.rb
@@ -4,7 +4,7 @@
 
 class TestClass
   def method_1
-    trace_execution_scoped(['a', 'b']) do
+    trace_execution_scoped(%w[a b]) do
       "hi"
     end
   end


### PR DESCRIPTION
# Overview

* PrivateInstanceMethods: Enable the require methods for different loggers. The order is not alphabetical because the memory_logger needs to be loaded for the agent_logger to be loaded [(original comment)](https://github.com/newrelic/newrelic-ruby-agent/pull/1494#discussion_r983847424)
* Everything else: Turn on the Style/WordArray cop [(original comment)](https://github.com/newrelic/newrelic-ruby-agent/pull/1499#discussion_r983814777)
