### PR TITLE
Raise SimpleCov thresholds

### DIFF
--- a/.github/actions/simplecov-report/README.md
+++ b/.github/actions/simplecov-report/README.md
@@ -11,7 +11,7 @@ The action works only with `pull_request` event.
 ### Inputs
 
 - `token` - The GITHUB_TOKEN secret.
-- `failedThreshold` - Failed threshold. (default: `90`)
+- `failedThreshold` - Failed threshold. (default: `93`)
 - `resultPath` - Path to last_run json file. (default: `coverage/.last_run.json`)
 
 ## Example

--- a/.github/actions/simplecov-report/action.yml
+++ b/.github/actions/simplecov-report/action.yml
@@ -7,11 +7,11 @@ branding:
 inputs:
   failedThreshold:
     description: Failed threshold (line)
-    default: "90"
+    default: "93"
     required: false
   failedThresholdBranch:
     description: Failed threshold (branch)
-    default: "70"
+    default: "84"
     required: false
   resultPath:
     description: "json path"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -397,5 +397,5 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           resultPath: lib/coverage_results/.last_run.json
-          failedThreshold: 90
-          failedThresholdBranch: 80
+          failedThreshold: 93
+          failedThresholdBranch: 84


### PR DESCRIPTION
On the road to 100%/100%, it's important to not relapse with the introduction of new pockets of uncovered code. Let's keep the forward momentum by having the thresholds creep towards 100%/100% along with the tests.
