### PR TITLE
CI: Remove unused variables in test

### DIFF
--- a/test/multiverse/lib/multiverse/suite.rb
+++ b/test/multiverse/lib/multiverse/suite.rb
@@ -155,9 +155,8 @@ module Multiverse
       `cd #{dir} && #{bundle_cmd} config build.nokogiri --use-system-libraries`
     end
 
-    def bundle_install(dir, exact_version = nil)
+    def bundle_install(dir)
       puts "Bundling in #{dir}..."
-      bundler_version = exact_version || explicit_bundler_version(dir)
       bundle_cmd = "bundle #{explicit_bundler_version(dir)}".strip
       bundle_config(dir, bundle_cmd)
       bundle_show_env(bundle_cmd)
@@ -699,7 +698,7 @@ module Multiverse
       env_plural = env_count > 1 ? 'environments' : 'environment'
       opening = "\nRunning \"#{suite}\" suite in"
       ending = "in #{label}"
-      message = [opening, execution_message_body(env_count, env_plural).join(' and '), ending].join(' ')
+      [opening, execution_message_body(env_count, env_plural).join(' and '), ending].join(' ')
     end
 
     def execution_message_body(env_count, env_plural)


### PR DESCRIPTION
## Overview

A part of https://github.com/newrelic/newrelic-ruby-agent/issues/1181#issue-1251019953.
This PR addresses warnings thrown by Minitest during test runs related to unused variables.

1. `bundler_version`
    - the local variable has been unused since it's introduced in https://github.com/ohbarye/newrelic-ruby-agent/commit/8e5886124ec017990400884285ad23dc6ccb9581#diff-5c92585b1f81da4bb4c96bff0e84e668725467ce36ed0b1915c68e866c50bbfdR140

2. `message`
    - the local variable has been unused since it's introduced in https://github.com/ohbarye/newrelic-ruby-agent/commit/1dd1650afd840f90acfe51e4df96651bb3c5932a#diff-5c92585b1f81da4bb4c96bff0e84e668725467ce36ed0b1915c68e866c50bbfdR688

ref https://github.com/newrelic/newrelic-ruby-agent/actions/runs/3228491027/jobs/5284669752

<img width="1197" alt="image" src="https://user-images.githubusercontent.com/1811616/195389242-ec486589-711d-45fe-9a2a-f4e104d37cdf.png">


Submitter Checklist:
- [x] Include a link to the related GitHub issue, if applicable
- [ ] Include a security review link, if applicable

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
GitHub Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
