### PR TITLE
Set Elasticsearch operation dynamically

### DIFF
--- a/lib/new_relic/agent/instrumentation/elasticsearch/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/elasticsearch/instrumentation.rb
@@ -33,7 +33,7 @@ module NewRelic::Agent::Instrumentation
     def nr_operation
       operation_index = caller_locations.index do |line|
         string = line.to_s
-        string.include?('lib/elasticsearch/api') && !string.include?('perform_request')
+        string.include?('lib/elasticsearch/api') && !string.include?(OPERATION)
       end
       return nil unless operation_index
 

--- a/newrelic.yml
+++ b/newrelic.yml
@@ -322,6 +322,10 @@ common: &default_settings
   # May be one of [auto|prepend|chain|disabled].
   # instrumentation.delayed_job: auto
 
+  # Controls auto-instrumentation of the elasticsearch library at start up.
+  # May be one of [auto|prepend|chain|disabled].
+  # instrumentation.elasticsearch: auto
+
   # Controls auto-instrumentation of Excon at start up.
   # May be one of [enabled|disabled].
   # instrumentation.excon: auto
@@ -458,10 +462,6 @@ common: &default_settings
 
   # If true, the agent obfuscates Mongo queries in transaction traces.
   # mongo.obfuscate_queries: true
-
-# Controls auto-instrumentation of the elasticsearch library at start up. 
-# May be one of [auto|prepend|chain|disabled].
-# instrumentation.elasticsearch: auto
 
   # If true, the agent captures Elasticsearch queries in transaction traces.
   # elasticsearch.capture_queries: true


### PR DESCRIPTION
# Overview
* Set Elasticsearch datastore segment's operation attribute dynamically from `caller_locations`
* Elasticsearch 8 Playground tested here: https://staging.onenr.io/0dBj3VPrvRX (internal)
* Elasticsearch 7 Playground tested here: https://staging.onenr.io/0dBj3VWe2RX (internal)
* Previously, the operations were all `query`, the fallback value is proposed to become `perform_request` since the dynamic operations are set to the methods called, it seems odd to have the operation default be unrelated to any Elasticsearch method name. Totally down to revert this change, however!
* **BONUS**: Reorganizes and indents the `instrumentation.elasticsearch` config value in `newrelic.yml`


Relates to #1525 