### PR TITLE
RuboCop: stop disabling EmptyLineAfterGuardClause

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -132,9 +132,6 @@ Layout/EmptyComment:
   AllowBorderComment: true
   AllowMarginComment: true
 
-Layout/EmptyLineAfterGuardClause:
-  Enabled: false
-
 # Disabling for now
 Layout/EmptyLineAfterMagicComment:
   Enabled: false

--- a/bin/nrdebug
+++ b/bin/nrdebug
@@ -219,6 +219,7 @@ class ProcessReport
         if c_backtraces =~ /could not attach/i
           fail("Failed to attach to target process. Please try again with sudo.")
         end
+
         section(f, "C Backtraces") { c_backtraces }
         section(f, "Ruby Backtrace(s)") { ruby_backtraces }
       end
@@ -282,6 +283,7 @@ end
 if !target.alive?
   fail("Could not find process with PID #{target_pid}")
 end
+
 target_cmd = target.procline
 
 prompt_for_confirmation(target_pid, target_cmd)

--- a/infinite_tracing/lib/infinite_tracing/agent_integrations/agent.rb
+++ b/infinite_tracing/lib/infinite_tracing/agent_integrations/agent.rb
@@ -33,6 +33,7 @@ module NewRelic::Agent
     def close_infinite_tracer
       NewRelic::Agent.logger.debug("Closing infinite tracer threads")
       return unless @infinite_tracer_thread
+
       @infinite_tracer_thread.join
       @infinite_tracer_thread.stop
       @infinite_tracer_thread = nil

--- a/infinite_tracing/lib/infinite_tracing/client.rb
+++ b/infinite_tracing/lib/infinite_tracing/client.rb
@@ -33,6 +33,7 @@ module NewRelic::Agent
       # client (if any) and returns self (so we chain the call)
       def transfer(previous_client)
         return self unless previous_client
+
         previous_client.buffer.transfer(buffer)
         self
       end
@@ -108,6 +109,7 @@ module NewRelic::Agent
       # The Suspended Streaming Buffer will be installed in this state.
       def suspend
         return if suspended?
+
         @lock.synchronize do
           @suspended = true
           @buffer = new_streaming_buffer
@@ -138,6 +140,7 @@ module NewRelic::Agent
 
       def stop
         return unless @response_handler
+
         @lock.synchronize do
           @response_handler.stop
           @response_handler = nil

--- a/infinite_tracing/lib/infinite_tracing/record_status_handler.rb
+++ b/infinite_tracing/lib/infinite_tracing/record_status_handler.rb
@@ -19,6 +19,7 @@ module NewRelic::Agent
 
       def stop
         return if @worker.nil?
+
         @lock.synchronize do
           NewRelic::Agent.logger.debug("gRPC Stopping Response Handler")
           @worker.stop
@@ -31,6 +32,7 @@ module NewRelic::Agent
       def handle_response
         @enumerator.each do |response|
           break if response.nil? || response.is_a?(Exception)
+
           @lock.synchronize do
             @messages_seen = response
             NewRelic::Agent.logger.debug("gRPC Infinite Tracer Observer saw #{messages_seen} messages")

--- a/infinite_tracing/lib/infinite_tracing/streaming_buffer.rb
+++ b/infinite_tracing/lib/infinite_tracing/streaming_buffer.rb
@@ -91,6 +91,7 @@ module NewRelic::Agent
       # application thread.
       def enumerator
         return enum_for(:enumerator) unless block_given?
+
         loop do
           if segment = @queue.pop(false)
             NewRelic::Agent.increment_metric(SPANS_SENT_METRIC)
@@ -117,6 +118,7 @@ module NewRelic::Agent
       # application thread.
       def batch_enumerator
         return enum_for(:enumerator) unless block_given?
+
         loop do
           if proc_or_segment = @queue.pop(false)
             NewRelic::Agent.increment_metric(SPANS_SENT_METRIC)

--- a/infinite_tracing/lib/infinite_tracing/worker.rb
+++ b/infinite_tracing/lib/infinite_tracing/worker.rb
@@ -22,8 +22,10 @@ module NewRelic::Agent
 
       def status
         return "error" if error?
+
         @lock.synchronize do
           return "stopped" if @worker_thread.nil?
+
           @worker_thread.status || "idle"
         end
       end
@@ -34,6 +36,7 @@ module NewRelic::Agent
 
       def join(timeout = nil)
         return unless @worker_thread
+
         NewRelic::Agent.logger.debug("joining worker #{@name} thread...")
         @worker_thread.join(timeout)
       end
@@ -41,6 +44,7 @@ module NewRelic::Agent
       def stop
         @lock.synchronize do
           return unless @worker_thread
+
           NewRelic::Agent.logger.debug("stopping worker #{@name} thread...")
           @worker_thread.kill
           @worker_thread = nil

--- a/infinite_tracing/test/support/enumerator_queue.rb
+++ b/infinite_tracing/test/support/enumerator_queue.rb
@@ -18,10 +18,12 @@ class EnumeratorQueue
 
   def each_item
     return enum_for(:each_item) unless block_given?
+
     loop do
       value = @queue.pop
       break if value.nil?
       fail value if value.is_a?(Exception)
+
       yield(value)
     end
   end

--- a/infinite_tracing/test/support/fake_trace_observer_helpers.rb
+++ b/infinite_tracing/test/support/fake_trace_observer_helpers.rb
@@ -12,6 +12,7 @@ if NewRelic::Agent::InfiniteTracing::Config.should_load?
       class EventListener
         def still_subscribed(event)
           return [] if @events[event].nil?
+
           @events[event].select { |e| e.inspect.include?('infinite_tracing') }
         end
       end
@@ -200,6 +201,7 @@ if NewRelic::Agent::InfiniteTracing::Config.should_load?
               @mock_thread = Thread.new do
                 enum.each do |span|
                   break if span.nil? # how grpc knows the stream is over
+
                   seen_spans << span unless span.nil? || simulate_broken_server
                 end
               end

--- a/infinite_tracing/test/support/server_response_simulator.rb
+++ b/infinite_tracing/test/support/server_response_simulator.rb
@@ -21,12 +21,14 @@ module NewRelic
 
         def enumerator
           return enum_for(:enumerator) unless block_given?
+
           loop do
             if return_value = @buffer.pop(false)
               # grpc raises any errors it gets rather than yielding them, this mimics that behavior
               if return_value.is_a?(GRPC::BadStatus) && !return_value.is_a?(GRPC::Ok)
                 raise return_value
               end
+
               yield(return_value)
             end
           end

--- a/infinite_tracing/test/test_helper.rb
+++ b/infinite_tracing/test/test_helper.rb
@@ -80,6 +80,7 @@ def trace
       :notice_span,
       :wait_for_notice
     ].include?(tp.method_id)
+
     p([tp.lineno, tp.defined_class, tp.method_id, tp.event])
   end
 end

--- a/lib/new_relic/agent.rb
+++ b/lib/new_relic/agent.rb
@@ -115,6 +115,7 @@ module NewRelic
     # The singleton Agent instance.  Used internally.
     def agent # :nodoc:
       return @agent if @agent
+
       NewRelic::Agent.logger.warn("Agent unavailable as it hasn't been started.")
       NewRelic::Agent.logger.warn(caller.join("\n"))
       nil
@@ -217,6 +218,7 @@ module NewRelic
 
     def increment_metric(metric_name, amount = 1) # THREAD_LOCAL_ACCESS
       return unless agent
+
       if amount == 1
         metrics = [metric_name, SUPPORTABILITY_INCREMENT_METRIC]
         agent.stats_engine.tl_record_unscoped_metrics(metrics) { |stats| stats.increment_count }
@@ -347,6 +349,7 @@ module NewRelic
     #
     def manual_start(options = {})
       raise "Options must be a hash" unless Hash === options
+
       NewRelic::Control.instance.init_plugin({:agent_enabled => true, :sync_startup => true}.merge(options))
       record_api_supportability_metric(:manual_start)
     end
@@ -757,6 +760,7 @@ module NewRelic
       record_api_supportability_metric(:browser_timing_header)
 
       return EMPTY_STR unless agent
+
       agent.javascript_instrumentor.browser_timing_header(nonce)
     end
 

--- a/lib/new_relic/agent/agent/shutdown.rb
+++ b/lib/new_relic/agent/agent/shutdown.rb
@@ -9,6 +9,7 @@ module NewRelic
       # data.
       def shutdown
         return unless started?
+
         ::NewRelic::Agent.logger.info("Starting Agent shutdown")
 
         stop_event_loop

--- a/lib/new_relic/agent/agent/special_startup.rb
+++ b/lib/new_relic/agent/agent/special_startup.rb
@@ -57,11 +57,13 @@ module NewRelic
 
       def should_install_exit_handler?
         return false unless Agent.config[:send_data_on_exit]
+
         !sinatra_classic_app? || Agent.config[:force_install_exit_handler]
       end
 
       def install_exit_handler
         return unless should_install_exit_handler?
+
         NewRelic::Agent.logger.debug("Installing at_exit handler")
         at_exit { shutdown }
       end

--- a/lib/new_relic/agent/agent/startup.rb
+++ b/lib/new_relic/agent/agent/startup.rb
@@ -37,6 +37,7 @@ module NewRelic
       def check_config_and_start_agent
         return unless monitoring? && has_correct_license_key?
         return if using_forking_dispatcher?
+
         setup_and_start_agent
       end
 

--- a/lib/new_relic/agent/attributes.rb
+++ b/lib/new_relic/agent/attributes.rb
@@ -58,6 +58,7 @@ module NewRelic
       def merge_custom_attributes(other)
         return unless Agent.config[:'custom_attributes.enabled']
         return if other.empty?
+
         AttributeProcessing.flatten_and_coerce(other) do |k, v|
           add_custom_attribute(k, v)
         end

--- a/lib/new_relic/agent/audit_logger.rb
+++ b/lib/new_relic/agent/audit_logger.rb
@@ -29,6 +29,7 @@ module NewRelic
 
       def log_request_headers(uri, headers)
         return unless enabled? && allowed_endpoint?(uri)
+
         @log.info("REQUEST HEADERS: #{headers}")
       rescue StandardError, SystemStackError, SystemCallError => e
         ::NewRelic::Agent.logger.warn("Failed writing request headers to audit log", e)

--- a/lib/new_relic/agent/commands/thread_profiler_session.rb
+++ b/lib/new_relic/agent/commands/thread_profiler_session.rb
@@ -42,6 +42,7 @@ module NewRelic
 
         def stop(report_data)
           return unless running?
+
           NewRelic::Agent.logger.debug("Stopping Thread Profiler.")
           @finished_profile = @backtrace_service.harvest(NewRelic::Agent::Threading::BacktraceService::ALL_TRANSACTIONS)
           @backtrace_service.unsubscribe(NewRelic::Agent::Threading::BacktraceService::ALL_TRANSACTIONS)

--- a/lib/new_relic/agent/configuration/dotted_hash.rb
+++ b/lib/new_relic/agent/configuration/dotted_hash.rb
@@ -36,6 +36,7 @@ module NewRelic
         def dot_flattened(nested_hash, names = [], result = {})
           nested_hash.each do |key, val|
             next if val.nil?
+
             if val.respond_to?(:has_key?)
               dot_flattened(val, names + [key], result)
             else

--- a/lib/new_relic/agent/configuration/environment_source.rb
+++ b/lib/new_relic/agent/configuration/environment_source.rb
@@ -34,6 +34,7 @@ module NewRelic
           set_dotted_alias(config_setting)
 
           return unless value[:aliases]
+
           value[:aliases].each do |config_alias|
             self.alias_map[config_alias] = config_setting
           end

--- a/lib/new_relic/agent/configuration/manager.rb
+++ b/lib/new_relic/agent/configuration/manager.rb
@@ -36,6 +36,7 @@ module NewRelic
 
         def add_config_for_testing(source, level = 0)
           raise 'Invalid config type for testing' unless [Hash, DottedHash].include?(source.class)
+
           invoke_callbacks(:add, source)
           @configs_for_testing << [source.freeze, level]
           reset_cache
@@ -110,6 +111,7 @@ module NewRelic
         def fetch(key)
           config_stack.each do |config|
             next unless config
+
             accessor = key.to_sym
 
             if config.has_key?(accessor)
@@ -160,6 +162,7 @@ module NewRelic
 
         def invoke_callbacks(direction, source)
           return unless source
+
           source.keys.each do |key|
             begin
               # we need to evaluate and apply transformations for the value to deal with procs as values

--- a/lib/new_relic/agent/configuration/security_policy_source.rb
+++ b/lib/new_relic/agent/configuration/security_policy_source.rb
@@ -212,6 +212,7 @@ module NewRelic
           security_policies.inject({}) do |settings, (policy_name, policy_settings)|
             SECURITY_SETTINGS_MAP[policy_name].each do |policy|
               next unless policy[:supported]
+
               if policy_settings[ENABLED]
                 if policy[:enabled_fn].call(policy[:option])
                   if permitted_fn = policy[:permitted_fn]

--- a/lib/new_relic/agent/configuration/yaml_source.rb
+++ b/lib/new_relic/agent/configuration/yaml_source.rb
@@ -156,6 +156,7 @@ module NewRelic
         def dot_flattened(nested_hash, names = [], result = {})
           nested_hash.each do |key, val|
             next if val.nil?
+
             if val.respond_to?(:has_key?) && !CONFIG_WITH_HASH_VALUE.include?(key)
               dot_flattened(val, names + [key], result)
             else

--- a/lib/new_relic/agent/connect/request_builder.rb
+++ b/lib/new_relic/agent/connect/request_builder.rb
@@ -42,6 +42,7 @@ module NewRelic
         # clear out so downstream code doesn't have to check again.
         def sanitize_environment_report(environment_report)
           return NewRelic::EMPTY_ARRAY unless @service.valid_to_marshal?(environment_report)
+
           environment_report
         end
 

--- a/lib/new_relic/agent/database.rb
+++ b/lib/new_relic/agent/database.rb
@@ -114,6 +114,7 @@ module NewRelic
       # in a report period, selected for shipment to New Relic
       def explain_sql(statement)
         return nil unless statement.sql && statement.explainer && statement.config
+
         statement.sql = statement.sql.split(";\n")[0] # only explain the first
         return statement.explain || []
       end
@@ -223,6 +224,7 @@ module NewRelic
 
         def explain
           return unless explainable?
+
           handle_exception_in_explain do
             start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
             plan = @explainer.call(self)
@@ -238,6 +240,7 @@ module NewRelic
 
         def append_sql(new_sql)
           return if new_sql.empty?
+
           @sql = Database.truncate_query(@sql << NEWLINE << new_sql)
         end
 

--- a/lib/new_relic/agent/database/obfuscation_helpers.rb
+++ b/lib/new_relic/agent/database/obfuscation_helpers.rb
@@ -53,6 +53,7 @@ module NewRelic
 
         def obfuscate_single_quote_literals(sql)
           return sql unless sql =~ COMPONENTS_REGEX_MAP[:single_quotes]
+
           sql.gsub(COMPONENTS_REGEX_MAP[:single_quotes], PLACEHOLDER)
         end
 

--- a/lib/new_relic/agent/database_adapter.rb
+++ b/lib/new_relic/agent/database_adapter.rb
@@ -13,6 +13,7 @@ module NewRelic
 
       def self.value
         return unless defined? ActiveRecord::Base
+
         new(::NewRelic::Control.instance.env, ActiveRecord::VERSION::STRING).value
       end
 
@@ -26,6 +27,7 @@ module NewRelic
       def value
         match = VERSIONS.keys.find { |key| version >= Gem::Version.new(key) }
         return unless match
+
         VERSIONS[match].call(env)
       end
     end

--- a/lib/new_relic/agent/datastores/mongo/event_formatter.rb
+++ b/lib/new_relic/agent/datastores/mongo/event_formatter.rb
@@ -26,6 +26,7 @@ module NewRelic
 
             command.each do |key, value|
               next if DENYLISTED_KEYS.include?(key)
+
               if OBFUSCATE_KEYS.include?(key)
                 obfuscated = obfuscate(value)
                 result[key] = obfuscated if obfuscated

--- a/lib/new_relic/agent/distributed_tracing/cross_app_tracing.rb
+++ b/lib/new_relic/agent/distributed_tracing/cross_app_tracing.rb
@@ -64,6 +64,7 @@ module NewRelic
 
       def add_message_cat_headers(headers)
         return unless CrossAppTracing.cross_app_enabled?
+
         @is_cross_app_caller = true
         insert_message_headers(headers,
           transaction.guid,
@@ -112,9 +113,11 @@ module NewRelic
         end
 
         return unless transaction.include_guid?
+
         payload[:guid] = transaction.guid
 
         return unless is_cross_app?
+
         trip_id = cat_trip_id
         path_hash = cat_path_hash
         referring_path_hash = cat_referring_path_hash

--- a/lib/new_relic/agent/distributed_tracing/distributed_trace_attributes.rb
+++ b/lib/new_relic/agent/distributed_tracing/distributed_trace_attributes.rb
@@ -25,6 +25,7 @@ module NewRelic
       # inserts them into the specified destination.
       def copy_to_hash(transaction_payload, destination)
         return unless enabled?
+
         INTRINSIC_KEYS.each do |key|
           value = transaction_payload[key]
           destination[key] = value unless value.nil?
@@ -35,8 +36,10 @@ module NewRelic
       # inserts them as intrinsics in the specified transaction_attributes
       def copy_to_attributes(transaction_payload, destination)
         return unless enabled?
+
         INTRINSIC_KEYS.each do |key|
           next unless transaction_payload.key?(key)
+
           destination.add_intrinsic_attribute(key, transaction_payload[key])
         end
       end

--- a/lib/new_relic/agent/distributed_tracing/distributed_trace_metrics.rb
+++ b/lib/new_relic/agent/distributed_tracing/distributed_trace_metrics.rb
@@ -23,6 +23,7 @@ module NewRelic
 
       def record_metrics_for_transaction(transaction)
         return unless Agent.config[:'distributed_tracing.enabled']
+
         dt = transaction.distributed_tracer
         payload = dt.distributed_trace_payload || dt.trace_state_payload
 

--- a/lib/new_relic/agent/distributed_tracing/distributed_trace_payload.rb
+++ b/lib/new_relic/agent/distributed_tracing/distributed_trace_payload.rb
@@ -58,6 +58,7 @@ module NewRelic
         def from_json(serialized_payload)
           raw_payload = JSON.parse(serialized_payload)
           return raw_payload if raw_payload.nil?
+
           payload_data = raw_payload[DATA_KEY]
 
           payload = new

--- a/lib/new_relic/agent/distributed_tracing/trace_context.rb
+++ b/lib/new_relic/agent/distributed_tracing/trace_context.rb
@@ -96,6 +96,7 @@ module NewRelic
           def extract_traceparent(format, carrier)
             header_name = trace_parent_header_for_format(format)
             return unless header = carrier[header_name]
+
             if matchdata = header.match(TRACE_PARENT_REGEX)
               TRACE_PARENT_REGEX.named_captures.inject({}) do |hash, (name, (index))|
                 hash[name] = matchdata[index]

--- a/lib/new_relic/agent/encoding_normalizer.rb
+++ b/lib/new_relic/agent/encoding_normalizer.rb
@@ -19,9 +19,11 @@ module NewRelic
           normalize_string(object.to_s)
         when Array
           return object if object.empty?
+
           object.map { |x| normalize_object(x) }
         when Hash
           return object if object.empty?
+
           hash = {}
           object.each_pair do |k, v|
             k = normalize_string(k) if k.is_a?(String)

--- a/lib/new_relic/agent/error_collector.rb
+++ b/lib/new_relic/agent/error_collector.rb
@@ -123,11 +123,13 @@ module NewRelic
 
       def exception_tagged_with?(ivar, exception)
         return false if exception_is_java_object?(exception)
+
         exception.instance_variable_defined?(ivar)
       end
 
       def tag_exception_using(ivar, exception)
         return if exception_is_java_object?(exception) || exception.frozen?
+
         begin
           exception.instance_variable_set(ivar, true)
         rescue => e
@@ -137,6 +139,7 @@ module NewRelic
 
       def tag_exception(exception)
         return if exception_is_java_object?(exception) || exception.frozen?
+
         begin
           exception.instance_variable_set(EXCEPTION_TAG_IVAR, true)
         rescue => e

--- a/lib/new_relic/agent/error_filter.rb
+++ b/lib/new_relic/agent/error_filter.rb
@@ -155,6 +155,7 @@ module NewRelic
         result = []
         code_list.each do |code|
           result << code && next if code.is_a?(Integer)
+
           m = code.match(/(\d{3})(-\d{3})?/)
           if m.nil? || m[1].nil?
             ::NewRelic::Agent.logger.warn("Invalid HTTP status code: '#{code}'; ignoring config")

--- a/lib/new_relic/agent/error_trace_aggregator.rb
+++ b/lib/new_relic/agent/error_trace_aggregator.rb
@@ -44,6 +44,7 @@ module NewRelic
       # floor after logging a warning.
       def add_to_error_queue(noticed_error)
         return unless enabled?
+
         @lock.synchronize do
           if !over_queue_limit?(noticed_error.message) && !@errors.include?(noticed_error)
             @errors << noticed_error

--- a/lib/new_relic/agent/event_aggregator.rb
+++ b/lib/new_relic/agent/event_aggregator.rb
@@ -136,6 +136,7 @@ module NewRelic
 
       def notify_if_full
         return unless !@notified_full && @buffer.full?
+
         NewRelic::Agent.logger.debug("#{self.class.named} capacity of #{@buffer.capacity} reached, beginning sampling")
         @notified_full = true
       end

--- a/lib/new_relic/agent/event_loop.rb
+++ b/lib/new_relic/agent/event_loop.rb
@@ -34,6 +34,7 @@ module NewRelic
         def calculate_next_fire_time
           now = Process.clock_gettime(Process::CLOCK_REALTIME)
           return now if @interval == 0
+
           fire_time = @last_fired_at || now
           while fire_time <= now
             fire_time += @interval
@@ -80,6 +81,7 @@ module NewRelic
 
       def next_timeout
         return nil if @timers.empty?
+
         timeout = @timers.values.map(&:next_fire_time).min - Process.clock_gettime(Process::CLOCK_REALTIME)
         timeout < 0 ? 0 : timeout
       end

--- a/lib/new_relic/agent/http_clients/abstract.rb
+++ b/lib/new_relic/agent/http_clients/abstract.rb
@@ -47,6 +47,7 @@ module NewRelic
           if wrapped_response.nil?
             raise ArgumentError, WHINY_NIL_ERROR % self.class
           end
+
           @wrapped_response = wrapped_response
         end
 
@@ -64,6 +65,7 @@ module NewRelic
 
         def get_status_code_using(method_name)
           return unless @wrapped_response.respond_to?(method_name)
+
           code = @wrapped_response.send(method_name).to_i
           code == 0 ? nil : code
         end

--- a/lib/new_relic/agent/http_clients/typhoeus_wrappers.rb
+++ b/lib/new_relic/agent/http_clients/typhoeus_wrappers.rb
@@ -67,6 +67,7 @@ module NewRelic
 
         def [](key)
           return nil unless @request.options && @request.options[:headers]
+
           @request.options[:headers][key]
         end
 

--- a/lib/new_relic/agent/instrumentation/active_merchant.rb
+++ b/lib/new_relic/agent/instrumentation/active_merchant.rb
@@ -38,6 +38,7 @@ DependencyDetection.defer do
 
   executes do
     next unless Gem::Version.new(ActiveMerchant::VERSION) < Gem::Version.new('1.65.0')
+
     deprecation_msg = 'The Ruby Agent is dropping support for ActiveMerchant versions below 1.65.0 ' \
       'in version 9.0.0. Please upgrade your ActiveMerchant version to continue receiving full support. ' \
 

--- a/lib/new_relic/agent/instrumentation/active_storage_subscriber.rb
+++ b/lib/new_relic/agent/instrumentation/active_storage_subscriber.rb
@@ -10,6 +10,7 @@ module NewRelic
       class ActiveStorageSubscriber < NotificationsSubscriber
         def start(name, id, payload)
           return unless state.is_execution_traced?
+
           start_segment(name, id, payload)
         rescue => e
           log_notification_error(e, name, 'start')
@@ -17,6 +18,7 @@ module NewRelic
 
         def finish(name, id, payload)
           return unless state.is_execution_traced?
+
           finish_segment(id, payload)
         rescue => e
           log_notification_error(e, name, 'finish')

--- a/lib/new_relic/agent/instrumentation/acts_as_solr.rb
+++ b/lib/new_relic/agent/instrumentation/acts_as_solr.rb
@@ -14,6 +14,7 @@ module NewRelic
               parse_query_without_newrelic(*args)
             ensure
               return unless txn = ::NewRelic::Agent::Tracer.current_transaction
+
               txn.current_segment.params[:statement] = ::NewRelic::Agent::Database.truncate_query(args.first.inspect) rescue nil
             end
           end

--- a/lib/new_relic/agent/instrumentation/controller_instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/controller_instrumentation.rb
@@ -273,6 +273,7 @@ module NewRelic
 
           def self.class_name(traced_obj, options = {})
             return options[:class_name] if options[:class_name]
+
             if traced_obj.is_a?(Class) || traced_obj.is_a?(Module)
               traced_obj.name
             else

--- a/lib/new_relic/agent/instrumentation/delayed_job_instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/delayed_job_instrumentation.rb
@@ -96,6 +96,7 @@ DependencyDetection.defer do
 
   executes do
     next unless delayed_job_version < Gem::Version.new('4.1.0')
+
     deprecation_msg = 'Instrumentation for DelayedJob versions below 4.1.0 is deprecated.' \
       'It will stop being monitored in version 9.0.0. ' \
       'Please upgrade your DelayedJob version to continue receiving full support. ' \

--- a/lib/new_relic/agent/instrumentation/grape/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/grape/instrumentation.rb
@@ -45,6 +45,7 @@ module NewRelic::Agent::Instrumentation
 
       def handle_transaction(endpoint, class_name, version)
         return unless endpoint && route = endpoint.route
+
         name_transaction(route, class_name, version)
         capture_params(endpoint)
       end

--- a/lib/new_relic/agent/instrumentation/logger/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/logger/instrumentation.rb
@@ -15,21 +15,25 @@ module NewRelic
         # and AuditLogger without them having to know the inner details.
         def self.mark_skip_instrumenting(logger)
           return if logger.frozen?
+
           logger.instance_variable_set(:@skip_instrumenting, true)
         end
 
         def self.clear_skip_instrumenting(logger)
           return if logger.frozen?
+
           logger.instance_variable_set(:@skip_instrumenting, false)
         end
 
         def mark_skip_instrumenting
           return if frozen?
+
           @skip_instrumenting = true
         end
 
         def clear_skip_instrumenting
           return if frozen?
+
           @skip_instrumenting = false
         end
 

--- a/lib/new_relic/agent/instrumentation/mongodb_command_subscriber.rb
+++ b/lib/new_relic/agent/instrumentation/mongodb_command_subscriber.rb
@@ -14,6 +14,7 @@ module NewRelic
         def started(event)
           begin
             return unless NewRelic::Agent::Tracer.tracing_enabled?
+
             segments[event.operation_id] = start_segment(event)
           rescue Exception => e
             log_notification_error('started', e)
@@ -33,6 +34,7 @@ module NewRelic
         def completed(event)
           begin
             return unless NewRelic::Agent::Tracer.tracing_enabled?
+
             segment = segments.delete(event.operation_id)
             return unless segment
 

--- a/lib/new_relic/agent/instrumentation/notifications_subscriber.rb
+++ b/lib/new_relic/agent/instrumentation/notifications_subscriber.rb
@@ -76,6 +76,7 @@ module NewRelic
           # defensive.
           return if defined?(exception_object)
           return unless defined?(::ActiveSupport::VERSION)
+
           if ::ActiveSupport::VERSION::STRING < "5.0.0"
             # Earlier versions of Rails did not add the exception itself to the
             # payload accessible via :exception_object, so we create a stand-in
@@ -85,6 +86,7 @@ module NewRelic
             def exception_object(payload)
               exception_class, message = payload[:exception]
               return nil unless exception_class
+
               NewRelic::Agent::NoticeableError.new(exception_class, message)
             end
           else

--- a/lib/new_relic/agent/instrumentation/rack/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/rack/instrumentation.rb
@@ -23,6 +23,7 @@ module NewRelic
 
         def check_for_late_instrumentation(app)
           return if defined?(@checked_for_late_instrumentation) && @checked_for_late_instrumentation
+
           @checked_for_late_instrumentation = true
           if middleware_instrumentation_enabled?
             if ::NewRelic::Agent::Instrumentation::MiddlewareProxy.needs_wrapping?(app)
@@ -49,12 +50,14 @@ module NewRelic
 
         def run_with_tracing(app)
           return yield(app) unless middleware_instrumentation_enabled?
+
           yield(::NewRelic::Agent::Instrumentation::MiddlewareProxy.wrap(app, true))
         end
 
         def use_with_tracing(middleware_class)
           return if middleware_class.nil?
           return yield(middleware_class) unless middleware_instrumentation_enabled?
+
           yield(::NewRelic::Agent::Instrumentation::MiddlewareProxy.for_class(middleware_class))
         end
       end

--- a/lib/new_relic/agent/instrumentation/rake/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/rake/instrumentation.rb
@@ -37,6 +37,7 @@ module NewRelic
 
         def safe_from_third_party_gem?
           return true unless NewRelic::LanguageSupport.bundled_gem?("newrelic-rake")
+
           ::NewRelic::Agent.logger.info("Not installing New Relic supported Rake instrumentation because the third party newrelic-rake gem is present")
           false
         end

--- a/lib/new_relic/agent/instrumentation/sidekiq.rb
+++ b/lib/new_relic/agent/instrumentation/sidekiq.rb
@@ -103,6 +103,7 @@ DependencyDetection.defer do
 
   executes do
     next unless Gem::Version.new(Sidekiq::VERSION) < Gem::Version.new('5.0.0')
+
     deprecation_msg = 'Instrumentation for Sidekiq versions below 5.0.0 is deprecated.' \
       'They will stop being monitored in version 9.0.0. ' \
       'Please upgrade your Sidekiq version to continue receiving full support. '

--- a/lib/new_relic/agent/instrumentation/sinatra.rb
+++ b/lib/new_relic/agent/instrumentation/sinatra.rb
@@ -45,6 +45,7 @@ DependencyDetection.defer do
 
   executes do
     next unless Gem::Version.new(Sinatra::VERSION) < Gem::Version.new('2.0.0')
+
     deprecation_msg = 'The Ruby Agent is dropping support for Sinatra versions below 2.0.0 ' \
       'in version 9.0.0. Please upgrade your Sinatra version to continue receiving full compatibility. ' \
 

--- a/lib/new_relic/agent/instrumentation/thread/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/thread/instrumentation.rb
@@ -15,6 +15,7 @@ module NewRelic
 
         def add_thread_tracing(*args, &block)
           return block if skip_tracing?
+
           NewRelic::Agent::Tracer.thread_block_with_current_transaction(*args, &block)
         end
 

--- a/lib/new_relic/agent/instrumentation/tilt/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/tilt/instrumentation.rb
@@ -14,6 +14,7 @@ module NewRelic
         # So here we are only grabbing the file name and name of directory it is in
         def create_filename_for_metric(file)
           return file unless defined?(::Sinatra) && defined?(::Sinatra::Base)
+
           file.split('/')[-2..-1].join('/')
         rescue NoMethodError
           file

--- a/lib/new_relic/agent/javascript_instrumentor.rb
+++ b/lib/new_relic/agent/javascript_instrumentor.rb
@@ -118,6 +118,7 @@ module NewRelic
 
       def create_nonce(nonce = nil)
         return '' unless nonce
+
         " nonce=\"#{nonce.to_s}\""
       end
 

--- a/lib/new_relic/agent/local_log_decorator.rb
+++ b/lib/new_relic/agent/local_log_decorator.rb
@@ -29,6 +29,7 @@ module NewRelic
 
       def escape_entity_name(entity_name)
         return unless entity_name
+
         URI::DEFAULT_PARSER.escape(entity_name)
       end
     end

--- a/lib/new_relic/agent/log_event_aggregator.rb
+++ b/lib/new_relic/agent/log_event_aggregator.rb
@@ -227,6 +227,7 @@ module NewRelic
 
       def truncate_message(message)
         return message if message.bytesize <= MAX_BYTES
+
         message.byteslice(0...MAX_BYTES)
       end
     end

--- a/lib/new_relic/agent/messaging.rb
+++ b/lib/new_relic/agent/messaging.rb
@@ -121,6 +121,7 @@ module NewRelic
 
         state = Tracer.state
         return yield if state.current_transaction
+
         txn = nil
 
         begin

--- a/lib/new_relic/agent/method_tracer.rb
+++ b/lib/new_relic/agent/method_tracer.rb
@@ -86,6 +86,7 @@ module NewRelic
       def trace_execution_unscoped(metric_names, options = NewRelic::EMPTY_HASH) # THREAD_LOCAL_ACCESS
         NewRelic::Agent.record_api_supportability_metric(:trace_execution_unscoped) unless options[:internal]
         return yield unless NewRelic::Agent.tl_is_execution_traced?
+
         t0 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
         begin
           yield
@@ -251,6 +252,7 @@ module NewRelic
         # may get removed as well.
         def remove_method_tracer(method_name) # :nodoc:
           return unless Agent.config[:agent_enabled]
+
           if _nr_traced_method_module.method_defined?(method_name)
             _nr_traced_method_module.send(:remove_method, method_name)
             ::NewRelic::Agent.logger.debug("removed method tracer #{method_name}\n")
@@ -264,6 +266,7 @@ module NewRelic
         def _nr_add_method_tracer_now(method_name, metric_name, options)
           NewRelic::Agent.record_api_supportability_metric(:add_method_tracer)
           return unless newrelic_method_exists?(method_name)
+
           remove_method_tracer(method_name) if method_traced?(method_name)
 
           options = _nr_validate_method_tracer_options(method_name, options)
@@ -304,6 +307,7 @@ module NewRelic
           _nr_traced_method_module.module_eval do
             define_method(method_name) do |*args, &block|
               return super(*args, &block) unless NewRelic::Agent.tl_is_execution_traced?
+
               scoped_metric_eval, unscoped_metrics_eval = nil, []
 
               scoped_metric_eval = case scoped_metric

--- a/lib/new_relic/agent/monitors/distributed_tracing_monitor.rb
+++ b/lib/new_relic/agent/monitors/distributed_tracing_monitor.rb
@@ -8,6 +8,7 @@ module NewRelic
       class Monitor < InboundRequestMonitor
         def on_finished_configuring(events)
           return unless NewRelic::Agent.config[:'distributed_tracing.enabled']
+
           events.subscribe(:before_call, &method(:on_before_call))
         end
 

--- a/lib/new_relic/agent/new_relic_service.rb
+++ b/lib/new_relic/agent/new_relic_service.rb
@@ -524,6 +524,7 @@ module NewRelic
         uri = String.new('/agent_listener/invoke_raw_method?')
         uri << params.map do |k, v|
           next unless v
+
           "#{k}=#{v}"
         end.compact.join('&')
         uri
@@ -592,6 +593,7 @@ module NewRelic
       # than the limit configured in the control object
       def check_post_size(post_string, endpoint)
         return if post_string.size < Agent.config[:max_payload_size_in_bytes]
+
         ::NewRelic::Agent.logger.debug("Tried to send too much data: #{post_string.size} bytes")
         NewRelic::Agent.increment_metric("Supportability/Agent/Collector/#{endpoint}/MaxPayloadSizeLimit")
         raise UnrecoverableServerException.new('413 Request Entity Too Large')

--- a/lib/new_relic/agent/pipe_channel_manager.rb
+++ b/lib/new_relic/agent/pipe_channel_manager.rb
@@ -160,6 +160,7 @@ module NewRelic
 
         def start
           return if @started == true
+
           @started = true
           @thread = NewRelic::Agent::Threading::AgentThread.create('Pipe Channel Manager') do
             now = nil
@@ -207,6 +208,7 @@ module NewRelic
 
         def stop
           return unless @started == true
+
           stop_listener_thread
           close_all_pipes
           @wake.close

--- a/lib/new_relic/agent/rules_engine.rb
+++ b/lib/new_relic/agent/rules_engine.rb
@@ -72,6 +72,7 @@ module NewRelic
       def rename(original_string)
         renamed = apply_rules(@rules, original_string)
         return nil unless renamed
+
         renamed = apply_rules(@segment_term_rules, renamed)
         renamed
       end

--- a/lib/new_relic/agent/samplers/cpu_sampler.rb
+++ b/lib/new_relic/agent/samplers/cpu_sampler.rb
@@ -44,6 +44,7 @@ module NewRelic
           if defined?(JRuby)
             return JRUBY_VERSION >= '1.7.0'
           end
+
           true
         end
 

--- a/lib/new_relic/agent/samplers/memory_sampler.rb
+++ b/lib/new_relic/agent/samplers/memory_sampler.rb
@@ -75,12 +75,14 @@ module NewRelic
 
           def can_run?
             return false if @broken
+
             m = get_memory rescue nil
             m && m > 0
           end
 
           def get_sample
             return nil if @broken
+
             begin
               m = get_memory
               if m.nil?
@@ -99,6 +101,7 @@ module NewRelic
         class JavaHeapSampler < Base
           def get_memory
             raise "Can't sample Java heap unless running in JRuby" unless defined? JRuby
+
             java.lang.Runtime.getRuntime.totalMemory / (1024 * 1024).to_f rescue nil
           end
 
@@ -121,6 +124,7 @@ module NewRelic
             # if for some reason the ps command doesn't work on the resident os,
             # then don't execute it any more.
             raise "Faulty command: `#{@command} #{process}`" if memory.nil? || memory <= 0
+
             memory
           end
 
@@ -140,6 +144,7 @@ module NewRelic
             if proc_status =~ /RSS:\s*(\d+) kB/i
               return $1.to_f / 1024.0
             end
+
             raise "Unable to find RSS in #{proc_status_file}"
           end
 

--- a/lib/new_relic/agent/span_event_primitive.rb
+++ b/lib/new_relic/agent/span_event_primitive.rb
@@ -52,6 +52,7 @@ module NewRelic
       # an error is present.  Otherwise, returns nil when no error present.
       def error_attributes(segment)
         return if Agent.config[:high_security] || !segment.noticed_error
+
         segment.noticed_error.build_error_attributes
         segment.noticed_error_attributes
       end

--- a/lib/new_relic/agent/stats.rb
+++ b/lib/new_relic/agent/stats.rb
@@ -159,6 +159,7 @@ module NewRelic
       def marshal_dump
         instance_variables.each_with_object({}) do |name, instance_copy|
           next if SKIP_MARSHALLING.include?(name)
+
           instance_copy[name] = instance_variable_get(name)
         end
       end

--- a/lib/new_relic/agent/stats_engine/gc_profiler.rb
+++ b/lib/new_relic/agent/stats_engine/gc_profiler.rb
@@ -11,6 +11,7 @@ module NewRelic
         def self.init
           @initialized ||= nil
           return @profiler if @initialized
+
           @profiler = if RailsBenchProfiler.enabled?
             RailsBenchProfiler.new
           elsif CoreGCProfiler.enabled?

--- a/lib/new_relic/agent/system_info.rb
+++ b/lib/new_relic/agent/system_info.rb
@@ -224,6 +224,7 @@ module NewRelic
         cgroup_info.split("\n").each do |line|
           parts = line.split(':')
           next unless parts.size == 3
+
           _, subsystems, cgroup_id = parts
           subsystems = subsystems.split(',')
           subsystems.each do |subsystem|
@@ -240,6 +241,7 @@ module NewRelic
       # for details on why we do it this way.
       def self.proc_try_read(path)
         return nil unless File.exist?(path)
+
         content = String.new('')
         File.open(path) do |f|
           loop do
@@ -281,6 +283,7 @@ module NewRelic
 
       def self.boot_id
         return nil unless linux?
+
         if bid = proc_try_read('/proc/sys/kernel/random/boot_id')
           bid.chomp!
 

--- a/lib/new_relic/agent/threading/agent_thread.rb
+++ b/lib/new_relic/agent/threading/agent_thread.rb
@@ -60,6 +60,7 @@ module NewRelic
             ::NewRelic::Agent.logger.debug("Failed to backtrace #{thread.inspect}: #{e.class.name}: #{e.to_s}")
           end
           return nil unless bt
+
           bt.reject! { |t| t.include?('/newrelic_rpm-') } unless profile_agent_code
           bt
         end

--- a/lib/new_relic/agent/threading/backtrace_service.rb
+++ b/lib/new_relic/agent/threading/backtrace_service.rb
@@ -151,6 +151,7 @@ module NewRelic
         # This method is expected to be called with @lock held
         def stop
           return unless @running
+
           @running = false
           self.worker_loop.stop
 

--- a/lib/new_relic/agent/threading/thread_profile.rb
+++ b/lib/new_relic/agent/threading/thread_profile.rb
@@ -54,6 +54,7 @@ module NewRelic
 
         def unique_thread_count
           return 0 if @unique_threads.nil?
+
           @unique_threads.length
         end
 
@@ -84,10 +85,12 @@ module NewRelic
 
           all_nodes.each_with_index do |n, i|
             break if i >= count_to_keep
+
             n.mark_for_array_conversion
           end
           all_nodes.each_with_index do |n, i|
             break if i >= count_to_keep
+
             n.complete_array_conversion
           end
         end

--- a/lib/new_relic/agent/tracer.rb
+++ b/lib/new_relic/agent/tracer.rb
@@ -187,11 +187,13 @@ module NewRelic
 
         def create_distributed_trace_payload
           return unless txn = current_transaction
+
           txn.distributed_tracer.create_distributed_trace_payload
         end
 
         def accept_distributed_trace_payload(payload)
           return unless txn = current_transaction
+
           txn.distributed_tracer.accept_distributed_trace_payload(payload)
         end
 
@@ -202,6 +204,7 @@ module NewRelic
         # @api public
         def current_segment
           return unless txn = current_transaction
+
           txn.current_segment
         end
 
@@ -348,6 +351,7 @@ module NewRelic
         # is effectively just a yield to the given &block
         def capture_segment_error(segment)
           return unless block_given?
+
           yield
         rescue => exception
           if segment && segment.is_a?(Transaction::AbstractSegment)

--- a/lib/new_relic/agent/transaction.rb
+++ b/lib/new_relic/agent/transaction.rb
@@ -268,6 +268,7 @@ module NewRelic
         current_thread_id = ::Thread.current.object_id
         return current_segment_by_thread[current_thread_id] if current_segment_by_thread[current_thread_id]
         return current_segment_by_thread[parent_thread_id] if current_segment_by_thread[parent_thread_id]
+
         current_segment_by_thread[@starting_thread_id]
       end
 
@@ -285,6 +286,7 @@ module NewRelic
 
       def sampled?
         return unless Agent.config[:'distributed_tracing.enabled']
+
         if @sampled.nil?
           @sampled = NewRelic::Agent.instance.adaptive_sampler.sampled?
         end
@@ -347,6 +349,7 @@ module NewRelic
 
       def set_default_transaction_name(name, category)
         return log_frozen_name(name) if name_frozen?
+
         if influences_transaction_name?(category)
           self.default_name = name
           @category = category if category
@@ -355,6 +358,7 @@ module NewRelic
 
       def set_overriding_transaction_name(name, category)
         return log_frozen_name(name) if name_frozen?
+
         if influences_transaction_name?(category)
           self.overridden_name = name
           @category = category if category
@@ -510,6 +514,7 @@ module NewRelic
 
       def finish
         return unless state.is_execution_traced?
+
         @end_time = Process.clock_gettime(Process::CLOCK_REALTIME)
         @duration = @end_time - @start_time
         freeze_name_and_execute_if_not_ignored
@@ -879,11 +884,13 @@ module NewRelic
 
       def normal_cpu_burn
         return unless @process_cpu_start
+
         process_cpu - @process_cpu_start
       end
 
       def jruby_cpu_burn
         return unless @jruby_cpu_start
+
         jruby_cpu_time - @jruby_cpu_start
       end
 
@@ -919,15 +926,18 @@ module NewRelic
 
       def process_cpu
         return nil if defined? JRuby
+
         p = Process.times
         p.stime + p.utime
       end
 
       def jruby_cpu_time
         return nil unless @@java_classes_loaded
+
         threadMBean = Java::JavaLangManagement::ManagementFactory.getThreadMXBean()
 
         return nil unless threadMBean.isCurrentThreadCpuTimeSupported
+
         java_utime = threadMBean.getCurrentThreadUserTime() # ns
 
         -1 == java_utime ? 0.0 : java_utime / 1e9

--- a/lib/new_relic/agent/transaction/abstract_segment.rb
+++ b/lib/new_relic/agent/transaction/abstract_segment.rb
@@ -55,6 +55,7 @@ module NewRelic
         def start
           @start_time ||= Process.clock_gettime(Process::CLOCK_REALTIME)
           return unless transaction
+
           parent.child_start(self) if parent
         end
 
@@ -63,6 +64,7 @@ module NewRelic
           @duration = end_time - start_time
 
           return unless transaction
+
           run_complete_callbacks
           finalize if record_on_finish?
         rescue => e
@@ -201,6 +203,7 @@ module NewRelic
 
         def noticed_error_attributes
           return unless @noticed_error
+
           @noticed_error.attributes_from_notice_error
         end
 

--- a/lib/new_relic/agent/transaction/datastore_segment.rb
+++ b/lib/new_relic/agent/transaction/datastore_segment.rb
@@ -63,6 +63,7 @@ module NewRelic
         # @api private
         def _notice_sql(sql, config = nil, explainer = nil, binds = nil, name = nil)
           return unless record_sql?
+
           @sql_statement = Database::Statement.new(sql, config, explainer, binds, name, host, port_path_or_id, database_name)
         end
 
@@ -85,6 +86,7 @@ module NewRelic
 
         def notice_nosql_statement(nosql_statement)
           return unless record_sql?
+
           @nosql_statement = Database.truncate_query(nosql_statement)
           nil
         end
@@ -119,6 +121,7 @@ module NewRelic
 
         def add_backtrace_parameter
           return unless duration >= Agent.config[:'transaction_tracer.stack_trace_threshold']
+
           params[:backtrace] = caller.join(NEWLINE)
         end
 

--- a/lib/new_relic/agent/transaction/distributed_tracer.rb
+++ b/lib/new_relic/agent/transaction/distributed_tracer.rb
@@ -74,6 +74,7 @@ module NewRelic
 
         def insert_headers(headers)
           return unless NewRelic::Agent.agent.connected?
+
           insert_trace_context_header(headers)
           insert_distributed_trace_header(headers)
           insert_cross_app_header(headers)
@@ -100,12 +101,14 @@ module NewRelic
         def insert_distributed_trace_header(headers)
           return unless dt_enabled?
           return if Agent.config[:'exclude_newrelic_header']
+
           payload = create_distributed_trace_payload
           headers[NewRelic::NEWRELIC_KEY] = payload.http_safe if payload
         end
 
         def insert_cat_headers(headers)
           return unless CrossAppTracing.cross_app_enabled?
+
           @is_cross_app_caller = true
           insert_message_headers(headers,
             transaction.guid,
@@ -161,6 +164,7 @@ module NewRelic
           decoded_id = encoded_id.nil? ? EMPTY_STRING : deobfuscate(encoded_id)
 
           return unless CrossAppTracing.trusted_valid_cross_app_id?(decoded_id)
+
           txn_header = headers[CrossAppTracing::NR_MESSAGE_BROKER_TXN_HEADER]
           txn_info = ::JSON.load(deobfuscate(txn_header))
           payload = CrossAppPayload.new(decoded_id, transaction, txn_info)

--- a/lib/new_relic/agent/transaction/distributed_tracing.rb
+++ b/lib/new_relic/agent/transaction/distributed_tracing.rb
@@ -156,6 +156,7 @@ module NewRelic
         def assign_payload_and_sampling_params(payload)
           @distributed_trace_payload = payload
           return if transaction.distributed_tracer.trace_context_header_data
+
           transaction.trace_id = payload.trace_id
           transaction.distributed_tracer.parent_transaction_id = payload.transaction_id
           transaction.parent_span_id = payload.id

--- a/lib/new_relic/agent/transaction/external_request_segment.rb
+++ b/lib/new_relic/agent/transaction/external_request_segment.rb
@@ -82,6 +82,7 @@ module NewRelic
         def read_response_headers(response)
           return unless record_metrics? && CrossAppTracing.cross_app_enabled?
           return unless CrossAppTracing.response_has_crossapp_header?(response)
+
           unless data = CrossAppTracing.extract_appdata(response)
             NewRelic::Agent.logger.debug("Couldn't extract_appdata from external segment response")
             return

--- a/lib/new_relic/agent/transaction/message_broker_segment.rb
+++ b/lib/new_relic/agent/transaction/message_broker_segment.rb
@@ -71,6 +71,7 @@ module NewRelic
 
         def name
           return @name if @name
+
           @name = METRIC_PREFIX + library
           @name << SLASH << TYPES[destination_type] << SLASH << ACTIONS[action] << SLASH
 

--- a/lib/new_relic/agent/transaction/segment.rb
+++ b/lib/new_relic/agent/transaction/segment.rb
@@ -38,6 +38,7 @@ module NewRelic
 
         def merge_untrusted_agent_attributes(agent_attributes, prefix, default_destinations)
           return if agent_attributes.nil?
+
           attributes.merge_untrusted_agent_attributes(agent_attributes, prefix, default_destinations)
         end
 

--- a/lib/new_relic/agent/transaction/trace.rb
+++ b/lib/new_relic/agent/transaction/trace.rb
@@ -31,6 +31,7 @@ module NewRelic
           node_count = 0
           each_node do |node|
             next if node == root_node
+
             node_count += 1
           end
           node_count
@@ -51,6 +52,7 @@ module NewRelic
 
         def create_node(time_since_start, metric_name = nil)
           raise FinishedTraceError.new("Can't create additional node for finished trace.") if self.finished
+
           self.node_count += 1
           NewRelic::Agent::Transaction::TraceNode.new(metric_name, time_since_start)
         end
@@ -75,6 +77,7 @@ module NewRelic
 
         def collect_explain_plans!
           return unless NewRelic::Agent::Database.should_collect_explain_plans?
+
           threshold = NewRelic::Agent.config[:'transaction_tracer.explain_threshold']
 
           each_node do |node|
@@ -87,6 +90,7 @@ module NewRelic
         def prepare_sql_for_transmission!
           each_node do |node|
             next unless node[:sql]
+
             node[:sql] = node[:sql].safe_sql
           end
         end

--- a/lib/new_relic/agent/transaction/trace_node.rb
+++ b/lib/new_relic/agent/transaction/trace_node.rb
@@ -28,6 +28,7 @@ module NewRelic
 
         def select_allowed_params(params)
           return unless params
+
           params.select do |p|
             NewRelic::Agent.instance.attribute_filter.allows_key?(p, AttributeFilter::DST_TRANSACTION_SEGMENTS)
           end

--- a/lib/new_relic/agent/transaction/transaction_sample_buffer.rb
+++ b/lib/new_relic/agent/transaction/transaction_sample_buffer.rb
@@ -34,6 +34,7 @@ module NewRelic
 
         def store(sample)
           return unless enabled?
+
           if allow_sample?(sample)
             add_sample(sample)
             truncate_samples_if_needed
@@ -42,6 +43,7 @@ module NewRelic
 
         def store_previous(previous_samples)
           return unless enabled?
+
           previous_samples.each do |sample|
             add_sample(sample) if allow_sample?(sample)
           end

--- a/lib/new_relic/agent/transaction_event_aggregator.rb
+++ b/lib/new_relic/agent/transaction_event_aggregator.rb
@@ -33,6 +33,7 @@ module NewRelic
 
       def after_harvest(metadata)
         return unless enabled?
+
         record_sampling_rate(metadata)
       end
 

--- a/lib/new_relic/agent/transaction_time_aggregator.rb
+++ b/lib/new_relic/agent/transaction_time_aggregator.rb
@@ -127,6 +127,7 @@ module NewRelic
 
         def split_transaction_at_harvest(timestamp, thread_id = nil)
           raise ArgumentError, 'thread_id required' unless thread_id
+
           @stats[thread_id].transaction_started_at = timestamp
           @stats[thread_id].elapsed_transaction_time = 0.0
         end

--- a/lib/new_relic/agent/utilization/pcf.rb
+++ b/lib/new_relic/agent/utilization/pcf.rb
@@ -15,6 +15,7 @@ module NewRelic
         def detect
           begin
             return false unless pcf_keys_present?
+
             process_response(ENV)
           rescue
             NewRelic::Agent.logger.error("Error occurred detecting: #{vendor_name}", e)

--- a/lib/new_relic/agent/utilization/vendor.rb
+++ b/lib/new_relic/agent/utilization/vendor.rb
@@ -134,6 +134,7 @@ module NewRelic
         def valid_chars?(value)
           value.each_char do |ch|
             next if ch =~ VALID_CHARS
+
             code_point = ch[0].ord # this works in Ruby 1.8.7 - 2.1.2
             next if code_point >= 0x80
 
@@ -145,6 +146,7 @@ module NewRelic
 
         def transform_key(key)
           return key unless key_transforms
+
           key_transforms.inject(key) { |memo, transform| memo.send(transform) }
         end
 

--- a/lib/new_relic/agent/utilization_data.rb
+++ b/lib/new_relic/agent/utilization_data.rb
@@ -87,6 +87,7 @@ module NewRelic
       def append_vendor_info(collector_hash)
         VENDORS.each_pair do |klass, config_option|
           next unless Agent.config[config_option]
+
           vendor = klass.new
 
           if vendor.detect
@@ -125,6 +126,7 @@ module NewRelic
 
       def append_kubernetes_info(collector_hash)
         return unless Agent.config[:'utilization.detect_kubernetes']
+
         if host = ENV[KUBERNETES_SERVICE_HOST]
           collector_hash[:vendors] ||= {}
           collector_hash[:vendors][:kubernetes] = {
@@ -136,6 +138,7 @@ module NewRelic
       def append_full_hostname(collector_hash)
         full_hostname = fqdn
         return if full_hostname.nil? || full_hostname.empty?
+
         collector_hash[:full_hostname] = full_hostname
       end
 

--- a/lib/new_relic/cli/commands/install.rb
+++ b/lib/new_relic/cli/commands/install.rb
@@ -42,6 +42,7 @@ class NewRelic::Cli::Install < NewRelic::Cli::Command
     if File.exist?(dest_file) && !@force
       raise NewRelic::Cli::Command::CommandFailure, "newrelic.yml file already exists.  Use --force flag to overwrite."
     end
+
     File.open(dest_file, 'w') { |out| out.puts(content) }
 
     puts <<-EOF unless quiet

--- a/lib/new_relic/coerce.rb
+++ b/lib/new_relic/coerce.rb
@@ -22,6 +22,7 @@ module NewRelic
 
     def int_or_nil(value, context = nil)
       return nil if value.nil?
+
       Integer(value)
     rescue => error
       log_failure(value, Integer, context, error)
@@ -31,6 +32,7 @@ module NewRelic
     def float(value, context = nil)
       result = Float(value)
       raise "Value #{result.inspect} is not finite." unless result.finite?
+
       result
     rescue => error
       log_failure(value, Float, context, error)
@@ -39,6 +41,7 @@ module NewRelic
 
     def string(value, context = nil)
       return value if value.nil?
+
       String(value)
     rescue => error
       log_failure(value.class, String, context, error)
@@ -62,6 +65,7 @@ module NewRelic
 
     def int!(value)
       return nil unless value_or_nil(value)
+
       Integer(value)
     end
 
@@ -74,11 +78,13 @@ module NewRelic
 
     def float!(value, precision = NewRelic::PRIORITY_PRECISION)
       return nil unless value_or_nil(value)
+
       value.to_f.round(precision)
     end
 
     def value_or_nil(value)
       return nil if value.nil? || (value.respond_to?(:empty?) && value.empty?)
+
       value
     end
 

--- a/lib/new_relic/collection_helper.rb
+++ b/lib/new_relic/collection_helper.rb
@@ -13,6 +13,7 @@ module NewRelic
         when Hash
           # Optimize for empty hash since that is often what this is called with.
           return params if params.empty?
+
           new_params = {}
           params.each do |key, value|
             new_params[truncate(normalize_params(key), 64)] = normalize_params(value)

--- a/lib/new_relic/control/frameworks/rails.rb
+++ b/lib/new_relic/control/frameworks/rails.rb
@@ -68,11 +68,14 @@ module NewRelic
 
         def install_agent_hooks(config)
           return if defined?(@agent_hooks_installed) && @agent_hooks_installed
+
           @agent_hooks_installed = true
           return if config.nil? || !config.respond_to?(:middleware)
+
           begin
             require 'new_relic/rack/agent_hooks'
             return unless NewRelic::Rack::AgentHooks.needed?
+
             config.middleware.use(NewRelic::Rack::AgentHooks)
             ::NewRelic::Agent.logger.debug("Installed New Relic Agent Hooks middleware")
           rescue => e
@@ -83,8 +86,10 @@ module NewRelic
         def install_browser_monitoring(config)
           @install_lock.synchronize do
             return if defined?(@browser_monitoring_installed) && @browser_monitoring_installed
+
             @browser_monitoring_installed = true
             return if config.nil? || !config.respond_to?(:middleware) || !Agent.config[:'browser_monitoring.auto_instrument']
+
             begin
               require 'new_relic/rack/browser_monitoring'
               config.middleware.use(NewRelic::Rack::BrowserMonitoring)

--- a/lib/new_relic/control/instrumentation.rb
+++ b/lib/new_relic/control/instrumentation.rb
@@ -70,6 +70,7 @@ module NewRelic
 
     def rails_32_deprecation
       return unless defined?(Rails::VERSION) && Gem::Version.new(Rails::VERSION::STRING) <= Gem::Version.new('3.2')
+
       deprecation_msg = 'The Ruby Agent is dropping support for Rails 3.2 ' \
         'in a future major release. Please upgrade your Rails version to continue receiving support. ' \
 
@@ -84,6 +85,7 @@ module NewRelic
 
     def ruby_22_deprecation
       return unless RUBY_VERSION <= '2.2.0'
+
       deprecation_msg = 'The Ruby Agent is dropping support for Ruby 2.2 ' \
         'in version 9.0.0. Please upgrade your Ruby version to continue receiving support. ' \
 

--- a/lib/new_relic/dependency_detection.rb
+++ b/lib/new_relic/dependency_detection.rb
@@ -165,6 +165,7 @@ module DependencyDetection
 
     def config_key
       return nil if self.config_name.nil?
+
       @config_key ||= "instrumentation.#{self.config_name}".to_sym
     end
 
@@ -193,6 +194,7 @@ module DependencyDetection
 
     def config_value
       return AUTO_CONFIG_VALUE unless config_key
+
       fetch_config_value(config_key)
     end
 

--- a/lib/new_relic/helper.rb
+++ b/lib/new_relic/helper.rb
@@ -17,6 +17,7 @@ module NewRelic
     # If not force the encoding to ASCII-8BIT (binary)
     def correctly_encoded(string)
       return string unless string.is_a?(String)
+
       # The .dup here is intentional, since force_encoding mutates the target,
       # and we don't know who is going to use this string downstream of us.
       string.valid_encoding? ? string : string.dup.force_encoding(Encoding::ASCII_8BIT)

--- a/lib/new_relic/language_support.rb
+++ b/lib/new_relic/language_support.rb
@@ -10,6 +10,7 @@ module NewRelic
     def can_fork?
       # this is expensive to check, so we should only check once
       return @@forkable if !@@forkable.nil?
+
       @@forkable = Process.respond_to?(:fork)
     end
 

--- a/lib/new_relic/latest_changes.rb
+++ b/lib/new_relic/latest_changes.rb
@@ -56,6 +56,7 @@ EOS
           version_count += 1
         end
         break if version_count >= 2
+
         changes << line.sub(/^  \* /, "* ").chomp
       end
       changes

--- a/lib/new_relic/local_environment.rb
+++ b/lib/new_relic/local_environment.rb
@@ -85,6 +85,7 @@ module NewRelic
     def check_for_torquebox
       return unless defined?(::JRuby) &&
         (org.torquebox::TorqueBox rescue nil)
+
       @discovered_dispatcher = :torquebox
     end
 
@@ -93,11 +94,13 @@ module NewRelic
         (((com.sun.grizzly.jruby.rack.DefaultRackApplicationFactory rescue nil) &&
           defined?(com::sun::grizzly::jruby::rack::DefaultRackApplicationFactory)) ||
          (jruby_rack? && defined?(::GlassFish::Server)))
+
       @discovered_dispatcher = :glassfish
     end
 
     def check_for_trinidad
       return unless defined?(::JRuby) && jruby_rack? && defined?(::Trinidad::Server)
+
       @discovered_dispatcher = :trinidad
     end
 
@@ -107,17 +110,20 @@ module NewRelic
 
     def check_for_webrick
       return unless defined?(::WEBrick) && defined?(::WEBrick::VERSION)
+
       @discovered_dispatcher = :webrick
     end
 
     def check_for_fastcgi
       return unless defined?(::FCGI)
+
       @discovered_dispatcher = :fastcgi
     end
 
     # this case covers starting by mongrel_rails
     def check_for_mongrel
       return unless defined?(::Mongrel) && defined?(::Mongrel::HttpServer)
+
       @discovered_dispatcher = :mongrel
     end
 

--- a/lib/new_relic/metric_spec.rb
+++ b/lib/new_relic/metric_spec.rb
@@ -44,6 +44,7 @@ class NewRelic::MetricSpec
 
   def to_s
     return name if scope.empty?
+
     "#{name}:#{scope}"
   end
 
@@ -59,6 +60,7 @@ class NewRelic::MetricSpec
   def <=>(o)
     namecmp = self.name <=> o.name
     return namecmp if namecmp != 0
+
     return (self.scope || '') <=> (o.scope || '')
   end
 end

--- a/lib/new_relic/rack/agent_middleware.rb
+++ b/lib/new_relic/rack/agent_middleware.rb
@@ -33,11 +33,13 @@ module NewRelic
       # response code before it goes back to the client.
       def capture_http_response_code(state, result)
         return if NewRelic::Agent.config[:disable_middleware_instrumentation]
+
         super
       end
 
       def capture_response_content_type(state, result)
         return if NewRelic::Agent.config[:disable_middleware_instrumentation]
+
         super
       end
     end

--- a/lib/new_relic/traced_thread.rb
+++ b/lib/new_relic/traced_thread.rb
@@ -28,6 +28,7 @@ module NewRelic
 
     def create_traced_block(*args, &block)
       return block if NewRelic::Agent.config[:'instrumentation.thread.tracing'] # if this is on, don't double trace
+
       NewRelic::Agent::Tracer.thread_block_with_current_transaction(*args, &block)
     end
   end

--- a/lib/tasks/helpers/format.rb
+++ b/lib/tasks/helpers/format.rb
@@ -25,6 +25,7 @@ module Format
     sections = Hash.new { |hash, key| hash[key] = [] }
     NewRelic::Agent::Configuration::DEFAULTS.each do |key, value|
       next unless value[:public]
+
       key = key.to_s
       section_key = section_key(key, key.split('.'))
       sections[section_key] << format_sections(key, value)
@@ -55,6 +56,7 @@ module Format
 
   def format_default_value(spec)
     return spec[:documentation_default] if !spec[:documentation_default].nil?
+
     if spec[:default].is_a?(Proc)
       '(Dynamic)'
     else
@@ -71,6 +73,7 @@ module Format
 
   def format_env_var(key)
     return "None" if NON_ENV_CONFIGS.include?(key)
+
     "NEW_RELIC_#{key.tr(".", "_").upcase}"
   end
 

--- a/test/agent_helper.rb
+++ b/test/agent_helper.rb
@@ -411,6 +411,7 @@ end
 def build_deferred_error_attributes(segment)
   return unless segment.noticed_error
   return if segment.noticed_error_attributes.frozen?
+
   segment.noticed_error.build_error_attributes
 end
 
@@ -454,6 +455,7 @@ end
 
 def last_transaction_trace
   return unless last_sample = NewRelic::Agent.agent.transaction_sampler.last_sample
+
   NewRelic::Agent::Transaction::TraceBuilder.build_trace(last_sample)
 end
 
@@ -639,6 +641,7 @@ def constant_path(name, opts = {})
     if !path.last.constants.include?(part.to_sym)
       return allow_partial ? path : nil
     end
+
     path << path.last.const_get(part)
   end
   path
@@ -655,6 +658,7 @@ def undefine_constant(constant_symbol)
   parent = get_parent(const_str)
   const_name = const_str.gsub(/.*::/, '')
   return yield unless parent && parent.constants.include?(const_name.to_sym)
+
   removed_constant = parent.send(:remove_const, const_name)
   yield
 ensure
@@ -929,6 +933,7 @@ def mock_http_response(headers, wrap_it = true)
     net_http_resp.add_field(key.to_s, value)
   end
   return net_http_resp unless wrap_it
+
   NewRelic::Agent::HTTPClients::NetHTTPResponse.new(net_http_resp)
 end
 
@@ -974,6 +979,7 @@ def refute_raises(*exp)
   rescue MiniTest::Skip => e
     puts "SKIP REPORTS: #{e.inspect}"
     return e if exp.include?(MiniTest::Skip)
+
     raise e
   rescue Exception => e
     puts "EXCEPTION RAISED: #{e.inspect}\n#{e.backtrace}"

--- a/test/config/test_control.rb
+++ b/test/config/test_control.rb
@@ -40,6 +40,7 @@ class NewRelic::Control::Frameworks::Test < parent_class
     super
     ActionController::Routing::RouteSet.class_eval do
       return if defined? draw_without_test_route
+
       def draw_with_test_route
         draw_without_test_route do |map|
           map.connect(':controller/:action/:id')

--- a/test/environments/lib/environments/runner.rb
+++ b/test/environments/lib/environments/runner.rb
@@ -55,6 +55,7 @@ module Environments
       original_dirs = Dir["#{env_root}/*"].reject { |d| File.basename(d) == "lib" }
 
       return original_dirs if envs.empty?
+
       dirs = []
       envs.each do |dir|
         dirs.concat(original_dirs.select { |d| File.basename(d).index(dir) == 0 })
@@ -65,12 +66,14 @@ module Environments
     # Ensures we bundle will recognize an explicit version number on command line
     def safe_explicit(version)
       return version if version.to_s == ""
+
       test_version = `bundle #{version} --version`.include?('Could not find command')
       test_version ? "" : version
     end
 
     def explicit_bundler_version(dir)
       return if RUBY_VERSION.to_f <= 2.3
+
       fn = File.join(dir, ".bundler-version")
       version = File.exist?(fn) ? File.read(fn).chomp!.strip : nil
       safe_explicit(version.to_s == "" ? nil : "_#{version}_")

--- a/test/helpers/misc.rb
+++ b/test/helpers/misc.rb
@@ -41,6 +41,7 @@ def fixture_tcp_socket(response)
     stubs(:sysread) do |size, buf = ''|
       @data ||= response.to_s
       raise EOFError if @data.empty?
+
       buf.replace(@data.slice!(0, size))
       buf
     end

--- a/test/multiverse/lib/multiverse/envfile.rb
+++ b/test/multiverse/lib/multiverse/envfile.rb
@@ -91,6 +91,7 @@ module Multiverse
       unless valid_modes.member?(mode)
         raise ArgumentError, "#{mode.inspect} is not a valid execute mode.  Valid modes: #{valid_modes.inspect}"
       end
+
       @mode = mode
     end
 
@@ -121,11 +122,13 @@ module Multiverse
 
     def last_supported_ruby_version?(last_supported_ruby_version)
       return false if last_supported_ruby_version.nil?
+
       last_supported_ruby_version && RUBY_VERSION.to_f > last_supported_ruby_version
     end
 
     def first_supported_ruby_version?(first_supported_ruby_version)
       return false if first_supported_ruby_version.nil?
+
       RUBY_VERSION.to_f < first_supported_ruby_version
     end
   end

--- a/test/multiverse/lib/multiverse/suite.rb
+++ b/test/multiverse/lib/multiverse/suite.rb
@@ -67,6 +67,7 @@ module Multiverse
       gemfiles = ["Gemfile.#{env_index}", "Gemfile.#{env_index}.lock"]
       gemfiles.each do |f|
         next unless File.exist?(f)
+
         File.delete(f)
       end
     end
@@ -111,6 +112,7 @@ module Multiverse
       yield
     rescue Bundler::LockfileError => error
       raise if @retried
+
       if verbose?
         puts "Encountered Bundler error: #{error.message}"
         puts "Currently Active Bundler Version: #{Bundler::VERSION}"
@@ -135,12 +137,14 @@ module Multiverse
     # Ensures we bundle will recognize an explicit version number on command line
     def safe_explicit(version)
       return version if version.to_s == ""
+
       test_version = `bundle #{version} --version`.include?('Could not find command')
       test_version ? "" : version
     end
 
     def explicit_bundler_version(dir)
       return if RUBY_VERSION.to_f < 2.3
+
       fn = File.join(dir, ".bundler-version")
       version = File.exist?(fn) ? File.read(fn).chomp.to_s.strip : nil
       safe_explicit(version.to_s == "" ? nil : "_#{version}_")
@@ -148,6 +152,7 @@ module Multiverse
 
     def bundle_show_env(bundle_cmd)
       return unless ENV["BUNDLE_SHOW_ENV"]
+
       puts `#{bundle_cmd} env`
     end
 
@@ -334,6 +339,7 @@ module Multiverse
       gems = with_potentially_mismatched_bundler do
         Bundler.definition.specs.inject([]) do |m, s|
           next m if s.name == 'bundler'
+
           m.push("#{s.name} (#{s.version})")
           m
         end
@@ -365,6 +371,7 @@ module Multiverse
     # the JVM.
     def optimize_jruby_startups
       return unless RUBY_PLATFORM == "java"
+
       ENV["JRUBY_OPTS"] = "--dev"
     end
 
@@ -434,6 +441,7 @@ module Multiverse
     # loads a new JVM for the tests to run in.
     def execute(instrumentation_method)
       return unless check_environment_condition
+
       configure_instrumentation_method(instrumentation_method)
 
       environments.before.call if environments.before
@@ -474,12 +482,14 @@ module Multiverse
     def with_each_environment
       environments.each_with_index do |gemfile_text, i|
         next unless should_run_environment?(i)
+
         yield(gemfile_text, i)
       end
     end
 
     def should_run_environment?(index)
       return true unless filter_env
+
       return filter_env == index
     end
 
@@ -647,6 +657,7 @@ module Multiverse
       ordered_ruby_files(directory).each do |file|
         puts yellow("Executing #{file.inspect}") if verbose?
         next if exclude?(file)
+
         require "./" + File.basename(file, ".rb")
       end
     end

--- a/test/multiverse/suites/deferred_instrumentation/sinatra_test.rb
+++ b/test/multiverse/suites/deferred_instrumentation/sinatra_test.rb
@@ -54,6 +54,7 @@ class DeferredSinatraTestApp < Sinatra::Base
 
   condition do
     raise "Boo" if $precondition_already_checked
+
     $precondition_already_checked = true
   end
   get('/precondition') { 'precondition only happened once' }

--- a/test/multiverse/suites/delayed_job/delayed_job_sampler_test.rb
+++ b/test/multiverse/suites/delayed_job/delayed_job_sampler_test.rb
@@ -47,6 +47,7 @@ if NewRelic::Agent::Samplers::DelayedJobSampler.supported_backend?
       job = IWantToWait.new.delay.take_action
 
       return unless job.respond_to?(:fail!)
+
       job.fail!
 
       @sampler.poll

--- a/test/multiverse/suites/memcache/memcached_test.rb
+++ b/test/multiverse/suites/memcache/memcached_test.rb
@@ -55,6 +55,7 @@ if defined?(Memcached)
 
     def test_get_multi_in_web
       return unless Memcached::VERSION >= '1.8.0'
+
       key = set_key_for_testcase
 
       expected_metrics = expected_web_metrics(:multi_get)

--- a/test/multiverse/suites/mongo/helpers/mongo_operation_tests.rb
+++ b/test/multiverse/suites/mongo/helpers/mongo_operation_tests.rb
@@ -539,6 +539,7 @@ module MongoOperationTests
   def server_is_2_6_or_later?
     client = @collection.db.respond_to?(:client) && @collection.db.client
     return false unless client
+
     client.respond_to?(:max_wire_version) && client.max_wire_version >= 2
   end
 

--- a/test/multiverse/suites/mongo/helpers/mongo_replica_set.rb
+++ b/test/multiverse/suites/mongo/helpers/mongo_replica_set.rb
@@ -71,6 +71,7 @@ class MongoReplicaSet
 
   def status
     return nil unless running?
+
     self.servers.first.client['admin'].command({'replSetGetStatus' => 1})
   rescue Mongo::OperationFailure => e
     raise e unless e.message.include?('EMPTYCONFIG')
@@ -90,6 +91,7 @@ class MongoReplicaSet
 
   def initiate
     return nil unless running?
+
     self.servers.first.client['admin'].command({'replSetInitiate' => config})
   rescue Mongo::OperationFailure => e
     raise e unless e.message.include?('already initialized')

--- a/test/multiverse/suites/mongo/helpers/mongo_server.rb
+++ b/test/multiverse/suites/mongo/helpers/mongo_server.rb
@@ -48,6 +48,7 @@ class MongoServer
 
   def ping
     return unless self.client
+
     self.client['admin'].command({'ping' => 1})
   end
 
@@ -163,6 +164,7 @@ class MongoServer
       self.client = client_class.new('localhost', self.port, :connect_timeout => 10)
     rescue Mongo::ConnectionFailure => e
       raise e unless message == "Failed to connect to a master node at localhost:#{port}"
+
       retry
     end
   end
@@ -189,6 +191,7 @@ class MongoServer
 
   def running?
     return false unless pid
+
     Process.kill(0, pid) == 1
   rescue Errno::ESRCH
     false

--- a/test/multiverse/suites/rails/middlewares.rb
+++ b/test/multiverse/suites/rails/middlewares.rb
@@ -12,8 +12,10 @@ class ErrorMiddleware
   def call(env)
     path = ::Rack::Request.new(env).path_info
     raise "middleware error" if path.include?('/middleware_error/before')
+
     result = @app.call(env)
     raise "middleware error" if path.include?('/middleware_error/after')
+
     result
   end
 end

--- a/test/multiverse/suites/rails/parameter_capture_test.rb
+++ b/test/multiverse/suites/rails/parameter_capture_test.rb
@@ -11,6 +11,7 @@ class ParameterCaptureController < ApplicationController
 
   def create
     raise 'problem' if params[:raise]
+
     render(body: 'created')
   end
 

--- a/test/multiverse/suites/rails/rails3_app/app_rails3_plus.rb
+++ b/test/multiverse/suites/rails/rails3_app/app_rails3_plus.rb
@@ -57,6 +57,7 @@ if !defined?(MyApp)
     class SinatraTestApp < Sinatra::Base
       get '/' do
         raise "Intentional error" if params["raise"]
+
         "SinatraTestApp#index"
       end
     end

--- a/test/multiverse/suites/rails/request_statistics_test.rb
+++ b/test/multiverse/suites/rails/request_statistics_test.rb
@@ -185,6 +185,7 @@ class RequestStatsTest < ActionDispatch::IntegrationTest
 
   def assert_encoding(encname, string)
     return unless string.respond_to?(:encoding)
+
     expected_encoding = Encoding.find(encname) or raise "no such encoding #{encname.dump}"
     msg = "Expected encoding of %p to be %p, but it was %p" %
       [string, expected_encoding, string.encoding]

--- a/test/multiverse/suites/sinatra/sinatra_classic_test.rb
+++ b/test/multiverse/suites/sinatra/sinatra_classic_test.rb
@@ -53,6 +53,7 @@ get('/error', :error_condition => true) {}
 set(:precondition_check) do |_|
   condition do
     raise "Boo" if $precondition_already_checked
+
     $precondition_already_checked = true
   end
 end

--- a/test/multiverse/suites/sinatra/sinatra_modular_test.rb
+++ b/test/multiverse/suites/sinatra/sinatra_modular_test.rb
@@ -52,6 +52,7 @@ class SinatraModularTestApp < Sinatra::Base
 
   condition do
     raise "Boo" if $precondition_already_checked
+
     $precondition_already_checked = true
   end
   get('/precondition') { 'precondition only happened once' }

--- a/test/multiverse/suites/typhoeus/typhoeus_test.rb
+++ b/test/multiverse/suites/typhoeus/typhoeus_test.rb
@@ -160,6 +160,7 @@ if NewRelic::Agent::Instrumentation::Typhoeus.is_supported_version?
 
       trace.each_node do |node|
         next if node.metric_name == "ROOT"
+
         assert node.params.key?(:exclusive_duration_millis), "Expected all nodes (except ROOT) to have :exclusive_duration_millis"
       end
 

--- a/test/new_relic/agent/database_test.rb
+++ b/test/new_relic/agent/database_test.rb
@@ -51,6 +51,7 @@ class NewRelic::Agent::DatabaseTest < Minitest::Test
   # doing now for explain plans in AR4 instrumentation
   def test_explain_sql_with_mysql2_activerecord_result
     return unless defined?(::ActiveRecord::Result)
+
     config = {:adapter => 'mysql2'}
     sql = 'SELECT * FROM spells where id=1'
 
@@ -67,6 +68,7 @@ class NewRelic::Agent::DatabaseTest < Minitest::Test
 
   def test_explain_sql_obfuscates_for_postgres_activerecord_result
     return unless defined?(::ActiveRecord::Result)
+
     config = {:adapter => 'postgres'}
     sql = "SELECT * FROM blogs WHERE blogs.id=1234 AND blogs.title='sensitive text'"
 

--- a/test/new_relic/agent/distributed_tracing/distributed_tracing_cross_agent_test.rb
+++ b/test/new_relic/agent/distributed_tracing/distributed_tracing_cross_agent_test.rb
@@ -151,6 +151,7 @@ module NewRelic::Agent
         end
 
         return {} unless (intrinsics = test_case['intrinsics'])
+
         target_events = intrinsics['target_events'] || []
         return {} unless target_events.include?(event_type)
 
@@ -209,6 +210,7 @@ module NewRelic::Agent
 
       def verify_outbound_payloads(test_case, actual_payloads)
         return unless (test_case_payloads = test_case['outbound_payloads'])
+
         assert_equal test_case_payloads.count, actual_payloads.count
 
         test_case_payloads.zip(actual_payloads).each do |test_case_data, actual|

--- a/test/new_relic/agent/distributed_tracing/trace_context_cross_agent_test.rb
+++ b/test/new_relic/agent/distributed_tracing/trace_context_cross_agent_test.rb
@@ -124,6 +124,7 @@ module NewRelic
 
         def assign_not_nil_value(headers, key, value)
           return if value.nil?
+
           headers[newrelic_key(key)] = value
         end
 
@@ -210,6 +211,7 @@ module NewRelic
           end
 
           return {} unless (intrinsics = test_case['intrinsics'])
+
           target_events = intrinsics['target_events'] || []
           return {} unless target_events.include?(event_type)
 
@@ -289,6 +291,7 @@ module NewRelic
 
         def verify_outbound_payloads(test_case, actual_payloads)
           return unless (test_case_payloads = test_case['outbound_payloads'])
+
           assert_equal test_case_payloads.count, actual_payloads.count
 
           test_case_payloads.zip(actual_payloads).each do |test_case_data, actual|

--- a/test/new_relic/agent/instrumentation/task_instrumentation_test.rb
+++ b/test/new_relic/agent/instrumentation/task_instrumentation_test.rb
@@ -9,6 +9,7 @@ class NewRelic::Agent::Instrumentation::TaskInstrumentationTest < Minitest::Test
 
   def run_task_inner(n)
     return if n == 0
+
     run_task_inner(n - 1)
   end
 

--- a/test/new_relic/agent/monitors/cross_app_monitor_test.rb
+++ b/test/new_relic/agent/monitors/cross_app_monitor_test.rb
@@ -243,6 +243,7 @@ module NewRelic::Agent
 
     def unpacked_response
       return nil unless response_app_data
+
       ::JSON.load(Base64.decode64(response_app_data))
     end
   end

--- a/test/new_relic/agent/new_relic_service_test.rb
+++ b/test/new_relic/agent/new_relic_service_test.rb
@@ -1152,6 +1152,7 @@ class NewRelicServiceTest < Minitest::Test
       if route
         response = @route_table[route]
         raise response if response.kind_of?(Exception)
+
         response
       else
         create_response_mock('not found', :code => 404)

--- a/test/new_relic/agent/samplers/memory_sampler_test.rb
+++ b/test/new_relic/agent/samplers/memory_sampler_test.rb
@@ -23,6 +23,7 @@ class NewRelic::Agent::Samplers::MemorySamplerTest < Minitest::Test
 
   def test_memory__linux
     return if RUBY_PLATFORM.include?('darwin')
+
     NewRelic::Agent::Samplers::MemorySampler.any_instance.stubs(:platform).returns('linux')
     stub_sampler_get_memory
     s = NewRelic::Agent::Samplers::MemorySampler.new
@@ -35,6 +36,7 @@ class NewRelic::Agent::Samplers::MemorySamplerTest < Minitest::Test
 
   def test_memory__solaris
     return if defined? JRuby
+
     NewRelic::Agent::Samplers::MemorySampler.any_instance.stubs(:platform).returns('solaris')
     NewRelic::Agent::Samplers::MemorySampler::ShellPS.any_instance.stubs(:get_memory).returns(999)
     s = NewRelic::Agent::Samplers::MemorySampler.new
@@ -44,6 +46,7 @@ class NewRelic::Agent::Samplers::MemorySamplerTest < Minitest::Test
 
   def test_memory__windows
     return if defined? JRuby
+
     NewRelic::Agent::Samplers::MemorySampler.any_instance.stubs(:platform).returns('win32')
     assert_raises NewRelic::Agent::Sampler::Unsupported do
       NewRelic::Agent::Samplers::MemorySampler.new

--- a/test/new_relic/agent/transaction_sampler_test.rb
+++ b/test/new_relic/agent/transaction_sampler_test.rb
@@ -11,6 +11,7 @@ module NewRelic::Agent
       def time
         return 0 if @@values.empty?
         raise "too many calls" if @@index >= @@values.size
+
         @@curtime ||= 0
         @@curtime += (@@values[@@index] * 1e09).to_i
         @@index += 1

--- a/test/new_relic/cli/commands/deployments_test.rb
+++ b/test/new_relic/cli/commands/deployments_test.rb
@@ -26,6 +26,7 @@ class NewRelic::Cli::DeploymentsTest < Minitest::Test
     super
     mocha_teardown
     return unless @deployment
+
     puts @deployment.errors
     puts @deployment.messages
     puts @deployment.exit_status

--- a/test/new_relic/control_test.rb
+++ b/test/new_relic/control_test.rb
@@ -10,6 +10,7 @@ class NewRelic::ControlTest < Minitest::Test
   def setup
     @control = NewRelic::Control.instance
     raise 'oh geez, wrong class' unless NewRelic::Control.instance.is_a?(::NewRelic::Control::Frameworks::Test)
+
     NewRelic::Agent.config.reset_to_defaults
   end
 

--- a/test/new_relic/evil_server.rb
+++ b/test/new_relic/evil_server.rb
@@ -35,6 +35,7 @@ module NewRelic
 
     def start
       return if @thread && @thread.alive?
+
       @requests = []
       @server = TCPServer.new(0)
       @port = @server.addr[1]

--- a/test/new_relic/fake_collector.rb
+++ b/test/new_relic/fake_collector.rb
@@ -226,6 +226,7 @@ module NewRelic
 
       def self.unblob(blob)
         return unless blob
+
         JSON.load(Zlib::Inflate.inflate(Base64.decode64(blob)))
       end
     end

--- a/test/new_relic/fake_server.rb
+++ b/test/new_relic/fake_server.rb
@@ -62,6 +62,7 @@ module NewRelic
 
     def run
       return if running?
+
       @started_options = build_webrick_options
 
       @server = WEBrick::HTTPServer.new(@started_options)
@@ -72,6 +73,7 @@ module NewRelic
 
     def stop
       return unless running?
+
       @server.shutdown
       @server = nil
       @thread.join if running?

--- a/test/new_relic/filtering_test_app.rb
+++ b/test/new_relic/filtering_test_app.rb
@@ -14,6 +14,7 @@ class FilteringTestApp
     txn.filtered_params = filtered
     txn.merge_request_parameters(filtered)
     raise "Intentional error" if params["raise"]
+
     [200, {}, ["Filters applied"]]
   end
 end

--- a/test/new_relic/language_support_test.rb
+++ b/test/new_relic/language_support_test.rb
@@ -7,6 +7,7 @@ require_relative '../test_helper'
 class NewRelic::LanguageSupportTest < Minitest::Test
   def test_object_space_usable_on_jruby_with_object_space_enabled
     return unless NewRelic::LanguageSupport.jruby?
+
     require 'jruby'
     JRuby.objectspace = true
     assert_truthy NewRelic::LanguageSupport.object_space_usable?
@@ -14,6 +15,7 @@ class NewRelic::LanguageSupportTest < Minitest::Test
 
   def test_object_space_not_usable_on_jruby_with_object_space_disabled
     return unless NewRelic::LanguageSupport.jruby?
+
     require 'jruby'
     JRuby.objectspace = false
     assert_falsy NewRelic::LanguageSupport.object_space_usable?
@@ -27,6 +29,7 @@ class NewRelic::LanguageSupportTest < Minitest::Test
 
   def test_gc_profiler_unavailable_on_jruby
     return unless NewRelic::LanguageSupport.jruby?
+
     refute NewRelic::LanguageSupport.gc_profiler_usable?
   end
 

--- a/test/new_relic/license_test.rb
+++ b/test/new_relic/license_test.rb
@@ -22,6 +22,7 @@ class LicenseTest < Minitest::Test
       File.open(file, 'r') do |f|
         f.each_line do |line|
           break unless line.start_with?('#')
+
           lines << line
         end
       end

--- a/test/new_relic/multiverse_helpers.rb
+++ b/test/new_relic/multiverse_helpers.rb
@@ -229,6 +229,7 @@ module MultiverseHelpers
 
   def capture_js_data
     return unless (transaction = NewRelic::Agent::Tracer.current_transaction)
+
     events = stub(:subscribe => nil)
     @instrumentor = NewRelic::Agent::JavaScriptInstrumentor.new(events)
     @js_data = @instrumentor.data_for_js_agent(transaction)


### PR DESCRIPTION
use the RuboCop default of `Layout/EmptyLineAfterGuardClause` and require an empty linen to separate a guard line (usually a `raise`, `fail`, or `return`) from other subsequent lines. Note that multiple sequential guard lines can still be grouped together and the blank line need only follow the entire group.