### PR TITLE
Remove unused error class `BackgroundLoadingError `

### DIFF
--- a/lib/new_relic/agent.rb
+++ b/lib/new_relic/agent.rb
@@ -102,8 +102,6 @@ module NewRelic
     # An error while serializing data for the collector
     class SerializationError < StandardError; end
 
-    class BackgroundLoadingError < StandardError; end
-
     # placeholder name used when we cannot determine a transaction's name
     UNKNOWN_METRIC = '(unknown)'.freeze
 


### PR DESCRIPTION
# Overview

I found `BackgroundLoadingError` class is no longer used anywhere.

The class is introduced by [this commit](https://github.com/newrelic/newrelic-ruby-agent/commit/f2168ff0d446faa0e43968cfad9561817d2d473f#diff-61a8aeaee4649719c4136512deca7e826560b227c576e18114154a6082311830R47) (Apr 23, 2009), and it became unused by [this commit](https://github.com/newrelic/newrelic-ruby-agent/commit/9e1b428460dd954f3037864c7b2309901261e241#diff-918c7f140adbe155d6f5234c69b3373615a0e2bb395ee3339182e229c60f0156L52) (Feb 10, 2010).


Submitter Checklist:
- [ ] Include a link to the related GitHub issue, if applicable
- [ ] Include a security review link, if applicable

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
GitHub Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
