### PR TITLE
8t batch time limit

### DIFF
--- a/infinite_tracing/newrelic-infinite_tracing.gemspec
+++ b/infinite_tracing/newrelic-infinite_tracing.gemspec
@@ -78,6 +78,7 @@ Gem or plugin, hosted on https://github.com/newrelic/newrelic-ruby-agent/
   s.add_development_dependency 'rb-inotify', '0.9.10' # locked to support < Ruby 2.3 (and listen 3.0.8)
   s.add_development_dependency 'listen', '3.0.8' # locked to support < Ruby 2.3
   s.add_development_dependency 'minitest', '~> 5.15'
+  s.add_development_dependency 'minitest-stub-const', '0.6'
   s.add_development_dependency 'mocha', '~> 1.9.0'
   s.add_development_dependency 'pry-nav', '~> 0.3.0'
   s.add_development_dependency 'pry-stack_explorer', '~> 0.4.9'

--- a/infinite_tracing/test/test_helper.rb
+++ b/infinite_tracing/test/test_helper.rb
@@ -13,6 +13,7 @@ $LOAD_PATH << agent_test_path
 require 'infinite_tracing'
 require 'minitest/autorun'
 require 'minitest/pride' unless ENV['CI']
+require 'minitest/stub_const'
 require 'mocha/setup'
 require 'newrelic_rpm'
 require 'rake'


### PR DESCRIPTION
Add a 5-second time limit for how long batches are kept before handing them to grpc and add corresponding tests. 

closes #1553