### PR TITLE
don't explicitly include jruby-openssl

### DIFF
--- a/test/environments/rails32/Gemfile
+++ b/test/environments/rails32/Gemfile
@@ -15,7 +15,6 @@ gem "newrelic_rpm", :path => "../../.."
 platforms :jruby do
   gem "activerecord-jdbcmysql-adapter"
   gem "activerecord-jdbcsqlite3-adapter"
-  gem "jruby-openssl"
 end
 
 platforms :ruby, :rbx do

--- a/test/environments/rails40/Gemfile
+++ b/test/environments/rails40/Gemfile
@@ -13,7 +13,6 @@ gem 'rack-test'
 platforms :jruby do
   gem 'activerecord-jdbcmysql-adapter', '~>1.3.0'
   gem 'activerecord-jdbcsqlite3-adapter', '~>1.3.0'
-  gem 'jruby-openssl'
 end
 
 platforms :ruby, :rbx do

--- a/test/environments/rails41/Gemfile
+++ b/test/environments/rails41/Gemfile
@@ -13,7 +13,6 @@ gem 'rack-test'
 platforms :jruby do
   gem "activerecord-jdbcmysql-adapter", "~>1.3.0"
   gem "activerecord-jdbcsqlite3-adapter", "~>1.3.0"
-  gem "jruby-openssl"
 end
 
 platforms :ruby do

--- a/test/environments/rails42/Gemfile
+++ b/test/environments/rails42/Gemfile
@@ -14,7 +14,6 @@ gem 'sprockets', '3.7.2'
 platforms :jruby do
   gem "activerecord-jdbcmysql-adapter", "~>1.3.0"
   gem "activerecord-jdbcsqlite3-adapter", "~>1.3.0"
-  gem "jruby-openssl"
 end
 
 platforms :ruby, :rbx do

--- a/test/environments/rails50/Gemfile
+++ b/test/environments/rails50/Gemfile
@@ -15,7 +15,6 @@ gem 'sprockets', '3.7.2'
 platforms :jruby do
   gem "activerecord-jdbcmysql-adapter", "~> 50.0"
   gem "activerecord-jdbcsqlite3-adapter", "~> 50.0"
-  gem "jruby-openssl"
 end
 
 platforms :ruby, :rbx do

--- a/test/environments/rails51/Gemfile
+++ b/test/environments/rails51/Gemfile
@@ -14,7 +14,6 @@ gem 'sprockets', '3.7.2'
 platforms :jruby do
   gem "activerecord-jdbcmysql-adapter", "~> 51.0"
   gem "activerecord-jdbcsqlite3-adapter", "~> 51.0"
-  gem "jruby-openssl"
 end
 
 platforms :ruby, :rbx do

--- a/test/environments/rails52/Gemfile
+++ b/test/environments/rails52/Gemfile
@@ -12,7 +12,6 @@ gem 'rack-test'
 gem 'sprockets', '3.7.2'
 
 platforms :jruby do
-  gem "jruby-openssl"
   gem "activerecord-jdbcmysql-adapter", "~> 52.0"
   gem "activerecord-jdbcsqlite3-adapter", "~> 52.0"
 end

--- a/test/environments/rails60/Gemfile
+++ b/test/environments/rails60/Gemfile
@@ -13,7 +13,6 @@ gem 'rack-test'
 gem 'sprockets', '3.7.2'
 
 platforms :jruby do
-  gem "jruby-openssl"
   gem "activerecord-jdbcmysql-adapter", "~> 60.0"
   gem "activerecord-jdbcsqlite3-adapter", "~> 60.0"
 end

--- a/test/environments/rails61/Gemfile
+++ b/test/environments/rails61/Gemfile
@@ -12,7 +12,6 @@ gem 'rack-test'
 gem 'sprockets', '3.7.2'
 
 platforms :jruby do
-  gem 'jruby-openssl'
   gem "activerecord-jdbcmysql-adapter", "~> 61.0"
   gem "activerecord-jdbcsqlite3-adapter", "~> 61.0"
 end

--- a/test/environments/rails70/Gemfile
+++ b/test/environments/rails70/Gemfile
@@ -8,10 +8,6 @@ gem 'minitest', '5.2.3'
 gem 'minitest-stub-const', '~> 0.6'
 gem 'mocha', '~> 1.1.0', require: false
 
-platforms :jruby do
-  gem 'jruby-openssl'
-end
-
 platforms :ruby, :rbx do
   gem 'mysql2', '>= 0.5.4'
   gem 'sqlite3', '~> 1.4'

--- a/test/environments/railsedge/Gemfile
+++ b/test/environments/railsedge/Gemfile
@@ -8,10 +8,6 @@ gem 'minitest', '5.2.3'
 gem 'minitest-stub-const', '~> 0.6'
 gem 'mocha', '~> 1.1.0', require: false
 
-platforms :jruby do
-  gem 'jruby-openssl'
-end
-
 platforms :ruby, :rbx do
   gem 'mysql2', '>= 0.5.4'
   gem 'sqlite3', '~> 1.4'

--- a/test/multiverse/lib/multiverse/suite.rb
+++ b/test/multiverse/lib/multiverse/suite.rb
@@ -264,7 +264,6 @@ module Multiverse
         f.puts 'source "https://rubygems.org"'
         f.print gemfile_text
         f.puts newrelic_gemfile_line unless gemfile_text =~ /^\s*gem .newrelic_rpm./
-        f.puts jruby_openssl_line unless gemfile_text =~ /^\s*gem .jruby-openssl./ || (defined?(JRUBY_VERSION) && JRUBY_VERSION > '1.7')
         f.puts minitest_line unless gemfile_text =~ /^\s*gem .minitest[^_]./
         f.puts "gem 'rake'" unless gemfile_text =~ /^\s*gem .rake[^_]./ || suite == 'rake'
 
@@ -291,10 +290,6 @@ module Multiverse
       path = ENV['NEWRELIC_GEM_PATH'] || '../../../..'
       line ||= "gem 'newrelic_rpm', :path => '#{path}'"
       line
-    end
-
-    def jruby_openssl_line
-      "gem 'jruby-openssl', '~> 0.11.0', :require => false, :platforms => [:jruby]"
     end
 
     def minitest_line

--- a/test/multiverse/suites/config_file_loading/Envfile
+++ b/test/multiverse/suites/config_file_loading/Envfile
@@ -16,9 +16,6 @@ def gem_list(psych_version = nil)
     # various places.
     gem 'fakefs', :require => false
 
-    # Because we delay the agent, order of jruby-openssl matters
-    gem 'jruby-openssl' if RUBY_PLATFORM == 'java'
-
     gem 'psych'#{psych_version}
     gem 'jar-dependencies', '0.4.1' if RUBY_PLATFORM == 'java' 
 


### PR DESCRIPTION
Previously, jruby-openssl was being brought in for both CRuby where it is absolutely not needed and JRuby 9k+, where it is likely not needed as a separate Gemfile entry. The gem is now no longer brought in.