### PR TITLE
8T compression: ensure that the value is a symbol

### DIFF
--- a/infinite_tracing/lib/infinite_tracing/channel.rb
+++ b/infinite_tracing/lib/infinite_tracing/channel.rb
@@ -51,7 +51,7 @@ module NewRelic::Agent
       end
 
       def configured_compression_level
-        NewRelic::Agent.config[:'infinite_tracing.compression_level']
+        NewRelic::Agent.config[:'infinite_tracing.compression_level'].to_sym
       end
 
       def credentials

--- a/infinite_tracing/lib/infinite_tracing/channel.rb
+++ b/infinite_tracing/lib/infinite_tracing/channel.rb
@@ -51,7 +51,7 @@ module NewRelic::Agent
       end
 
       def configured_compression_level
-        NewRelic::Agent.config[:'infinite_tracing.compression_level'].to_sym
+        @configured_compression_level ||= NewRelic::Agent.config[:'infinite_tracing.compression_level'].to_sym
       end
 
       def credentials

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2472,7 +2472,7 @@ A map of error classes to a list of messages. When an error of one of the classe
         :'infinite_tracing.compression_level' => {
           :default => :none,
           :public => false,
-          :type => Symbol,
+          :type => String,
           :allowed_from_server => false,
           :external => :infinite_tracing,
           :description => "Configure the compression level for data sent to the Trace Observer\nMay be one of " \

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2470,7 +2470,7 @@ A map of error classes to a list of messages. When an error of one of the classe
           :description => "Configures the TCP/IP port for the Trace Observer Host"
         },
         :'infinite_tracing.compression_level' => {
-          :default => :none,
+          :default => 'none',
           :public => false,
           :type => String,
           :allowed_from_server => false,


### PR DESCRIPTION
for the 8T compression setting, specify that it comes in as a string and then convert it to a symbol when using it with grpc