### PR TITLE
Temporarily disable Sidekiq 7.0 testing 

### DIFF
--- a/test/multiverse/suites/sidekiq/Envfile
+++ b/test/multiverse/suites/sidekiq/Envfile
@@ -7,7 +7,7 @@ suite_condition("Sidekiq does not run on JRuby") do
 end
 
 SIDEKIQ_VERSIONS = [
-  [nil, 2.5],
+  # [nil, 2.5],
   ['6.4.0', 2.5],
   ['5.0.3', 2.3],
   ['4.2.0', 2.2]

--- a/test/multiverse/suites/sidekiq/Envfile
+++ b/test/multiverse/suites/sidekiq/Envfile
@@ -7,6 +7,7 @@ suite_condition("Sidekiq does not run on JRuby") do
 end
 
 SIDEKIQ_VERSIONS = [
+  # TODO: Uncomment once we refactor tests to use Sidekiq 7's logger, issue #1567 
   # [nil, 2.5],
   ['6.4.0', 2.5],
   ['5.0.3', 2.3],


### PR DESCRIPTION
Sidekiq 7.0 changed the way logging works in the gem. Our tests for Sidekiq rely on the logger.
Disable the tests for the latest version (7.0) until we can address issue #1567
