### PR TITLE
Update Community Plus header image source

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Blue banner - Community Plus: This code is currently maintained by New Relic engineering teams and delivered here in GitHub. See the README for troubleshooting and defect reporting instructions.](https://github.com/newrelic/opensource-website/raw/master/src/images/categories/Community_Plus.png)](https://opensource.newrelic.com/oss-category/#community-plus)
+[![Blue banner - Community Plus: This code is currently maintained by New Relic engineering teams and delivered here in GitHub. See the README for troubleshooting and defect reporting instructions.](https://github.com/newrelic/opensource-website/raw/main/src/images/categories/Community_Plus.png)](https://opensource.newrelic.com/oss-category/#community-plus)
 
 # New Relic Ruby Agent
 


### PR DESCRIPTION
The previous source for the Community Plus header used `master` as the default branch. The source the repolinter looks for pulls from `main`.

Resolves #1569 