### PR TITLE
Redis version 5.0 instrumentation updates

### DIFF
--- a/lib/new_relic/agent/instrumentation/redis.rb
+++ b/lib/new_relic/agent/instrumentation/redis.rb
@@ -30,10 +30,13 @@ DependencyDetection.defer do
 
   executes do
     NewRelic::Agent.logger.info('Installing Redis Instrumentation')
-    if NewRelic::Agent::Instrumentation::Redis::USE_MIDDLEWARE
+    if NewRelic::Agent::Instrumentation::Redis::REDIS_5
       ::RedisClient.register(NewRelic::Agent::Instrumentation::RedisClient::Middleware)
-    elsif use_prepend?
-      prepend_instrument ::Redis::Client, NewRelic::Agent::Instrumentation::Redis::Prepend
+    end
+
+    if use_prepend?
+      prepend_class = NewRelic::Agent::Instrumentation::Redis::REDIS_5 ? ::RedisClient : ::Redis::Client
+      prepend_instrument prepend_class, NewRelic::Agent::Instrumentation::Redis::Prepend
     else
       chain_instrument NewRelic::Agent::Instrumentation::Redis::Chain
     end

--- a/lib/new_relic/agent/instrumentation/redis.rb
+++ b/lib/new_relic/agent/instrumentation/redis.rb
@@ -30,18 +30,12 @@ DependencyDetection.defer do
 
   executes do
     NewRelic::Agent.logger.info('Installing Redis Instrumentation')
-    if redis_5_or_above? && defined?(::RedisClient)
+    if NewRelic::Agent::Instrumentation::Redis::USE_MIDDLEWARE
       ::RedisClient.register(NewRelic::Agent::Instrumentation::RedisClient::Middleware)
+    elsif use_prepend?
+      prepend_instrument ::Redis::Client, NewRelic::Agent::Instrumentation::Redis::Prepend
     else
-      if use_prepend?
-        prepend_instrument ::Redis::Client, NewRelic::Agent::Instrumentation::Redis::Prepend
-      else
-        chain_instrument NewRelic::Agent::Instrumentation::Redis::Chain
-      end
+      chain_instrument NewRelic::Agent::Instrumentation::Redis::Chain
     end
-  end
-
-  def redis_5_or_above?
-    Gem::Version.new(::Redis::VERSION) >= Gem::Version.new('5.0.0')
   end
 end

--- a/lib/new_relic/agent/instrumentation/redis/chain.rb
+++ b/lib/new_relic/agent/instrumentation/redis/chain.rb
@@ -9,16 +9,20 @@ module NewRelic::Agent::Instrumentation
         ::Redis::Client.class_eval do
           include NewRelic::Agent::Instrumentation::Redis
 
-          alias_method(:call_v_without_new_relic, :call_v)
+          if method_defined?(:call_v)
+            alias_method(:call_v_without_new_relic, :call_v)
 
-          def call_v(*args, &block)
-            call_with_tracing(args[0]) { call_v_without_new_relic(*args, &block) }
+            def call_v(*args, &block)
+              call_with_tracing(args[0]) { call_v_without_new_relic(*args, &block) }
+            end
           end
 
-          alias_method(:call_without_new_relic, :call)
+          if method_defined?(:call)
+            alias_method(:call_without_new_relic, :call)
 
-          def call(*args, &block)
-            call_with_tracing(args[0]) { call_without_new_relic(*args, &block) }
+            def call(*args, &block)
+              call_with_tracing(args[0]) { call_without_new_relic(*args, &block) }
+            end
           end
 
           alias_method(:call_pipeline_without_new_relic, :call_pipeline)

--- a/lib/new_relic/agent/instrumentation/redis/chain.rb
+++ b/lib/new_relic/agent/instrumentation/redis/chain.rb
@@ -25,10 +25,28 @@ module NewRelic::Agent::Instrumentation
             end
           end
 
-          alias_method(:call_pipeline_without_new_relic, :call_pipeline)
+          if method_defined?(:call_pipeline)
+            alias_method(:call_pipeline_without_new_relic, :call_pipeline)
 
-          def call_pipeline(*args, &block)
-            call_pipeline_with_tracing(args[0]) { call_pipeline_without_new_relic(*args, &block) }
+            def call_pipeline(*args, &block)
+              call_pipeline_with_tracing(args[0]) { call_pipeline_without_new_relic(*args, &block) }
+            end
+          end
+
+          if method_defined?(:pipelined)
+            alias_method(:pipelined_without_new_relic, :pipelined)
+
+            def pipelined(&block)
+              pipelined_with_tracing { pipelined_without_new_relic(&block) }
+            end
+          end
+
+          if method_defined?(:multi)
+            alias_method(:multi_without_new_relic, :multi)
+
+            def multi(&block)
+              multi_with_tracing { multi_without_new_relic(&block) }
+            end
           end
 
           alias_method(:connect_without_new_relic, :connect)

--- a/lib/new_relic/agent/instrumentation/redis/chain.rb
+++ b/lib/new_relic/agent/instrumentation/redis/chain.rb
@@ -9,16 +9,28 @@ module NewRelic::Agent::Instrumentation
         ::Redis::Client.class_eval do
           include NewRelic::Agent::Instrumentation::Redis
 
-          alias_method(:call_without_new_relic, :call)
+          if method_defined?(:call_v)
+            alias_method(:call_v_without_new_relic, :call_v)
 
-          def call(*args, &block)
-            call_with_tracing(args[0]) { call_without_new_relic(*args, &block) }
+            def call_v(*args, &block)
+              call_v_with_tracing(args[0]) { call_v_without_new_relic(*args, &block) }
+            end
           end
 
-          alias_method(:call_pipeline_without_new_relic, :call_pipeline)
+          if method_defined?(:call)
+            alias_method(:call_without_new_relic, :call)
 
-          def call_pipeline(*args, &block)
-            call_pipeline_with_tracing(args[0]) { call_pipeline_without_new_relic(*args, &block) }
+            def call(*args, &block)
+              call_with_tracing(args[0]) { call_without_new_relic(*args, &block) }
+            end
+          end
+
+          if method_defined?(:call_pipeline)
+            alias_method(:call_pipeline_without_new_relic, :call_pipeline)
+
+            def call_pipeline(*args, &block)
+              call_pipeline_with_tracing(args[0]) { call_pipeline_without_new_relic(*args, &block) }
+            end
           end
 
           alias_method(:connect_without_new_relic, :connect)

--- a/lib/new_relic/agent/instrumentation/redis/chain.rb
+++ b/lib/new_relic/agent/instrumentation/redis/chain.rb
@@ -9,6 +9,12 @@ module NewRelic::Agent::Instrumentation
         ::Redis::Client.class_eval do
           include NewRelic::Agent::Instrumentation::Redis
 
+          alias_method(:call_v_without_new_relic, :call_v)
+
+          def call_v(*args, &block)
+            call_with_tracing(args[0]) { call_v_without_new_relic(*args, &block) }
+          end
+
           alias_method(:call_without_new_relic, :call)
 
           def call(*args, &block)

--- a/lib/new_relic/agent/instrumentation/redis/chain.rb
+++ b/lib/new_relic/agent/instrumentation/redis/chain.rb
@@ -9,44 +9,16 @@ module NewRelic::Agent::Instrumentation
         ::Redis::Client.class_eval do
           include NewRelic::Agent::Instrumentation::Redis
 
-          if method_defined?(:call_v)
-            alias_method(:call_v_without_new_relic, :call_v)
+          alias_method(:call_without_new_relic, :call)
 
-            def call_v(*args, &block)
-              call_with_tracing(args[0]) { call_v_without_new_relic(*args, &block) }
-            end
+          def call(*args, &block)
+            call_with_tracing(args[0]) { call_without_new_relic(*args, &block) }
           end
 
-          if method_defined?(:call)
-            alias_method(:call_without_new_relic, :call)
+          alias_method(:call_pipeline_without_new_relic, :call_pipeline)
 
-            def call(*args, &block)
-              call_with_tracing(args[0]) { call_without_new_relic(*args, &block) }
-            end
-          end
-
-          if method_defined?(:call_pipeline)
-            alias_method(:call_pipeline_without_new_relic, :call_pipeline)
-
-            def call_pipeline(*args, &block)
-              call_pipeline_with_tracing(args[0]) { call_pipeline_without_new_relic(*args, &block) }
-            end
-          end
-
-          if method_defined?(:pipelined)
-            alias_method(:pipelined_without_new_relic, :pipelined)
-
-            def pipelined(&block)
-              pipelined_with_tracing { pipelined_without_new_relic(&block) }
-            end
-          end
-
-          if method_defined?(:multi)
-            alias_method(:multi_without_new_relic, :multi)
-
-            def multi(&block)
-              multi_with_tracing { multi_without_new_relic(&block) }
-            end
+          def call_pipeline(*args, &block)
+            call_pipeline_with_tracing(args[0]) { call_pipeline_without_new_relic(*args, &block) }
           end
 
           alias_method(:connect_without_new_relic, :connect)

--- a/lib/new_relic/agent/instrumentation/redis/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/redis/instrumentation.rb
@@ -6,8 +6,8 @@ module NewRelic::Agent::Instrumentation
   module Redis
     PRODUCT_NAME = 'Redis'
     CONNECT = 'connect'
-    UNKNOWN = "unknown"
-    LOCALHOST = "localhost"
+    UNKNOWN = 'unknown'
+    LOCALHOST = 'localhost'
     MULTI_OPERATION = 'multi'
     PIPELINE_OPERATION = 'pipeline'
 
@@ -16,6 +16,7 @@ module NewRelic::Agent::Instrumentation
       with_tracing(CONNECT, database: db) { yield }
     end
 
+    # Used for Redis 4.x and 3.x
     def call_with_tracing(command, &block)
       operation = command[0]
       statement = ::NewRelic::Agent::Datastores::Redis.format_command(command)
@@ -23,6 +24,7 @@ module NewRelic::Agent::Instrumentation
       with_tracing(operation, statement: statement, database: db) { yield }
     end
 
+    # Used for Redis 4.x and 3.x
     def call_pipeline_with_tracing(pipeline)
       operation = pipeline.is_a?(::Redis::Pipeline::Multi) ? MULTI_OPERATION : PIPELINE_OPERATION
       statement = ::NewRelic::Agent::Datastores::Redis.format_pipeline_commands(pipeline.commands)
@@ -38,11 +40,12 @@ module NewRelic::Agent::Instrumentation
       with_tracing(operation, statement: statement, database: database) { yield }
     end
 
-    def connect_middleware_with_tracing(config)
-      database = config.db
-      with_tracing(CONNECT, database: database) { yield }
+    # Used for Redis 5.x
+    def connect_middleware_with_tracing(_config)
+      with_tracing(CONNECT, database: client.db) { yield }
     end
 
+    # Used for Redis 5.x
     def call_middleware_with_tracing(command, &block)
       operation = command[0]
       statement = ::NewRelic::Agent::Datastores::Redis.format_command(command)

--- a/lib/new_relic/agent/instrumentation/redis/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/redis/instrumentation.rb
@@ -34,7 +34,7 @@ module NewRelic::Agent::Instrumentation
 
     # Used for Redis 5.x
     def call_pipelined_with_tracing(pipeline)
-      operation = pipeline.flatten.include?('MULTI') ? MULTI_OPERATION : PIPELINE_OPERATION # (how can we separate this from multi?)
+      operation = pipeline.flatten.include?('MULTI') ? MULTI_OPERATION : PIPELINE_OPERATION
       statement = ::NewRelic::Agent::Datastores::Redis.format_pipeline_commands(pipeline)
       database = client.db
       with_tracing(operation, statement: statement, database: database) { yield }

--- a/lib/new_relic/agent/instrumentation/redis/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/redis/instrumentation.rb
@@ -11,47 +11,54 @@ module NewRelic::Agent::Instrumentation
     MULTI_OPERATION = 'multi'
     PIPELINE_OPERATION = 'pipeline'
 
+    # Used for Redis 4.x and 3.x
+    def connect_with_tracing
+      with_tracing(CONNECT, database: db) { yield }
+    end
+
     def call_with_tracing(command, &block)
       operation = command[0]
       statement = ::NewRelic::Agent::Datastores::Redis.format_command(command)
 
-      with_tracing(operation, statement) { yield }
+      with_tracing(operation, statement: statement, database: db) { yield }
     end
 
     def call_pipeline_with_tracing(pipeline)
       operation = pipeline.is_a?(::Redis::Pipeline::Multi) ? MULTI_OPERATION : PIPELINE_OPERATION
       statement = ::NewRelic::Agent::Datastores::Redis.format_pipeline_commands(pipeline.commands)
 
-      with_tracing(operation, statement) { yield }
+      with_tracing(operation, statement: statement, database: db) { yield }
     end
 
-    def pipelined_with_tracing
-      # How do we get the command? They're values within the block?
-      # This doesn't have the statement, how can we get it?
-      # Should we be getting pipelined statements for #get? something unique?
-      statement = 'FIX ME'
-      with_tracing(PIPELINE_OPERATION, statement) { yield }
+    # Used for Redis 5.x
+    def call_pipelined_with_tracing(pipeline)
+      operation = PIPELINE_OPERATION # (how can we separate this from multi?)
+      statement = ::NewRelic::Agent::Datastores::Redis.format_pipeline_commands(pipeline)
+      database = client.db
+      with_tracing(operation, statement: statement, database: database) { yield }
     end
 
-    def multi_with_tracing
-      # How can we get the dynamic statement name?
-      statement = 'FIX ME'
-      with_tracing(MULTI_OPERATION, statement) { yield }
+    def connect_middleware_with_tracing(config)
+      database = config.db
+      with_tracing(CONNECT, database: database) { yield }
     end
 
-    def connect_with_tracing
-      with_tracing(CONNECT) { yield }
+    def call_middleware_with_tracing(command, &block)
+      operation = command[0]
+      statement = ::NewRelic::Agent::Datastores::Redis.format_command(command)
+      database = client.db
+      with_tracing(operation, statement: statement, database: database) { yield }
     end
 
     private
 
-    def with_tracing(operation, statement = nil)
+    def with_tracing(operation, statement: nil, database: nil)
       segment = NewRelic::Agent::Tracer.start_datastore_segment(
         product: PRODUCT_NAME,
         operation: operation,
         host: _nr_hostname,
         port_path_or_id: _nr_port_path_or_id,
-        database_name: db
+        database_name: database
       )
       begin
         segment.notice_nosql_statement(statement) if statement
@@ -62,17 +69,29 @@ module NewRelic::Agent::Instrumentation
     end
 
     def _nr_hostname
-      self.path ? LOCALHOST : self.host
+      if redis_5_or_above?
+        client.path ? LOCALHOST : client.host
+      else
+        self.path ? LOCALHOST : self.host
+      end
     rescue => e
       NewRelic::Agent.logger.debug("Failed to retrieve Redis host: #{e}")
       UNKNOWN
     end
 
     def _nr_port_path_or_id
-      self.path || self.port
+      if redis_5_or_above?
+        client.path || client.port
+      else
+        self.path || self.port
+      end
     rescue => e
       NewRelic::Agent.logger.debug("Failed to retrieve Redis port_path_or_id: #{e}")
       UNKNOWN
+    end
+
+    def redis_5_or_above?
+      Gem::Version.new(::Redis::VERSION) >= Gem::Version.new('5.0.0')
     end
   end
 end

--- a/lib/new_relic/agent/instrumentation/redis/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/redis/instrumentation.rb
@@ -25,6 +25,20 @@ module NewRelic::Agent::Instrumentation
       with_tracing(operation, statement) { yield }
     end
 
+    def pipelined_with_tracing
+      # How do we get the command? They're values within the block?
+      # This doesn't have the statement, how can we get it?
+      # Should we be getting pipelined statements for #get? something unique?
+      statement = 'FIX ME'
+      with_tracing(PIPELINE_OPERATION, statement) { yield }
+    end
+
+    def multi_with_tracing
+      # How can we get the dynamic statement name?
+      statement = 'FIX ME'
+      with_tracing(MULTI_OPERATION, statement) { yield }
+    end
+
     def connect_with_tracing
       with_tracing(CONNECT) { yield }
     end

--- a/lib/new_relic/agent/instrumentation/redis/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/redis/instrumentation.rb
@@ -10,6 +10,7 @@ module NewRelic::Agent::Instrumentation
     LOCALHOST = 'localhost'
     MULTI_OPERATION = 'multi'
     PIPELINE_OPERATION = 'pipeline'
+    USE_MIDDLEWARE = Gem::Version.new(::Redis::VERSION) >= Gem::Version.new('5.0.0') && defined?(::RedisClient)
 
     # Used for Redis 4.x and 3.x
     def connect_with_tracing
@@ -86,11 +87,7 @@ module NewRelic::Agent::Instrumentation
     end
 
     def _nr_redis_client
-      @_nr_redis_client ||= redis_5_or_above? ? client : self
-    end
-
-    def redis_5_or_above?
-      Gem::Version.new(::Redis::VERSION) >= Gem::Version.new('5.0.0')
+      @_nr_redis_client ||= USE_MIDDLEWARE ? client : self
     end
   end
 end

--- a/lib/new_relic/agent/instrumentation/redis/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/redis/instrumentation.rb
@@ -32,7 +32,7 @@ module NewRelic::Agent::Instrumentation
 
     # Used for Redis 5.x
     def call_pipelined_with_tracing(pipeline)
-      operation = PIPELINE_OPERATION # (how can we separate this from multi?)
+      operation = pipeline.flatten.include?('MULTI') ? MULTI_OPERATION : PIPELINE_OPERATION # (how can we separate this from multi?)
       statement = ::NewRelic::Agent::Datastores::Redis.format_pipeline_commands(pipeline)
       database = client.db
       with_tracing(operation, statement: statement, database: database) { yield }

--- a/lib/new_relic/agent/instrumentation/redis/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/redis/instrumentation.rb
@@ -10,9 +10,8 @@ module NewRelic::Agent::Instrumentation
     LOCALHOST = 'localhost'
     MULTI_OPERATION = 'multi'
     PIPELINE_OPERATION = 'pipeline'
-    USE_MIDDLEWARE = Gem::Version.new(::Redis::VERSION) >= Gem::Version.new('5.0.0') && !!defined?(::RedisClient)
+    REDIS_5 = Gem::Version.new(::Redis::VERSION) >= Gem::Version.new('5.0.0') && !!defined?(::RedisClient)
 
-    # Used for Redis 4.x and 3.x
     def connect_with_tracing
       with_tracing(CONNECT, database: db) { yield }
     end
@@ -37,21 +36,17 @@ module NewRelic::Agent::Instrumentation
     def call_pipelined_with_tracing(pipeline)
       operation = pipeline.flatten.include?('MULTI') ? MULTI_OPERATION : PIPELINE_OPERATION
       statement = ::NewRelic::Agent::Datastores::Redis.format_pipeline_commands(pipeline)
-      database = client.db
-      with_tracing(operation, statement: statement, database: database) { yield }
+
+      # call_pipelined isn't invoked on the client object, so use client.db to
+      # access the client instance var on self
+      with_tracing(operation, statement: statement, database: client.db) { yield }
     end
 
     # Used for Redis 5.x
-    def connect_middleware_with_tracing(_config)
-      with_tracing(CONNECT, database: client.db) { yield }
-    end
-
-    # Used for Redis 5.x
-    def call_middleware_with_tracing(command, &block)
+    def call_v_with_tracing(command, &block)
       operation = command[0]
       statement = ::NewRelic::Agent::Datastores::Redis.format_command(command)
-      database = client.db
-      with_tracing(operation, statement: statement, database: database) { yield }
+      with_tracing(operation, statement: statement, database: db) { yield }
     end
 
     private
@@ -73,21 +68,21 @@ module NewRelic::Agent::Instrumentation
     end
 
     def _nr_hostname
-      _nr_redis_client.path ? LOCALHOST : _nr_redis_client.host
+      _nr_client.path ? LOCALHOST : _nr_client.host
     rescue => e
       NewRelic::Agent.logger.debug("Failed to retrieve Redis host: #{e}")
       UNKNOWN
     end
 
     def _nr_port_path_or_id
-      _nr_redis_client.path || _nr_redis_client.port
+      _nr_client.path || _nr_client.port
     rescue => e
       NewRelic::Agent.logger.debug("Failed to retrieve Redis port_path_or_id: #{e}")
       UNKNOWN
     end
 
-    def _nr_redis_client
-      @_nr_redis_client ||= USE_MIDDLEWARE ? client : self
+    def _nr_client
+      @nr_client ||= self.is_a?(::Redis::Client) ? self : client
     end
   end
 end

--- a/lib/new_relic/agent/instrumentation/redis/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/redis/instrumentation.rb
@@ -10,7 +10,7 @@ module NewRelic::Agent::Instrumentation
     LOCALHOST = 'localhost'
     MULTI_OPERATION = 'multi'
     PIPELINE_OPERATION = 'pipeline'
-    USE_MIDDLEWARE = Gem::Version.new(::Redis::VERSION) >= Gem::Version.new('5.0.0') && defined?(::RedisClient)
+    USE_MIDDLEWARE = Gem::Version.new(::Redis::VERSION) >= Gem::Version.new('5.0.0') && !!defined?(::RedisClient)
 
     # Used for Redis 4.x and 3.x
     def connect_with_tracing

--- a/lib/new_relic/agent/instrumentation/redis/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/redis/instrumentation.rb
@@ -72,25 +72,21 @@ module NewRelic::Agent::Instrumentation
     end
 
     def _nr_hostname
-      if redis_5_or_above?
-        client.path ? LOCALHOST : client.host
-      else
-        self.path ? LOCALHOST : self.host
-      end
+      _nr_redis_client.path ? LOCALHOST : _nr_redis_client.host
     rescue => e
       NewRelic::Agent.logger.debug("Failed to retrieve Redis host: #{e}")
       UNKNOWN
     end
 
     def _nr_port_path_or_id
-      if redis_5_or_above?
-        client.path || client.port
-      else
-        self.path || self.port
-      end
+      _nr_redis_client.path || _nr_redis_client.port
     rescue => e
       NewRelic::Agent.logger.debug("Failed to retrieve Redis port_path_or_id: #{e}")
       UNKNOWN
+    end
+
+    def _nr_redis_client
+      @_nr_redis_client ||= redis_5_or_above? ? client : self
     end
 
     def redis_5_or_above?

--- a/lib/new_relic/agent/instrumentation/redis/middleware.rb
+++ b/lib/new_relic/agent/instrumentation/redis/middleware.rb
@@ -1,0 +1,24 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+module NewRelic::Agent::Instrumentation
+  module RedisClient
+    module Middleware
+      # This module is used to instrument Redis 5.x+
+      include NewRelic::Agent::Instrumentation::Redis
+
+      def connect(*args, &block)
+        connect_middleware_with_tracing(args[0]) { super }
+      end
+
+      def call(*args, &block)
+        call_middleware_with_tracing(args[0]) { super }
+      end
+
+      def call_pipelined(*args, &block)
+        call_pipelined_with_tracing(args[0]) { super }
+      end
+    end
+  end
+end

--- a/lib/new_relic/agent/instrumentation/redis/middleware.rb
+++ b/lib/new_relic/agent/instrumentation/redis/middleware.rb
@@ -8,14 +8,6 @@ module NewRelic::Agent::Instrumentation
       # This module is used to instrument Redis 5.x+
       include NewRelic::Agent::Instrumentation::Redis
 
-      def connect(*args, &block)
-        connect_middleware_with_tracing(args[0]) { super }
-      end
-
-      def call(*args, &block)
-        call_middleware_with_tracing(args[0]) { super }
-      end
-
       def call_pipelined(*args, &block)
         call_pipelined_with_tracing(args[0]) { super }
       end

--- a/lib/new_relic/agent/instrumentation/redis/prepend.rb
+++ b/lib/new_relic/agent/instrumentation/redis/prepend.rb
@@ -7,6 +7,12 @@ module NewRelic::Agent::Instrumentation
     module Prepend
       include NewRelic::Agent::Instrumentation::Redis
 
+      # Defined in version 5.x
+      def call_v(*args, &block)
+        call_v_with_tracing(args[0]) { super }
+      end
+
+      # Defined in version 4.x, 3.x
       def call(*args, &block)
         call_with_tracing(args[0]) { super }
       end

--- a/lib/new_relic/agent/instrumentation/redis/prepend.rb
+++ b/lib/new_relic/agent/instrumentation/redis/prepend.rb
@@ -21,6 +21,14 @@ module NewRelic::Agent::Instrumentation
         call_pipeline_with_tracing(args[0]) { super }
       end
 
+      def pipelined
+        pipelined_with_tracing { super }
+      end
+
+      def multi
+        multi_with_tracing { super }
+      end
+
       def connect(*args, &block)
         connect_with_tracing { super }
       end

--- a/lib/new_relic/agent/instrumentation/redis/prepend.rb
+++ b/lib/new_relic/agent/instrumentation/redis/prepend.rb
@@ -7,6 +7,12 @@ module NewRelic::Agent::Instrumentation
     module Prepend
       include NewRelic::Agent::Instrumentation::Redis
 
+      # Defined in version 5.x
+      def call_v(*args, &block)
+        call_with_tracing(args[0]) { super }
+      end
+
+      # Defined in version 4.x, 3.x
       def call(*args, &block)
         call_with_tracing(args[0]) { super }
       end

--- a/lib/new_relic/agent/instrumentation/redis/prepend.rb
+++ b/lib/new_relic/agent/instrumentation/redis/prepend.rb
@@ -7,26 +7,13 @@ module NewRelic::Agent::Instrumentation
     module Prepend
       include NewRelic::Agent::Instrumentation::Redis
 
-      # Defined in version 5.x
-      def call_v(*args, &block)
-        call_with_tracing(args[0]) { super }
-      end
 
-      # Defined in version 4.x, 3.x
       def call(*args, &block)
         call_with_tracing(args[0]) { super }
       end
 
       def call_pipeline(*args, &block)
         call_pipeline_with_tracing(args[0]) { super }
-      end
-
-      def pipelined
-        pipelined_with_tracing { super }
-      end
-
-      def multi
-        multi_with_tracing { super }
       end
 
       def connect(*args, &block)

--- a/lib/new_relic/agent/instrumentation/redis/prepend.rb
+++ b/lib/new_relic/agent/instrumentation/redis/prepend.rb
@@ -7,7 +7,6 @@ module NewRelic::Agent::Instrumentation
     module Prepend
       include NewRelic::Agent::Instrumentation::Redis
 
-
       def call(*args, &block)
         call_with_tracing(args[0]) { super }
       end

--- a/newrelic.yml
+++ b/newrelic.yml
@@ -394,6 +394,7 @@ common: &default_settings
 
   # Controls auto-instrumentation of Redis at start up.
   # May be one of [auto|prepend|chain|disabled].
+  # Prepend and chain behave the same way when Redis gem 5.x is installed
   # instrumentation.redis: auto
 
   # Controls auto-instrumentation of resque at start up.

--- a/newrelic.yml
+++ b/newrelic.yml
@@ -394,7 +394,6 @@ common: &default_settings
 
   # Controls auto-instrumentation of Redis at start up.
   # May be one of [auto|prepend|chain|disabled].
-  # Prepend and chain behave the same way when Redis gem 5.x is installed
   # instrumentation.redis: auto
 
   # Controls auto-instrumentation of resque at start up.

--- a/test/multiverse/suites/redis/Envfile
+++ b/test/multiverse/suites/redis/Envfile
@@ -5,10 +5,8 @@
 instrumentation_methods :chain, :prepend
 
 REDIS_VERSIONS = [
-  # TODO: add support for redis v5+, re-enable nil
-  # https://github.com/newrelic/newrelic-ruby-agent/issues/1361
-  # [nil, 2.4],
-  ['4.7.1', 2.4],
+  [nil, 2.5],
+  ['4.8.0', 2.4],
   ['3.3.0']
 ]
 

--- a/test/multiverse/suites/redis/redis_instrumentation_test.rb
+++ b/test/multiverse/suites/redis/redis_instrumentation_test.rb
@@ -13,8 +13,6 @@ if NewRelic::Agent::Datastores::Redis.is_supported_version?
     def after_setup
       super
       # Default timeout is 5 secs; a flushall takes longer on a busy box (i.e. CI)
-      # @redis ||= Redis.new(:host => redis_host, :timeout => 25)
-      # When running locally, not defining the host allows things to connect on v5
       @redis ||= Redis.new(timeout: 25)
 
       # Creating a new client doesn't actually establish a connection, so make

--- a/test/multiverse/suites/redis/redis_instrumentation_test.rb
+++ b/test/multiverse/suites/redis/redis_instrumentation_test.rb
@@ -57,7 +57,7 @@ if NewRelic::Agent::Datastores::Redis.is_supported_version?
 
     def test_records_connect_tt_node_within_call_that_triggered_it
       in_transaction do
-        redis = Redis.new(:host => redis_host)
+        redis = Redis.new
         redis.get("foo")
       end
 
@@ -274,7 +274,7 @@ if NewRelic::Agent::Datastores::Redis.is_supported_version?
     end
 
     def test_records_hostname_on_tt_node_for_get_with_unix_domain_socket
-      redis = Redis.new(:host => redis_host)
+      redis = Redis.new
       redis.send(client).stubs(:path).returns('/tmp/redis.sock')
 
       in_transaction do
@@ -306,7 +306,7 @@ if NewRelic::Agent::Datastores::Redis.is_supported_version?
     end
 
     def test_records_hostname_on_tt_node_for_multi_with_unix_domain_socket
-      redis = Redis.new(:host => redis_host)
+      redis = Redis.new
       redis.send(client).stubs(:path).returns('/tmp/redis.sock')
 
       in_transaction do
@@ -324,7 +324,7 @@ if NewRelic::Agent::Datastores::Redis.is_supported_version?
     end
 
     def test_records_unknown_unknown_metric_when_error_gathering_instance_data
-      redis = Redis.new(:host => redis_host)
+      redis = Redis.new
       redis.send(client).stubs(:path).raises(StandardError.new)
       in_transaction do
         redis.get("foo")
@@ -354,6 +354,7 @@ if NewRelic::Agent::Datastores::Redis.is_supported_version?
       rescue StandardError => e
         # NOOP -- allowing span and transaction to notice error
       end
+
       assert_segment_noticed_error txn, /redis/, simulated_error_class.name, /Error connecting to Redis/i
       assert_transaction_noticed_error txn, simulated_error_class.name
     end

--- a/test/multiverse/suites/redis/redis_instrumentation_test.rb
+++ b/test/multiverse/suites/redis/redis_instrumentation_test.rb
@@ -62,24 +62,14 @@ if NewRelic::Agent::Datastores::Redis.is_supported_version?
       end
 
       tt = last_transaction_trace
-      # TODO: Does this difference matter? Do we need to take action so that the nesting remains the same?
-      if Gem::Version.new(::Redis::VERSION) >= Gem::Version.new('5.0.0')
-        get_node = tt.root_node.children[0].children[1]
 
-        assert_equal('Datastore/operation/Redis/get', get_node.metric_name)
+      get_node = tt.root_node.children[0].children[0]
 
-        connect_node = tt.root_node.children[0].children[0]
+      assert_equal('Datastore/operation/Redis/get', get_node.metric_name)
 
-        assert_equal('Datastore/operation/Redis/connect', connect_node.metric_name)
-      else
-        get_node = tt.root_node.children[0].children[0]
+      connect_node = get_node.children[0]
 
-        assert_equal('Datastore/operation/Redis/get', get_node.metric_name)
-
-        connect_node = get_node.children[0]
-
-        assert_equal('Datastore/operation/Redis/connect', connect_node.metric_name)
-      end
+      assert_equal('Datastore/operation/Redis/connect', connect_node.metric_name)
     end
 
     def test_records_metrics_for_set

--- a/test/multiverse/suites/redis/redis_instrumentation_test.rb
+++ b/test/multiverse/suites/redis/redis_instrumentation_test.rb
@@ -13,7 +13,9 @@ if NewRelic::Agent::Datastores::Redis.is_supported_version?
     def after_setup
       super
       # Default timeout is 5 secs; a flushall takes longer on a busy box (i.e. CI)
-      @redis = Redis.new(:host => redis_host, :timeout => 25)
+      # @redis ||= Redis.new(:host => redis_host, :timeout => 25)
+      # When running locally, not defining the host allows things to connect on v5
+      @redis ||= Redis.new(timeout: 25)
 
       # Creating a new client doesn't actually establish a connection, so make
       # sure we do that by issuing a dummy get command, and then drop metrics
@@ -27,7 +29,7 @@ if NewRelic::Agent::Datastores::Redis.is_supported_version?
     end
 
     def test_records_metrics_for_connect
-      redis = Redis.new(:host => redis_host)
+      redis = Redis.new
 
       in_transaction("test_txn") do
         redis.get("foo")

--- a/test/multiverse/suites/redis/redis_instrumentation_test.rb
+++ b/test/multiverse/suites/redis/redis_instrumentation_test.rb
@@ -339,15 +339,15 @@ if NewRelic::Agent::Datastores::Redis.is_supported_version?
 
     def simulate_read_error
       redis = Redis.new
-      redis.stub(:get, raise(simulated_error_class.new, "Error connecting to Redis")) do
-        redis.get("foo")
-      end
+      redis.send(client).stubs("connect").raises(simulated_error_class, "Error connecting to Redis")
+      redis.get("foo")
+    ensure
     end
 
     def test_noticed_error_at_segment_and_txn_on_error
       txn = nil
       begin
-        in_transaction('redis') do |redis_txn|
+        in_transaction do |redis_txn|
           txn = redis_txn
           simulate_read_error
         end
@@ -355,22 +355,20 @@ if NewRelic::Agent::Datastores::Redis.is_supported_version?
         # NOOP -- allowing span and transaction to notice error
       end
 
-      assert_segment_noticed_error txn, /redis/, simulated_error_class.name, /Error connecting to Redis/i
+      assert_segment_noticed_error txn, /Redis\/get$/, simulated_error_class.name, /Error connecting to Redis/i
       assert_transaction_noticed_error txn, simulated_error_class.name
     end
 
     def test_noticed_error_only_at_segment_on_error
       txn = nil
       in_transaction do |redis_txn|
-        begin
-          txn = redis_txn
-          simulate_read_error
-        rescue StandardError => e
-          # NOP -- allowing ONLY span to notice error
-        end
+        txn = redis_txn
+        simulate_read_error
+      rescue StandardError => e
+        # NOOP -- allowing ONLY span to notice error
       end
 
-      assert_segment_noticed_error txn, /Redis\/connect$/, simulated_error_class.name, /error connecting/i
+      assert_segment_noticed_error txn, /Redis\/get$/, simulated_error_class.name, /Error connecting to Redis/i
       refute_transaction_noticed_error txn, simulated_error_class.name
     end
 

--- a/test/multiverse/suites/redis/redis_instrumentation_test.rb
+++ b/test/multiverse/suites/redis/redis_instrumentation_test.rb
@@ -54,6 +54,8 @@ if NewRelic::Agent::Datastores::Redis.is_supported_version?
     end
 
     def test_records_connect_tt_node_within_call_that_triggered_it
+      skip ('Transaction node nesting changes in Redis 5') if ::NewRelic::Agent::Instrumentation::Redis::USE_MIDDLEWARE
+
       in_transaction do
         redis = Redis.new
         redis.get("foo")

--- a/test/multiverse/suites/redis/redis_instrumentation_test.rb
+++ b/test/multiverse/suites/redis/redis_instrumentation_test.rb
@@ -338,24 +338,23 @@ if NewRelic::Agent::Datastores::Redis.is_supported_version?
     end
 
     def simulate_read_error
-      redis = Redis.new(:host => redis_host)
-      redis.send(client).stubs("establish_connection").raises(simulated_error_class, "Error connecting to Redis")
-      redis.get("foo")
-    ensure
+      redis = Redis.new
+      redis.stub(:get, raise(simulated_error_class.new, "Error connecting to Redis")) do
+        redis.get("foo")
+      end
     end
 
     def test_noticed_error_at_segment_and_txn_on_error
       txn = nil
       begin
-        in_transaction do |redis_txn|
+        in_transaction('redis') do |redis_txn|
           txn = redis_txn
           simulate_read_error
         end
       rescue StandardError => e
         # NOOP -- allowing span and transaction to notice error
       end
-
-      assert_segment_noticed_error txn, /Redis\/connect$/, simulated_error_class.name, /error connecting/i
+      assert_segment_noticed_error txn, /redis/, simulated_error_class.name, /Error connecting to Redis/i
       assert_transaction_noticed_error txn, simulated_error_class.name
     end
 

--- a/test/multiverse/suites/redis/redis_instrumentation_test.rb
+++ b/test/multiverse/suites/redis/redis_instrumentation_test.rb
@@ -53,27 +53,7 @@ if NewRelic::Agent::Datastores::Redis.is_supported_version?
       assert_metrics_recorded_exclusive(expected, :ignore_filter => /Supportability/)
     end
 
-    def test_records_connect_node_at_a_peer_level_with_call_that_triggered_it
-      skip ('Transaction node nesting does not have this behavior in Redis 4 and below') unless
-        ::NewRelic::Agent::Instrumentation::Redis::USE_MIDDLEWARE
-
-      in_transaction do
-        redis = Redis.new
-        redis.get("foo")
-      end
-
-      tt = last_transaction_trace
-
-      connect_node = tt.root_node.children[0].children[0]
-      get_node = tt.root_node.children[0].children[1]
-
-      assert_equal('Datastore/operation/Redis/connect', connect_node.metric_name)
-      assert_equal('Datastore/operation/Redis/get', get_node.metric_name)
-    end
-
     def test_records_connect_tt_node_within_call_that_triggered_it
-      skip ('Transaction node nesting changes in Redis 5') if ::NewRelic::Agent::Instrumentation::Redis::USE_MIDDLEWARE
-
       in_transaction do
         redis = Redis.new
         redis.get("foo")

--- a/test/multiverse/suites/redis/redis_instrumentation_test.rb
+++ b/test/multiverse/suites/redis/redis_instrumentation_test.rb
@@ -89,7 +89,7 @@ if NewRelic::Agent::Datastores::Redis.is_supported_version?
       assert_metrics_recorded(expected)
     end
 
-    def test_records_metrics_for_get_in_web_transaction
+    def test_records_metrics_for_set_in_web_transaction
       in_web_transaction do
         @redis.set('prodigal', 'sorcerer')
       end
@@ -146,7 +146,7 @@ if NewRelic::Agent::Datastores::Redis.is_supported_version?
       refute get_node[:statement]
     end
 
-    def test_records_metrics_for_set_in_web_transaction
+    def test_records_metrics_for_get_in_web_transaction
       in_web_transaction do
         @redis.get('timetwister')
       end

--- a/test/multiverse/suites/redis/redis_instrumentation_test.rb
+++ b/test/multiverse/suites/redis/redis_instrumentation_test.rb
@@ -372,10 +372,12 @@ if NewRelic::Agent::Datastores::Redis.is_supported_version?
     def test_noticed_error_only_at_segment_on_error
       txn = nil
       in_transaction do |redis_txn|
-        txn = redis_txn
-        simulate_read_error
-      rescue StandardError => e
-        # NOOP -- allowing ONLY span to notice error
+        begin
+          txn = redis_txn
+          simulate_read_error
+        rescue StandardError => e
+          # NOOP -- allowing ONLY span to notice error
+        end
       end
 
       assert_segment_noticed_error txn, /Redis\/get$/, simulated_error_class.name, /Error connecting to Redis/i

--- a/test/multiverse/suites/redis/redis_instrumentation_test.rb
+++ b/test/multiverse/suites/redis/redis_instrumentation_test.rb
@@ -53,6 +53,24 @@ if NewRelic::Agent::Datastores::Redis.is_supported_version?
       assert_metrics_recorded_exclusive(expected, :ignore_filter => /Supportability/)
     end
 
+    def test_records_connect_node_at_a_peer_level_with_call_that_triggered_it
+      skip ('Transaction node nesting does not have this behavior in Redis 4 and below') unless
+        ::NewRelic::Agent::Instrumentation::Redis::USE_MIDDLEWARE
+
+      in_transaction do
+        redis = Redis.new
+        redis.get("foo")
+      end
+
+      tt = last_transaction_trace
+
+      connect_node = tt.root_node.children[0].children[0]
+      get_node = tt.root_node.children[0].children[1]
+
+      assert_equal('Datastore/operation/Redis/connect', connect_node.metric_name)
+      assert_equal('Datastore/operation/Redis/get', get_node.metric_name)
+    end
+
     def test_records_connect_tt_node_within_call_that_triggered_it
       skip ('Transaction node nesting changes in Redis 5') if ::NewRelic::Agent::Instrumentation::Redis::USE_MIDDLEWARE
 

--- a/test/multiverse/suites/redis/redis_instrumentation_test.rb
+++ b/test/multiverse/suites/redis/redis_instrumentation_test.rb
@@ -165,9 +165,9 @@ if NewRelic::Agent::Datastores::Redis.is_supported_version?
 
     def test_records_metrics_for_pipelined_commands
       in_transaction('test_txn') do
-        @redis.pipelined do
-          @redis.get('great log')
-          @redis.get('late log')
+        @redis.pipelined do |pipeline|
+          pipeline.get('great log')
+          pipeline.get('late log')
         end
       end
 
@@ -191,9 +191,9 @@ if NewRelic::Agent::Datastores::Redis.is_supported_version?
 
     def test_records_commands_without_args_in_pipelined_block_by_default
       in_transaction do
-        @redis.pipelined do
-          @redis.set('late log', 'goof')
-          @redis.get('great log')
+        @redis.pipelined do |pipeline|
+          pipeline.set('late log', 'goof')
+          pipeline.get('great log')
         end
       end
 
@@ -205,9 +205,9 @@ if NewRelic::Agent::Datastores::Redis.is_supported_version?
 
     def test_records_metrics_for_multi_blocks
       in_transaction('test_txn') do
-        @redis.multi do
-          @redis.get('darkpact')
-          @redis.get('chaos orb')
+        @redis.multi do |pipeline|
+          pipeline.get('darkpact')
+          pipeline.get('chaos orb')
         end
       end
 
@@ -231,9 +231,9 @@ if NewRelic::Agent::Datastores::Redis.is_supported_version?
 
     def test_records_commands_without_args_in_tt_node_for_multi_blocks
       in_transaction do
-        @redis.multi do
-          @redis.set('darkpact', 'sorcery')
-          @redis.get('chaos orb')
+        @redis.multi do |pipeline|
+          pipeline.set('darkpact', 'sorcery')
+          pipeline.get('chaos orb')
         end
       end
 
@@ -246,9 +246,9 @@ if NewRelic::Agent::Datastores::Redis.is_supported_version?
     def test_records_commands_with_args_in_tt_node_for_multi_blocks
       with_config(:'transaction_tracer.record_redis_arguments' => true) do
         in_transaction do
-          @redis.multi do
-            @redis.set('darkpact', 'sorcery')
-            @redis.get('chaos orb')
+          @redis.multi do |pipeline|
+            pipeline.set('darkpact', 'sorcery')
+            pipeline.get('chaos orb')
           end
         end
       end
@@ -291,8 +291,8 @@ if NewRelic::Agent::Datastores::Redis.is_supported_version?
 
     def test_records_instance_parameters_on_tt_node_for_multi
       in_transaction do
-        @redis.multi do
-          @redis.get("foo")
+        @redis.multi do |pipeline|
+          pipeline.get("foo")
         end
       end
 
@@ -310,8 +310,8 @@ if NewRelic::Agent::Datastores::Redis.is_supported_version?
       redis.send(client).stubs(:path).returns('/tmp/redis.sock')
 
       in_transaction do
-        redis.multi do
-          redis.get("foo")
+        redis.multi do |pipeline|
+          pipeline.get("foo")
         end
       end
 
@@ -381,12 +381,12 @@ if NewRelic::Agent::Datastores::Redis.is_supported_version?
       assert_equal 'bar', @redis.get('foo')
       assert_equal 1, @redis.del('foo')
 
-      assert_equal %w[OK OK], @redis.multi { @redis.set('foo', 'bar'); @redis.set('baz', 'bat') }
-      assert_equal %w[bar bat], @redis.multi { @redis.get('foo'); @redis.get('baz') }
+      assert_equal %w[OK OK], @redis.multi { |pipeline| pipeline.set('foo', 'bar'); pipeline.set('baz', 'bat') }
+      assert_equal %w[bar bat], @redis.multi { |pipeline| pipeline.get('foo'); pipeline.get('baz') }
       assert_equal 2, @redis.del('foo', 'baz')
 
-      assert_equal %w[OK OK], @redis.pipelined { @redis.set('foo', 'bar'); @redis.set('baz', 'bat') }
-      assert_equal %w[bar bat], @redis.pipelined { @redis.get('foo'); @redis.get('baz') }
+      assert_equal %w[OK OK], @redis.pipelined { |pipeline| pipeline.set('foo', 'bar'); pipeline.set('baz', 'bat') }
+      assert_equal %w[bar bat], @redis.pipelined { |pipeline| pipeline.get('foo'); pipeline.get('baz') }
       assert_equal 2, @redis.del('foo', 'baz')
     end
 


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview:

* Redis v5 changed a lot of the underlying structure of the gem to separate concerns like client and cluster commands into their own gems
* Redis v5 [introduced an API for instrumentation that leverages a middleware pattern](https://github.com/redis-rb/redis-client#instrumentation-and-middlewares)
    * The focus is on the same three methods we traditionally instrument:
        * connect
        * call
        * call_pipeline(d)

* Resolves #1361 

Submitter Checklist:
- [X] Include a link to the related GitHub issue, if applicable
- [ ] Include a security review link, if applicable

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
GitHub Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
