### PR TITLE
Correctly identify Unicorn when used with Rack v3

### DIFF
--- a/lib/new_relic/local_environment.rb
+++ b/lib/new_relic/local_environment.rb
@@ -71,10 +71,10 @@ module NewRelic
         thin
         mongrel
         litespeed
+        unicorn
         webrick
         fastcgi
         rainbows
-        unicorn
       ]
       # TODO: MAJOR VERSION - remove rainbows
       while dispatchers.any? && @discovered_dispatcher.nil?

--- a/test/multiverse/suites/unicorn/Envfile
+++ b/test/multiverse/suites/unicorn/Envfile
@@ -7,40 +7,20 @@ suite_condition("unicorn not supported for JRuby") do
 end
 
 SUPPORTED_UNICORN_VERSIONS = [
-  [nil, 2.2],
+  [nil , 2.2],
   ['6.1.0', 2.2],
   ['5.3.0', 2.2, 2.7],
   ['4.9.0', 2.2]
 ]
 
 def rack_version
-  if RUBY_VERSION < '2.3.0'
-    '~> 2.1.4.1'
-  elsif RUBY_VERSION < '3.0.0'
-    '~> 2.2.4'
-  else
-    # TODO: CI - rack v3.0.0 causes 2 test failures
-    #
-    # UnicornTest#test_unicorn_set_as_discovered_dispatcher
-    # [test/multiverse/suites/unicorn/unicorn_test.rb:32]:
-    # Didn't see message 'Dispatcher: unicorn'
-    #
-    # and
-    #
-    # UnicornTest#test_defer_message_logged_when_unicorn_in_use
-    # [test/multiverse/suites/unicorn/unicorn_test.rb:36]:
-    # Didn't see message 'Deferring startup of agent reporting thread because unicorn may fork.'
-    #
-    # Once the issue is resolved, rack should be set to '~> 3.0.0' below
-    # '~> 3.0.0'
-    '~> 2.2.4'
-  end
+  RUBY_VERSION >= '2.4' ? '3.0.0' : '2.1.4.1'
 end
 
 def gem_list(unicorn_version = nil)
   <<-RB
     gem 'unicorn'#{unicorn_version}
-    gem 'rack', "#{rack_version}"
+    gem 'rack', '~> #{rack_version}'
   RB
 end
 

--- a/test/multiverse/suites/unicorn/Envfile
+++ b/test/multiverse/suites/unicorn/Envfile
@@ -7,7 +7,7 @@ suite_condition("unicorn not supported for JRuby") do
 end
 
 SUPPORTED_UNICORN_VERSIONS = [
-  [nil , 2.2],
+  [nil, 2.2],
   ['6.1.0', 2.2],
   ['5.3.0', 2.2, 2.7],
   ['4.9.0', 2.2]


### PR DESCRIPTION
With version 3.0.0 of Rack in play, the agent can be fooled into thinking that web dispatching duties are being handled by Webrick. This is because the agent performs a less strict test for Webrick compared to other dispatchers; checking only for the existence of related namespaces to be defined.

With these changes, the agent will now treat Webrick as the last dispatcher checked after all other anticipated production use dispatchers have not been located. Specifically, this means that Webrick is checked after Unicorn, Rainbows, and FastCGI; all of which may have been incorrectly reporting as having Webrick as the dispatcher if Rack v3.0.0 was being used.

Resolves #1394