### PR TITLE
Update NewRelic::Agent::Tracer.in_transaction to identify category as a required kwarg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
     Unicorn, Rainbows, or FastCGI web applications using Rack v3.0.0 may previously have had the "dispatcher" value incorrectly reported as "Webrick" instead of "Unicorn", "Rainbows", or "FastCGI". This issue has now been addressed. [PR#1585](https://github.com/newrelic/newrelic-ruby-agent/pull/1585)
 
+  * **Bugfix: Category is a required keyword arg for NewRelic::Agent::Tracer.in_transaction**
+
+    When support for Ruby 2.0 was dropped in version 8.0.0 of the agent, the agent API methods were updated to use the required keyword argument feature built in to Ruby, rather than manually raising `ArgumentError`'s. The API method NewRelic::Agent::Tracer.in_transaction removed the ArgumentError raised by the agent, but did not update the method arguments to identify category as a required keyword argument. This is now resolved. Thank you to @tatzsuzuki for bringing this to our attention. [PR#](https://github.com/newrelic/newrelic-ruby-agent/pull/1587)
+
 
   ## v8.12.0
 

--- a/lib/new_relic/agent/tracer.rb
+++ b/lib/new_relic/agent/tracer.rb
@@ -87,7 +87,7 @@ module NewRelic
         # @api public
         def in_transaction(name: nil,
           partial_name: nil,
-          category: nil,
+          category:,
           options: {})
 
           finishable = start_transaction_or_segment(

--- a/test/new_relic/agent/tracer_test.rb
+++ b/test/new_relic/agent/tracer_test.rb
@@ -101,6 +101,14 @@ module NewRelic
         assert_metrics_recorded(['test'])
       end
 
+      def test_in_transaction_missing_category
+        assert_raises ArgumentError do
+          NewRelic::Agent::Tracer.in_transaction(name: 'test') do
+            # No-op
+          end
+        end
+      end
+
       def test_in_transaction_with_early_failure
         yielded = false
         NewRelic::Agent::Transaction.any_instance.stubs(:start).raises("Boom")


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
When support for Ruby 2.0 was dropped in version 8.0.0 of the agent, the agent API methods were updated to use the required keyword argument feature built in to Ruby, rather than manually raising `ArgumentError`'s. The API method NewRelic::Agent::Tracer.in_transaction removed the ArgumentError raised by the agent, but did not update the method arguments to identify category as a required keyword argument. resolves #1583 

Submitter Checklist:
- [ ] Include a link to the related GitHub issue, if applicable
- [ ] Include a security review link, if applicable

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
GitHub Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
