### PR TITLE
NR-1222/rack-test-v2

### DIFF
--- a/lib/new_relic/rack/browser_monitoring.rb
+++ b/lib/new_relic/rack/browser_monitoring.rb
@@ -104,6 +104,7 @@ module NewRelic
       end
 
       def streaming?(env, headers)
+        # Chunked transfer encoding is a streaming data transfer mechanism available only in HTTP/1.1
         return true if headers && headers['Transfer-Encoding'] == 'chunked'
 
         defined?(ActionController::Live) &&

--- a/test/multiverse/suites/rails/Envfile
+++ b/test/multiverse/suites/rails/Envfile
@@ -44,7 +44,7 @@ def minitest_rails_version(rails_version = nil)
 end
 
 def pre2_rack_test
-  %Q(gem 'rack-test', '< 2')
+  %Q(gem 'rack-test')
 end
 
 def gem_list(rails_version = nil)

--- a/test/multiverse/suites/rails/action_controller_live_rum_test.rb
+++ b/test/multiverse/suites/rails/action_controller_live_rum_test.rb
@@ -42,7 +42,7 @@ if defined?(ActionController::Live)
     end
 
     def test_excludes_rum_instrumentation_when_streaming_with_action_stream_true
-      get('/undead/brain_stream')
+      get('/undead/brain_stream', env: {'HTTP_VERSION' => 'HTTP/1.1'})
 
       assert_includes(response.body, UndeadController::RESPONSE_BODY)
       assert_not_includes(response.body, JS_LOADER)


### PR DESCRIPTION
As of v2.0.0, rack-test defaults to HTTP/1.0 to work around the fact some apps return Transfer-Encoding: chunked responses, which rack-test doesn't have a decoder for. See [rack-test discussion](https://github.com/rack/rack-test/issues/300) on this decision.

Only HTTP/1.1 supports chunking, which our [`steaming?`](https://github.com/newrelic/newrelic-ruby-agent/blob/dev/lib/new_relic/rack/browser_monitoring.rb#L106-L111) method checks for. For streaming tests to work with rack-test v2, we need to specify HTTP/1.1 when using streaming.

Closes #1222 