### PR TITLE
Bugfix: Record code level metric attributes for private methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@
 
     Unicorn, Rainbows, or FastCGI web applications using Rack v3.0.0 may previously have had the "dispatcher" value incorrectly reported as "Webrick" instead of "Unicorn", "Rainbows", or "FastCGI". This issue has now been addressed. [PR#1585](https://github.com/newrelic/newrelic-ruby-agent/pull/1585)
 
+  * **Bugfix: add_method_tracer fails to record code level metric attributes on private methods**
+
+    When using add_method_tracer on a private method, the agent was unable to record code level metrics for the method. This resulted in the following being logged to the newrelic_agent.log file.
+    ```
+    WARN : Unable to determine source code info for 'Example', method 'private_method' - NameError: undefined method 'private_method' for class '#<Class:Example>'
+    ```
+    Thanks to @jdelStrother for bringing this issue to our attention and suggesting a fix! [PR#1593](https://github.com/newrelic/newrelic-ruby-agent/pull/1593)
+
+
   * **Bugfix: Category is a required keyword arg for NewRelic::Agent::Tracer.in_transaction**
 
     When support for Ruby 2.0 was dropped in version 8.0.0 of the agent, the agent API methods were updated to use the required keyword argument feature built into Ruby, rather than manually raising ArgumentErrors. The API method `NewRelic::Agent::Tracer.in_transaction` removed the ArgumentError raised by the agent, but did not update the method arguments to identify category as a required keyword argument. This is now resolved. Thank you to @tatzsuzuki for bringing this to our attention. [PR#](https://github.com/newrelic/newrelic-ruby-agent/pull/1587)

--- a/lib/new_relic/agent/method_tracer_helpers.rb
+++ b/lib/new_relic/agent/method_tracer_helpers.rb
@@ -106,7 +106,7 @@ module NewRelic
         klass = object.singleton_class? ? klassify_singleton(object) : object
         name = klass.name || '(Anonymous)'
         is_class_method = false
-        method = if klass.instance_methods.include?(method_name)
+        method = if (klass.instance_methods + klass.private_instance_methods).include?(method_name)
           klass.instance_method(method_name)
         else
           is_class_method = true

--- a/test/new_relic/agent/method_tracer_helpers_test.rb
+++ b/test/new_relic/agent/method_tracer_helpers_test.rb
@@ -8,6 +8,8 @@ module ::The
   class Example
     def self.class_method; end
     def instance_method; end
+    private # rubocop:disable Layout/EmptyLinesAroundAccessModifier
+    def private_method; end
   end
 end
 
@@ -78,6 +80,18 @@ class NewRelic::Agent::MethodTracerHelpersTest < Minitest::Test
       assert_equal({filepath: __FILE__,
         lineno: The::Example.instance_method(:instance_method).source_location.last,
         function: 'instance_method',
+        namespace: 'The::Example'},
+        info)
+    end
+  end
+
+  def test_provides_accurate_info_for_an_instance_method
+    with_config(:'code_level_metrics.enabled' => true) do
+      info = NewRelic::Agent::MethodTracerHelpers.code_information(::The::Example, :private_method)
+
+      assert_equal({filepath: __FILE__,
+        lineno: The::Example.instance_method(:private_method).source_location.last,
+        function: 'private_method',
         namespace: 'The::Example'},
         info)
     end


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
This resolves the error caused by setting add_method_tracer on a private method. Previously, the agent would fail to check the private method as an instance method because it was not included in the instance_methods array, so it attempted to record it as a class method, resulting in the following error in the logs
```
WARN : Unable to determine source code info for 'Example', method 'private_method' - NameError: undefined method 'private_method' for class '#<Class:Example>'
```

resolves #1589 Thanks @jdelStrother for the suggested fix!

Submitter Checklist:
- [ ] Include a link to the related GitHub issue, if applicable
- [ ] Include a security review link, if applicable

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
GitHub Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
