### PR TITLE
Resolve Minitest/EmptyLineBeforeAssertionMethods rubocop failures

### DIFF
--- a/infinite_tracing/test/infinite_tracing/channel_test.rb
+++ b/infinite_tracing/test/infinite_tracing/channel_test.rb
@@ -85,6 +85,7 @@ module NewRelic
           expected_result = {'grpc.default_compression_level' => 1,
                              'grpc.default_compression_algorithm' => 2,
                              'grpc.compression_enabled_algorithms_bitset' => 7}
+
           with_config(remote_config.merge('infinite_tracing.compression_level': level)) do
             assert_equal Channel.new.channel_args, expected_result
           end

--- a/infinite_tracing/test/infinite_tracing/config_test.rb
+++ b/infinite_tracing/test/infinite_tracing/config_test.rb
@@ -70,6 +70,7 @@ module NewRelic
               :'infinite_tracing.trace_observer.host' => hostname,
               :'infinite_tracing.trace_observer.port' => 443
             }
+
             with_config(config) do
               assert_equal port, Config.trace_observer_port, "expected #{port} for port because host overrides: #{hostname}"
             end
@@ -89,6 +90,7 @@ module NewRelic
             config = {
               :'infinite_tracing.trace_observer.host' => hostname
             }
+
             with_config(config) do
               assert_equal host_and_port,
                 Config.trace_observer_host_and_port,

--- a/test/agent_helper.rb
+++ b/test/agent_helper.rb
@@ -141,6 +141,7 @@ def assert_audit_log_contains_object(audit_log_contents, o, format = :json)
       assert_audit_log_contains_object(audit_log_contents, k, format)
     end
   when Array
+
     o.each do |el|
       assert_audit_log_contains_object(audit_log_contents, el, format)
     end

--- a/test/multiverse/suites/agent_only/audit_log_test.rb
+++ b/test/multiverse/suites/agent_only/audit_log_test.rb
@@ -43,6 +43,7 @@ class AuditLogTest < Minitest::Test
   def test_logs_request_bodies_human_readably_ish
     run_agent(:'audit_log.enabled' => true) do
       perform_actions
+
       $collector.agent_data.each do |req|
         assert_audit_log_contains_object(audit_log_contents, req.body)
       end

--- a/test/multiverse/suites/grpc/grpc_server_test.rb
+++ b/test/multiverse/suites/grpc/grpc_server_test.rb
@@ -282,6 +282,7 @@ class GrpcServerTest < Minitest::Test
     desc.instance_variable_set(host_var, host)
     mock = MiniTest::Mock.new
     mock.expect(:[], unwanted_host_patterns, [:'instrumentation.grpc.host_denylist'])
+
     NewRelic::Agent.stub(:config, mock) do
       refute desc.send(:trace_with_newrelic?)
     end
@@ -294,6 +295,7 @@ class GrpcServerTest < Minitest::Test
     desc.instance_variable_set(host_var, 'wanted.host.net')
     mock = MiniTest::Mock.new
     mock.expect(:[], unwanted_host_patterns, [:'instrumentation.grpc.host_denylist'])
+
     NewRelic::Agent.stub(:config, mock) do
       assert desc.send(:trace_with_newrelic?)
     end

--- a/test/multiverse/suites/grpc/helper_test.rb
+++ b/test/multiverse/suites/grpc/helper_test.rb
@@ -42,6 +42,7 @@ class GrpcHelperTest < Minitest::Test
   def test_confirms_that_host_is_not_on_the_config_defined_denylist
     mock = MiniTest::Mock.new
     mock.expect(:[], unwanted_host_patterns, [:'instrumentation.grpc.host_denylist'])
+
     NewRelic::Agent.stub(:config, mock) do
       refute helped_class.host_denylisted?('wanted_host')
     end
@@ -50,6 +51,7 @@ class GrpcHelperTest < Minitest::Test
   def test_confirms_that_host_is_denylisted_from_config
     mock = MiniTest::Mock.new
     mock.expect(:[], unwanted_host_patterns, [:'instrumentation.grpc.host_denylist'])
+
     NewRelic::Agent.stub(:config, mock) do
       assert helped_class.host_denylisted?('unwanted_host')
     end

--- a/test/multiverse/suites/rack/rack_builder_test.rb
+++ b/test/multiverse/suites/rack/rack_builder_test.rb
@@ -95,6 +95,7 @@ class RackBuilderTest < Minitest::Test
     instance = TestBuilderClass.new
     app = :the_app
     def instance.middleware_instrumentation_enabled; true; end
+
     ::NewRelic::Agent::Instrumentation::MiddlewareProxy.stub :wrap, true, [app, true] do
       assert instance.run_with_tracing(app) { app }
     end
@@ -117,6 +118,7 @@ class RackBuilderTest < Minitest::Test
     instance = TestBuilderClass.new
     def instance.middleware_instrumentation_enabled?; true; end
     middleware = 'lucky tiger cup'
+
     ::NewRelic::Agent::Instrumentation::MiddlewareProxy.stub :for_class, middleware, [middleware] do
       assert_equal middleware, instance.use_with_tracing(middleware) { middleware }
     end

--- a/test/multiverse/suites/rails/error_tracing_test.rb
+++ b/test/multiverse/suites/rails/error_tracing_test.rb
@@ -132,8 +132,8 @@ class ErrorsWithoutSSCTest < ActionDispatch::IntegrationTest
       'request.parameters.eat' => 'static',
       'http.statusCode' => 500
     }
-
     attributes = agent_attributes_for_single_error_posted
+
     expected_params.each do |key, value|
       assert_equal value, attributes[key]
     end

--- a/test/multiverse/suites/rails/parameter_capture_test.rb
+++ b/test/multiverse/suites/rails/parameter_capture_test.rb
@@ -296,8 +296,8 @@ class ParameterCaptureTest < ActionDispatch::IntegrationTest
         "request.parameters.name" => "name",
         "request.parameters.raise" => "1"
       }
-
       attributes = agent_attributes_for_single_error_posted
+
       expected.each do |key, value|
         assert_equal value, attributes[key]
       end

--- a/test/multiverse/suites/resque/instrumentation_test.rb
+++ b/test/multiverse/suites/resque/instrumentation_test.rb
@@ -159,6 +159,7 @@ class ResqueTest < Minitest::Test
     transaction_event_posts = $collector.calls_for('analytic_event_data')[0].events
     span_event_posts = $collector.calls_for('span_event_data')[0].events
     events = transaction_event_posts + span_event_posts
+
     events.each do |event|
       assert_includes event[2].keys, "job.resque.args.0"
     end

--- a/test/new_relic/agent/agent/connect_test.rb
+++ b/test/new_relic/agent/agent/connect_test.rb
@@ -103,6 +103,7 @@ class NewRelic::Agent::Agent::ConnectTest < Minitest::Test
 
   def test_configure_transaction_tracer_server_disabled
     config = NewRelic::Agent::Configuration::ServerSource.new('collect_traces' => false)
+
     with_config(config) do
       refute @transaction_sampler.enabled?
     end

--- a/test/new_relic/agent/autostart_test.rb
+++ b/test/new_relic/agent/autostart_test.rb
@@ -64,6 +64,7 @@ class AutostartTest < Minitest::Test
 
   def test_denylisted_executable_can_be_configured
     @orig_dollar_0, $0 = $0, '/foo/bar/baz'
+
     with_config('autostart.denylisted_executables' => 'boo,baz') do
       refute ::NewRelic::Agent::Autostart.agent_should_start?, "Agent shouldn't autostart when process is invoked by denylisted executable"
     end

--- a/test/new_relic/agent/error_collector_test.rb
+++ b/test/new_relic/agent/error_collector_test.rb
@@ -324,6 +324,7 @@ module NewRelic::Agent
           :'error_collector.enabled' => false,
           :'error_collector.capture_events' => false
         }
+
         with_server_source(server_source) do
           assert @error_collector.skip_notice_error?(error)
         end
@@ -331,6 +332,7 @@ module NewRelic::Agent
 
       def test_skip_notice_error_is_true_if_the_error_is_nil
         error = nil
+
         with_config(:'error_collector.enabled' => true) do
           assert @error_collector.skip_notice_error?(error)
         end
@@ -359,6 +361,7 @@ module NewRelic::Agent
 
       def test_ignore_error
         error = AnError.new
+
         with_config(:'error_collector.ignore_errors' => 'AnError') do
           assert @error_collector.ignore?(error)
         end
@@ -379,6 +382,7 @@ module NewRelic::Agent
 
       def test_ignore_status_codes
         error = AnError.new
+
         with_config(:'error_collector.ignore_status_codes' => '400-408') do
           assert @error_collector.ignore?(error, 404)
         end

--- a/test/new_relic/agent/event_aggregator_test.rb
+++ b/test/new_relic/agent/event_aggregator_test.rb
@@ -74,6 +74,7 @@ module NewRelic
 
       def test_enabled_uses_multiple_keys_by_default
         @aggregator = MultiKeyTestAggregator.new(@events)
+
         with_server_source(:enabled_key2 => true) do
           assert_predicate @aggregator, :enabled?
         end

--- a/test/new_relic/agent/hostname_test.rb
+++ b/test/new_relic/agent/hostname_test.rb
@@ -91,6 +91,7 @@ module NewRelic
       def test_local_predicate_true_when_host_local
         hosts = %w[localhost 0.0.0.0 127.0.0.1 0:0:0:0:0:0:0:1
           0:0:0:0:0:0:0:0 ::1 ::]
+
         hosts.each do |host|
           assert NewRelic::Agent::Hostname.local?(host)
         end
@@ -98,6 +99,7 @@ module NewRelic
 
       def test_localhost_predicate_false_when_host_nonlocal
         hosts = %w[drscheffler jonan-show jonan.tm]
+
         hosts.each do |host|
           refute NewRelic::Agent::Hostname.local?(host)
         end

--- a/test/new_relic/agent/instrumentation/rails/active_record_subscriber.rb
+++ b/test/new_relic/agent/instrumentation/rails/active_record_subscriber.rb
@@ -232,6 +232,7 @@ class NewRelic::Agent::Instrumentation::ActiveRecordSubscriberTest < Minitest::T
     handler = MiniTest::Mock.new
     handler.expect(:connections, [])
     4.times { handler.expect(:spec, spec) }
+
     ::ActiveRecord::Base.connection_handler.stub(:connection_pool_list, [handler]) do
       assert_equal config, @subscriber.active_record_config(payload)
     end

--- a/test/new_relic/agent/method_tracer_params_test.rb
+++ b/test/new_relic/agent/method_tracer_params_test.rb
@@ -169,6 +169,7 @@ class NewRelic::Agent::MethodTracerParamsTest < Minitest::Test
 
       # This is what changes in 3.0!
       version_specific_expected = RUBY_VERSION >= "3.0.0" ? {foo: {}} : expected
+
       silence_expected_warnings { assert_equal version_specific_expected, instance.args_and_kwargs(:foo, {bar: "foobar"}) }
     end
   end

--- a/test/new_relic/agent/monitors/synthetics_monitor_test.rb
+++ b/test/new_relic/agent/monitors/synthetics_monitor_test.rb
@@ -44,6 +44,7 @@ module NewRelic::Agent
 
     def test_doesnt_record_synthetics_if_incoming_request_higher_version
       synthetics_payload = [BAD_VERSION_ID] + STANDARD_DATA
+
       with_synthetics_headers(synthetics_payload) do
         assert_no_synthetics_payload
       end
@@ -51,6 +52,7 @@ module NewRelic::Agent
 
     def test_doesnt_record_synthetics_if_not_trusted_account
       synthetics_payload = [VERSION_ID, BAD_ACCOUNT_ID] + STANDARD_DATA[1..-1]
+
       with_synthetics_headers(synthetics_payload) do
         assert_no_synthetics_payload
       end
@@ -58,6 +60,7 @@ module NewRelic::Agent
 
     def test_doesnt_record_synthetics_if_data_too_short
       synthetics_payload = [VERSION_ID, ACCOUNT_ID]
+
       with_synthetics_headers(synthetics_payload) do
         assert_no_synthetics_payload
       end

--- a/test/new_relic/agent/new_relic_service/json_marshaller_test.rb
+++ b/test/new_relic/agent/new_relic_service/json_marshaller_test.rb
@@ -18,6 +18,7 @@ module NewRelic
 
         def test_default_encoder_is_identity_with_simple_compression_enabled
           marshaller = JsonMarshaller.new
+
           with_config(:simple_compression => true) do
             assert_equal Encoders::Identity, marshaller.default_encoder
           end

--- a/test/new_relic/agent/new_relic_service_test.rb
+++ b/test/new_relic/agent/new_relic_service_test.rb
@@ -210,6 +210,7 @@ class NewRelicServiceTest < Minitest::Test
 
   def test_cert_file_path_uses_path_from_config
     fake_cert_path = '/certpath/cert.pem'
+
     with_config(:ca_bundle_path => fake_cert_path) do
       assert_equal @service.cert_file_path, fake_cert_path
     end

--- a/test/new_relic/agent/rules_engine_test.rb
+++ b/test/new_relic/agent/rules_engine_test.rb
@@ -132,6 +132,7 @@ class RulesEngineTest < Minitest::Test
   load_cross_agent_test('transaction_segment_terms').each do |testcase|
     define_method("test_app_segment_terms_#{testcase['testname']}") do
       engine = NewRelic::Agent::RulesEngine.create_transaction_rules(testcase)
+
       testcase['tests'].each do |test|
         assert_equal(test["expected"], engine.rename(test["input"]), "Input: #{test['input'].inspect}")
       end

--- a/test/new_relic/agent/stats_test.rb
+++ b/test/new_relic/agent/stats_test.rb
@@ -19,6 +19,7 @@ class NewRelic::Agent::StatsTest < Minitest::Test
         b.send("#{attr}=", 3)
       end
     end
+
     attrs.each do |attr|
       assert_equal(5, merged.send(attr))
     end

--- a/test/new_relic/agent/system_info_test.rb
+++ b/test/new_relic/agent/system_info_test.rb
@@ -172,6 +172,7 @@ class NewRelic::Agent::SystemInfoTest < Minitest::Test
     NewRelic::Agent::SystemInfo.stub(:sysctl_value, sysctl_stub) do
       NewRelic::Agent::SystemInfo.processor_info_darwin
       info = NewRelic::Agent::SystemInfo.instance_variable_get(:@processor_info)
+
       counts.each do |key, value|
         assert_equal value, info[mappings[key]]
       end
@@ -282,6 +283,7 @@ class NewRelic::Agent::SystemInfoTest < Minitest::Test
     NewRelic::Agent::SystemInfo.stubs(:ruby_os_identifier).returns("linux")
     cgroup_info = File.read(File.join(cross_agent_tests_dir, 'docker_container_id', 'invalid-length.txt'))
     NewRelic::Agent::SystemInfo.expects(:proc_try_read).with('/proc/self/cgroup').returns(cgroup_info)
+
     in_transaction('txn') do
       assert_nil NewRelic::Agent::SystemInfo.docker_container_id
     end

--- a/test/new_relic/agent/transaction_test.rb
+++ b/test/new_relic/agent/transaction_test.rb
@@ -35,6 +35,7 @@ module NewRelic::Agent
     # ActionController::AbstractRequest)
     def test_request_with_path_with_query_string
       request = stub(:path => '/path?hello=bob#none')
+
       in_transaction(:request => request) do |txn|
         assert_equal "/path", txn.request_path
       end
@@ -42,6 +43,7 @@ module NewRelic::Agent
 
     def test_request_parsing_referer
       request = stub(:referer => 'https://www.yahoo.com:8080/path/hello?bob=none&foo=bar', :path => "/")
+
       in_transaction(:request => request) do |txn|
         assert_equal "https://www.yahoo.com:8080/path/hello", txn.referer
       end
@@ -57,6 +59,7 @@ module NewRelic::Agent
 
     def test_transaction_referer_nil_if_request_referer_nil
       request = stub(:path => '/path?hello=bob#none', :referer => nil)
+
       in_transaction(:request => request) do |txn|
         assert_nil txn.referer
       end

--- a/test/new_relic/agent/utilization_data_test.rb
+++ b/test/new_relic/agent/utilization_data_test.rb
@@ -110,6 +110,7 @@ module NewRelic::Agent
     def test_pcf_information_is_omitted_when_available_but_disabled_by_config
       with_config(:'utilization.detect_pcf' => false, :'utilization.detect_docker' => false) do
         utilization_data = UtilizationData.new
+
         with_pcf_env("CF_INSTANCE_GUID" => "ab326c0e-123e-47a1-65cc-45f6",
           "CF_INSTANCE_IP"   => "101.1.149.48",
           "MEMORY_LIMIT"     => "2048m") do

--- a/test/new_relic/language_support_test.rb
+++ b/test/new_relic/language_support_test.rb
@@ -62,6 +62,7 @@ class NewRelic::LanguageSupportTest < Minitest::Test
 
     def test_gc_profiler_enabled_when_config_is_disabled
       ::GC::Profiler.stubs(:enabled?).returns(true)
+
       with_config(:disable_gc_profiler => true) do
         refute NewRelic::LanguageSupport.gc_profiler_enabled?
       end

--- a/test/new_relic/slack_notifications_tests/gem_notifier_tests.rb
+++ b/test/new_relic/slack_notifications_tests/gem_notifier_tests.rb
@@ -31,6 +31,7 @@ class GemNotifierTests < Minitest::Test
 
   def test_valid_gem_name
     response = successful_http_response
+
     HTTParty.stub(:get, response) do
       assert GemNotifier.verify_gem("puma!")
     end
@@ -39,6 +40,7 @@ class GemNotifierTests < Minitest::Test
   def test_invalid_gem_name
     response = unsuccessful_http_response
     response.expect(:ouch?, true)
+
     HTTParty.stub(:get, response) do
       GemNotifier.stub(:abort, nil) do
         assert_predicate GemNotifier.verify_gem("TrexRawr!"), :ouch?


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
Describe the changes present in the pull request

Submitter Checklist:
- [ ] Include a link to the related GitHub issue, if applicable
- [ ] Include a security review link, if applicable

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
GitHub Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
