### PR TITLE
CI: pause testing of Rack/Puma with Ruby 3.2.0

### DIFF
--- a/test/multiverse/suites/rack/Envfile
+++ b/test/multiverse/suites/rack/Envfile
@@ -25,7 +25,9 @@ def gem_list(puma_version = nil)
   RB
 end
 
-create_gemfiles(PUMA_VERSIONS, gem_list)
+# TODO: Puma not working on 3.2.0-preview2
+#       https://github.com/newrelic/newrelic-ruby-agent/issues/1446
+create_gemfiles(PUMA_VERSIONS, gem_list) if RUBY_VERSION < '3.2.0'
 
 if RUBY_VERSION >= '2.3.0'
   gemfile <<-RB


### PR DESCRIPTION
revert PR 1604, and go back to skipping the Rack/Puma tests with Ruby 3.2.0-preview2 until we determine the root cause of the compatibility
  issues that still persist in our CI system