### PR TITLE
CI: address Rack 3 / Ruby 3.2.0-preview2 issue

### DIFF
--- a/test/multiverse/suites/rack/example_app.rb
+++ b/test/multiverse/suites/rack/example_app.rb
@@ -80,7 +80,11 @@ class MiddlewareTwo
 end
 
 class MiddlewareThree
-  def initialize(app, tag:)
+  def initialize(app, *args, tag: nil)
+    # for Ruby 3.2+, the tag key/val pair might end up as a hash within args
+    if idx = (args || []).find_index { |a| a.is_a?(Hash) && a.key?(:tag) }
+      tag ||= args[idx][:tag]
+    end
     @app = app
     @tag = tag
   end


### PR DESCRIPTION
rework example app 3's `initialize` method to work properly with Rack 3 and Ruby 3.2.0-preview2