### PR TITLE
Update Redis instrumentation to support v5

### DIFF
--- a/lib/new_relic/agent/instrumentation/redis.rb
+++ b/lib/new_relic/agent/instrumentation/redis.rb
@@ -35,8 +35,7 @@ DependencyDetection.defer do
     end
 
     if use_prepend?
-      prepend_class = NewRelic::Agent::Instrumentation::Redis::REDIS_5 ? ::RedisClient : ::Redis::Client
-      prepend_instrument prepend_class, NewRelic::Agent::Instrumentation::Redis::Prepend
+      prepend_instrument ::Redis::Client, NewRelic::Agent::Instrumentation::Redis::Prepend
     else
       chain_instrument NewRelic::Agent::Instrumentation::Redis::Chain
     end

--- a/lib/new_relic/agent/instrumentation/redis.rb
+++ b/lib/new_relic/agent/instrumentation/redis.rb
@@ -30,7 +30,7 @@ DependencyDetection.defer do
 
   executes do
     NewRelic::Agent.logger.info('Installing Redis Instrumentation')
-    if NewRelic::Agent::Instrumentation::Redis::REDIS_5
+    if NewRelic::Agent::Instrumentation::Redis::HAS_REDIS_CLIENT
       ::RedisClient.register(NewRelic::Agent::Instrumentation::RedisClient::Middleware)
     end
 

--- a/lib/new_relic/agent/instrumentation/redis/chain.rb
+++ b/lib/new_relic/agent/instrumentation/redis/chain.rb
@@ -9,16 +9,28 @@ module NewRelic::Agent::Instrumentation
         ::Redis::Client.class_eval do
           include NewRelic::Agent::Instrumentation::Redis
 
-          alias_method(:call_without_new_relic, :call)
+          if method_defined?(:call_v)
+            alias_method(:call_v_without_new_relic, :call_v)
 
-          def call(*args, &block)
-            call_with_tracing(args[0]) { call_without_new_relic(*args, &block) }
+            def call_v(*args, &block)
+              call_v_with_tracing(args[0]) { call_v_without_new_relic(*args, &block) }
+            end
           end
 
-          alias_method(:call_pipeline_without_new_relic, :call_pipeline)
+          if method_defined?(:call)
+            alias_method(:call_without_new_relic, :call)
 
-          def call_pipeline(*args, &block)
-            call_pipeline_with_tracing(args[0]) { call_pipeline_without_new_relic(*args, &block) }
+            def call(*args, &block)
+              call_with_tracing(args[0]) { call_without_new_relic(*args, &block) }
+            end
+          end
+
+          if method_defined?(:call_pipeline)
+            alias_method(:call_pipeline_without_new_relic, :call_pipeline)
+
+            def call_pipeline(*args, &block)
+              call_pipeline_with_tracing(args[0]) { call_pipeline_without_new_relic(*args, &block) }
+            end
           end
 
           alias_method(:connect_without_new_relic, :connect)

--- a/lib/new_relic/agent/instrumentation/redis/chain.rb
+++ b/lib/new_relic/agent/instrumentation/redis/chain.rb
@@ -13,7 +13,7 @@ module NewRelic::Agent::Instrumentation
             alias_method(:call_v_without_new_relic, :call_v)
 
             def call_v(*args, &block)
-              call_v_with_tracing(args[0]) { call_v_without_new_relic(*args, &block) }
+              call_with_tracing(args[0]) { call_v_without_new_relic(*args, &block) }
             end
           end
 

--- a/lib/new_relic/agent/instrumentation/redis/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/redis/instrumentation.rb
@@ -10,7 +10,7 @@ module NewRelic::Agent::Instrumentation
     LOCALHOST = 'localhost'
     MULTI_OPERATION = 'multi'
     PIPELINE_OPERATION = 'pipeline'
-    REDIS_5 = Gem::Version.new(::Redis::VERSION) >= Gem::Version.new('5.0.0') && !!defined?(::RedisClient)
+    HAS_REDIS_CLIENT = Gem::Version.new(::Redis::VERSION) >= Gem::Version.new('5.0.0') && !!defined?(::RedisClient)
 
     def connect_with_tracing
       with_tracing(CONNECT, database: db) { yield }

--- a/lib/new_relic/agent/instrumentation/redis/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/redis/instrumentation.rb
@@ -31,7 +31,7 @@ module NewRelic::Agent::Instrumentation
       with_tracing(operation, statement: statement, database: db) { yield }
     end
 
-    # Used for Redis 5.x
+    # Used for Redis 5.x+
     def call_pipelined_with_tracing(pipeline)
       operation = pipeline.flatten.include?('MULTI') ? MULTI_OPERATION : PIPELINE_OPERATION
       statement = ::NewRelic::Agent::Datastores::Redis.format_pipeline_commands(pipeline)

--- a/lib/new_relic/agent/instrumentation/redis/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/redis/instrumentation.rb
@@ -6,38 +6,58 @@ module NewRelic::Agent::Instrumentation
   module Redis
     PRODUCT_NAME = 'Redis'
     CONNECT = 'connect'
-    UNKNOWN = "unknown"
-    LOCALHOST = "localhost"
+    UNKNOWN = 'unknown'
+    LOCALHOST = 'localhost'
     MULTI_OPERATION = 'multi'
     PIPELINE_OPERATION = 'pipeline'
+    REDIS_5 = Gem::Version.new(::Redis::VERSION) >= Gem::Version.new('5.0.0') && !!defined?(::RedisClient)
 
+    def connect_with_tracing
+      with_tracing(CONNECT, database: db) { yield }
+    end
+
+    # Used for Redis 4.x and 3.x
     def call_with_tracing(command, &block)
       operation = command[0]
       statement = ::NewRelic::Agent::Datastores::Redis.format_command(command)
 
-      with_tracing(operation, statement) { yield }
+      with_tracing(operation, statement: statement, database: db) { yield }
     end
 
+    # Used for Redis 4.x and 3.x
     def call_pipeline_with_tracing(pipeline)
       operation = pipeline.is_a?(::Redis::Pipeline::Multi) ? MULTI_OPERATION : PIPELINE_OPERATION
       statement = ::NewRelic::Agent::Datastores::Redis.format_pipeline_commands(pipeline.commands)
 
-      with_tracing(operation, statement) { yield }
+      with_tracing(operation, statement: statement, database: db) { yield }
     end
 
-    def connect_with_tracing
-      with_tracing(CONNECT) { yield }
+    # Used for Redis 5.x
+    def call_pipelined_with_tracing(pipeline)
+      operation = pipeline.flatten.include?('MULTI') ? MULTI_OPERATION : PIPELINE_OPERATION
+      statement = ::NewRelic::Agent::Datastores::Redis.format_pipeline_commands(pipeline)
+
+      # call_pipelined isn't invoked on the client object, so use client.db to
+      # access the client instance var on self
+      with_tracing(operation, statement: statement, database: client.db) { yield }
+    end
+
+    # Used for Redis 5.x
+    def call_v_with_tracing(command, &block)
+      operation = command[0]
+      statement = ::NewRelic::Agent::Datastores::Redis.format_command(command)
+      with_tracing(operation, statement: statement, database: db) { yield }
     end
 
     private
 
-    def with_tracing(operation, statement = nil)
+    def with_tracing(operation, statement: nil, database: nil)
       segment = NewRelic::Agent::Tracer.start_datastore_segment(
         product: PRODUCT_NAME,
         operation: operation,
         host: _nr_hostname,
         port_path_or_id: _nr_port_path_or_id,
-        database_name: db
+        database_name: database
       )
       begin
         segment.notice_nosql_statement(statement) if statement
@@ -48,17 +68,21 @@ module NewRelic::Agent::Instrumentation
     end
 
     def _nr_hostname
-      self.path ? LOCALHOST : self.host
+      _nr_client.path ? LOCALHOST : _nr_client.host
     rescue => e
       NewRelic::Agent.logger.debug("Failed to retrieve Redis host: #{e}")
       UNKNOWN
     end
 
     def _nr_port_path_or_id
-      self.path || self.port
+      _nr_client.path || _nr_client.port
     rescue => e
       NewRelic::Agent.logger.debug("Failed to retrieve Redis port_path_or_id: #{e}")
       UNKNOWN
+    end
+
+    def _nr_client
+      @nr_client ||= self.is_a?(::Redis::Client) ? self : client
     end
   end
 end

--- a/lib/new_relic/agent/instrumentation/redis/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/redis/instrumentation.rb
@@ -16,7 +16,6 @@ module NewRelic::Agent::Instrumentation
       with_tracing(CONNECT, database: db) { yield }
     end
 
-    # Used for Redis 4.x and 3.x
     def call_with_tracing(command, &block)
       operation = command[0]
       statement = ::NewRelic::Agent::Datastores::Redis.format_command(command)
@@ -40,13 +39,6 @@ module NewRelic::Agent::Instrumentation
       # call_pipelined isn't invoked on the client object, so use client.db to
       # access the client instance var on self
       with_tracing(operation, statement: statement, database: client.db) { yield }
-    end
-
-    # Used for Redis 5.x
-    def call_v_with_tracing(command, &block)
-      operation = command[0]
-      statement = ::NewRelic::Agent::Datastores::Redis.format_command(command)
-      with_tracing(operation, statement: statement, database: db) { yield }
     end
 
     private

--- a/lib/new_relic/agent/instrumentation/redis/middleware.rb
+++ b/lib/new_relic/agent/instrumentation/redis/middleware.rb
@@ -1,0 +1,16 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+module NewRelic::Agent::Instrumentation
+  module RedisClient
+    module Middleware
+      # This module is used to instrument Redis 5.x+
+      include NewRelic::Agent::Instrumentation::Redis
+
+      def call_pipelined(*args, &block)
+        call_pipelined_with_tracing(args[0]) { super }
+      end
+    end
+  end
+end

--- a/lib/new_relic/agent/instrumentation/redis/prepend.rb
+++ b/lib/new_relic/agent/instrumentation/redis/prepend.rb
@@ -7,6 +7,12 @@ module NewRelic::Agent::Instrumentation
     module Prepend
       include NewRelic::Agent::Instrumentation::Redis
 
+      # Defined in version 5.x
+      def call_v(*args, &block)
+        call_v_with_tracing(args[0]) { super }
+      end
+
+      # Defined in version 4.x, 3.x
       def call(*args, &block)
         call_with_tracing(args[0]) { super }
       end

--- a/lib/new_relic/agent/instrumentation/redis/prepend.rb
+++ b/lib/new_relic/agent/instrumentation/redis/prepend.rb
@@ -9,7 +9,7 @@ module NewRelic::Agent::Instrumentation
 
       # Defined in version 5.x
       def call_v(*args, &block)
-        call_v_with_tracing(args[0]) { super }
+        call_with_tracing(args[0]) { super }
       end
 
       # Defined in version 4.x, 3.x

--- a/lib/new_relic/agent/instrumentation/redis/prepend.rb
+++ b/lib/new_relic/agent/instrumentation/redis/prepend.rb
@@ -7,7 +7,7 @@ module NewRelic::Agent::Instrumentation
     module Prepend
       include NewRelic::Agent::Instrumentation::Redis
 
-      # Defined in version 5.x
+      # Defined in version 5.x+
       def call_v(*args, &block)
         call_with_tracing(args[0]) { super }
       end

--- a/test/multiverse/suites/redis/Envfile
+++ b/test/multiverse/suites/redis/Envfile
@@ -5,10 +5,8 @@
 instrumentation_methods :chain, :prepend
 
 REDIS_VERSIONS = [
-  # TODO: add support for redis v5+, re-enable nil
-  # https://github.com/newrelic/newrelic-ruby-agent/issues/1361
-  # [nil, 2.4],
-  ['4.7.1', 2.4],
+  [nil, 2.5],
+  ['4.8.0', 2.4],
   ['3.3.0']
 ]
 

--- a/test/multiverse/suites/redis/redis_instrumentation_test.rb
+++ b/test/multiverse/suites/redis/redis_instrumentation_test.rb
@@ -13,7 +13,7 @@ if NewRelic::Agent::Datastores::Redis.is_supported_version?
     def after_setup
       super
       # Default timeout is 5 secs; a flushall takes longer on a busy box (i.e. CI)
-      @redis = Redis.new(:host => redis_host, :timeout => 25)
+      @redis ||= Redis.new(timeout: 25)
 
       # Creating a new client doesn't actually establish a connection, so make
       # sure we do that by issuing a dummy get command, and then drop metrics
@@ -27,7 +27,7 @@ if NewRelic::Agent::Datastores::Redis.is_supported_version?
     end
 
     def test_records_metrics_for_connect
-      redis = Redis.new(:host => redis_host)
+      redis = Redis.new
 
       in_transaction("test_txn") do
         redis.get("foo")
@@ -55,7 +55,7 @@ if NewRelic::Agent::Datastores::Redis.is_supported_version?
 
     def test_records_connect_tt_node_within_call_that_triggered_it
       in_transaction do
-        redis = Redis.new(:host => redis_host)
+        redis = Redis.new
         redis.get("foo")
       end
 
@@ -87,7 +87,7 @@ if NewRelic::Agent::Datastores::Redis.is_supported_version?
       assert_metrics_recorded(expected)
     end
 
-    def test_records_metrics_for_get_in_web_transaction
+    def test_records_metrics_for_set_in_web_transaction
       in_web_transaction do
         @redis.set('prodigal', 'sorcerer')
       end
@@ -144,7 +144,7 @@ if NewRelic::Agent::Datastores::Redis.is_supported_version?
       refute get_node[:statement]
     end
 
-    def test_records_metrics_for_set_in_web_transaction
+    def test_records_metrics_for_get_in_web_transaction
       in_web_transaction do
         @redis.get('timetwister')
       end
@@ -163,9 +163,9 @@ if NewRelic::Agent::Datastores::Redis.is_supported_version?
 
     def test_records_metrics_for_pipelined_commands
       in_transaction('test_txn') do
-        @redis.pipelined do
-          @redis.get('great log')
-          @redis.get('late log')
+        @redis.pipelined do |pipeline|
+          pipeline.get('great log')
+          pipeline.get('late log')
         end
       end
 
@@ -189,9 +189,9 @@ if NewRelic::Agent::Datastores::Redis.is_supported_version?
 
     def test_records_commands_without_args_in_pipelined_block_by_default
       in_transaction do
-        @redis.pipelined do
-          @redis.set('late log', 'goof')
-          @redis.get('great log')
+        @redis.pipelined do |pipeline|
+          pipeline.set('late log', 'goof')
+          pipeline.get('great log')
         end
       end
 
@@ -203,9 +203,9 @@ if NewRelic::Agent::Datastores::Redis.is_supported_version?
 
     def test_records_metrics_for_multi_blocks
       in_transaction('test_txn') do
-        @redis.multi do
-          @redis.get('darkpact')
-          @redis.get('chaos orb')
+        @redis.multi do |pipeline|
+          pipeline.get('darkpact')
+          pipeline.get('chaos orb')
         end
       end
 
@@ -229,32 +229,32 @@ if NewRelic::Agent::Datastores::Redis.is_supported_version?
 
     def test_records_commands_without_args_in_tt_node_for_multi_blocks
       in_transaction do
-        @redis.multi do
-          @redis.set('darkpact', 'sorcery')
-          @redis.get('chaos orb')
+        @redis.multi do |pipeline|
+          pipeline.set('darkpact', 'sorcery')
+          pipeline.get('chaos orb')
         end
       end
 
       tt = last_transaction_trace
       pipeline_node = tt.root_node.children[0].children[0]
-
-      assert_equal("multi\nset ?\nget ?\nexec", pipeline_node[:statement])
+      # Redis 5.x returns MULTI and EXEC as capitalized, unlike 4.x, 3.x
+      assert_equal("multi\nset ?\nget ?\nexec", pipeline_node[:statement].downcase)
     end
 
     def test_records_commands_with_args_in_tt_node_for_multi_blocks
       with_config(:'transaction_tracer.record_redis_arguments' => true) do
         in_transaction do
-          @redis.multi do
-            @redis.set('darkpact', 'sorcery')
-            @redis.get('chaos orb')
+          @redis.multi do |pipeline|
+            pipeline.set('darkpact', 'sorcery')
+            pipeline.get('chaos orb')
           end
         end
       end
 
       tt = last_transaction_trace
       pipeline_node = tt.root_node.children[0].children[0]
-
-      assert_equal("multi\nset \"darkpact\" \"sorcery\"\nget \"chaos orb\"\nexec", pipeline_node[:statement])
+      # Redis 5.x returns MULTI and EXEC as capitalized, unlike 4.x, 3.x
+      assert_equal("multi\nset \"darkpact\" \"sorcery\"\nget \"chaos orb\"\nexec", pipeline_node[:statement].downcase)
     end
 
     def test_records_instance_parameters_on_tt_node_for_get
@@ -272,7 +272,7 @@ if NewRelic::Agent::Datastores::Redis.is_supported_version?
     end
 
     def test_records_hostname_on_tt_node_for_get_with_unix_domain_socket
-      redis = Redis.new(:host => redis_host)
+      redis = Redis.new
       redis.send(client).stubs(:path).returns('/tmp/redis.sock')
 
       in_transaction do
@@ -289,8 +289,8 @@ if NewRelic::Agent::Datastores::Redis.is_supported_version?
 
     def test_records_instance_parameters_on_tt_node_for_multi
       in_transaction do
-        @redis.multi do
-          @redis.get("foo")
+        @redis.multi do |pipeline|
+          pipeline.get("foo")
         end
       end
 
@@ -304,12 +304,12 @@ if NewRelic::Agent::Datastores::Redis.is_supported_version?
     end
 
     def test_records_hostname_on_tt_node_for_multi_with_unix_domain_socket
-      redis = Redis.new(:host => redis_host)
+      redis = Redis.new
       redis.send(client).stubs(:path).returns('/tmp/redis.sock')
 
       in_transaction do
-        redis.multi do
-          redis.get("foo")
+        redis.multi do |pipeline|
+          pipeline.get("foo")
         end
       end
 
@@ -322,7 +322,7 @@ if NewRelic::Agent::Datastores::Redis.is_supported_version?
     end
 
     def test_records_unknown_unknown_metric_when_error_gathering_instance_data
-      redis = Redis.new(:host => redis_host)
+      redis = Redis.new
       redis.send(client).stubs(:path).raises(StandardError.new)
       in_transaction do
         redis.get("foo")
@@ -336,8 +336,8 @@ if NewRelic::Agent::Datastores::Redis.is_supported_version?
     end
 
     def simulate_read_error
-      redis = Redis.new(:host => redis_host)
-      redis.send(client).stubs("establish_connection").raises(simulated_error_class, "Error connecting to Redis")
+      redis = Redis.new
+      redis.send(client).stubs("connect").raises(simulated_error_class, "Error connecting to Redis")
       redis.get("foo")
     ensure
     end
@@ -353,7 +353,7 @@ if NewRelic::Agent::Datastores::Redis.is_supported_version?
         # NOOP -- allowing span and transaction to notice error
       end
 
-      assert_segment_noticed_error txn, /Redis\/connect$/, simulated_error_class.name, /error connecting/i
+      assert_segment_noticed_error txn, /Redis\/get$/, simulated_error_class.name, /Error connecting to Redis/i
       assert_transaction_noticed_error txn, simulated_error_class.name
     end
 
@@ -364,11 +364,11 @@ if NewRelic::Agent::Datastores::Redis.is_supported_version?
           txn = redis_txn
           simulate_read_error
         rescue StandardError => e
-          # NOP -- allowing ONLY span to notice error
+          # NOOP -- allowing ONLY span to notice error
         end
       end
 
-      assert_segment_noticed_error txn, /Redis\/connect$/, simulated_error_class.name, /error connecting/i
+      assert_segment_noticed_error txn, /Redis\/get$/, simulated_error_class.name, /Error connecting to Redis/i
       refute_transaction_noticed_error txn, simulated_error_class.name
     end
 
@@ -379,12 +379,12 @@ if NewRelic::Agent::Datastores::Redis.is_supported_version?
       assert_equal 'bar', @redis.get('foo')
       assert_equal 1, @redis.del('foo')
 
-      assert_equal %w[OK OK], @redis.multi { @redis.set('foo', 'bar'); @redis.set('baz', 'bat') }
-      assert_equal %w[bar bat], @redis.multi { @redis.get('foo'); @redis.get('baz') }
+      assert_equal %w[OK OK], @redis.multi { |pipeline| pipeline.set('foo', 'bar'); pipeline.set('baz', 'bat') }
+      assert_equal %w[bar bat], @redis.multi { |pipeline| pipeline.get('foo'); pipeline.get('baz') }
       assert_equal 2, @redis.del('foo', 'baz')
 
-      assert_equal %w[OK OK], @redis.pipelined { @redis.set('foo', 'bar'); @redis.set('baz', 'bat') }
-      assert_equal %w[bar bat], @redis.pipelined { @redis.get('foo'); @redis.get('baz') }
+      assert_equal %w[OK OK], @redis.pipelined { |pipeline| pipeline.set('foo', 'bar'); pipeline.set('baz', 'bat') }
+      assert_equal %w[bar bat], @redis.pipelined { |pipeline| pipeline.get('foo'); pipeline.get('baz') }
       assert_equal 2, @redis.del('foo', 'baz')
     end
 

--- a/test/multiverse/suites/redis/redis_instrumentation_test.rb
+++ b/test/multiverse/suites/redis/redis_instrumentation_test.rb
@@ -396,6 +396,10 @@ if NewRelic::Agent::Datastores::Redis.is_supported_version?
       end
     end
 
+    def redis_host
+      docker? ? 'redis' : NewRelic::Agent::Hostname.get
+    end
+
     def either_hostname
       [NewRelic::Agent::Hostname.get, 'redis']
     end

--- a/test/multiverse/suites/redis/redis_instrumentation_test.rb
+++ b/test/multiverse/suites/redis/redis_instrumentation_test.rb
@@ -237,7 +237,7 @@ if NewRelic::Agent::Datastores::Redis.is_supported_version?
 
       tt = last_transaction_trace
       pipeline_node = tt.root_node.children[0].children[0]
-      # Redis 5.x returns MULTI and EXEC as capitalized, unlike 4.x, 3.x
+      # Redis 5.x+ returns MULTI and EXEC as capitalized, unlike 4.x, 3.x
       assert_equal("multi\nset ?\nget ?\nexec", pipeline_node[:statement].downcase)
     end
 
@@ -253,7 +253,7 @@ if NewRelic::Agent::Datastores::Redis.is_supported_version?
 
       tt = last_transaction_trace
       pipeline_node = tt.root_node.children[0].children[0]
-      # Redis 5.x returns MULTI and EXEC as capitalized, unlike 4.x, 3.x
+      # Redis 5.x+ returns MULTI and EXEC as capitalized, unlike 4.x, 3.x
       assert_equal("multi\nset \"darkpact\" \"sorcery\"\nget \"chaos orb\"\nexec", pipeline_node[:statement].downcase)
     end
 

--- a/test/multiverse/suites/redis/redis_instrumentation_test.rb
+++ b/test/multiverse/suites/redis/redis_instrumentation_test.rb
@@ -396,10 +396,6 @@ if NewRelic::Agent::Datastores::Redis.is_supported_version?
       end
     end
 
-    def redis_host
-      docker? ? 'redis' : NewRelic::Agent::Hostname.get
-    end
-
     def either_hostname
       [NewRelic::Agent::Hostname.get, 'redis']
     end


### PR DESCRIPTION
Co-authored-by: hramadan <hramadan@newrelic.com>

Redis gem 5.x comprises a major structural refactor for the library.

* Calls to methods like get and set are no longer routed through `call`, but through a method named `call_v`
* The methods we instrument have been moved into a new library, redis-client, a dependency of the redis gem.
* Prepending onto the new library's class (::RedisClient) for the `call_v` and connect methods maintains consistent reporting behavior with earlier versions of Redis.
* The location, behavior, and arguments of pipelined and multi methods changed.
* In previous versions, pipeline and multi calls were routed through a method named `call_pipeline`. There is a similar method in Redis 5.x named `call_pipelined`. However, this method is not defined in ::RedisClient, preventing our prepend instrumentation from working. ::RedisClient defines `multi` and `pipelined` methods, but they do not have access to the NoSQL statement as an argument or other instance variable/method on the caller.
* For `call_pipelined`, we now leverage Redis 5.x's new instrumentation API, `::RedisClient.register(module_name)`.
* This process introduces instrumentation too late to capture errors at the segment level. Despite this shortcoming, this strategy is used for `pipelined` and `multi` calls because it has access to the NoSQL statement

Closes: #1361

P.S. Test coverage is very high for Redis instrumentation, so we could rely on the existing test suite to inform us of the gaps with this new major version.