### PR TITLE
Support Sidekiq v7.0+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
   ## v8.13.0
 
-  Version 8.13.0 of the agent updates our Rack instrumentation and delivers some bugfixes.
+  Version 8.13.0 of the agent updates our Rack and Sidekiq instrumentation and delivers some bugfixes.
+
+  * **Support for Sidekiq v7**
+
+    Sidekiq v7.0 has removed Delayed Extensions and began offering client and server [middleware](https://github.com/mperham/sidekiq/blob/main/docs/middleware.md) classes to inherit from. The agent's Sidekiq instrumentation has been updated accordingly. The agent's behavior when used with older Sidekiq versions will remain unaffected. [PR#1615](https://github.com/newrelic/newrelic-ruby-agent/pull/1615)
 
   * **Support for Rack v3+ Rack::Builder#new accepting a block**
 

--- a/lib/new_relic/agent/instrumentation/sidekiq/client.rb
+++ b/lib/new_relic/agent/instrumentation/sidekiq/client.rb
@@ -4,6 +4,8 @@
 
 module NewRelic::Agent::Instrumentation::Sidekiq
   class Client
+    include Sidekiq::ClientMiddleware if defined?(Sidekiq::ClientMiddleware)
+
     def call(_worker_class, job, *_)
       job[NewRelic::NEWRELIC_KEY] ||= distributed_tracing_headers if ::NewRelic::Agent.config[:'distributed_tracing.enabled']
       yield

--- a/lib/new_relic/agent/instrumentation/sidekiq/extensions/delayed_class.rb
+++ b/lib/new_relic/agent/instrumentation/sidekiq/extensions/delayed_class.rb
@@ -2,21 +2,23 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
-class Sidekiq::Extensions::DelayedClass
-  def newrelic_trace_args(msg, queue)
-    (target, method_name, _args) = if YAML.respond_to?(:unsafe_load)
-      YAML.unsafe_load(msg['args'][0])
-    else
-      YAML.load(msg['args'][0])
-    end
+if Sidekiq::VERSION < '7.0.0'
+  class Sidekiq::Extensions::DelayedClass
+    def newrelic_trace_args(msg, queue)
+      (target, method_name, _args) = if YAML.respond_to?(:unsafe_load)
+        YAML.unsafe_load(msg['args'][0])
+      else
+        YAML.load(msg['args'][0])
+      end
 
-    {
-      :name => method_name,
-      :class_name => target.name,
-      :category => 'OtherTransaction/SidekiqJob'
-    }
-  rescue => e
-    NewRelic::Agent.logger.error("Failure during deserializing YAML for Sidekiq::Extensions::DelayedClass", e)
-    NewRelic::Agent::Instrumentation::Sidekiq::Server.default_trace_args(msg)
+      {
+        :name => method_name,
+        :class_name => target.name,
+        :category => 'OtherTransaction/SidekiqJob'
+      }
+    rescue => e
+      NewRelic::Agent.logger.error("Failure during deserializing YAML for Sidekiq::Extensions::DelayedClass", e)
+      NewRelic::Agent::Instrumentation::Sidekiq::Server.default_trace_args(msg)
+    end
   end
 end

--- a/lib/new_relic/agent/instrumentation/sidekiq/server.rb
+++ b/lib/new_relic/agent/instrumentation/sidekiq/server.rb
@@ -5,6 +5,7 @@
 module NewRelic::Agent::Instrumentation::Sidekiq
   class Server
     include NewRelic::Agent::Instrumentation::ControllerInstrumentation
+    include Sidekiq::ServerMiddleware if defined?(Sidekiq::ServerMiddleware)
 
     # Client middleware has additional parameters, and our tests use the
     # middleware client-side to work inline.

--- a/test/multiverse/suites/sidekiq/Envfile
+++ b/test/multiverse/suites/sidekiq/Envfile
@@ -7,8 +7,7 @@ suite_condition("Sidekiq does not run on JRuby") do
 end
 
 SIDEKIQ_VERSIONS = [
-  # TODO: Uncomment once we refactor tests to use Sidekiq 7's logger, issue #1567
-  # [nil, 2.5],
+  [nil, 2.7],
   ['6.4.0', 2.5],
   ['5.0.3', 2.3],
   ['4.2.0', 2.2]

--- a/test/multiverse/suites/sidekiq/sidekiq_instrumentation_test.rb
+++ b/test/multiverse/suites/sidekiq/sidekiq_instrumentation_test.rb
@@ -33,7 +33,15 @@ class SidekiqTest < Minitest::Test
 
     string_logger = ::Logger.new(@sidekiq_log)
     string_logger.formatter = Sidekiq.logger.formatter
-    Sidekiq.logger = string_logger
+    set_sidekiq_logger(string_logger)
+  end
+
+  def set_sidekiq_logger(logger)
+    if Sidekiq::VERSION >= '7.0.0'
+      Sidekiq.default_configuration.logger = logger
+    else
+      Sidekiq.logger = logger
+    end
   end
 
   def teardown


### PR DESCRIPTION
* Conditionally stop attempting to apply instrumentation to Delayed Extensions, which were dropped in v7.0. Attempting to do so was causing the installation of Sidekiq instrumentation by the agent to fail when used with Sidekiq v7.0.
* Have the agent's client and server middleware classes inherit from the new Sidekiq v7.0 middleware base classes.

resolves #1567