### PR TITLE
Sidekiq delayed extensions support TODO

### DIFF
--- a/lib/new_relic/agent/instrumentation/sidekiq/extensions/delayed_class.rb
+++ b/lib/new_relic/agent/instrumentation/sidekiq/extensions/delayed_class.rb
@@ -2,6 +2,12 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
+# TODO: remove this class once Sidekiq v6 is no longer supported.
+#       Delayed extensions are disabled by default in Sidekiq 5 and 6 and
+#       were removed entirely in Sidekiq 7.
+#
+#       see https://github.com/mperham/sidekiq/issues/5076 for the discussion
+#       of the removal, which includes mentions of alternatives
 if Sidekiq::VERSION < '7.0.0'
   class Sidekiq::Extensions::DelayedClass
     def newrelic_trace_args(msg, queue)


### PR DESCRIPTION
Added TODO to remove instrumentation for Sidekiq delayed extensions now that they are no longer available in Sidekiq v7+