### PR TITLE
Nr794 update excon version testing

### DIFF
--- a/lib/new_relic/agent/instrumentation/excon.rb
+++ b/lib/new_relic/agent/instrumentation/excon.rb
@@ -17,6 +17,7 @@ DependencyDetection.defer do
   # so we could safely subscribe and not be clobbered by future subscribers,
   # but alas, it does not yet.
 
+  # TODO: MAJOR VERSION - update min version to 0.56.0
   EXCON_MIN_VERSION = Gem::Version.new("0.19.0")
 
   depends_on do

--- a/test/multiverse/suites/excon/Envfile
+++ b/test/multiverse/suites/excon/Envfile
@@ -5,10 +5,6 @@
 excon_versions = [
   nil,
   '0.56.0',
-  '0.64.0',
-  '0.70.0',
-  '0.78.1',
-  '0.85.0'
 ]
 
 def gem_list(excon_version = nil)

--- a/test/multiverse/suites/excon/Envfile
+++ b/test/multiverse/suites/excon/Envfile
@@ -4,7 +4,7 @@
 
 excon_versions = [
   nil,
-  '0.56.0',
+  '0.56.0'
 ]
 
 def gem_list(excon_version = nil)


### PR DESCRIPTION
Removes testing versions of Excon that aren't our minimum supported version or the latest version. There are no significant changes between versions that would require separate testing. 

Related to #794 