### PR TITLE
Test minimum supported version

### DIFF
--- a/lib/new_relic/agent/instrumentation/excon.rb
+++ b/lib/new_relic/agent/instrumentation/excon.rb
@@ -33,6 +33,22 @@ DependencyDetection.defer do
     end
   end
 
+  executes do
+    next unless Gem::Version.new(::Excon::VERSION) < Gem::Version.new('0.56.0')
+
+    deprecation_msg = 'Instrumentation for Excon versions below 0.56.0 is deprecated.' \
+      'They will stop being monitored in version 9.0.0. ' \
+      'Please upgrade your Excon version to continue receiving full support. '
+
+    ::NewRelic::Agent.logger.log_once(
+      :warn,
+      :deprecated_excon_version,
+      deprecation_msg
+    )
+
+    ::NewRelic::Agent.record_metric("Supportability/Deprecated/Excon", 1)
+  end
+
   def install_excon_instrumentation(excon_version)
     require 'new_relic/agent/distributed_tracing/cross_app_tracing'
     require 'new_relic/agent/http_clients/excon_wrappers'

--- a/test/multiverse/suites/excon/Envfile
+++ b/test/multiverse/suites/excon/Envfile
@@ -3,9 +3,9 @@
 # frozen_string_literal: true
 
 excon_versions = [
-  nil,
-  '0.56.0',
-  '0.19.0'
+  [nil],
+  ['0.56.0'],
+  ['0.19.0', 2.2, 2.6]
 ]
 
 def gem_list(excon_version = nil)

--- a/test/multiverse/suites/excon/Envfile
+++ b/test/multiverse/suites/excon/Envfile
@@ -4,7 +4,8 @@
 
 excon_versions = [
   nil,
-  '0.56.0'
+  '0.56.0',
+  '0.19.0'
 ]
 
 def gem_list(excon_version = nil)

--- a/test/new_relic/http_client_test_cases.rb
+++ b/test/new_relic/http_client_test_cases.rb
@@ -60,6 +60,13 @@ module HttpClientTestCases
     res.body
   end
 
+  # TODO: MAJOR VERSION - update min version to 0.56.0
+  def jruby_excon_skip?
+    defined?(JRUBY_VERSION) &&
+      defined?(::Excon::VERSION) &&
+      Gem::Version.new(::Excon::VERSION) < Gem::Version.new('0.19.0')
+  end
+
   # Tests
 
   def test_validate_request_wrapper
@@ -212,6 +219,8 @@ module HttpClientTestCases
   end
 
   def test_ignore
+    skip "Don't test JRuby with old Excon." if jruby_excon_skip?
+
     in_transaction do
       NewRelic::Agent.disable_all_tracing do
         post_response
@@ -228,12 +237,16 @@ module HttpClientTestCases
   end
 
   def test_post
+    skip "Don't test JRuby with old Excon." if jruby_excon_skip?
+
     in_transaction { post_response }
 
     assert_externals_recorded_for("localhost", "POST")
   end
 
   def test_put
+    skip "Don't test JRuby with old Excon." if jruby_excon_skip?
+
     in_transaction { put_response }
 
     assert_externals_recorded_for("localhost", "PUT")

--- a/test/new_relic/http_client_test_cases.rb
+++ b/test/new_relic/http_client_test_cases.rb
@@ -60,7 +60,7 @@ module HttpClientTestCases
     res.body
   end
 
-  # TODO: MAJOR VERSION - update min version to 0.56.0
+  # TODO: remove method and its callers once Excon version is at or above 0.20.0
   def jruby_excon_skip?
     defined?(JRUBY_VERSION) &&
       defined?(::Excon::VERSION) &&

--- a/test/new_relic/http_client_test_cases.rb
+++ b/test/new_relic/http_client_test_cases.rb
@@ -64,7 +64,7 @@ module HttpClientTestCases
   def jruby_excon_skip?
     defined?(JRUBY_VERSION) &&
       defined?(::Excon::VERSION) &&
-      Gem::Version.new(::Excon::VERSION) < Gem::Version.new('0.19.0')
+      Gem::Version.new(::Excon::VERSION) < Gem::Version.new('0.20.0')
   end
 
   # Tests


### PR DESCRIPTION
- Test the minimum supported version of Excon
- Add deprecation message
- Don't test JRuby on old versions of Excon

Related to #794 