### PR TITLE
Create Ruby 2.3 logged deprecation message

### DIFF
--- a/lib/new_relic/control/instrumentation.rb
+++ b/lib/new_relic/control/instrumentation.rb
@@ -94,8 +94,6 @@ module NewRelic
         :deprecated_ruby_version,
         deprecation_msg
       )
-
-      ::NewRelic::Agent.record_metric("Supportability/Deprecated/RubyVersion", 1)
     end
 
     include Instrumentation

--- a/lib/new_relic/control/instrumentation.rb
+++ b/lib/new_relic/control/instrumentation.rb
@@ -62,7 +62,7 @@ module NewRelic
           File.join(instrumentation_path, app.to_s, '*.rb')
         @instrumentation_files.each { |pattern| load_instrumentation_files(pattern) }
         DependencyDetection.detect!
-        ruby_22_deprecation
+        ruby_deprecation
         rails_32_deprecation
         ::NewRelic::Agent.logger.info("Finished instrumentation")
       end
@@ -83,10 +83,10 @@ module NewRelic
       ::NewRelic::Agent.record_metric("Supportability/Deprecated/Rails32", 1)
     end
 
-    def ruby_22_deprecation
-      return unless RUBY_VERSION <= '2.2.0'
+    def ruby_deprecation
+      return unless RUBY_VERSION < '2.4.0'
 
-      deprecation_msg = 'The Ruby Agent is dropping support for Ruby 2.2 ' \
+      deprecation_msg = 'The Ruby Agent is dropping support for Rubies below 2.4 ' \
         'in version 9.0.0. Please upgrade your Ruby version to continue receiving support. ' \
 
       ::NewRelic::Agent.logger.log_once(
@@ -95,7 +95,7 @@ module NewRelic
         deprecation_msg
       )
 
-      ::NewRelic::Agent.record_metric("Supportability/Deprecated/Ruby22", 1)
+      ::NewRelic::Agent.record_metric("Supportability/Deprecated/RubyVersion", 1)
     end
 
     include Instrumentation


### PR DESCRIPTION
This change will log a message to our users if they're on Ruby 2.3, warning them about the eventual removal of support.