### PR TITLE
Remove record_metric calls for deprecated gems

### DIFF
--- a/lib/new_relic/agent/instrumentation/active_merchant.rb
+++ b/lib/new_relic/agent/instrumentation/active_merchant.rb
@@ -47,7 +47,5 @@ DependencyDetection.defer do
       :deprecated_active_merchant_version,
       deprecation_msg
     )
-
-    ::NewRelic::Agent.record_metric("Supportability/Deprecated/ActiveMerchant", 1)
   end
 end

--- a/lib/new_relic/agent/instrumentation/acts_as_solr.rb
+++ b/lib/new_relic/agent/instrumentation/acts_as_solr.rb
@@ -53,8 +53,6 @@ DependencyDetection.defer do
       :deprecated_acts_as_solr,
       deprecation_msg
     )
-
-    ::NewRelic::Agent.record_metric("Supportability/Deprecated/ActsAsSolr", 1)
   end
 
   executes do

--- a/lib/new_relic/agent/instrumentation/authlogic.rb
+++ b/lib/new_relic/agent/instrumentation/authlogic.rb
@@ -21,8 +21,6 @@ DependencyDetection.defer do
       :deprecated_authlogic,
       deprecation_msg
     )
-
-    ::NewRelic::Agent.record_metric("Supportability/Deprecated/Authlogic", 1)
   end
 
   executes do

--- a/lib/new_relic/agent/instrumentation/data_mapper.rb
+++ b/lib/new_relic/agent/instrumentation/data_mapper.rb
@@ -26,7 +26,6 @@ DependencyDetection.defer do
       :deprecated_datamapper,
       deprecation_msg
     )
-    ::NewRelic::Agent.record_metric("Supportability/Deprecated/DataMapper", 1)
   end
 
   executes do

--- a/lib/new_relic/agent/instrumentation/delayed_job_instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/delayed_job_instrumentation.rb
@@ -106,8 +106,6 @@ DependencyDetection.defer do
       :deprecated_delayed_job_version,
       deprecation_msg
     )
-
-    ::NewRelic::Agent.record_metric("Supportability/Deprecated/DelayedJob", 1)
   end
 
   def delayed_job_version

--- a/lib/new_relic/agent/instrumentation/rainbows_instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/rainbows_instrumentation.rb
@@ -22,7 +22,6 @@ DependencyDetection.defer do
       :deprecated_rainbows_dispatcher,
       deprecation_msg
     )
-    ::NewRelic::Agent.record_metric("Supportability/Deprecated/Rainbows", 1)
   end
 
   executes do

--- a/lib/new_relic/agent/instrumentation/sidekiq.rb
+++ b/lib/new_relic/agent/instrumentation/sidekiq.rb
@@ -51,7 +51,5 @@ DependencyDetection.defer do
       :deprecated_sidekiq_version,
       deprecation_msg
     )
-
-    ::NewRelic::Agent.record_metric("Supportability/Deprecated/Sidekiq", 1)
   end
 end

--- a/lib/new_relic/agent/instrumentation/sinatra.rb
+++ b/lib/new_relic/agent/instrumentation/sinatra.rb
@@ -54,7 +54,5 @@ DependencyDetection.defer do
       :deprecated_sinatra_version,
       deprecation_msg
     )
-
-    ::NewRelic::Agent.record_metric("Supportability/Deprecated/Sinatra", 1)
   end
 end

--- a/lib/new_relic/agent/instrumentation/sunspot.rb
+++ b/lib/new_relic/agent/instrumentation/sunspot.rb
@@ -19,8 +19,6 @@ DependencyDetection.defer do
       :deprecated_sunspot,
       deprecation_msg
     )
-
-    ::NewRelic::Agent.record_metric("Supportability/Deprecated/Sunspot", 1)
   end
 
   executes do

--- a/lib/new_relic/control/instrumentation.rb
+++ b/lib/new_relic/control/instrumentation.rb
@@ -79,8 +79,6 @@ module NewRelic
         :deprecated_rails_version,
         deprecation_msg
       )
-
-      ::NewRelic::Agent.record_metric("Supportability/Deprecated/Rails32", 1)
     end
 
     def ruby_deprecation


### PR DESCRIPTION
This information can be accessed using other means. We don't need a metric.
