### PR TITLE
move Redis instrumentation constants to a class

### DIFF
--- a/lib/new_relic/agent/instrumentation/redis.rb
+++ b/lib/new_relic/agent/instrumentation/redis.rb
@@ -7,6 +7,7 @@ require 'new_relic/agent/datastores/redis'
 
 require_relative 'redis/instrumentation'
 require_relative 'redis/chain'
+require_relative 'redis/constants'
 require_relative 'redis/prepend'
 require_relative 'redis/middleware'
 
@@ -30,7 +31,7 @@ DependencyDetection.defer do
 
   executes do
     NewRelic::Agent.logger.info('Installing Redis Instrumentation')
-    if NewRelic::Agent::Instrumentation::Redis::HAS_REDIS_CLIENT
+    if NewRelic::Agent::Instrumentation::Redis::Constants::HAS_REDIS_CLIENT
       ::RedisClient.register(NewRelic::Agent::Instrumentation::RedisClient::Middleware)
     end
 

--- a/lib/new_relic/agent/instrumentation/redis/constants.rb
+++ b/lib/new_relic/agent/instrumentation/redis/constants.rb
@@ -1,0 +1,17 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+module NewRelic::Agent::Instrumentation::Redis
+  class Constants
+    PRODUCT_NAME = 'Redis'
+    CONNECT = 'connect'
+    UNKNOWN = 'unknown'
+    LOCALHOST = 'localhost'
+    MULTI_OPERATION = 'multi'
+    PIPELINE_OPERATION = 'pipeline'
+    HAS_REDIS_CLIENT = defined?(::Redis) &&
+      Gem::Version.new(::Redis::VERSION) >= Gem::Version.new('5.0.0') &&
+      !!defined?(::RedisClient)
+  end
+end


### PR DESCRIPTION
the nightly CI system is reporting tens of thousands of 'already defined constant' warnings from the new Redis instrumentation changes.

moving the constants out into a class to help with this
