### PR TITLE
CI: use non-frozen strings for Excon testing

### DIFF
--- a/test/multiverse/suites/excon/excon_test.rb
+++ b/test/multiverse/suites/excon/excon_test.rb
@@ -47,11 +47,11 @@ class ExconTest < Minitest::Test
   end
 
   def post_response
-    Excon.post(default_url, :body => "")
+    Excon.post(default_url, body: String.new)
   end
 
   def put_response
-    Excon.put(default_url, :body => "")
+    Excon.put(default_url, body: String.new)
   end
 
   def delete_response


### PR DESCRIPTION
to prevent older Excon gem versions from being unable to force encoding on a frozen string, use `String.new` to set the body string in the unit tests