### PR TITLE
CI: ensure 8T json test ivars are sorted similarly

### DIFF
--- a/test/new_relic/agent/distributed_tracing/distributed_trace_payload_test.rb
+++ b/test/new_relic/agent/distributed_tracing/distributed_trace_payload_test.rb
@@ -170,8 +170,9 @@ module NewRelic::Agent
       payload1 = DistributedTracePayload.for_transaction(transaction)
       payload2 = DistributedTracePayload.from_json(payload1.text)
 
-      payload1_ivars = payload1.instance_variables.map { |iv| payload1.instance_variable_get(iv) }
-      payload2_ivars = payload2.instance_variables.map { |iv| payload2.instance_variable_get(iv) }
+      ivar_names = payload1.instance_variables
+      payload1_ivars = ivar_names.map { |iv| payload1.instance_variable_get(iv) }
+      payload2_ivars = ivar_names.map { |iv| payload2.instance_variable_get(iv) }
 
       assert_equal payload1_ivars, payload2_ivars
     end


### PR DESCRIPTION
to fix a CI issue, don't assume that the `#instance_variables` responses from 2 objects of the same type will have identical ordering