### PR TITLE
Add workflow_dispatch to ci_cron

### DIFF
--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -6,7 +6,8 @@ on:
       - main
       - dev
   schedule:
-    - cron:  '0 9 * * *'
+    - cron: '0 9 * * *'
+  workflow_dispatch:
 
 jobs:
   run_rubocop:


### PR DESCRIPTION
workflow_dispatch allows workflows to be run on demand in the GitHub UI
