### PR TITLE
Remove rack-test references from Rails envfile

### DIFF
--- a/test/multiverse/suites/rails/Envfile
+++ b/test/multiverse/suites/rails/Envfile
@@ -2,12 +2,6 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
-# TODO: UNIT TESTS - Determine the root cause of our compatibility issues with
-#       rack-test 2+. If rack-test is not specified in Gemfile, the rum tests
-#       fail because the JS header is always included, even when not desired.
-#       Once the compatibility issue is addressed, all "rack_test" lines from
-#       this file and this comment should be removed.
-
 RAILS_VERSIONS = [
   [nil, 2.7],
   ['7.0.4', 2.7],
@@ -43,10 +37,6 @@ def minitest_rails_version(rails_version = nil)
   end
 end
 
-def pre2_rack_test
-  %Q(gem 'rack-test')
-end
-
 def gem_list(rails_version = nil)
   <<-RB
     gem 'rails'#{rails_version}
@@ -54,7 +44,6 @@ def gem_list(rails_version = nil)
     #{haml_rails(rails_version)}
     gem 'minitest', '#{minitest_rails_version(rails_version)}'
     gem 'erubis' if RUBY_PLATFORM.eql?('java')
-    #{pre2_rack_test}
     #{ruby3_gem_webrick}
   RB
 end
@@ -70,7 +59,6 @@ if RUBY_VERSION < '2.4.0'
     gem 'haml', '4.0.2'   # Getting load issues with haml 4.0.3
     gem 'minitest', '~> 4.7.5'
     gem 'minitest_tu_shim', :require => false
-    #{pre2_rack_test}
   RB
 
   gemfile <<-RB
@@ -80,6 +68,5 @@ if RUBY_VERSION < '2.4.0'
     gem 'haml', '4.0.2'   # Getting load issues with haml 4.0.3
     gem 'minitest', '~> 4.7.5'
     gem 'minitest_tu_shim', :require => false
-    #{pre2_rack_test}
   RB
 end


### PR DESCRIPTION
Remove rack-test references from Rails envfile.

TODOs added with #1220
This issue was fixed by #1591
Closes #1442