### PR TITLE
Capistrano - lookup fallback changelog from git

### DIFF
--- a/lib/new_relic/recipes/helpers/send_deployment.rb
+++ b/lib/new_relic/recipes/helpers/send_deployment.rb
@@ -29,7 +29,8 @@ module SendDeployment
   end
 
   def fetch_changelog
-    has_scm? ? fetch(:newrelic_changelog) : lookup_changelog
+    newrelic_changelog = fetch(:newrelic_changelog)
+    has_scm? && !newrelic_changelog ? lookup_changelog : newrelic_changelog
   end
 
   def fetch_environment


### PR DESCRIPTION
# Overview
PR https://github.com/newrelic/newrelic-ruby-agent/pull/1498 introduced a regression in the resolution of `changelog` content. Originally, when `newrelic_revision` or `newrelic_changelog` was missing and SCM was in use, revision/changelog was taken from SCM (https://github.com/newrelic/newrelic-ruby-agent/pull/1498/files#diff-8617c3d884fd8d418ce71c6e5c8b3574b405debef725642d04cd1fa2db1d0596L39). 

However, refactoring kept this logic only for `revision` (https://github.com/newrelic/newrelic-ruby-agent/pull/1498/files#diff-62409e781fcfec20b77d79fd9f324cd395030f9b7ae9fb3a85c4a0e92f7add3dR39), not `changelog` (https://github.com/newrelic/newrelic-ruby-agent/pull/1498/files#diff-62409e781fcfec20b77d79fd9f324cd395030f9b7ae9fb3a85c4a0e92f7add3dR31). 

This PR adds a fallback to the changelog resolution from GIT. 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
