### PR TITLE
Defer agent initialization in Rails until after :load_config_initializers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,15 @@ Version 8.14.0 of the agent restores desired Capistrano-based changelog lookup f
 
   With version 8.13.0 of the agent, support was added for the [redis-rb](https://github.com/redis/redis-rb) gem v5+ and the new [RedisClient](https://rubygems.org/gems/redis-client) gem. With versions of RedisClient older than v0.11, the agent could cause the monitored application to crash when attempting to determine the Redis database index. Version 8.14.0 adds two related improvements. Firstly, support for RedisClient versions older than v0.11 has been added to get at the database index value. Secondly, the agent will no longer crash or impact the monitored application in the event that the database index cannot be obtained. Thank you very much to our community members [@mbsmartee](https://github.com/mbsmartee) and [@patatepartie](https://github.com/patatepartie) for bringing this issue to our attention, for helping us determine how to best reproduce it, and for testing out the update. We appreciate your help! [Issue#1650](https://github.com/newrelic/newrelic-ruby-agent/issues/1650) [PR#1673](https://github.com/newrelic/newrelic-ruby-agent/pull/1673)
 
-- **Bugfix: Defer agent startup in Rails until after config/initializers are run**
+- **Bugfix: Defer agent startup in Rails until after application-defined initializers have run**
 
-  In Rails, the agent previously loaded before any files in the `config/initializers` directory. This allowed initializers to reference the `add_method_tracer` API. However, this had the side-effect of forcing some framework libraries to load before `config/initializers`, preventing any configuration values related to these libraries from being applied. This fix splits initialization into two parts: load `add_method_tracer` before `config/initializers` and start the agent after `config/initializers`. Furthermore, our Action View instrumentation was missing an `ActiveSupport.on_load` block around the code that loads our instrumentation. Thank you [@jdelStrother](https://github.com/jdelStrother) for bringing this to our attention and collaborating with us on a fix. [PR#1658](https://github.com/newrelic/newrelic-ruby-agent/pull/1658)
+  In Rails, the agent previously loaded before any application-defined initializers. This allowed initializers to reference the `add_method_tracer` API. However, this had the side-effect of forcing some framework libraries to load before initializers ran, preventing any configuration values related to these libraries from being applied. This fix provides an option to split initialization into two parts: load `add_method_tracer` before application-defined initializers and start the agent after application-defined initializers. This may cause other initializers to behave differently.
+
+  If you'd like to use this feature, set `defer_rails_initialization` to `true`. It is `false` by default, but may become `true` by default in a future release.
+
+  Furthermore, our Action View instrumentation was missing an `ActiveSupport.on_load` block around the code that loads our instrumentation.
+
+  Thank you [@jdelStrother](https://github.com/jdelStrother) for bringing this to our attention and collaborating with us on a fix. [PR#1658](https://github.com/newrelic/newrelic-ruby-agent/pull/1658)
 
 ## v8.13.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v8.14.0
 
-Version 8.14.0 of the agent restores desired Capistrano-based changelog lookup functionalty when a deployment is performed, delivers support for instrumenting Rails custom event notifications, and fixes potential compatibility issues with Redis gems, and reformats the Changelog to match Kayla's ghost linter.
+Version 8.14.0 of the agent restores desired Capistrano-based changelog lookup functionalty when a deployment is performed, delivers support for instrumenting Rails custom event notifications, and fixes potential compatibility issues with Redis gems, and fixes bugs related to initialization in Rails.
 
 - **Deployment Recipe: Restore desired Capistrano-based changelog lookup behavior**
 
@@ -16,9 +16,9 @@ Version 8.14.0 of the agent restores desired Capistrano-based changelog lookup f
 
   With version 8.13.0 of the agent, support was added for the [redis-rb](https://github.com/redis/redis-rb) gem v5+ and the new [RedisClient](https://rubygems.org/gems/redis-client) gem. With versions of RedisClient older than v0.11, the agent could cause the monitored application to crash when attempting to determine the Redis database index. Version 8.14.0 adds two related improvements. Firstly, support for RedisClient versions older than v0.11 has been added to get at the database index value. Secondly, the agent will no longer crash or impact the monitored application in the event that the database index cannot be obtained. Thank you very much to our community members [@mbsmartee](https://github.com/mbsmartee) and [@patatepartie](https://github.com/patatepartie) for bringing this issue to our attention, for helping us determine how to best reproduce it, and for testing out the update. We appreciate your help! [Issue#1650](https://github.com/newrelic/newrelic-ruby-agent/issues/1650) [PR#1673](https://github.com/newrelic/newrelic-ruby-agent/pull/1673)
 
-- **Test**
+- **Bugfix: Defer agent startup in Rails until after config/initializers are run**
 
-  This is a test entry to force the ghost linter to run. Remove this before release.
+  In Rails, the agent previously loaded before any files in the `config/initializers` directory. This allowed initializers to reference the `add_method_tracer` API. However, this had the side-effect of forcing some framework libraries to load before `config/initializers`, preventing any configuration values related to these libraries from being applied. This fix splits initialization into two parts: load `add_method_tracer` before `config/initializers` and start the agent after `config/initializers`. Furthermore, our Action View instrumentation was missing an `ActiveSupport.on_load` block around the code that loads our instrumentation. Thank you [@jdelStrother](https://github.com/jdelStrother) for bringing this to our attention and collaborating with us on a fix. [PR#1658](https://github.com/newrelic/newrelic-ruby-agent/pull/1658)
 
 ## v8.13.1
 

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -1850,6 +1850,15 @@ If `true`, disables agent middleware for Sinatra. This middleware is responsible
           :allowed_from_server => false,
           :description => 'Specify a custom host name for [display in the New Relic UI](/docs/apm/new-relic-apm/maintenance/add-rename-remove-hosts#display_name).'
         },
+        # Rails
+        :'defer_rails_initialization' => {
+          :default => false,
+          :public => true,
+          :type => Boolean,
+          :allowed_from_server => true,
+          :description => 'If `true`, when the agent is in an application using Ruby on Rails, it will start after ' \
+            'config/initializers are run.'
+        },
         # Rake
         :'rake.tasks' => {
           :default => [],

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -1855,7 +1855,7 @@ If `true`, disables agent middleware for Sinatra. This middleware is responsible
           :default => false,
           :public => true,
           :type => Boolean,
-          :allowed_from_server => true,
+          :allowed_from_server => false,
           :description => 'If `true`, when the agent is in an application using Ruby on Rails, it will start after ' \
             'config/initializers are run.'
         },

--- a/lib/new_relic/agent/instrumentation/rails_notifications/action_view.rb
+++ b/lib/new_relic/agent/instrumentation/rails_notifications/action_view.rb
@@ -22,7 +22,9 @@ DependencyDetection.defer do
   end
 
   executes do
-    NewRelic::Agent::Instrumentation::ActionViewSubscriber.subscribe(/render_.+\.action_view$/)
-    NewRelic::Agent::PrependSupportability.record_metrics_for(::ActionView::Base, ::ActionView::Template, ::ActionView::Renderer)
+    ActiveSupport.on_load(:action_view) do
+      NewRelic::Agent::Instrumentation::ActionViewSubscriber.subscribe(/render_.+\.action_view$/)
+      NewRelic::Agent::PrependSupportability.record_metrics_for(::ActionView::Base, ::ActionView::Template, ::ActionView::Renderer)
+    end
   end
 end

--- a/lib/new_relic/control/instance_methods.rb
+++ b/lib/new_relic/control/instance_methods.rb
@@ -64,8 +64,12 @@ module NewRelic
 
         # An artifact of earlier implementation, we put both #add_method_tracer and #trace_execution
         # methods in the module methods.
-        Module.send(:include, NewRelic::Agent::MethodTracer::ClassMethods)
-        Module.send(:include, NewRelic::Agent::MethodTracer)
+        # Rails applications load the next two lines before any other initializers are run
+        unless defined?(Rails::VERSION)
+          Module.send(:include, NewRelic::Agent::MethodTracer::ClassMethods)
+          Module.send(:include, NewRelic::Agent::MethodTracer)
+        end
+
         init_config(options)
         NewRelic::Agent.agent = NewRelic::Agent::Agent.instance
         init_instrumentation

--- a/lib/new_relic/control/instance_methods.rb
+++ b/lib/new_relic/control/instance_methods.rb
@@ -65,7 +65,7 @@ module NewRelic
         # An artifact of earlier implementation, we put both #add_method_tracer and #trace_execution
         # methods in the module methods.
         # Rails applications load the next two lines before any other initializers are run
-        unless defined?(Rails::VERSION)
+        unless defined?(Rails::VERSION) && NewRelic::Agent.config[:defer_rails_initialization]
           Module.send(:include, NewRelic::Agent::MethodTracer::ClassMethods)
           Module.send(:include, NewRelic::Agent::MethodTracer)
         end

--- a/lib/newrelic_rpm.rb
+++ b/lib/newrelic_rpm.rb
@@ -20,7 +20,12 @@ require 'new_relic/control'
 if defined?(Rails::VERSION)
   module NewRelic
     class Railtie < Rails::Railtie
-      initializer "newrelic_rpm.start_plugin", before: :load_config_initializers do |app|
+      initializer "newrelic_rpm.include_method_tracers", before: :load_config_initializers do |app|
+        Module.send(:include, NewRelic::Agent::MethodTracer::ClassMethods)
+        Module.send(:include, NewRelic::Agent::MethodTracer)
+      end
+
+      initializer "newrelic_rpm.start_plugin", after: :load_config_initializers do |app|
         NewRelic::Control.instance.init_plugin(config: app.config)
       end
     end

--- a/lib/newrelic_rpm.rb
+++ b/lib/newrelic_rpm.rb
@@ -20,13 +20,19 @@ require 'new_relic/control'
 if defined?(Rails::VERSION)
   module NewRelic
     class Railtie < Rails::Railtie
-      initializer "newrelic_rpm.include_method_tracers", before: :load_config_initializers do |app|
-        Module.send(:include, NewRelic::Agent::MethodTracer::ClassMethods)
-        Module.send(:include, NewRelic::Agent::MethodTracer)
-      end
+      if NewRelic::Agent.config[:defer_rails_initialization]
+        initializer "newrelic_rpm.include_method_tracers", before: :load_config_initializers do |app|
+          Module.send(:include, NewRelic::Agent::MethodTracer::ClassMethods)
+          Module.send(:include, NewRelic::Agent::MethodTracer)
+        end
 
-      initializer "newrelic_rpm.start_plugin", after: :load_config_initializers do |app|
-        NewRelic::Control.instance.init_plugin(config: app.config)
+        initializer "newrelic_rpm.start_plugin", after: :load_config_initializers do |app|
+          NewRelic::Control.instance.init_plugin(config: app.config)
+        end
+      else
+        initializer "newrelic_rpm.start_plugin", before: :load_config_initializers do |app|
+          NewRelic::Control.instance.init_plugin(config: app.config)
+        end
       end
     end
   end

--- a/test/README.md
+++ b/test/README.md
@@ -28,9 +28,9 @@ In CI, these unit tests are run against all supported major.minor versions of Ra
 
 ### Running Specific Tests
 
-The file parameter can be added to the test:env invocation to run a specific unit file.  It can be exact file name, or a wildcard pattern.  Multiple file patterns can be specified by separating with a comma with no spaces surrounding:
+The file environment variable can be added to the test:env invocation to run a specific unit file.  It can be exact file name, or a wildcard pattern.  Multiple file patterns can be specified by separating with a comma with no spaces surrounding:
 
-    bundle exec rake 'test:env[rails60]' file=test/new_relic/agent/distributed_tracing/*  # everything in this folder
-    bundle exec rake 'test:env[rails60]' file=test/new_relic/agent/tracer_state_test.rb   # single file
-    bundle exec rake 'test:env[rails60]' file=test/new_relic/agent/*_test.rb              # all *_test.rb files in this folder
-    bundle exec rake 'test:env[rails60]' file=test/new_relic/agent/distributed_tracing/*,test/new_relic/agent/datastores/*  # all files in two folders
+    file=test/new_relic/agent/distributed_tracing/* bundle exec rake 'test:env[rails60]'  # everything in this folder
+    file=test/new_relic/agent/tracer_state_test.rb bundle exec rake 'test:env[rails60]'   # single file
+    file=test/new_relic/agent/*_test.rb  bundle exec rake 'test:env[rails60]'             # all *_test.rb files in this folder
+    file=test/new_relic/agent/distributed_tracing/*,test/new_relic/agent/datastores/* bundle exec rake 'test:env[rails60]' # all files in two folders

--- a/test/environments/rails40/config/initializers/test.rb
+++ b/test/environments/rails40/config/initializers/test.rb
@@ -1,0 +1,20 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+require 'new_relic/agent/method_tracer'
+
+class Bloodhound < ActiveRecord::Base
+  include ::NewRelic::Agent::MethodTracer
+
+  def sniff
+    puts "When a bloodhound sniffs a scent article (a piece of clothing or item touched only by the subject), " \
+    "air rushes through its nasal cavity and chemical vapors — or odors — lodge in the mucus and bombard the dog's " \
+    "scent receptors. " \
+    "Source: https://www.pbs.org/wnet/nature/underdogs-the-bloodhounds-amazing-sense-of-smell/350/"
+  end
+
+  add_method_tracer :sniff
+end
+
+Rails.application.config.active_record.timestamped_migrations = false

--- a/test/environments/rails41/config/initializers/test.rb
+++ b/test/environments/rails41/config/initializers/test.rb
@@ -1,0 +1,19 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+require 'new_relic/agent/method_tracer'
+
+class Bloodhound < ActiveRecord::Base
+  include ::NewRelic::Agent::MethodTracer
+
+  def sniff
+    puts "When a bloodhound sniffs a scent article (a piece of clothing or item touched only by the subject)," \
+    "air rushes through its nasal cavity and chemical vapors — or odors — lodge in the mucus and bombard the dog's scent receptors. " \
+    "Source: https://www.pbs.org/wnet/nature/underdogs-the-bloodhounds-amazing-sense-of-smell/350/"
+  end
+
+  add_method_tracer :sniff
+end
+
+Rails.application.config.active_record.timestamped_migrations = false

--- a/test/environments/rails42/config/initializers/test.rb
+++ b/test/environments/rails42/config/initializers/test.rb
@@ -1,0 +1,20 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+require 'new_relic/agent/method_tracer'
+
+class Bloodhound < ActiveRecord::Base
+  include ::NewRelic::Agent::MethodTracer
+
+  def sniff
+    puts "When a bloodhound sniffs a scent article (a piece of clothing or item touched only by the subject), " \
+    "air rushes through its nasal cavity and chemical vapors — or odors — lodge in the mucus and bombard the dog's " \
+    "scent receptors. " \
+    "Source: https://www.pbs.org/wnet/nature/underdogs-the-bloodhounds-amazing-sense-of-smell/350/"
+  end
+
+  add_method_tracer :sniff
+end
+
+Rails.application.config.active_record.timestamped_migrations = false

--- a/test/environments/rails50/config/initializers/test.rb
+++ b/test/environments/rails50/config/initializers/test.rb
@@ -1,0 +1,20 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+require 'new_relic/agent/method_tracer'
+
+class Bloodhound < ActiveRecord::Base
+  include ::NewRelic::Agent::MethodTracer
+
+  def sniff
+    puts "When a bloodhound sniffs a scent article (a piece of clothing or item touched only by the subject), " \
+    "air rushes through its nasal cavity and chemical vapors — or odors — lodge in the mucus and bombard the dog's " \
+    "scent receptors. " \
+    "Source: https://www.pbs.org/wnet/nature/underdogs-the-bloodhounds-amazing-sense-of-smell/350/"
+  end
+
+  add_method_tracer :sniff
+end
+
+Rails.application.config.active_record.timestamped_migrations = false

--- a/test/environments/rails51/config/initializers/test.rb
+++ b/test/environments/rails51/config/initializers/test.rb
@@ -1,0 +1,20 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+require 'new_relic/agent/method_tracer'
+
+class Bloodhound < ActiveRecord::Base
+  include ::NewRelic::Agent::MethodTracer
+
+  def sniff
+    puts "When a bloodhound sniffs a scent article (a piece of clothing or item touched only by the subject), " \
+    "air rushes through its nasal cavity and chemical vapors — or odors — lodge in the mucus and bombard the dog's " \
+    "scent receptors. " \
+    "Source: https://www.pbs.org/wnet/nature/underdogs-the-bloodhounds-amazing-sense-of-smell/350/"
+  end
+
+  add_method_tracer :sniff
+end
+
+Rails.application.config.active_record.timestamped_migrations = false

--- a/test/environments/rails52/config/initializers/test.rb
+++ b/test/environments/rails52/config/initializers/test.rb
@@ -1,0 +1,20 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+require 'new_relic/agent/method_tracer'
+
+class Bloodhound < ActiveRecord::Base
+  include ::NewRelic::Agent::MethodTracer
+
+  def sniff
+    puts "When a bloodhound sniffs a scent article (a piece of clothing or item touched only by the subject), " \
+    "air rushes through its nasal cavity and chemical vapors — or odors — lodge in the mucus and bombard the dog's " \
+    "scent receptors. " \
+    "Source: https://www.pbs.org/wnet/nature/underdogs-the-bloodhounds-amazing-sense-of-smell/350/"
+  end
+
+  add_method_tracer :sniff
+end
+
+Rails.application.config.active_record.timestamped_migrations = false

--- a/test/environments/rails60/config/initializers/test.rb
+++ b/test/environments/rails60/config/initializers/test.rb
@@ -1,0 +1,20 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+require 'new_relic/agent/method_tracer'
+
+class Bloodhound < ActiveRecord::Base
+  include ::NewRelic::Agent::MethodTracer
+
+  def sniff
+    puts "When a bloodhound sniffs a scent article (a piece of clothing or item touched only by the subject), " \
+    "air rushes through its nasal cavity and chemical vapors — or odors — lodge in the mucus and bombard the dog's " \
+    "scent receptors. " \
+    "Source: https://www.pbs.org/wnet/nature/underdogs-the-bloodhounds-amazing-sense-of-smell/350/"
+  end
+
+  add_method_tracer :sniff
+end
+
+Rails.application.config.active_record.timestamped_migrations = false

--- a/test/environments/rails61/config/initializers/test.rb
+++ b/test/environments/rails61/config/initializers/test.rb
@@ -1,0 +1,20 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+require 'new_relic/agent/method_tracer'
+
+class Bloodhound < ActiveRecord::Base
+  include ::NewRelic::Agent::MethodTracer
+
+  def sniff
+    puts "When a bloodhound sniffs a scent article (a piece of clothing or item touched only by the subject), " \
+    "air rushes through its nasal cavity and chemical vapors — or odors — lodge in the mucus and bombard the dog's " \
+    "scent receptors. " \
+    "Source: https://www.pbs.org/wnet/nature/underdogs-the-bloodhounds-amazing-sense-of-smell/350/"
+  end
+
+  add_method_tracer :sniff
+end
+
+Rails.application.config.active_record.timestamped_migrations = false

--- a/test/environments/rails70/config/initializers/test.rb
+++ b/test/environments/rails70/config/initializers/test.rb
@@ -1,0 +1,20 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+require 'new_relic/agent/method_tracer'
+
+class Bloodhound < ActiveRecord::Base
+  include ::NewRelic::Agent::MethodTracer
+
+  def sniff
+    puts "When a bloodhound sniffs a scent article (a piece of clothing or item touched only by the subject), " \
+    "air rushes through its nasal cavity and chemical vapors — or odors — lodge in the mucus and bombard the dog's " \
+    "scent receptors. " \
+    "Source: https://www.pbs.org/wnet/nature/underdogs-the-bloodhounds-amazing-sense-of-smell/350/"
+  end
+
+  add_method_tracer :sniff
+end
+
+Rails.application.config.active_record.timestamped_migrations = false

--- a/test/environments/railsedge/config/initializers/test.rb
+++ b/test/environments/railsedge/config/initializers/test.rb
@@ -1,0 +1,20 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+require 'new_relic/agent/method_tracer'
+
+class Bloodhound < ActiveRecord::Base
+  include ::NewRelic::Agent::MethodTracer
+
+  def sniff
+    puts "When a bloodhound sniffs a scent article (a piece of clothing or item touched only by the subject), " \
+    "air rushes through its nasal cavity and chemical vapors — or odors — lodge in the mucus and bombard the dog's " \
+    "scent receptors. " \
+    "Source: https://www.pbs.org/wnet/nature/underdogs-the-bloodhounds-amazing-sense-of-smell/350/"
+  end
+
+  add_method_tracer :sniff
+end
+
+Rails.application.config.active_record.timestamped_migrations = false

--- a/test/new_relic/newrelic_rpm_test.rb
+++ b/test/new_relic/newrelic_rpm_test.rb
@@ -10,38 +10,76 @@ class NewRelicRpmTest < Minitest::Test
 
   # We have documentation recommending customers call add_method_tracer
   # in their initializers, let's make sure this works
-  def test_add_method_tracer_in_initializer_gets_traced
+  def test_add_method_tracer_in_initializer_gets_traced_when_agent_initialized_before_config_initializers
     skip unless defined?(Rails::VERSION)
     skip 'MySQL error for Rails 3.2' if Rails::VERSION::MAJOR == 3
 
-    assert Bloodhound.newrelic_method_exists?('sniff'),
-      'Bloodhound#sniff not found by' \
-      'NewRelic::Agent::MethodTracer::ClassMethods::AddMethodTracer.newrelic_method_exists?'
-    assert Bloodhound.method_traced?('sniff'),
-      'Bloodhound#sniff not found by' \
-      'NewRelic::Agent::MethodTracer::ClassMethods::AddMethodTracer.method_traced?'
+    with_config(defer_rails_initialization: false) do
+      assert Bloodhound.newrelic_method_exists?('sniff'),
+        'Bloodhound#sniff not found by' \
+        'NewRelic::Agent::MethodTracer::ClassMethods::AddMethodTracer.newrelic_method_exists?'
+      assert Bloodhound.method_traced?('sniff'),
+        'Bloodhound#sniff not found by' \
+        'NewRelic::Agent::MethodTracer::ClassMethods::AddMethodTracer.method_traced?'
+    end
+  end
+
+  def test_add_method_tracer_in_initializer_gets_traced_when_agent_initialized_after_config_initializers
+    skip unless defined?(Rails::VERSION)
+    skip 'MySQL error for Rails 3.2 if we define an initializer in config/initializers' if Rails::VERSION::MAJOR == 3
+
+    with_config(defer_rails_initialization: true) do
+      assert Bloodhound.newrelic_method_exists?('sniff'),
+        'Bloodhound#sniff not found by' \
+        'NewRelic::Agent::MethodTracer::ClassMethods::AddMethodTracer.newrelic_method_exists?'
+      assert Bloodhound.method_traced?('sniff'),
+        'Bloodhound#sniff not found by' \
+        'NewRelic::Agent::MethodTracer::ClassMethods::AddMethodTracer.method_traced?'
+    end
   end
 
   # All supported Rails versions have the default value for
   # timestamped_migrations as true. Our initializer sets it to false.
   # Test to resolve: https://github.com/newrelic/newrelic-ruby-agent/issues/662
-  def test_active_record_initializer_config_change_saved
+
+  def test_active_record_initializer_config_change_saved_when_agent_initialized_after_config_initializers
     skip unless defined?(Rails::VERSION)
     # TODO: This test passes in a Rails console in a playground app and in the customer's environment
     # but fails in this unit test context
     skip if Gem::Version.new(NewRelic::VERSION::STRING) >= Gem::Version.new('8.13.0')
     skip 'MySQL error for Rails 3.2' if Rails::VERSION::MAJOR == 3
 
-    # Verify the configuration value was set to the initializer value
-    refute Rails.application.config.active_record.timestamped_migrations,
-      "Rails.application.config.active_record.timestamped_migrations equals true, expected false"
+    with_config(defer_rails_initialization: true) do
+      # Verify the configuration value was set to the initializer value
+      refute Rails.application.config.active_record.timestamped_migrations,
+        "Rails.application.config.active_record.timestamped_migrations equals true, expected false"
 
-    # Verify the configuration value was applied to the ActiveRecord class variable
-    if Gem::Version.new(Rails::VERSION::STRING) >= Gem::Version.new('7.1')
-      refute ActiveRecord.timestamped_migrations, "ActiveRecord.timestamped_migrations equals true, expected false"
-    else
-      refute ActiveRecord::Base.timestamped_migrations,
-        "ActiveRecord::Base.timestamped_migrations equals true, expected false"
+      # Verify the configuration value was applied to the ActiveRecord class variable
+      if Gem::Version.new(Rails::VERSION::STRING) >= Gem::Version.new('7.1')
+        refute ActiveRecord.timestamped_migrations, "ActiveRecord.timestamped_migrations equals true, expected false"
+      else
+        refute ActiveRecord::Base.timestamped_migrations,
+          "ActiveRecord::Base.timestamped_migrations equals true, expected false"
+      end
+    end
+  end
+
+  def test_active_record_initializer_config_change_not_saved_when_agent_initialized_before_config_initializers
+    skip unless defined?(Rails::VERSION)
+    skip 'MySQL error for Rails 3.2' if Rails::VERSION::MAJOR == 3
+
+    with_config(defer_rails_initialization: false) do
+      # Verify the configuration value was set to the initializer value
+      refute Rails.application.config.active_record.timestamped_migrations,
+        "Rails.application.config.active_record.timestamped_migrations equals true, expected false"
+
+      # Rails.application.config value should not be applied (this is the state of the original bug)
+      if Gem::Version.new(Rails::VERSION::STRING) >= Gem::Version.new('7.1')
+        assert ActiveRecord.timestamped_migrations, "ActiveRecord.timestamped_migrations equals false, expected true"
+      else
+        refute ActiveRecord::Base.timestamped_migrations,
+          "ActiveRecord::Base.timestamped_migrations equals false, expected true"
+      end
     end
   end
 end

--- a/test/new_relic/newrelic_rpm_test.rb
+++ b/test/new_relic/newrelic_rpm_test.rb
@@ -77,7 +77,7 @@ class NewRelicRpmTest < Minitest::Test
       if Gem::Version.new(Rails::VERSION::STRING) >= Gem::Version.new('7.1')
         assert ActiveRecord.timestamped_migrations, "ActiveRecord.timestamped_migrations equals false, expected true"
       else
-        refute ActiveRecord::Base.timestamped_migrations,
+        assert ActiveRecord::Base.timestamped_migrations,
           "ActiveRecord::Base.timestamped_migrations equals false, expected true"
       end
     end

--- a/test/new_relic/newrelic_rpm_test.rb
+++ b/test/new_relic/newrelic_rpm_test.rb
@@ -1,0 +1,47 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+class NewRelicRpmTest < Minitest::Test
+  # This test examines the behavior of an initializer when the agent is started in a Rails context
+  # The initializer used for these tests is defined in test/environments/*/config/inititalizers/test.rb
+
+  # We have documentation recommending customers call add_method_tracer
+  # in their initializers, let's make sure this works
+  def test_add_method_tracer_in_initializer_gets_traced
+    skip unless defined?(Rails::VERSION)
+    skip 'MySQL error for Rails 3.2' if Rails::VERSION::MAJOR == 3
+
+    assert Bloodhound.newrelic_method_exists?('sniff'),
+      'Bloodhound#sniff not found by' \
+      'NewRelic::Agent::MethodTracer::ClassMethods::AddMethodTracer.newrelic_method_exists?'
+    assert Bloodhound.method_traced?('sniff'),
+      'Bloodhound#sniff not found by' \
+      'NewRelic::Agent::MethodTracer::ClassMethods::AddMethodTracer.method_traced?'
+  end
+
+  # All supported Rails versions have the default value for
+  # timestamped_migrations as true. Our initializer sets it to false.
+  # Test to resolve: https://github.com/newrelic/newrelic-ruby-agent/issues/662
+  def test_active_record_initializer_config_change_saved
+    skip unless defined?(Rails::VERSION)
+    # TODO: This test passes in a Rails console in a playground app and in the customer's environment
+    # but fails in this unit test context
+    skip if Gem::Version.new(NewRelic::VERSION::STRING) >= Gem::Version.new('8.13.0')
+    skip 'MySQL error for Rails 3.2' if Rails::VERSION::MAJOR == 3
+
+    # Verify the configuration value was set to the initializer value
+    refute Rails.application.config.active_record.timestamped_migrations,
+      "Rails.application.config.active_record.timestamped_migrations equals true, expected false"
+
+    # Verify the configuration value was applied to the ActiveRecord class variable
+    if Gem::Version.new(Rails::VERSION::STRING) >= Gem::Version.new('7.1')
+      refute ActiveRecord.timestamped_migrations, "ActiveRecord.timestamped_migrations equals true, expected false"
+    else
+      refute ActiveRecord::Base.timestamped_migrations,
+        "ActiveRecord::Base.timestamped_migrations equals true, expected false"
+    end
+  end
+end


### PR DESCRIPTION
For Rails applications, the agent initialized before all other initializers with the `before: :load_config_initializers` hook.

Though this enables initializers to reference the `add_method_tracer` API, there are actions within the agent's initialization that load Rails framework libraries (ActiveJob, ActiveRecord, ActionView). This caused initializers referencing these libraries to be skipped entirely.

Since we only need the `add_method_tracer` API to be available before the initializers are run, the modules that include this API will be loaded before config initializers. All other agent-initialization activity will be loaded after config initializers.

Furthermore, ActionView was the only Rails framework library that did not have an `ActiveSupport.on_load` block around the instrumentation executes block. This has been added.

Closes #662