### PR TITLE
CI: compatibility fix for Sidekiq v7.0.2

### DIFF
--- a/test/multiverse/suites/sidekiq/sidekiq_with_redis_test.rb
+++ b/test/multiverse/suites/sidekiq/sidekiq_with_redis_test.rb
@@ -50,10 +50,11 @@ class SidekiqWithRedisTest < MiniTest::Test
     result = nil
 
     conn.with do |c|
-      c._client.pipelined do |p|
+      client = c.instance_variable_get(:@client)
+      client.pipelined do |p|
         p.call_v([:set, key, value])
       end
-      result = c._client.call(:get, key)
+      result = client.call(:get, key)
     end
 
     assert_equal value, result


### PR DESCRIPTION
We recently introduced a regression test for issue 1639, which involved Sidekiq v7.0.1.

The test made use of Sidekiq's `CompatClient` class, and leveraged its `_client` method to get at the underlying Redis client object.

With Sidekiq v7.0.2, `_client` is gone, and the underlying client can now be accessed with `@client`.