### PR TITLE
Re-enable test_harvest_during_transaction_safety

### DIFF
--- a/test/new_relic/agent/transaction_sampler_test.rb
+++ b/test/new_relic/agent/transaction_sampler_test.rb
@@ -401,17 +401,16 @@ module NewRelic::Agent
       end
     end
 
-    # TODO: this test seems to be destabilizing CI in a way that I don't grok.
-    # def sadly_do_not_test_harvest_during_transaction_safety
-    #  n = 3000
-    #  harvester = Thread.new do
-    #    n.times { @sampler.harvest! }
-    #  end
+    def test_harvest_during_transaction_safety
+      n = 3000
+      harvester = Thread.new do
+        n.times { @sampler.harvest! }
+      end
 
-    #  Dummy.new.run(n)
+      Dummy.new.run(n)
 
-    #  harvester.join
-    # end
+      harvester.join
+    end
 
     private
 


### PR DESCRIPTION
# Overview

Re-enable `test_harvest_during_transaction_safety` test within Transaction Sampler tests. It was commented out because it used to have problems with the CI. We've made a lot of changes to our CI since the comment was written. It doesn't seem to be a problem anymore.

Closes: #1433 

Submitter Checklist:
- [X] Include a link to the related GitHub issue, if applicable
- [ ] Include a security review link, if applicable

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
GitHub Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
