### PR TITLE
Nr1430 add method tracer helper test

### DIFF
--- a/lib/new_relic/agent/method_tracer_helpers.rb
+++ b/lib/new_relic/agent/method_tracer_helpers.rb
@@ -17,8 +17,7 @@ module NewRelic
       extend self
 
       def trace_execution_scoped(metric_names, options = NewRelic::EMPTY_HASH) # THREAD_LOCAL_ACCESS
-        state = NewRelic::Agent::Tracer.state
-        return yield unless state.is_execution_traced?
+        return yield unless NewRelic::Agent::Tracer.state.is_execution_traced?
 
         metric_names = Array(metric_names)
         first_name = metric_names.shift
@@ -77,7 +76,7 @@ module NewRelic
         name = Regexp.last_match(1) if object.to_s =~ /^#<Class:(.*)>$/
         return name if name
 
-        raise "Unable to glean a class name from string '#{object}'" unless name
+        raise "Unable to glean a class name from string '#{object}'"
       end
 
       # get at the underlying class from the singleton class

--- a/test/new_relic/agent/method_tracer_helpers_test.rb
+++ b/test/new_relic/agent/method_tracer_helpers_test.rb
@@ -2,7 +2,7 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
-require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', 'test_helper'))
+require_relative '../../test_helper'
 
 module ::The
   class Example
@@ -14,7 +14,23 @@ module ::The
 end
 
 class NewRelic::Agent::MethodTracerHelpersTest < Minitest::Test
-  # TODO: trace_execution_scoped should have test coverage
+  # No assert here. This test helps increase branch coverage.
+  def test_trace_execution_scoped_not_traced
+    in_transaction do
+      self.class.trace_execution_scoped('chocolate latte') do
+        NewRelic::Agent::Tracer.state.untraced << false
+      end
+    end
+  end
+
+  # No assert here. This test helps increase branch coverage.
+  def test_trace_execution_scoped_no_segment
+    in_transaction do
+      NewRelic::Agent::Tracer.stub(:start_segment, nil) do
+        NewRelic::Agent::MethodTracerHelpers.trace_execution_scoped('meowmix') { 'yummy' }
+      end
+    end
+  end
 
   def test_obtains_a_class_name_from_a_singleton_class_string
     with_config(:'code_level_metrics.enabled' => true) do


### PR DESCRIPTION
The method `NewRelic::Agent::MethodTracerHelpers#trace_execution_scoped` appeared to have no test coverage in its corresponding test file, `method_tracer_helpers_test.rb`. 

However, Simplecov shows nearly complete coverage of this method by calling its caller, `NewRelic::Agent::MethodTracer#trace_execution_scoped`, coverage for which exists in `method_tracer_test.rb`.

We've increased branch coverage on this method by adding two additional tests. This commit also adds a minor code cleanup for `NewRelic::Agent::MethodTracer#klass_name`.

Closes #1430.

