### PR TITLE
Remove # from end of release notes title

### DIFF
--- a/test/new_relic/latest_changes_test.rb
+++ b/test/new_relic/latest_changes_test.rb
@@ -9,7 +9,7 @@ module NewRelic
     def test_read_default_changelog
       result = NewRelic::LatestChanges.read
 
-      assert_match(/# New Relic Ruby Agent Release Notes #/, result)
+      assert_match(/# New Relic Ruby Agent Release Notes/, result)
       assert_match(/## v\d\.\d{1,2}\.\d{1,2}/, result)
     end
 


### PR DESCRIPTION
PR #1679 removed the # from the end of the title. This fixes the test to match the new title format
