### PR TITLE
CI: fix redis-rb instrumentation test

### DIFF
--- a/test/multiverse/suites/redis/redis_instrumentation_test.rb
+++ b/test/multiverse/suites/redis/redis_instrumentation_test.rb
@@ -452,7 +452,7 @@ if NewRelic::Agent::Datastores::Redis.is_supported_version?
 
       Object.stub_const :RedisClient, nil do
         client.stub :with_tracing, with_tracing_validator do
-          client.call_pipelined_with_tracing([]) { yield_value }
+          client.call_pipelined_with_tracing([]) { 'His key to the locks on the chains he saw everywhere' }
         end
       end
     end


### PR DESCRIPTION
A redis-rb instrumentation update for v8.14.0 was initially going to perform an early yield but was later changed to not have to. The corresponding test needs to be updated to no longer refer to a now missing yield related variable.