### PR TITLE
Update test and test case 'vendors' key

### DIFF
--- a/test/fixtures/cross_agent_tests/distributed_tracing/trace_context.json
+++ b/test/fixtures/cross_agent_tests/distributed_tracing/trace_context.json
@@ -1311,7 +1311,7 @@
           "tracestate.sampled",
           "tracestate.priority"
         ],
-        "vendors": [
+        "tracingVendors": [
           "foo",
           "bar"
         ]
@@ -1476,7 +1476,7 @@
           "tracestate.sampled",
           "tracestate.priority"
         ],
-        "vendors": [
+        "tracingVendors": [
         ]
       }
     ],
@@ -1559,7 +1559,7 @@
           "tracestate.parent_application_id",
           "tracestate.timestamp"
         ],
-        "vendors": [
+        "tracingVendors": [
           "44@nr"
         ]
       }

--- a/test/new_relic/agent/distributed_tracing/trace_context_cross_agent_test.rb
+++ b/test/new_relic/agent/distributed_tracing/trace_context_cross_agent_test.rb
@@ -258,6 +258,7 @@ module NewRelic
 
           if test_case_attributes.key?(test_key)
             vendors = Array(test_case_attributes[test_key]).join(',')
+
             assert_equal vendors, actual_attributes[actual_key],
               %Q(Wrong "#{test_key}" #{event_type} attribute; expected #{vendors}, was #{actual_attributes[actual_key]})
           end

--- a/test/new_relic/agent/distributed_tracing/trace_context_cross_agent_test.rb
+++ b/test/new_relic/agent/distributed_tracing/trace_context_cross_agent_test.rb
@@ -231,15 +231,15 @@ module NewRelic
 
           (test_case_attributes['exact'] || []).each do |k, v|
             assert_equal v,
-              actual_attributes[k.to_s],
-              %Q(Wrong "#{k}" #{event_type} attribute; expected #{v.inspect}, was #{actual_attributes[k.to_s].inspect})
+              actual_attributes[k],
+              %Q(Wrong "#{k}" #{event_type} attribute; expected #{v}, was #{actual_attributes[k]})
           end
 
           (test_case_attributes['notequal'] || []).each do |k, v|
             refute_equal(
               v,
-              actual_attributes[k.to_s],
-              "#{event_type} #{k.to_s.inspect} attribute should not equal #{v.inspect}"
+              actual_attributes[k],
+              "#{event_type} #{k} attribute should not equal #{v}"
             )
           end
 
@@ -253,10 +253,13 @@ module NewRelic
               %Q(Unexpected #{event_type} attribute "#{key}")
           end
 
-          (test_case_attributes['vendors'] || []).each do |k, v|
-            assert_equal v,
-              actual_attributes[k.to_s],
-              %Q(Wrong "#{k}" #{event_type} attribute; expected #{v.inspect}, was #{actual_attributes[k.to_s].inspect})
+          test_key = 'tracingVendors'
+          actual_key = "tracestate.#{test_key}"
+
+          if test_case_attributes.key?(test_key)
+            vendors = Array(test_case_attributes[test_key]).join(',')
+            assert_equal vendors, actual_attributes[actual_key],
+              %Q(Wrong "#{test_key}" #{event_type} attribute; expected #{vendors}, was #{actual_attributes[actual_key]})
           end
         end
 
@@ -350,6 +353,7 @@ module NewRelic
             tracestate['sampled'] = tracestate_values[6]
             tracestate['priority'] = tracestate_values[7].chomp("0")
             tracestate['timestamp'] = tracestate_values[8]
+            tracestate['tracingVendors'] = header_data.trace_state_vendors
           else
             tracestate = nil
           end


### PR DESCRIPTION
The trace_context test cases received through cross-agent testing are out of spec according to W3C header naming convention, which these tests should follow. `vendors` should be `tracingVendors`. This update has been made.

To resolve the TODO of testing `vendors` (aka `tracingVendors`), a new test reaches into `header_data` (vs `tracestate` where other similar tests are pulling in data). For testing purposes, `header_data.trace_state_vendors` was added to the `actual_attributes` hash that we are testing.

closes #1434 
