### PR TITLE
update newrelic.yml with defer_rails_initialization parameter

### DIFF
--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -1857,7 +1857,7 @@ If `true`, disables agent middleware for Sinatra. This middleware is responsible
           :type => Boolean,
           :allowed_from_server => false,
           :description => 'If `true`, when the agent is in an application using Ruby on Rails, it will start after ' \
-            'config/initializers are run.'
+            'config/initializers have run.'
         },
         # Rake
         :'rake.tasks' => {

--- a/newrelic.yml
+++ b/newrelic.yml
@@ -162,6 +162,10 @@ common: &default_settings
   # or  port_path_or_id parameters to transaction or slow SQL traces.
   # datastore_tracer.instance_reporting.enabled: true
 
+  # If true, when the agent is in an application using Ruby on Rails, it will start after
+  # config/initializers have run.
+  # defer_rails_initialization: false
+
   # If true, disables Action Cable instrumentation.
   # disable_action_cable_instrumentation: false
 


### PR DESCRIPTION
* update `newrelic.yml` with `defer_rails_initialization` parameter
* update `default_source.rb` to backport the "have run" grammar change that was made to the CHANGELOG for this config parameter