### PR TITLE
Remove defer_rails_initialization config

### DIFF
--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -1850,15 +1850,6 @@ If `true`, disables agent middleware for Sinatra. This middleware is responsible
           :allowed_from_server => false,
           :description => 'Specify a custom host name for [display in the New Relic UI](/docs/apm/new-relic-apm/maintenance/add-rename-remove-hosts#display_name).'
         },
-        # Rails
-        :'defer_rails_initialization' => {
-          :default => false,
-          :public => true,
-          :type => Boolean,
-          :allowed_from_server => false,
-          :description => 'If `true`, when the agent is in an application using Ruby on Rails, it will start after ' \
-            'config/initializers have run.'
-        },
         # Rake
         :'rake.tasks' => {
           :default => [],

--- a/lib/new_relic/control/instance_methods.rb
+++ b/lib/new_relic/control/instance_methods.rb
@@ -65,7 +65,7 @@ module NewRelic
         # An artifact of earlier implementation, we put both #add_method_tracer and #trace_execution
         # methods in the module methods.
         # Rails applications load the next two lines before any other initializers are run
-        unless defined?(Rails::VERSION) && NewRelic::Agent.config[:defer_rails_initialization]
+        unless defined?(Rails::VERSION)
           Module.send(:include, NewRelic::Agent::MethodTracer::ClassMethods)
           Module.send(:include, NewRelic::Agent::MethodTracer)
         end

--- a/lib/newrelic_rpm.rb
+++ b/lib/newrelic_rpm.rb
@@ -20,19 +20,13 @@ require 'new_relic/control'
 if defined?(Rails::VERSION)
   module NewRelic
     class Railtie < Rails::Railtie
-      if NewRelic::Agent.config[:defer_rails_initialization]
-        initializer "newrelic_rpm.include_method_tracers", before: :load_config_initializers do |app|
-          Module.send(:include, NewRelic::Agent::MethodTracer::ClassMethods)
-          Module.send(:include, NewRelic::Agent::MethodTracer)
-        end
+      initializer "newrelic_rpm.include_method_tracers", before: :load_config_initializers do |app|
+        Module.send(:include, NewRelic::Agent::MethodTracer::ClassMethods)
+        Module.send(:include, NewRelic::Agent::MethodTracer)
+      end
 
-        initializer "newrelic_rpm.start_plugin", after: :load_config_initializers do |app|
-          NewRelic::Control.instance.init_plugin(config: app.config)
-        end
-      else
-        initializer "newrelic_rpm.start_plugin", before: :load_config_initializers do |app|
-          NewRelic::Control.instance.init_plugin(config: app.config)
-        end
+      initializer "newrelic_rpm.start_plugin", after: :load_config_initializers do |app|
+        NewRelic::Control.instance.init_plugin(config: app.config)
       end
     end
   end

--- a/newrelic.yml
+++ b/newrelic.yml
@@ -162,10 +162,6 @@ common: &default_settings
   # or  port_path_or_id parameters to transaction or slow SQL traces.
   # datastore_tracer.instance_reporting.enabled: true
 
-  # If true, when the agent is in an application using Ruby on Rails, it will start after
-  # config/initializers have run.
-  # defer_rails_initialization: false
-
   # If true, disables Action Cable instrumentation.
   # disable_action_cable_instrumentation: false
 

--- a/test/new_relic/newrelic_rpm_test.rb
+++ b/test/new_relic/newrelic_rpm_test.rb
@@ -5,37 +5,22 @@
 require_relative '../test_helper'
 
 class NewRelicRpmTest < Minitest::Test
+  RAILS_32_SKIP_MESSAGE = 'MySQL error for Rails 3.2 when we add an initializer to config/initializers'
   # This test examines the behavior of an initializer when the agent is started in a Rails context
   # The initializer used for these tests is defined in test/environments/*/config/inititalizers/test.rb
 
   # We have documentation recommending customers call add_method_tracer
   # in their initializers, let's make sure this works
-  def test_add_method_tracer_in_initializer_gets_traced_when_agent_initialized_before_config_initializers
-    skip unless defined?(Rails::VERSION)
-    skip 'MySQL error for Rails 3.2' if Rails::VERSION::MAJOR == 3
-
-    with_config(defer_rails_initialization: false) do
-      assert Bloodhound.newrelic_method_exists?('sniff'),
-        'Bloodhound#sniff not found by' \
-        'NewRelic::Agent::MethodTracer::ClassMethods::AddMethodTracer.newrelic_method_exists?'
-      assert Bloodhound.method_traced?('sniff'),
-        'Bloodhound#sniff not found by' \
-        'NewRelic::Agent::MethodTracer::ClassMethods::AddMethodTracer.method_traced?'
-    end
-  end
-
   def test_add_method_tracer_in_initializer_gets_traced_when_agent_initialized_after_config_initializers
     skip unless defined?(Rails::VERSION)
-    skip 'MySQL error for Rails 3.2 if we define an initializer in config/initializers' if Rails::VERSION::MAJOR == 3
+    skip RAILS_32_SKIP_MESSAGE if Rails::VERSION::MAJOR == 3
 
-    with_config(defer_rails_initialization: true) do
-      assert Bloodhound.newrelic_method_exists?('sniff'),
-        'Bloodhound#sniff not found by' \
-        'NewRelic::Agent::MethodTracer::ClassMethods::AddMethodTracer.newrelic_method_exists?'
-      assert Bloodhound.method_traced?('sniff'),
-        'Bloodhound#sniff not found by' \
-        'NewRelic::Agent::MethodTracer::ClassMethods::AddMethodTracer.method_traced?'
-    end
+    assert Bloodhound.newrelic_method_exists?('sniff'),
+      'Bloodhound#sniff not found by' \
+      'NewRelic::Agent::MethodTracer::ClassMethods::AddMethodTracer.newrelic_method_exists?'
+    assert Bloodhound.method_traced?('sniff'),
+      'Bloodhound#sniff not found by' \
+      'NewRelic::Agent::MethodTracer::ClassMethods::AddMethodTracer.method_traced?'
   end
 
   # All supported Rails versions have the default value for
@@ -46,40 +31,18 @@ class NewRelicRpmTest < Minitest::Test
     skip unless defined?(Rails::VERSION)
     # TODO: This test passes in a Rails console in a playground app and in the customer's environment
     # but fails in this unit test context
-    skip if Gem::Version.new(NewRelic::VERSION::STRING) >= Gem::Version.new('8.13.0')
-    skip 'MySQL error for Rails 3.2' if Rails::VERSION::MAJOR == 3
+    skip RAILS_32_SKIP_MESSAGE if Rails::VERSION::MAJOR == 3
 
-    with_config(defer_rails_initialization: true) do
-      # Verify the configuration value was set to the initializer value
-      refute Rails.application.config.active_record.timestamped_migrations,
-        "Rails.application.config.active_record.timestamped_migrations equals true, expected false"
+    # Verify the configuration value was set to the initializer value
+    refute Rails.application.config.active_record.timestamped_migrations,
+      "Rails.application.config.active_record.timestamped_migrations equals true, expected false"
 
-      # Verify the configuration value was applied to the ActiveRecord class variable
-      if Gem::Version.new(Rails::VERSION::STRING) >= Gem::Version.new('7.1')
-        refute ActiveRecord.timestamped_migrations, "ActiveRecord.timestamped_migrations equals true, expected false"
-      else
-        refute ActiveRecord::Base.timestamped_migrations,
-          "ActiveRecord::Base.timestamped_migrations equals true, expected false"
-      end
-    end
-  end
-
-  def test_active_record_initializer_config_change_not_saved_when_agent_initialized_before_config_initializers
-    skip unless defined?(Rails::VERSION)
-    skip 'MySQL error for Rails 3.2' if Rails::VERSION::MAJOR == 3
-
-    with_config(defer_rails_initialization: false) do
-      # Verify the configuration value was set to the initializer value
-      refute Rails.application.config.active_record.timestamped_migrations,
-        "Rails.application.config.active_record.timestamped_migrations equals true, expected false"
-
-      # Rails.application.config value should not be applied (this is the state of the original bug)
-      if Gem::Version.new(Rails::VERSION::STRING) >= Gem::Version.new('7.1')
-        assert ActiveRecord.timestamped_migrations, "ActiveRecord.timestamped_migrations equals false, expected true"
-      else
-        assert ActiveRecord::Base.timestamped_migrations,
-          "ActiveRecord::Base.timestamped_migrations equals false, expected true"
-      end
+    # Verify the configuration value was applied to the ActiveRecord class variable
+    if Gem::Version.new(Rails::VERSION::STRING) >= Gem::Version.new('7.1')
+      refute ActiveRecord.timestamped_migrations, "ActiveRecord.timestamped_migrations equals true, expected false"
+    else
+      refute ActiveRecord::Base.timestamped_migrations,
+        "ActiveRecord::Base.timestamped_migrations equals true, expected false"
     end
   end
 end


### PR DESCRIPTION
# Overview

Configs are loaded during initialization. This fix was placed behind a feature flag referencing the config value, but that value will always be falsey at initialization, so the fix was unreachable.

This change will always use the new, split initialization process.

Closes: #662 

Submitter Checklist:
- [ ] Include a link to the related GitHub issue, if applicable
- [ ] Include a security review link, if applicable

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
GitHub Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
