### PR TITLE
CI: test Padrino with both Sinatra 2 and 3

### DIFF
--- a/test/multiverse/suites/padrino/Envfile
+++ b/test/multiverse/suites/padrino/Envfile
@@ -4,10 +4,20 @@
 
 instrumentation_methods :chain, :prepend
 
-# TODO: sinatra 3's CALLERS_TO_IGNORE array is frozen, causes issues
+# Sinatra 3+
+gemfile <<-RB
+  gem 'activesupport'
+  gem 'padrino'
+  gem 'rack-test'
+  gem 'sinatra'
+  gem 'webrick' if RUBY_VERSION >= '2.7.0'
+  gem 'date', '>= 3.3.3' # for padrino-mailer's mail dependency
+RB
+
+# Sinatra <3
 gemfile <<-RB
   gem 'activesupport', '~> 3'
-  gem 'padrino', '~> 0.15.1'
+  gem 'padrino', '0.15.1'
   gem 'rack-test', '>= 0.8.0', :require => 'rack/test'
   gem 'sinatra', '< 3'
   gem 'webrick' if RUBY_VERSION >= '2.7.0'

--- a/test/multiverse/suites/padrino/Envfile
+++ b/test/multiverse/suites/padrino/Envfile
@@ -11,7 +11,6 @@ gemfile <<-RB
   gem 'rack-test'
   gem 'sinatra'
   gem 'webrick' if RUBY_VERSION >= '2.7.0'
-  gem 'date', '>= 3.3.3' # for padrino-mailer's mail dependency
 RB
 
 # Sinatra <3


### PR DESCRIPTION
Now that Padrino 0.15.2 is out with support for Sinatra 3, let's test Padrino with both Sinatra 2 and 3.

thanks, @nesquena