### PR TITLE
Update new rubocop-minitest failures and rubygems version issues

### DIFF
--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -389,7 +389,7 @@ jobs:
         uses: nick-invision/retry@v1.0.0
         with:
           timeout_minutes: 60
-          max_attempts: 1
+          max_attempts: 2
           command:  jruby -v; bundle exec rake test:multiverse[group=${{ matrix.multiverse }},verbose]
         env:
           DB_PORT: ${{ job.services.mysql.ports[3306] }}

--- a/.github/workflows/scripts/setup_bundler
+++ b/.github/workflows/scripts/setup_bundler
@@ -33,14 +33,9 @@ function update_to_desired_rubygems_version {
     gem install rubygems-update:2.7.11
     echo "DEBUG: running 'rubygems-update'"
     update_rubygems
-  elif [[ $RUBY_VERSION =~ 2.[3456] ]]; then
+  elif [[ $RUBY_VERSION =~ 2.[^7] ]]; then
     echo "DEBUG: running 'gem update --system 3.0.6 --force'"
     gem update --system 3.0.6 --force >/dev/null
-  # elif [[ $RUBY_VERSION = "2.6.10" ]]; then
-    # Rails 4 still runs on 2.6 which requires bundler 1.17 
-    # rubygems > 3.1.6 forces bundler 2 to be default which breaks rails 4
-    # echo "DEBUG: running 'gem update --system 3.1.6 --force'"
-    # gem update --system 3.1.6 --force >/dev/null
   else
     echo "DEBUG: running 'gem update --system 3.4.1 --force'"
     gem update --system 3.4.1 --force >/dev/null
@@ -110,11 +105,6 @@ function set_up_bundler {
     echo "DEBUG: Skipping Bundler setup, as JRuby is in use"
     return
   fi
-
-  # if ! using_old_rails && ! using_old_ruby; then
-  #   echo "DEBUG: Skipping Bundler setup, as neither an old Rails or Ruby version is in use"
-  #   return
-  # fi
 
   update_to_desired_rubygems_version
   install_desired_bundler_version

--- a/.github/workflows/scripts/setup_bundler
+++ b/.github/workflows/scripts/setup_bundler
@@ -33,9 +33,10 @@ function update_to_desired_rubygems_version {
     gem install rubygems-update:2.7.11
     echo "DEBUG: running 'rubygems-update'"
     update_rubygems
+  elif [[ $RUBY_VERSION =~ 2.[345] ]]; then
+    gem update --system 3.0.6 --force
   else
     echo "DEBUG: running 'gem update --system --force'"
-    # gem update --system 3.0.6 --force
     gem update --system --force
   fi
 }

--- a/.github/workflows/scripts/setup_bundler
+++ b/.github/workflows/scripts/setup_bundler
@@ -33,10 +33,15 @@ function update_to_desired_rubygems_version {
     gem install rubygems-update:2.7.11
     echo "DEBUG: running 'rubygems-update'"
     update_rubygems
-  # elif [[ $RUBY_VERSION =~ 2.[345] ]]; then
+  elif [[ $RUBY_VERSION =~ 2.[345] ]]; then
+    gem update --system 3.0.6 --force
+  elif [[$RUBY_VERSION =~ 2.[6]]]; then
+    gem update --system 3.1.6 --force
   else
     echo "DEBUG: running 'gem update --system --force'"
-    gem update --system 3.0.6 --force
+    gem update --system 3.4.1 --force
+    # gem update --system 3.1.6 --force
+    # 3.4.1
   # else
     # gem update --system --force
   fi

--- a/.github/workflows/scripts/setup_bundler
+++ b/.github/workflows/scripts/setup_bundler
@@ -34,17 +34,18 @@ function update_to_desired_rubygems_version {
     echo "DEBUG: running 'rubygems-update'"
     update_rubygems
   elif [[ $RUBY_VERSION =~ 2.[345] ]]; then
+    echo "DEBUG: running 'gem update --system 3.0.6 --force'"
     gem update --system 3.0.6 --force
   elif [[$RUBY_VERSION =~ 2.[6]]]; then
+    echo "DEBUG: running 'gem update --system 3.1.6 --force'"
     gem update --system 3.1.6 --force
   else
-    echo "DEBUG: running 'gem update --system --force'"
+    echo "DEBUG: running 'gem update --system 3.4.1 --force'"
     gem update --system 3.4.1 --force
-    # gem update --system 3.1.6 --force
-    # 3.4.1
-  # else
-    # gem update --system --force
   fi
+  echo "Rubygems version installed: "
+  gem --version
+  echo "---------------------------"
 }
 
 function install_desired_bundler_version {

--- a/.github/workflows/scripts/setup_bundler
+++ b/.github/workflows/scripts/setup_bundler
@@ -33,17 +33,17 @@ function update_to_desired_rubygems_version {
     gem install rubygems-update:2.7.11
     echo "DEBUG: running 'rubygems-update'"
     update_rubygems
-  elif [[ $RUBY_VERSION =~ 2.[345] ]]; then
+  elif [[ $RUBY_VERSION =~ 2.[3456] ]]; then
     echo "DEBUG: running 'gem update --system 3.0.6 --force'"
-    gem update --system 3.0.6 --force
-  elif [[ $RUBY_VERSION = "2.6.10" ]]; then
+    gem update --system 3.0.6 --force >/dev/null
+  # elif [[ $RUBY_VERSION = "2.6.10" ]]; then
     # Rails 4 still runs on 2.6 which requires bundler 1.17 
     # rubygems > 3.1.6 forces bundler 2 to be default which breaks rails 4
-    echo "DEBUG: running 'gem update --system 3.1.6 --force'"
-    gem update --system 3.1.6 --force --silent
+    # echo "DEBUG: running 'gem update --system 3.1.6 --force'"
+    # gem update --system 3.1.6 --force >/dev/null
   else
     echo "DEBUG: running 'gem update --system 3.4.1 --force'"
-    gem update --system 3.4.1 --force --silent
+    gem update --system 3.4.1 --force >/dev/null
   fi
   echo "DEBUG: Rubygems version installed: $(gem --version)"
 }

--- a/.github/workflows/scripts/setup_bundler
+++ b/.github/workflows/scripts/setup_bundler
@@ -35,7 +35,8 @@ function update_to_desired_rubygems_version {
     update_rubygems
   else
     echo "DEBUG: running 'gem update --system --force'"
-    gem update --system 3.0.6 --force
+    # gem update --system 3.0.6 --force
+    gem update --system --force
   fi
 }
 

--- a/.github/workflows/scripts/setup_bundler
+++ b/.github/workflows/scripts/setup_bundler
@@ -35,7 +35,7 @@ function update_to_desired_rubygems_version {
     update_rubygems
   elif [[ $RUBY_VERSION =~ 2.[345] ]]; then
     echo "DEBUG: running 'gem update --system 3.0.6 --force'"
-    gem update --system 3.0.6 --force --silent
+    gem update --system 3.0.6 --force
   elif [[ $RUBY_VERSION = "2.6.10" ]]; then
     # Rails 4 still runs on 2.6 which requires bundler 1.17 
     # rubygems > 3.1.6 forces bundler 2 to be default which breaks rails 4
@@ -111,10 +111,10 @@ function set_up_bundler {
     return
   fi
 
-  if ! using_old_rails && ! using_old_ruby; then
-    echo "DEBUG: Skipping Bundler setup, as neither an old Rails or Ruby version is in use"
-    return
-  fi
+  # if ! using_old_rails && ! using_old_ruby; then
+  #   echo "DEBUG: Skipping Bundler setup, as neither an old Rails or Ruby version is in use"
+  #   return
+  # fi
 
   update_to_desired_rubygems_version
   install_desired_bundler_version

--- a/.github/workflows/scripts/setup_bundler
+++ b/.github/workflows/scripts/setup_bundler
@@ -33,11 +33,12 @@ function update_to_desired_rubygems_version {
     gem install rubygems-update:2.7.11
     echo "DEBUG: running 'rubygems-update'"
     update_rubygems
-  elif [[ $RUBY_VERSION =~ 2.[345] ]]; then
-    gem update --system 3.0.6 --force
+  # elif [[ $RUBY_VERSION =~ 2.[345] ]]; then
   else
     echo "DEBUG: running 'gem update --system --force'"
-    gem update --system --force
+    gem update --system 3.0.6 --force
+  # else
+    # gem update --system --force
   fi
 }
 

--- a/.github/workflows/scripts/setup_bundler
+++ b/.github/workflows/scripts/setup_bundler
@@ -35,13 +35,15 @@ function update_to_desired_rubygems_version {
     update_rubygems
   elif [[ $RUBY_VERSION =~ 2.[345] ]]; then
     echo "DEBUG: running 'gem update --system 3.0.6 --force'"
-    gem update --system 3.0.6 --force
-  elif [[$RUBY_VERSION =~ 2.[6]]]; then
+    gem update --system 3.0.6 --force --silent
+  elif [[ $RUBY_VERSION = "2.6.10" ]]; then
+    # Rails 4 still runs on 2.6 which requires bundler 1.17 
+    # rubygems > 3.1.6 forces bundler 2 to be default which breaks rails 4
     echo "DEBUG: running 'gem update --system 3.1.6 --force'"
-    gem update --system 3.1.6 --force
+    gem update --system 3.1.6 --force --silent
   else
     echo "DEBUG: running 'gem update --system 3.4.1 --force'"
-    gem update --system 3.4.1 --force
+    gem update --system 3.4.1 --force --silent
   fi
   echo "Rubygems version installed: "
   gem --version

--- a/.github/workflows/scripts/setup_bundler
+++ b/.github/workflows/scripts/setup_bundler
@@ -45,9 +45,7 @@ function update_to_desired_rubygems_version {
     echo "DEBUG: running 'gem update --system 3.4.1 --force'"
     gem update --system 3.4.1 --force --silent
   fi
-  echo "Rubygems version installed: "
-  gem --version
-  echo "---------------------------"
+  echo "DEBUG: Rubygems version installed: $(gem --version)"
 }
 
 function install_desired_bundler_version {

--- a/test/agent_helper.rb
+++ b/test/agent_helper.rb
@@ -31,7 +31,7 @@ def fake_guid(length = 16)
 end
 
 def assert_between(floor, ceiling, value, message = "expected #{floor} <= #{value} <= #{ceiling}")
-  assert((floor <= value && value <= ceiling), message) # rubocop:disable Minitest/AssertWithExpectedArgument
+  assert((floor <= value && value <= ceiling), message)
 end
 
 def assert_in_delta(expected, actual, delta)
@@ -236,7 +236,7 @@ def assert_metrics_recorded(expected)
       msg += "\nDid find specs: [\n#{matches.join(",\n")}\n]" unless matches.empty?
       msg += "\nAll specs in there were: #{format_metric_spec_list(all_specs)}"
 
-      assert(actual_stats, msg) # rubocop:disable Minitest/AssertWithExpectedArgument
+      assert(actual_stats, msg)
     end
 
     assert_stats_has_values(actual_stats, expected_spec, expected_attrs)

--- a/test/multiverse/suites/sidekiq/sidekiq_instrumentation_test.rb
+++ b/test/multiverse/suites/sidekiq/sidekiq_instrumentation_test.rb
@@ -201,7 +201,7 @@ class SidekiqTest < Minitest::Test
     metric = metrics.find { |m| m[0]['name'] == name }
     message = "Could not find metric named #{name}. Did have metrics:\n" + metrics.map { |m| m[0]['name'] }.join("\t\n")
 
-    assert(metric, message) # rubocop:disable Minitest/AssertWithExpectedArgument
+    assert(metric, message)
 
     call_count = metric[1][0]
 

--- a/test/new_relic/agent/distributed_tracing/distributed_tracing_cross_agent_test.rb
+++ b/test/new_relic/agent/distributed_tracing/distributed_tracing_cross_agent_test.rb
@@ -171,7 +171,7 @@ module NewRelic::Agent
         (test_case_attributes['expected'] || []).each do |key|
           msg = %Q(Missing expected #{event_type} attribute "#{key}")
 
-          assert actual_attributes.has_key?(key), msg # rubocop:disable Minitest/AssertWithExpectedArgument
+          assert actual_attributes.has_key?(key), msg
         end
 
         (test_case_attributes['unexpected'] || []).each do |key|


### PR DESCRIPTION
This PR fixes the new rubocop-minitest failures and fixes new failures related to the rubygems version.