### PR TITLE
Use Node 16 GitHub Actions

### DIFF
--- a/.github/actions/annotate/action.yml
+++ b/.github/actions/annotate/action.yml
@@ -2,5 +2,5 @@ name: 'Annotate Errors'
 description: 'Annotates errors if an errors.txt file is present'
 author: New Relic
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'

--- a/.github/actions/simplecov-report/action.yml
+++ b/.github/actions/simplecov-report/action.yml
@@ -21,5 +21,5 @@ inputs:
     description: "GitHub token"
     required: true
 runs:
-  using: "node12"
+  using: "node16"
   main: "dist/index.js"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
       - if: matrix.ruby-version == '2.2.10' || matrix.ruby-version == 'jruby-9.3.9.0'
         name: Cache mysql55
         id: mysql55-cache
-        uses: john-shaffer/cache@sudo-tar
+        uses: actions/cache@v3.2.2
         with:
           path: /usr/local/mysql55
           key: mysql55-install
@@ -82,7 +82,7 @@ jobs:
           RUBY_VERSION: ${{ matrix.ruby-version }}
           RAILS_VERSION: ${{ env.rails }}
       - name: Run Unit Tests
-        uses: nick-invision/retry@v1.0.0
+        uses: nick-fields/retry@v2.8.2
         with:
           timeout_minutes: 30
           max_attempts: 2
@@ -200,7 +200,7 @@ jobs:
       - if: matrix.ruby-version == '2.2.10' || matrix.ruby-version == '2.3.8'
         name: Cache mysql55
         id: mysql55-cache
-        uses: john-shaffer/cache@sudo-tar
+        uses: actions/cache@v3.2.2
         with:
           path: /usr/local/mysql55
           key: mysql55-install
@@ -218,7 +218,7 @@ jobs:
         run: mysql --host 127.0.0.1 --port ${{ job.services.mysql.ports[3306] }} -uroot -proot -e "SHOW GRANTS FOR 'root'@'localhost'"
 
       - name: Run Multiverse Tests
-        uses: nick-invision/retry@v1.0.0
+        uses: nick-fields/retry@v2.8.2
         with:
           timeout_minutes: 60
           max_attempts: 2
@@ -266,7 +266,7 @@ jobs:
         run: bundle install
 
       - name: Run Multiverse Tests
-        uses: nick-invision/retry@v1.0.0
+        uses: nick-fields/retry@v2.8.2
         with:
           timeout_minutes: 15
           max_attempts: 2
@@ -401,7 +401,7 @@ jobs:
           JAVA_HOME: /usr/lib/jvm/temurin-8-jdk-amd64
 
       - name: Run Multiverse Tests
-        uses: nick-invision/retry@v1.0.0
+        uses: nick-fields/retry@v2.8.2
         with:
           timeout_minutes: 60
           max_attempts: 1

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -94,7 +94,7 @@ jobs:
       - if: matrix.ruby-version == '2.2.10' || matrix.ruby-version == '2.3.8' || matrix.ruby-version == '2.4.10' || matrix.ruby-version == '2.5.9' || matrix.ruby-version == '2.6.10'
         name: Cache mysql55
         id: mysql55-cache
-        uses: john-shaffer/cache@sudo-tar
+        uses: actions/cache@v3.2.2
         with:
           path: /usr/local/mysql55
           key: mysql55-install
@@ -110,7 +110,7 @@ jobs:
           RAILS_VERSION: ${{ env.rails }}
 
       - name: Run Unit Tests
-        uses: nick-invision/retry@v1.0.0
+        uses: nick-fields/retry@v2.8.2
         with:
           timeout_minutes: 30
           max_attempts: 2
@@ -219,7 +219,7 @@ jobs:
       - if: matrix.ruby-version == '2.2.10' || matrix.ruby-version == '2.3.8'
         name: Cache mysql55
         id: mysql55-cache
-        uses: john-shaffer/cache@sudo-tar
+        uses: actions/cache@v3.2.2
         with:
           path: /usr/local/mysql55
           key: mysql55-install
@@ -237,7 +237,7 @@ jobs:
         run: mysql --host 127.0.0.1 --port ${{ job.services.mysql.ports[3306] }} -uroot -proot -e "SHOW GRANTS FOR 'root'@'localhost'"
 
       - name: Run Multiverse Tests
-        uses: nick-invision/retry@v1.0.0
+        uses: nick-fields/retry@v2.8.2
         with:
           timeout_minutes: 60
           max_attempts: 2
@@ -276,7 +276,7 @@ jobs:
         run: bundle install
 
       - name: Run Multiverse Tests
-        uses: nick-invision/retry@v1.0.0
+        uses: nick-fields/retry@v2.8.2
         with:
           timeout_minutes: 15
           max_attempts: 2
@@ -386,7 +386,7 @@ jobs:
           JAVA_HOME: /usr/lib/jvm/temurin-8-jdk-amd64
 
       - name: Run Multiverse Tests
-        uses: nick-invision/retry@v1.0.0
+        uses: nick-fields/retry@v2.8.2
         with:
           timeout_minutes: 60
           max_attempts: 2


### PR DESCRIPTION
Node 12 is deprecated for GitHub Actions and Node 16+ is required. This PR upgrades actions from the marketplace that have been identified by GitHub as running on Node 12 to newer versions. It also updates our self-written actions to use Node 16.

Actions run with deprecation warnings: https://github.com/newrelic/newrelic-ruby-agent/actions/runs/3795916450 

One issue I'm seeing in the output with this change is a warning related to caching mysql: "Failed to restore: Tar failed with error: The process '/usr/bin/tar' failed with exit code 2" 

I believe this is because it's running for the first time, so there isn't a cache to restore. We should keep an eye on this when the PR is merged.