### PR TITLE
Fix new Rubocop linters

### DIFF
--- a/lib/new_relic/agent/agent_helpers/connect.rb
+++ b/lib/new_relic/agent/agent_helpers/connect.rb
@@ -128,7 +128,7 @@ module NewRelic
 
         # apdex_f is always 4 times the apdex_t
         def apdex_f
-          (4 * Agent.config[:apdex_t]).to_f
+          (Agent.config[:apdex_t] * 4).to_f
         end
 
         class WaitOnConnectTimeout < StandardError

--- a/lib/new_relic/agent/event_loop.rb
+++ b/lib/new_relic/agent/event_loop.rb
@@ -83,7 +83,7 @@ module NewRelic
         return nil if @timers.empty?
 
         timeout = @timers.values.map(&:next_fire_time).min - Process.clock_gettime(Process::CLOCK_REALTIME)
-        timeout < 0 ? 0 : timeout
+        [timeout, 0].max
       end
 
       def stopped?

--- a/lib/new_relic/agent/heap.rb
+++ b/lib/new_relic/agent/heap.rb
@@ -94,7 +94,7 @@ module NewRelic
       end
 
       def left_child_index_for(parent_index)
-        2 * parent_index + 1
+        parent_index * 2 + 1
       end
 
       def right_sibling_smaller?(lchild_index)

--- a/lib/new_relic/agent/javascript_instrumentor.rb
+++ b/lib/new_relic/agent/javascript_instrumentor.rb
@@ -141,8 +141,8 @@ module NewRelic
         start_time_in_seconds = [transaction.start_time, 0.0].max
         app_time_in_seconds = Process.clock_gettime(Process::CLOCK_REALTIME) - start_time_in_seconds
 
-        queue_time_in_millis = (1000.0 * queue_time_in_seconds).round
-        app_time_in_millis = (1000.0 * app_time_in_seconds).round
+        queue_time_in_millis = (queue_time_in_seconds * 1000.0).round
+        app_time_in_millis = (app_time_in_seconds * 1000.0).round
 
         transaction_name = transaction.best_name || ::NewRelic::Agent::UNKNOWN_METRIC
 

--- a/lib/new_relic/agent/range_extensions.rb
+++ b/lib/new_relic/agent/range_extensions.rb
@@ -18,8 +18,8 @@ module NewRelic
         ranges.inject(0) do |memo, other|
           next memo unless intersects?(range, other)
 
-          memo += (range.end < other.end ? range.end : other.end) -
-            (range.begin > other.begin ? range.begin : other.begin)
+          memo += ([range.end, other.end].min) -
+            ([range.begin, other.begin].max)
         end
       end
     end

--- a/lib/new_relic/agent/transaction.rb
+++ b/lib/new_relic/agent/transaction.rb
@@ -168,7 +168,7 @@ module NewRelic
           :apdex_f
         when duration <= apdex_t
           :apdex_s
-        when duration <= 4 * apdex_t
+        when duration <= apdex_t * 4
           :apdex_t
         else
           :apdex_f
@@ -302,7 +302,7 @@ module NewRelic
       end
 
       def priority
-        @priority ||= (sampled? ? 1.0 + rand : rand).round(NewRelic::PRIORITY_PRECISION)
+        @priority ||= (sampled? ? rand + 1.0 : rand).round(NewRelic::PRIORITY_PRECISION)
       end
 
       def referer
@@ -635,7 +635,7 @@ module NewRelic
         return unless distributed_trace_payload
 
         duration = start_time - (distributed_trace_payload.timestamp / 1000.0)
-        duration < 0 ? 0 : duration
+        [duration, 0].max
       end
 
       # The summary metrics recorded by this method all end up with a duration

--- a/lib/new_relic/agent/transaction/abstract_segment.rb
+++ b/lib/new_relic/agent/transaction/abstract_segment.rb
@@ -111,8 +111,8 @@ module NewRelic
         end
 
         def merge_timings(timing1, timing2)
-          [(timing1.first < timing2.first ? timing1.first : timing2.first),
-            (timing1.last > timing2.last ? timing1.last : timing2.last)]
+          [([timing1.first, timing2.first].min),
+            ([timing1.last, timing2.last].max)]
         end
 
         # @children_timings is an array of array, with each inner array

--- a/lib/new_relic/agent/transaction/transaction_sample_buffer.rb
+++ b/lib/new_relic/agent/transaction/transaction_sample_buffer.rb
@@ -72,7 +72,7 @@ module NewRelic
         # A typical buffer should NOT override this method (although we do for
         # odd things like dev-mode)
         def max_capacity
-          capacity > SINGLE_BUFFER_MAX ? SINGLE_BUFFER_MAX : capacity
+          [capacity, SINGLE_BUFFER_MAX].min
         end
 
         # Our default truncation strategy is to keep max_capacity

--- a/test/new_relic/agent/new_relic_service_test.rb
+++ b/test/new_relic/agent/new_relic_service_test.rb
@@ -759,7 +759,7 @@ class NewRelicServiceTest < Minitest::Test
   def test_compress_request_if_needed_compresses_large_payloads_gzip
     large_payload = 'a' * 65 * 1024
     body, encoding = @service.compress_request_if_needed(large_payload, :foobar)
-    zstream = Zlib::Inflate.new(16 + Zlib::MAX_WBITS)
+    zstream = Zlib::Inflate.new(Zlib::MAX_WBITS + 16)
 
     assert_equal(large_payload, zstream.inflate(body))
     assert_equal('gzip', encoding)
@@ -1226,7 +1226,7 @@ class NewRelicServiceTest < Minitest::Test
       body = if content_encoding == 'deflate'
         Zlib::Inflate.inflate(@last_request.body)
       elsif content_encoding == 'gzip'
-        zstream = Zlib::Inflate.new(16 + Zlib::MAX_WBITS)
+        zstream = Zlib::Inflate.new(Zlib::MAX_WBITS + 16)
         zstream.inflate(@last_request.body)
       else
         @last_request.body

--- a/test/performance/suites/active_record_subscriber.rb
+++ b/test/performance/suites/active_record_subscriber.rb
@@ -39,7 +39,7 @@ unless defined?(ActiveSupport::Notifications::Event)
         #
         #   @event.duration # => 1000.138
         def duration
-          @duration ||= 1000.0 * (self.end - time)
+          @duration ||= (self.end - time) * 1000.0
         end
 
         def <<(event)


### PR DESCRIPTION
# Overview
The following new default linters have been addressed in our code: 
* Style/MinMaxComparison
* Style/YodaExpression 

Submitter Checklist:
- [ ] Include a link to the related GitHub issue, if applicable
- [ ] Include a security review link, if applicable

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
GitHub Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
