### PR TITLE
Infinite Tracing: batching and compression

### DIFF
--- a/infinite_tracing/lib/infinite_tracing/channel.rb
+++ b/infinite_tracing/lib/infinite_tracing/channel.rb
@@ -5,8 +5,8 @@
 module NewRelic::Agent
   module InfiniteTracing
     class Channel
-      COMPRESSION_LEVELS = %i[none low medium high].freeze
-      DEFAULT_COMPRESSION_LEVEL = :none
+      SETTINGS_BASE = {'grpc.enable_deadline_checking' => 0}.freeze
+      SETTINGS_COMPRESSION_DISABLED = SETTINGS_BASE.merge({'grpc.minimal_stack' => 1}).freeze
 
       def stub
         NewRelic::Agent.logger.debug("Infinite Tracer Opening Channel to #{host_and_port}")
@@ -19,64 +19,29 @@ module NewRelic::Agent
         )
       end
 
-      def channel
-        GRPC::Core::Channel.new(host_and_port, settings, credentials)
-      end
-
-      def channel_args
-        return NewRelic::EMPTY_HASH unless compression_enabled?
-
-        GRPC::Core::CompressionOptions.new(compression_options).to_channel_arg_hash
-      end
-
-      def compression_enabled?
-        compression_level != :none
-      end
-
-      def compression_level
-        @compression_level ||= begin
-          level = if valid_compression_level?(configured_compression_level)
-            configured_compression_level
-          else
-            DEFAULT_COMPRESSION_LEVEL
-          end
-          NewRelic::Agent.logger.debug("Infinite Tracer compression level set to #{level}")
-          level
-        end
-      end
-
-      def compression_options
-        {default_algorithm: :gzip,
-         default_level: compression_level}
-      end
-
-      def configured_compression_level
-        NewRelic::Agent.config[:'infinite_tracing.compression_level']
-      end
-
-      def credentials
-        # Uses system configured certificates by default
-        GRPC::Core::ChannelCredentials.new
-      end
-
       def host_and_port
         Config.trace_observer_host_and_port
       end
 
-      def settings
-        {
-          'grpc.minimal_stack' => 1,
-          'grpc.enable_deadline_checking' => 0
-        }
+      def credentials
+        @credentials ||= GRPC::Core::ChannelCredentials.new
       end
 
-      def valid_compression_level?(level)
-        return true if COMPRESSION_LEVELS.include?(level)
+      def channel
+        GRPC::Core::Channel.new(host_and_port, settings, credentials)
+      end
 
-        NewRelic::Agent.logger.error("Invalid compression level '#{level}' specified! Must be one of " \
-          "#{COMPRESSION_LEVELS.join('|')}. Using default level of '#{DEFAULT_COMPRESSION_LEVEL}'")
+      def settings
+        return channel_args.merge(SETTINGS_COMPRESSION_DISABLED).freeze unless Config.compression_enabled?
 
-        false
+        channel_args.merge(SETTINGS_BASE).freeze
+      end
+
+      def channel_args
+        return NewRelic::EMPTY_HASH unless Config.compression_enabled?
+
+        GRPC::Core::CompressionOptions.new(default_algorithm: :gzip,
+          default_level: Config.compression_level).to_channel_arg_hash
       end
     end
   end

--- a/infinite_tracing/lib/infinite_tracing/config.rb
+++ b/infinite_tracing/lib/infinite_tracing/config.rb
@@ -7,6 +7,9 @@ module NewRelic::Agent
     module Config
       extend self
 
+      COMPRESSION_LEVEL_DISABLED = :none
+      COMPRESSION_LEVEL_DEFAULT = :high
+      COMPRESSION_LEVEL_LIST = %i[none low medium high].freeze
       TRACE_OBSERVER_NOT_CONFIGURED_ERROR = "Trace Observer host not configured!"
 
       # We only want to load the infinite tracing gem's files when
@@ -108,6 +111,29 @@ module NewRelic::Agent
       # Infinite Tracing is configured when a non empty string is set as the host
       def trace_observer_configured?
         trace_observer_host != NewRelic::EMPTY_STR
+      end
+
+      def compression_enabled?
+        compression_level != COMPRESSION_LEVEL_DISABLED
+      end
+
+      def compression_level
+        @compression_level ||= begin
+          level = if COMPRESSION_LEVEL_LIST.include?(configured_compression_level)
+            configured_compression_level
+          else
+            NewRelic::Agent.logger.error("Invalid compression level '#{configured_compression_level}' specified! " \
+                                         "Must be one of #{COMPRESSION_LEVEL_LIST.join('|')}. Using default level " \
+                                         "of '#{COMPRESSION_LEVEL_DEFAULT}'")
+            COMPRESSION_LEVEL_DEFAULT
+          end
+          NewRelic::Agent.logger.debug("Infinite Tracer compression level set to #{level}")
+          level
+        end
+      end
+
+      def configured_compression_level
+        NewRelic::Agent.config[:'infinite_tracing.compression_level']
       end
     end
   end

--- a/infinite_tracing/lib/infinite_tracing/connection.rb
+++ b/infinite_tracing/lib/infinite_tracing/connection.rb
@@ -17,6 +17,12 @@
 module NewRelic::Agent
   module InfiniteTracing
     class Connection
+      GZIP_METADATA = {'grpc-internal-encoding-request' => 'gzip',
+                       'grpc-encoding' => 'gzip',
+                       'grpc-accept-encoding' => ['gzip'],
+                       'content-coding' => 'gzip',
+                       'content-encoding' => 'gzip'}.freeze
+
       # listens for server side configurations added to the agent.  When a new config is
       # added, we have a new agent run token and need to restart the client's RPC stream
       # with the new metadata information.
@@ -51,6 +57,7 @@ module NewRelic::Agent
         # so we're able to signal the client to restart when connectivity to the
         # server is disrupted.
         def record_span_batches(client, enumerator, exponential_backoff)
+          puts "\n\n\n\n\n\n\n\n\n\n\nRECORDED A SPAN BATCH!!!!!!\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n"
           instance.record_span_batches(client, enumerator, exponential_backoff)
         end
 
@@ -100,7 +107,16 @@ module NewRelic::Agent
             "agent_run_token" => agent_id
           }
           @metadata.merge!(request_headers_map)
+          merge_gzip_metadata
         end
+      end
+
+      # If (gzip based) compression is enabled, explicitly provide all
+      # relevant metadata
+      def merge_gzip_metadata
+        return @metadata unless Config.compression_enabled?
+
+        @metadata.merge!(GZIP_METADATA)
       end
 
       # Initializes rpc so we can get a Channel and Stub (connect to gRPC server)

--- a/infinite_tracing/test/infinite_tracing/config_test.rb
+++ b/infinite_tracing/test/infinite_tracing/config_test.rb
@@ -108,6 +108,36 @@ module NewRelic
           assert_match(/not configured/, error.message)
         end
 
+        def test_compression_enabled_returns_true
+          reset_compression_level
+
+          with_config({'infinite_tracing.compression_level': :high}) do
+            assert_predicate Config, :compression_enabled?
+          end
+        end
+
+        def test_compression_enabled_returns_false
+          reset_compression_level
+
+          with_config({'infinite_tracing.compression_level': :none}) do
+            refute Config.compression_enabled?
+          end
+        end
+
+        def test_invalid_compression_level
+          reset_compression_level
+          logger = MiniTest::Mock.new
+          logger.expect :error, nil, [/Invalid compression level/]
+          logger.expect :debug, nil, [/compression level set to/]
+
+          with_config({'infinite_tracing.compression_level': :bogus}) do
+            NewRelic::Agent.stub :logger, logger do
+              assert_equal Config::COMPRESSION_LEVEL_DEFAULT, Config.compression_level
+              logger.verify
+            end
+          end
+        end
+
         private
 
         def non_test_files

--- a/infinite_tracing/test/test_helper.rb
+++ b/infinite_tracing/test/test_helper.rb
@@ -93,3 +93,9 @@ def with_detailed_trace
     yield
   end
 end
+
+def reset_compression_level
+  return unless NewRelic::Agent::InfiniteTracing::Config.instance_variables.include?(:@compression_level)
+
+  NewRelic::Agent::InfiniteTracing::Config.remove_instance_variable(:@compression_level)
+end

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2317,21 +2317,21 @@ If `true`, disables agent middleware for Sinatra. This middleware is responsible
         },
         :'infinite_tracing.batching' => {
           :default => false,
-          :public => false,
+          :public => true,
           :type => Boolean,
           :allowed_from_server => false,
           :external => :infinite_tracing,
-          :description => "If true, data sent to the Trace Observer will be batched instead of the default of each " \
+          :description => "If true (the default), data sent to the Trace Observer will be batched\ninstead of each " \
                           "span being sent individually"
         },
         :'infinite_tracing.compression_level' => {
-          :default => :none,
-          :public => false,
+          :default => :high,
+          :public => true,
           :type => Symbol,
           :allowed_from_server => false,
           :external => :infinite_tracing,
           :description => "Configure the compression level for data sent to the Trace Observer\nMay be one of " \
-                          "[none|low|medium|high]\nBy default, compression is not used (level = none)"
+          "[none|low|medium|high]\n'high' is the default. Set the level to 'none' to disable compression"
         },
         :js_agent_file => {
           :default => '',

--- a/newrelic.yml
+++ b/newrelic.yml
@@ -317,12 +317,12 @@ common: &default_settings
 
   # Configure the compression level for data sent to the Trace Observer
   # May be one of [none|low|medium|high]
-  # By default, compression is not used (level = none)
-  # infinite_tracing.compression_level: none
+  # 'high' is the default. Set the level to 'none' to disable compression
+  # infinite_tracing.compression_level: high
 
-  # If true, data sent to the Trace Observer will be batched instead of
-  # the default of each span being sent individually
-  # infinite_tracing.batching: false
+  # If true (the default), data sent to the Trace Observer will be batched
+  # instead of each span being sent individually
+  # infinite_tracing.batching: true
 
   # Controls auto-instrumentation of bunny at start up.
   # May be one of [auto|prepend|chain|disabled].

--- a/test/multiverse/lib/multiverse/runner.rb
+++ b/test/multiverse/lib/multiverse/runner.rb
@@ -3,6 +3,7 @@
 # frozen_string_literal: true
 
 require 'fileutils'
+require 'pry'
 
 module Multiverse
   module Runner

--- a/test/multiverse/lib/multiverse/suite.rb
+++ b/test/multiverse/lib/multiverse/suite.rb
@@ -67,6 +67,10 @@ module Multiverse
       opts.fetch(:file, nil)
     end
 
+    def infinite_tracing_suite?
+      suite == 'infinite_tracing'
+    end
+
     def clean_gemfiles(env_index)
       gemfiles = ["Gemfile.#{env_index}", "Gemfile.#{env_index}.lock"]
       gemfiles.each do |f|
@@ -657,6 +661,7 @@ module Multiverse
         puts yellow("Executing #{file.inspect}") if verbose?
         next if exclude?(file)
 
+        ENV['FILTER_FILE'] = filter_file if filter_file && infinite_tracing_suite?
         require "./" + File.basename(file, ".rb")
       end
     end
@@ -672,7 +677,7 @@ module Multiverse
 
       # Important that we filter after removing before/after so they don't get
       # tromped for not matching our pattern!
-      files.select! { |file| file.include?(filter_file) } if filter_file
+      files.select! { |file| file.include?(filter_file) } if filter_file && !infinite_tracing_suite?
 
       # Just put before_suite.rb at the head of the list.
       # Will explicitly load after_suite.rb after the test run

--- a/test/multiverse/suites/infinite_tracing/infinite_tracing_test.rb
+++ b/test/multiverse/suites/infinite_tracing/infinite_tracing_test.rb
@@ -11,7 +11,10 @@ if NewRelic::Agent::InfiniteTracing::Config.should_load?
 
   class InfiniteTracingTest < Minitest::Test
     def self.load_test_files(pattern)
-      Dir.glob(File.join(INFINITE_TRACING_TEST_PATH, pattern)).each { |fn| require fn }
+      Dir.glob(File.join(INFINITE_TRACING_TEST_PATH, pattern)).each do |fn|
+        # see multiverse/suite.rb for the setting of FILTER_FILE
+        require fn if fn.match?(ENV.fetch('FILTER_FILE', '.'))
+      end
     end
 
     load_test_files '*_test.rb'


### PR DESCRIPTION
* reimplement gRPC compression, now that we understand that the `minimal_stack` configuration setting will disable all compression
* enable 'high' compression by default
* enable batching by default
* make the compression level and batching toggle publicly configurable