### PR TITLE
8T: enable batching in default_source.rb as well

### DIFF
--- a/infinite_tracing/test/infinite_tracing/agent_integrations/datastore_segment_test.rb
+++ b/infinite_tracing/test/infinite_tracing/agent_integrations/datastore_segment_test.rb
@@ -11,107 +11,113 @@ module NewRelic
         include FakeTraceObserverHelpers
 
         def test_sampled_segment_records_span_event
-          trace_id = nil
-          txn_guid = nil
-          sampled = nil
-          priority = nil
-          timestamp = nil
-          sql_statement = "select * from table"
+          with_config('infinite_tracing.batching': false) do
+            trace_id = nil
+            txn_guid = nil
+            sampled = nil
+            priority = nil
+            timestamp = nil
+            sql_statement = "select * from table"
 
-          span_events = generate_and_stream_segments do
-            in_web_transaction('wat') do |txn|
-              txn.stubs(:sampled?).returns(true)
+            span_events = generate_and_stream_segments do
+              in_web_transaction('wat') do |txn|
+                txn.stubs(:sampled?).returns(true)
 
-              segment = Tracer.start_datastore_segment(
-                product: "SQLite",
-                collection: "Blahg",
-                operation: "select",
-                host: "rachel.foo",
-                port_path_or_id: 1337807,
-                database_name: "calzone_zone"
-              )
+                segment = Tracer.start_datastore_segment(
+                  product: "SQLite",
+                  collection: "Blahg",
+                  operation: "select",
+                  host: "rachel.foo",
+                  port_path_or_id: 1337807,
+                  database_name: "calzone_zone"
+                )
 
-              segment.notice_sql(sql_statement)
-              advance_process_time(1)
-              segment.finish
+                segment.notice_sql(sql_statement)
+                advance_process_time(1)
+                segment.finish
 
-              timestamp = Integer(segment.start_time.to_f * 1000.0)
+                timestamp = Integer(segment.start_time.to_f * 1000.0)
 
-              trace_id = txn.trace_id
-              txn_guid = txn.guid
-              sampled = txn.sampled?
-              priority = txn.priority
+                trace_id = txn.trace_id
+                txn_guid = txn.guid
+                sampled = txn.sampled?
+                priority = txn.priority
+              end
             end
+
+            assert_equal 2, span_events.size
+
+            intrinsics = span_events[0]['intrinsics']
+            agent_attributes = span_events[0]['agent_attributes']
+
+            root_span_event = span_events[1]
+            root_guid = root_span_event['intrinsics']['guid'].string_value
+
+            datastore = 'Datastore/statement/SQLite/Blahg/select'
+
+            assert_equal 'Span', intrinsics['type'].string_value
+            assert_equal trace_id, intrinsics['traceId'].string_value
+            refute_empty intrinsics['guid'].string_value
+            assert_equal root_guid, intrinsics['parentId'].string_value
+            assert_equal txn_guid, intrinsics['transactionId'].string_value
+            assert_equal sampled, intrinsics['sampled'].bool_value
+            assert_equal priority, intrinsics['priority'].double_value
+            assert_equal timestamp, intrinsics['timestamp'].int_value
+            assert_in_delta(1.0, intrinsics['duration'].double_value)
+            assert_equal datastore, intrinsics['name'].string_value
+            assert_equal 'datastore', intrinsics['category'].string_value
+            assert_equal 'SQLite', intrinsics['component'].string_value
+            assert_equal 'client', intrinsics['span.kind'].string_value
+
+            assert_equal 'calzone_zone', agent_attributes['db.instance'].string_value
+            assert_equal 'rachel.foo:1337807', agent_attributes['peer.address'].string_value
+            assert_equal 'rachel.foo', agent_attributes['peer.hostname'].string_value
+            assert_equal sql_statement, agent_attributes['db.statement'].string_value
           end
-
-          assert_equal 2, span_events.size
-
-          intrinsics = span_events[0]['intrinsics']
-          agent_attributes = span_events[0]['agent_attributes']
-
-          root_span_event = span_events[1]
-          root_guid = root_span_event['intrinsics']['guid'].string_value
-
-          datastore = 'Datastore/statement/SQLite/Blahg/select'
-
-          assert_equal 'Span', intrinsics['type'].string_value
-          assert_equal trace_id, intrinsics['traceId'].string_value
-          refute_empty intrinsics['guid'].string_value
-          assert_equal root_guid, intrinsics['parentId'].string_value
-          assert_equal txn_guid, intrinsics['transactionId'].string_value
-          assert_equal sampled, intrinsics['sampled'].bool_value
-          assert_equal priority, intrinsics['priority'].double_value
-          assert_equal timestamp, intrinsics['timestamp'].int_value
-          assert_in_delta(1.0, intrinsics['duration'].double_value)
-          assert_equal datastore, intrinsics['name'].string_value
-          assert_equal 'datastore', intrinsics['category'].string_value
-          assert_equal 'SQLite', intrinsics['component'].string_value
-          assert_equal 'client', intrinsics['span.kind'].string_value
-
-          assert_equal 'calzone_zone', agent_attributes['db.instance'].string_value
-          assert_equal 'rachel.foo:1337807', agent_attributes['peer.address'].string_value
-          assert_equal 'rachel.foo', agent_attributes['peer.hostname'].string_value
-          assert_equal sql_statement, agent_attributes['db.statement'].string_value
         end
 
         def test_non_sampled_segment_does_record_span_event
-          span_events = generate_and_stream_segments do
-            in_web_transaction('wat') do |txn|
-              txn.stubs(:sampled?).returns(false)
+          with_config('infinite_tracing.batching': false) do
+            span_events = generate_and_stream_segments do
+              in_web_transaction('wat') do |txn|
+                txn.stubs(:sampled?).returns(false)
 
-              segment = Tracer.start_datastore_segment(
-                product: "SQLite",
-                operation: "select",
-                port_path_or_id: 1337807
-              )
+                segment = Tracer.start_datastore_segment(
+                  product: "SQLite",
+                  operation: "select",
+                  port_path_or_id: 1337807
+                )
 
-              segment.start
-              advance_process_time(1.0)
-              segment.finish
+                segment.start
+                advance_process_time(1.0)
+                segment.finish
+              end
             end
-          end
 
-          assert_equal 2, span_events.size
+            assert_equal 2, span_events.size
+          end
         end
 
         def test_ignored_transaction_does_not_record_span_event
-          span_events = generate_and_stream_segments do
-            in_web_transaction('wat') do |txn|
-              txn.stubs(:ignore?).returns(true)
+          with_config('infinite_tracing.batching': false) do
+            span_events = generate_and_stream_segments do
+              in_web_transaction('wat') do |txn|
+                txn.stubs(:ignore?).returns(true)
 
-              segment = Tracer.start_datastore_segment(
-                product: "SQLite",
-                operation: "select",
-                port_path_or_id: 1337807
-              )
+                segment = Tracer.start_datastore_segment(
+                  product: "SQLite",
+                  operation: "select",
+                  port_path_or_id: 1337807
+                )
 
-              segment.start
-              advance_process_time(1.0)
-              segment.finish
+                segment.start
+                advance_process_time(1.0)
+                segment.finish
+              end
             end
-          end
 
-          assert_equal 0, span_events.size
+            assert_equal 0, span_events.size
+          end
         end
       end
     end

--- a/infinite_tracing/test/infinite_tracing/agent_integrations/external_request_segment_test.rb
+++ b/infinite_tracing/test/infinite_tracing/agent_integrations/external_request_segment_test.rb
@@ -11,101 +11,107 @@ module NewRelic
         include FakeTraceObserverHelpers
 
         def test_sampled_external_records_span_event
-          trace_id = nil
-          txn_guid = nil
-          sampled = nil
-          priority = nil
-          timestamp = nil
-          segment = nil
+          with_config('infinite_tracing.batching': false) do
+            trace_id = nil
+            txn_guid = nil
+            sampled = nil
+            priority = nil
+            timestamp = nil
+            segment = nil
 
-          span_events = generate_and_stream_segments do
-            in_transaction('wat') do |txn|
-              txn.stubs(:sampled?).returns(true)
+            span_events = generate_and_stream_segments do
+              in_transaction('wat') do |txn|
+                txn.stubs(:sampled?).returns(true)
 
-              segment = Transaction::ExternalRequestSegment.new( \
-                "Typhoeus",
-                "http://remotehost.com/blogs/index",
-                "GET"
-              )
+                segment = Transaction::ExternalRequestSegment.new( \
+                  "Typhoeus",
+                  "http://remotehost.com/blogs/index",
+                  "GET"
+                )
 
-              txn.add_segment(segment)
-              segment.start
-              advance_process_time(1.0)
-              segment.finish
+                txn.add_segment(segment)
+                segment.start
+                advance_process_time(1.0)
+                segment.finish
 
-              timestamp = Integer(segment.start_time.to_f * 1000.0)
+                timestamp = Integer(segment.start_time.to_f * 1000.0)
 
-              trace_id = txn.trace_id
-              txn_guid = txn.guid
-              sampled = txn.sampled?
-              priority = txn.priority
+                trace_id = txn.trace_id
+                txn_guid = txn.guid
+                sampled = txn.sampled?
+                priority = txn.priority
+              end
             end
+
+            assert_equal 2, span_events.size
+            external_intrinsics = span_events[0]['intrinsics']
+            external_agent_attributes = span_events[0]['agent_attributes']
+            root_span_event = span_events[1]['intrinsics']
+            root_guid = root_span_event['guid'].string_value
+
+            expected_name = 'External/remotehost.com/Typhoeus/GET'
+
+            assert_equal 'Span', external_intrinsics['type'].string_value
+            assert_equal trace_id, external_intrinsics['traceId'].string_value
+            refute_nil external_intrinsics['guid'].string_value
+            assert_equal root_guid, external_intrinsics['parentId'].string_value
+            assert_equal txn_guid, external_intrinsics['transactionId'].string_value
+            assert_equal sampled, external_intrinsics['sampled'].bool_value
+            assert_equal priority, external_intrinsics['priority'].double_value
+            assert_equal timestamp, external_intrinsics['timestamp'].int_value
+            assert_in_delta(1.0, external_intrinsics['duration'].double_value)
+            assert_equal expected_name, external_intrinsics['name'].string_value
+            assert_equal segment.library, external_intrinsics['component'].string_value
+            assert_equal segment.procedure, external_intrinsics['http.method'].string_value
+            assert_equal 'http', external_intrinsics['category'].string_value
+            assert_equal segment.uri.to_s, external_agent_attributes['http.url'].string_value
           end
-
-          assert_equal 2, span_events.size
-          external_intrinsics = span_events[0]['intrinsics']
-          external_agent_attributes = span_events[0]['agent_attributes']
-          root_span_event = span_events[1]['intrinsics']
-          root_guid = root_span_event['guid'].string_value
-
-          expected_name = 'External/remotehost.com/Typhoeus/GET'
-
-          assert_equal 'Span', external_intrinsics['type'].string_value
-          assert_equal trace_id, external_intrinsics['traceId'].string_value
-          refute_nil external_intrinsics['guid'].string_value
-          assert_equal root_guid, external_intrinsics['parentId'].string_value
-          assert_equal txn_guid, external_intrinsics['transactionId'].string_value
-          assert_equal sampled, external_intrinsics['sampled'].bool_value
-          assert_equal priority, external_intrinsics['priority'].double_value
-          assert_equal timestamp, external_intrinsics['timestamp'].int_value
-          assert_in_delta(1.0, external_intrinsics['duration'].double_value)
-          assert_equal expected_name, external_intrinsics['name'].string_value
-          assert_equal segment.library, external_intrinsics['component'].string_value
-          assert_equal segment.procedure, external_intrinsics['http.method'].string_value
-          assert_equal 'http', external_intrinsics['category'].string_value
-          assert_equal segment.uri.to_s, external_agent_attributes['http.url'].string_value
         end
 
         def test_non_sampled_segment_does_record_span_event
-          span_events = generate_and_stream_segments do
-            in_transaction('wat') do |txn|
-              txn.stubs(:sampled?).returns(false)
+          with_config('infinite_tracing.batching': false) do
+            span_events = generate_and_stream_segments do
+              in_transaction('wat') do |txn|
+                txn.stubs(:sampled?).returns(false)
 
-              segment = Transaction::ExternalRequestSegment.new( \
-                "Typhoeus",
-                "http://remotehost.com/blogs/index",
-                "GET"
-              )
+                segment = Transaction::ExternalRequestSegment.new( \
+                  "Typhoeus",
+                  "http://remotehost.com/blogs/index",
+                  "GET"
+                )
 
-              txn.add_segment(segment)
-              segment.start
-              advance_process_time(1.0)
-              segment.finish
+                txn.add_segment(segment)
+                segment.start
+                advance_process_time(1.0)
+                segment.finish
+              end
             end
-          end
 
-          assert_equal 2, span_events.size
+            assert_equal 2, span_events.size
+          end
         end
 
         def test_ignored_transaction_does_not_record_span_event
-          span_events = generate_and_stream_segments do
-            in_transaction('wat') do |txn|
-              txn.stubs(:ignore?).returns(true)
+          with_config('infinite_tracing.batching': false) do
+            span_events = generate_and_stream_segments do
+              in_transaction('wat') do |txn|
+                txn.stubs(:ignore?).returns(true)
 
-              segment = Transaction::ExternalRequestSegment.new( \
-                "Typhoeus",
-                "http://remotehost.com/blogs/index",
-                "GET"
-              )
+                segment = Transaction::ExternalRequestSegment.new( \
+                  "Typhoeus",
+                  "http://remotehost.com/blogs/index",
+                  "GET"
+                )
 
-              txn.add_segment(segment)
-              segment.start
-              advance_process_time(1.0)
-              segment.finish
+                txn.add_segment(segment)
+                segment.start
+                advance_process_time(1.0)
+                segment.finish
+              end
             end
-          end
 
-          assert_equal 0, span_events.size
+            assert_equal 0, span_events.size
+          end
         end
       end
     end

--- a/infinite_tracing/test/infinite_tracing/agent_integrations/segment_test.rb
+++ b/infinite_tracing/test/infinite_tracing/agent_integrations/segment_test.rb
@@ -11,96 +11,104 @@ module NewRelic
         include FakeTraceObserverHelpers
 
         def test_sampled_segment_records_span_event
-          trace_id = nil
-          txn_guid = nil
-          sampled = nil
-          priority = nil
-          timestamp = nil
+          with_config('infinite_tracing.batching': false) do
+            trace_id = nil
+            txn_guid = nil
+            sampled = nil
+            priority = nil
+            timestamp = nil
 
-          span_events = generate_and_stream_segments do
-            in_transaction('wat') do |txn|
-              txn.stubs(:sampled?).returns(true)
+            span_events = generate_and_stream_segments do
+              in_transaction('wat') do |txn|
+                txn.stubs(:sampled?).returns(true)
 
-              segment = Transaction::Segment.new('Ummm')
-              txn.add_segment(segment)
-              segment.start
-              advance_process_time(1.0)
-              segment.finish
+                segment = Transaction::Segment.new('Ummm')
+                txn.add_segment(segment)
+                segment.start
+                advance_process_time(1.0)
+                segment.finish
 
-              timestamp = Integer(segment.start_time.to_f * 1000.0)
+                timestamp = Integer(segment.start_time.to_f * 1000.0)
 
-              trace_id = txn.trace_id
-              txn_guid = txn.guid
-              sampled = txn.sampled?
-              priority = txn.priority
+                trace_id = txn.trace_id
+                txn_guid = txn.guid
+                sampled = txn.sampled?
+                priority = txn.priority
+              end
             end
+
+            assert_equal 2, span_events.size
+
+            custom_span_event = span_events[0]
+            root_span_event = span_events[1]
+            root_guid = root_span_event['intrinsics']['guid'].string_value
+
+            assert_equal 'Span', custom_span_event['intrinsics']['type'].string_value
+            assert_equal trace_id, custom_span_event['intrinsics']['traceId'].string_value
+            refute_empty custom_span_event['intrinsics']['guid'].string_value
+            assert_equal root_guid, custom_span_event['intrinsics']['parentId'].string_value
+            assert_equal txn_guid, custom_span_event['intrinsics']['transactionId'].string_value
+            assert_equal sampled, custom_span_event['intrinsics']['sampled'].bool_value
+            assert_equal priority, custom_span_event['intrinsics']['priority'].double_value
+            assert_equal timestamp, custom_span_event['intrinsics']['timestamp'].int_value
+            assert_in_delta(1.0, custom_span_event['intrinsics']['duration'].double_value)
+            assert_equal 'Ummm', custom_span_event['intrinsics']['name'].string_value
+            assert_equal 'generic', custom_span_event['intrinsics']['category'].string_value
           end
-
-          assert_equal 2, span_events.size
-
-          custom_span_event = span_events[0]
-          root_span_event = span_events[1]
-          root_guid = root_span_event['intrinsics']['guid'].string_value
-
-          assert_equal 'Span', custom_span_event['intrinsics']['type'].string_value
-          assert_equal trace_id, custom_span_event['intrinsics']['traceId'].string_value
-          refute_empty custom_span_event['intrinsics']['guid'].string_value
-          assert_equal root_guid, custom_span_event['intrinsics']['parentId'].string_value
-          assert_equal txn_guid, custom_span_event['intrinsics']['transactionId'].string_value
-          assert_equal sampled, custom_span_event['intrinsics']['sampled'].bool_value
-          assert_equal priority, custom_span_event['intrinsics']['priority'].double_value
-          assert_equal timestamp, custom_span_event['intrinsics']['timestamp'].int_value
-          assert_in_delta(1.0, custom_span_event['intrinsics']['duration'].double_value)
-          assert_equal 'Ummm', custom_span_event['intrinsics']['name'].string_value
-          assert_equal 'generic', custom_span_event['intrinsics']['category'].string_value
         end
 
         def test_non_sampled_segment_does_record_span_event
-          span_events = generate_and_stream_segments do
-            in_transaction('wat') do |txn|
-              txn.stubs(:sampled?).returns(false)
+          with_config('infinite_tracing.batching': false) do
+            span_events = generate_and_stream_segments do
+              in_transaction('wat') do |txn|
+                txn.stubs(:sampled?).returns(false)
 
-              segment = Transaction::Segment.new('Ummm')
-              txn.add_segment(segment)
-              segment.start
-              advance_process_time(1.0)
-              segment.finish
+                segment = Transaction::Segment.new('Ummm')
+                txn.add_segment(segment)
+                segment.start
+                advance_process_time(1.0)
+                segment.finish
+              end
             end
-          end
 
-          assert_equal 2, span_events.size
+            assert_equal 2, span_events.size
+          end
         end
 
         def test_ignored_transaction_does_not_record_span_event
-          span_events = generate_and_stream_segments do
-            in_transaction('wat') do |txn|
-              txn.stubs(:ignore?).returns(true)
+          with_config('infinite_tracing.batching': false) do
+            span_events = generate_and_stream_segments do
+              in_transaction('wat') do |txn|
+                txn.stubs(:ignore?).returns(true)
 
-              segment = Transaction::Segment.new('Ummm')
-              txn.add_segment(segment)
-              segment.start
-              advance_process_time(1.0)
-              segment.finish
+                segment = Transaction::Segment.new('Ummm')
+                txn.add_segment(segment)
+                segment.start
+                advance_process_time(1.0)
+                segment.finish
+              end
             end
-          end
 
-          assert_equal 0, span_events.size
+            assert_equal 0, span_events.size
+          end
         end
 
         def test_streams_multiple_segments
-          total_spans = 5
-          segments = []
+          with_config('infinite_tracing.batching': false) do
+            total_spans = 5
+            segments = []
 
-          span_events = generate_and_stream_segments do
-            total_spans.times do |index|
-              with_segment do |segment|
-                segments << segment
+            span_events = generate_and_stream_segments do
+              total_spans.times do |index|
+                with_segment do |segment|
+                  segments << segment
+                end
               end
             end
-          end
 
-          assert_equal total_spans, span_events.size
-          assert_equal total_spans, segments.size
+            assert_equal total_spans, span_events.size
+            assert_equal total_spans, segments.size
+          end
         end
       end
     end

--- a/infinite_tracing/test/infinite_tracing/client_test.rb
+++ b/infinite_tracing/test/infinite_tracing/client_test.rb
@@ -11,133 +11,143 @@ module NewRelic
         include FakeTraceObserverHelpers
 
         def test_streams_multiple_segments
-          with_serial_lock do
-            NewRelic::Agent::Transaction::Segment.any_instance.stubs('record_span_event')
-            total_spans = 5
-            spans, segments = emulate_streaming_segments(total_spans)
+          with_config('infinite_tracing.batching': false) do
+            with_serial_lock do
+              NewRelic::Agent::Transaction::Segment.any_instance.stubs('record_span_event')
+              total_spans = 5
+              spans, segments = emulate_streaming_segments(total_spans)
 
-            assert_equal total_spans, spans.size
-            assert_equal total_spans, segments.size
-            spans.each_with_index do |span, index|
-              assert_kind_of NewRelic::Agent::InfiniteTracing::Span, span
-              assert_equal segments[index].transaction.trace_id, span["trace_id"]
+              assert_equal total_spans, spans.size
+              assert_equal total_spans, segments.size
+              spans.each_with_index do |span, index|
+                assert_kind_of NewRelic::Agent::InfiniteTracing::Span, span
+                assert_equal segments[index].transaction.trace_id, span["trace_id"]
+              end
+
+              refute_metrics_recorded(["Supportability/InfiniteTracing/Span/AgentQueueDumped"])
+              assert_metrics_recorded({
+                "Supportability/InfiniteTracing/Span/Seen" => {:call_count => 5},
+                "Supportability/InfiniteTracing/Span/Sent" => {:call_count => 5}
+              })
             end
-
-            refute_metrics_recorded(["Supportability/InfiniteTracing/Span/AgentQueueDumped"])
-            assert_metrics_recorded({
-              "Supportability/InfiniteTracing/Span/Seen" => {:call_count => 5},
-              "Supportability/InfiniteTracing/Span/Sent" => {:call_count => 5}
-            })
           end
         end
 
         def test_streams_across_reconnects
-          with_serial_lock do
-            NewRelic::Agent::Transaction::Segment.any_instance.stubs('record_span_event')
-            total_spans = 5
-            spans, segments = emulate_streaming_segments(total_spans) do |client, current_segments|
-              if current_segments.size == 3
-                client.restart
-              else
-                simulate_server_response
+          with_config('infinite_tracing.batching': false) do
+            with_serial_lock do
+              NewRelic::Agent::Transaction::Segment.any_instance.stubs('record_span_event')
+              total_spans = 5
+              spans, segments = emulate_streaming_segments(total_spans) do |client, current_segments|
+                if current_segments.size == 3
+                  client.restart
+                else
+                  simulate_server_response
+                end
               end
+
+              assert_equal total_spans, segments.size
+              assert_equal total_spans, spans.size
+
+              span_ids = spans.map { |s| s["trace_id"] }.sort
+              segment_ids = segments.map { |s| s.transaction.trace_id }.sort
+
+              assert_equal segment_ids, span_ids
+
+              refute_metrics_recorded(["Supportability/InfiniteTracing/Span/AgentQueueDumped"])
+              assert_metrics_recorded({
+                "Supportability/InfiniteTracing/Span/Seen" => {:call_count => 5},
+                "Supportability/InfiniteTracing/Span/Sent" => {:call_count => 5}
+              })
             end
-
-            assert_equal total_spans, segments.size
-            assert_equal total_spans, spans.size
-
-            span_ids = spans.map { |s| s["trace_id"] }.sort
-            segment_ids = segments.map { |s| s.transaction.trace_id }.sort
-
-            assert_equal segment_ids, span_ids
-
-            refute_metrics_recorded(["Supportability/InfiniteTracing/Span/AgentQueueDumped"])
-            assert_metrics_recorded({
-              "Supportability/InfiniteTracing/Span/Seen" => {:call_count => 5},
-              "Supportability/InfiniteTracing/Span/Sent" => {:call_count => 5}
-            })
           end
         end
 
         def test_handles_server_disconnects
-          with_serial_lock do
-            unstub_reconnection
-            Connection.any_instance.stubs(:retry_connection_period).returns(0)
-            NewRelic::Agent::Transaction::Segment.any_instance.stubs('record_span_event')
+          with_config('infinite_tracing.batching': false) do
+            with_serial_lock do
+              unstub_reconnection
+              Connection.any_instance.stubs(:retry_connection_period).returns(0)
+              NewRelic::Agent::Transaction::Segment.any_instance.stubs('record_span_event')
 
-            total_spans = 5
-            leftover_spans = 2
+              total_spans = 5
+              leftover_spans = 2
 
-            spans, segments = emulate_streaming_segments(total_spans) do |client, current_segments|
-              if current_segments.size == total_spans - leftover_spans
-                # we do this here instead of server_proc because we are testing that if
-                # the server restarts while the CLIENT is currently running, it
-                # behaves as expected (since we just testing the client behavior)
-                simulate_server_response(GRPC::Ok.new)
-              else
-                # we need to do this so the client streaming helpers know when
-                # the mock server has done its thing
-                simulate_server_response
+              spans, segments = emulate_streaming_segments(total_spans) do |client, current_segments|
+                if current_segments.size == total_spans - leftover_spans
+                  # we do this here instead of server_proc because we are testing that if
+                  # the server restarts while the CLIENT is currently running, it
+                  # behaves as expected (since we just testing the client behavior)
+                  simulate_server_response(GRPC::Ok.new)
+                else
+                  # we need to do this so the client streaming helpers know when
+                  # the mock server has done its thing
+                  simulate_server_response
+                end
               end
+
+              assert_equal total_spans, segments.size
+              assert_equal total_spans, spans.size
+
+              span_ids = spans.map { |s| s["trace_id"] }.sort
+              segment_ids = segments.map { |s| s.transaction.trace_id }.sort
+
+              assert_equal segment_ids, span_ids
+
+              refute_metrics_recorded(["Supportability/InfiniteTracing/Span/AgentQueueDumped"])
+              assert_metrics_recorded({
+                "Supportability/InfiniteTracing/Span/Seen" => {:call_count => 5},
+                "Supportability/InfiniteTracing/Span/Sent" => {:call_count => 5}
+              })
             end
-
-            assert_equal total_spans, segments.size
-            assert_equal total_spans, spans.size
-
-            span_ids = spans.map { |s| s["trace_id"] }.sort
-            segment_ids = segments.map { |s| s.transaction.trace_id }.sort
-
-            assert_equal segment_ids, span_ids
-
-            refute_metrics_recorded(["Supportability/InfiniteTracing/Span/AgentQueueDumped"])
-            assert_metrics_recorded({
-              "Supportability/InfiniteTracing/Span/Seen" => {:call_count => 5},
-              "Supportability/InfiniteTracing/Span/Sent" => {:call_count => 5}
-            })
           end
         end
 
         def test_handles_server_error_responses
-          with_serial_lock do
-            NewRelic::Agent::Transaction::Segment.any_instance.stubs('record_span_event')
-            connection = Connection.instance
-            connection.stubs(:retry_connection_period).returns(0)
+          with_config('infinite_tracing.batching': false) do
+            with_serial_lock do
+              NewRelic::Agent::Transaction::Segment.any_instance.stubs('record_span_event')
+              connection = Connection.instance
+              connection.stubs(:retry_connection_period).returns(0)
 
-            total_spans = 2
-            emulate_streaming_with_initial_error(total_spans)
+              total_spans = 2
+              emulate_streaming_with_initial_error(total_spans)
 
-            assert_metrics_recorded "Supportability/InfiniteTracing/Span/Sent"
-            assert_metrics_recorded "Supportability/InfiniteTracing/Span/Response/Error"
-            assert_metrics_recorded({
-              "Supportability/InfiniteTracing/Span/Seen" => {:call_count => total_spans},
-              "Supportability/InfiniteTracing/Span/gRPC/PERMISSION_DENIED" => {:call_count => 1}
-            })
+              assert_metrics_recorded "Supportability/InfiniteTracing/Span/Sent"
+              assert_metrics_recorded "Supportability/InfiniteTracing/Span/Response/Error"
+              assert_metrics_recorded({
+                "Supportability/InfiniteTracing/Span/Seen" => {:call_count => total_spans},
+                "Supportability/InfiniteTracing/Span/gRPC/PERMISSION_DENIED" => {:call_count => 1}
+              })
+            end
           end
         end
 
         def test_handles_suspended_state
-          with_serial_lock do
-            NewRelic::Agent::Transaction::Segment.any_instance.stubs('record_span_event')
-            connection = Connection.instance
-            connection.stubs(:retry_connection_period).returns(0)
+          with_config('infinite_tracing.batching': false) do
+            with_serial_lock do
+              NewRelic::Agent::Transaction::Segment.any_instance.stubs('record_span_event')
+              connection = Connection.instance
+              connection.stubs(:retry_connection_period).returns(0)
 
-            total_spans = 5
-            emulate_streaming_segments(total_spans) do |client, segments|
-              if segments.size == 3
-                simulate_server_response_shutdown(GRPC::Unimplemented.new("i dont exist"))
-              else
-                simulate_server_response
+              total_spans = 5
+              emulate_streaming_segments(total_spans) do |client, segments|
+                if segments.size == 3
+                  simulate_server_response_shutdown(GRPC::Unimplemented.new("i dont exist"))
+                else
+                  simulate_server_response
+                end
               end
-            end
 
-            assert_metrics_recorded "Supportability/InfiniteTracing/Span/gRPC/UNIMPLEMENTED"
-            assert_metrics_recorded "Supportability/InfiniteTracing/Span/Sent"
-            assert_metrics_recorded "Supportability/InfiniteTracing/Span/Response/Error"
-            assert_metrics_recorded({
-              "Supportability/InfiniteTracing/Span/Seen" => {:call_count => total_spans},
-              "Supportability/InfiniteTracing/Span/Sent" => {:call_count => 3},
-              "Supportability/InfiniteTracing/Span/gRPC/UNIMPLEMENTED" => {:call_count => 1}
-            })
+              assert_metrics_recorded "Supportability/InfiniteTracing/Span/gRPC/UNIMPLEMENTED"
+              assert_metrics_recorded "Supportability/InfiniteTracing/Span/Sent"
+              assert_metrics_recorded "Supportability/InfiniteTracing/Span/Response/Error"
+              assert_metrics_recorded({
+                "Supportability/InfiniteTracing/Span/Seen" => {:call_count => total_spans},
+                "Supportability/InfiniteTracing/Span/Sent" => {:call_count => 3},
+                "Supportability/InfiniteTracing/Span/gRPC/UNIMPLEMENTED" => {:call_count => 1}
+              })
+            end
           end
         end
 
@@ -189,7 +199,7 @@ module NewRelic
         end
 
         def test_streams_multiple_batches
-          with_config(:'infinite_tracing.batching' => true) do
+          with_config('infinite_tracing.batching': true) do
             with_serial_lock do
               NewRelic::Agent::Transaction::Segment.any_instance.stubs('record_span_event')
               total_spans = 5

--- a/infinite_tracing/test/infinite_tracing/connection_test.rb
+++ b/infinite_tracing/test/infinite_tracing/connection_test.rb
@@ -86,74 +86,82 @@ module NewRelic
         end
 
         def test_sending_spans_to_server
-          with_serial_lock do
-            total_spans = 5
-            spans, segments = emulate_streaming_segments(total_spans)
+          with_config('infinite_tracing.batching': false) do
+            with_serial_lock do
+              total_spans = 5
+              spans, segments = emulate_streaming_segments(total_spans)
 
-            assert_equal total_spans, segments.size
-            assert_equal total_spans, spans.size
+              assert_equal total_spans, segments.size
+              assert_equal total_spans, spans.size
+            end
           end
         end
 
         def test_handling_unimplemented_server_response
-          with_serial_lock do
-            total_spans = 5
-            active_client = nil
+          with_config('infinite_tracing.batching': false) do
+            with_serial_lock do
+              total_spans = 5
+              active_client = nil
 
-            spans, segments, active_client = emulate_streaming_to_unimplemented(total_spans)
+              spans, segments, active_client = emulate_streaming_to_unimplemented(total_spans)
 
-            assert_kind_of SuspendedStreamingBuffer, active_client.buffer
-            assert_predicate active_client, :suspended?, "expected client to be suspended."
+              assert_kind_of SuspendedStreamingBuffer, active_client.buffer
+              assert_predicate active_client, :suspended?, "expected client to be suspended."
 
-            assert_equal total_spans, segments.size
-            assert_equal 0, spans.size
+              assert_equal total_spans, segments.size
+              assert_equal 0, spans.size
 
-            assert_metrics_recorded "Supportability/InfiniteTracing/Span/Sent"
-            assert_metrics_recorded "Supportability/InfiniteTracing/Span/Response/Error"
+              assert_metrics_recorded "Supportability/InfiniteTracing/Span/Sent"
+              assert_metrics_recorded "Supportability/InfiniteTracing/Span/Response/Error"
 
-            assert_metrics_recorded({
-              "Supportability/InfiniteTracing/Span/Seen" => {:call_count => total_spans},
-              "Supportability/InfiniteTracing/Span/gRPC/UNIMPLEMENTED" => {:call_count => 1}
-            })
+              assert_metrics_recorded({
+                "Supportability/InfiniteTracing/Span/Seen" => {:call_count => total_spans},
+                "Supportability/InfiniteTracing/Span/gRPC/UNIMPLEMENTED" => {:call_count => 1}
+              })
+            end
           end
         end
 
         def test_handling_failed_precondition_server_response
-          with_serial_lock do
-            total_spans = 5
-            active_client = nil
+          with_config('infinite_tracing.batching': false) do
+            with_serial_lock do
+              total_spans = 5
+              active_client = nil
 
-            spans, segments, active_client = emulate_streaming_to_failed_precondition(total_spans)
+              spans, segments, active_client = emulate_streaming_to_failed_precondition(total_spans)
 
-            refute_kind_of SuspendedStreamingBuffer, active_client.buffer
-            refute active_client.suspended?, "expected client to not be suspended."
+              refute_kind_of SuspendedStreamingBuffer, active_client.buffer
+              refute active_client.suspended?, "expected client to not be suspended."
 
-            assert_equal total_spans, segments.size
-            assert_equal 0, spans.size
+              assert_equal total_spans, segments.size
+              assert_equal 0, spans.size
 
-            assert_metrics_recorded "Supportability/InfiniteTracing/Span/Sent"
-            assert_metrics_recorded "Supportability/InfiniteTracing/Span/Response/Error"
+              assert_metrics_recorded "Supportability/InfiniteTracing/Span/Sent"
+              assert_metrics_recorded "Supportability/InfiniteTracing/Span/Response/Error"
 
-            assert_metrics_recorded({
-              "Supportability/InfiniteTracing/Span/Seen" => {:call_count => total_spans},
-              "Supportability/InfiniteTracing/Span/gRPC/FAILED_PRECONDITION" => {:call_count => 5}
-            })
+              assert_metrics_recorded({
+                "Supportability/InfiniteTracing/Span/Seen" => {:call_count => total_spans},
+                "Supportability/InfiniteTracing/Span/gRPC/FAILED_PRECONDITION" => {:call_count => 5}
+              })
+            end
           end
         end
 
         def test_handling_ok_and_close_server_response
-          with_detailed_trace do
-            total_spans = 5
-            expects_logging(:debug, all_of(includes("closed the stream"), includes("OK response.")), anything)
+          with_config('infinite_tracing.batching': false) do
+            with_detailed_trace do
+              total_spans = 5
+              expects_logging(:debug, all_of(includes("closed the stream"), includes("OK response.")), anything)
 
-            spans, segments = emulate_streaming_with_ok_close_response(total_spans)
+              spans, segments = emulate_streaming_with_ok_close_response(total_spans)
 
-            assert_equal total_spans, segments.size
-            assert_equal total_spans, spans.size, "spans got dropped/discarded?"
+              assert_equal total_spans, segments.size
+              assert_equal total_spans, spans.size, "spans got dropped/discarded?"
 
-            refute_metrics_recorded "Supportability/InfiniteTracing/Span/Response/Error"
+              refute_metrics_recorded "Supportability/InfiniteTracing/Span/Response/Error"
 
-            assert_metrics_recorded("Supportability/InfiniteTracing/Span/Sent")
+              assert_metrics_recorded("Supportability/InfiniteTracing/Span/Sent")
+            end
           end
         end
 

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2331,7 +2331,7 @@ If `true`, disables agent middleware for Sinatra. This middleware is responsible
           :description => "URI for the New Relic data collection service."
         },
         :'infinite_tracing.batching' => {
-          :default => false,
+          :default => true,
           :public => true,
           :type => Boolean,
           :allowed_from_server => false,


### PR DESCRIPTION
PR 1723 was intended to enable batching everywhere, but default_source.rb was unfortunately overlooked.

enable batching in default_source.rb and leave the tests as-is for now (to be revisited when we tackle code coverage for 8T), given that batching was already covered with unit tests previously.