### PR TITLE
Update Gemfiles for Rails testing

### DIFF
--- a/test/environments/rails60/Gemfile
+++ b/test/environments/rails60/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 
 gem 'rake', '~> 12.3.3'
 
-gem 'rails', '~> 6.0.6.1'
+gem 'rails', '~> 6.0.6'
 
 gem 'minitest', '5.2.3'
 gem 'minitest-stub-const', '~> 0.6'

--- a/test/environments/rails60/Gemfile
+++ b/test/environments/rails60/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 
 gem 'rake', '~> 12.3.3'
 
-gem 'rails', '~> 6.0.0'
+gem 'rails', '~> 6.0.6.1'
 
 gem 'minitest', '5.2.3'
 gem 'minitest-stub-const', '~> 0.6'
@@ -19,7 +19,13 @@ end
 
 platforms :ruby, :rbx do
   gem "mysql2", '>= 0.5.4'
-  gem 'sqlite3', '~> 1.4'
+  if RUBY_VERSION < '2.6'
+    gem 'sqlite3', '~> 1.4.0'
+  elsif RUBY_VERSION < '2.7'
+    gem 'sqlite3', '~> 1.5.4'
+  else
+    gem 'sqlite3'
+  end
 end
 
 gem "newrelic_rpm", :path => "../../.."

--- a/test/environments/rails61/Gemfile
+++ b/test/environments/rails61/Gemfile
@@ -2,7 +2,7 @@
 source 'https://rubygems.org'
 
 gem 'rake', '~> 12.3.3'
-gem 'rails', '~> 6.1.0'
+gem 'rails', '~> 6.1.7.1'
 
 gem 'minitest', '5.2.3'
 gem 'minitest-stub-const', '~> 0.6'
@@ -18,7 +18,13 @@ end
 
 platforms :ruby, :rbx do
   gem 'mysql2'
-  gem 'sqlite3', '~> 1.4'
+  if RUBY_VERSION < '2.6'
+    gem 'sqlite3', '~> 1.4.0'
+  elsif RUBY_VERSION < '2.7'
+    gem 'sqlite3', '< 1.6'
+  else
+    gem 'sqlite3'
+  end
 end
 
 gem 'newrelic_rpm', path: '../../..'

--- a/test/environments/rails61/Gemfile
+++ b/test/environments/rails61/Gemfile
@@ -2,7 +2,7 @@
 source 'https://rubygems.org'
 
 gem 'rake', '~> 12.3.3'
-gem 'rails', '~> 6.1.7.1'
+gem 'rails', '~> 6.1.7'
 
 gem 'minitest', '5.2.3'
 gem 'minitest-stub-const', '~> 0.6'

--- a/test/environments/rails70/Gemfile
+++ b/test/environments/rails70/Gemfile
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 source 'https://rubygems.org'
 
-gem 'rails', '~> 7.0.4.1'
+gem 'rails', '~> 7.0.4'
 gem "bootsnap", ">= 1.4.4", require: false
 
 gem 'minitest', '5.2.3'

--- a/test/environments/rails70/Gemfile
+++ b/test/environments/rails70/Gemfile
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 source 'https://rubygems.org'
 
-gem 'rails', '~> 7.0.4'
+gem 'rails', '~> 7.0.4.1'
 gem "bootsnap", ">= 1.4.4", require: false
 
 gem 'minitest', '5.2.3'

--- a/test/multiverse/suites/sequel/Envfile
+++ b/test/multiverse/suites/sequel/Envfile
@@ -8,11 +8,19 @@ SEQUEL_VERSIONS = [
   ['5.17.0', 2.2, 2.7]
 ]
 
+def sqlite3_version
+  if RUBY_VERSION < '2.6'
+    "'< 1.5.0', "
+  elsif RUBY_VERSION < '2.7'
+    "'< 1.6.0', "
+  end
+end
+
 def gem_list(sequel_version = nil)
   <<-RB
     gem 'newrelic_rpm', :require => false, :path => File.expand_path('../../../../')
     gem 'jdbc-sqlite3', '3.7.2', :platform => :jruby
-    gem 'sqlite3',#{" '< 1.5.0'," if RUBY_VERSION < '2.6'} :platform => :ruby
+    gem 'sqlite3',#{sqlite3_version} :platform => :ruby
     gem 'sequel'#{sequel_version}
   RB
 end


### PR DESCRIPTION
Specify sqlite3 version by Ruby version
* Version 1.6.0 supports Ruby 2.7+
* Version 1.5.x supports 2.6
* Version 1.4.x supports 2.5

Add security patch versions for Rails 6.0, 6.1, 7.0