### PR TITLE
Active Support instrumentation: add test

### DIFF
--- a/test/new_relic/agent/instrumentation/rails/active_support_subscriber.rb
+++ b/test/new_relic/agent/instrumentation/rails/active_support_subscriber.rb
@@ -200,6 +200,10 @@ module NewRelic
         end
 
         def test_an_actual_active_storage_cache_write
+          unless defined?(ActiveSupport::VERSION::MAJOR) && ActiveSupport::VERSION::MAJOR >= 5
+            skip 'Test restricted to Active Support v5+'
+          end
+
           in_transaction do |txn|
             store = ActiveSupport::Cache::MemoryStore
             key = 'city'


### PR DESCRIPTION
Add a unit test for the Active Support instrumentation that does not directly invoke the subscriber class's `#start` and `#finish` methods manually, but instead performs a real Active Storage cache write and confirms that the instrumentation works as expected.

@kreopelle I have found a potential problem with the `NotificationsSubscriber` class being used for `ActionMailer` and `ActionMailbox` notifications. I wanted to be sure that your new `ActiveSupport` instrumentation did not have the same problem. I authored this new test and am happy to report that it confirms the new `ActiveSupport` instrumentation is not impacted by the same problem. I figured we might as well commit the test, so here's a PR.