### PR TITLE
Action Dispatch instrumentation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1470,6 +1470,7 @@ Style/MethodCallWithArgsParentheses:
     - source
     - stub
     - stub_const
+    - use
   AllowedPatterns: [^assert, ^refute]
 
 Style/MethodCallWithoutArgsParentheses:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The upcoming release of the agent introduces additional Ruby on Rails instrument
 
   The agent now newly supports or has updated support for the following libraries:
 
-  - Action Dispatch (for middleware) [PR#1745] (https://github.com/newrelic/newrelic-ruby-agent/pull/1745)
+  - Action Dispatch (for middleware) [PR#1745](https://github.com/newrelic/newrelic-ruby-agent/pull/1745)
   - Action Mailbox (for sending mail) [PR#1740](https://github.com/newrelic/newrelic-ruby-agent/pull/1740)
   - Action Mailer (for routing mail) [PR#1740](https://github.com/newrelic/newrelic-ruby-agent/pull/1740)
   - Active Support (for caching operations) [PR#1742](https://github.com/newrelic/newrelic-ruby-agent/pull/1742)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,15 @@
 
 ## Upcoming Release
 
-The upcoming release of the agent introduces additional Ruby on Rails instrumentation (especially for Rails 6 and 7) for various Action*/Active* libraries whose actions produce Active Support notifications events.
+The upcoming release of the agent introduces additional Ruby on Rails instrumentation (especially for Rails 6 and 7) for various Action\*/Active\* libraries whose actions produce Active Support notifications events.
 
 - **Add Various Additional Ruby on Rails Library Instrumentations**
 
-  New instrumentation is now automatically provided by several Action*/Active* libaries that generate Active Support notifications. With each new Ruby on Rails release, new events are added to the Rails libraries and sometimes existing events have their payload parameters updated as well. The New Relic Ruby agent will now automatically process more of these events and parameters with New Relic segments that are created for each event. At a minimum, each segment will provide timing information for the event. In several cases, all non-sensitive event payload parameters are also passed along in the segment.
+  New instrumentation is now automatically provided by several Action\*/Active\* libaries that generate Active Support notifications. With each new Ruby on Rails release, new events are added to the Rails libraries and sometimes existing events have their payload parameters updated as well. The New Relic Ruby agent will now automatically process more of these events and parameters with New Relic segments that are created for each event. At a minimum, each segment will provide timing information for the event. In several cases, all non-sensitive event payload parameters are also passed along in the segment.
 
   The agent now newly supports or has updated support for the following libraries:
 
-  - Action Dispatch (for middleware)[PR#1745] (https://github.com/newrelic/newrelic-ruby-agent/pull/1745)
+  - Action Dispatch (for middleware) [PR#1745] (https://github.com/newrelic/newrelic-ruby-agent/pull/1745)
   - Action Mailbox (for sending mail) [PR#1740](https://github.com/newrelic/newrelic-ruby-agent/pull/1740)
   - Action Mailer (for routing mail) [PR#1740](https://github.com/newrelic/newrelic-ruby-agent/pull/1740)
   - Active Support (for caching operations) [PR#1742](https://github.com/newrelic/newrelic-ruby-agent/pull/1742)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Upcoming Release
 
-This upcoming release of the agent adds instrumentation for Active Support caching operations.
+This upcoming release of the agent adds instrumentation for Active Support caching operations and Action Dispatch middleware event notifications.
 
 - **Add Active Support Instrumentation**
 
@@ -11,6 +11,14 @@ This upcoming release of the agent adds instrumentation for Active Support cachi
   | Configuration name | Default | Behavior |
   | ----- | ----- | ----- |
   | `disable_active_support` | `false` | If `true`, disables Active Support instrumentation. |
+
+- **Add Action Dispatch Instrumentation**
+
+  Instrumentation is now automatically provided for all Action Dispatch middleware events that generate Active Support notifications. Whenever a middleware operation is performed a New Relic segment is created that contains timing information. [PR#1745](https://github.com/newrelic/newrelic-ruby-agent/pull/1745)
+
+  | Configuration name | Default | Behavior |
+  | ----- | ----- | ----- |
+  | `disable_action_dispatch` | `false` | If `true`, disables Action Dispatch instrumentation. |
 
 ## 8.15.0
 

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -1141,6 +1141,14 @@ A map of error classes to a list of messages. When an error of one of the classe
           :allowed_from_server => false,
           :description => 'If `true`, disables Action Cable instrumentation.'
         },
+        :disable_action_dispatch => {
+          :default => false,
+          :public => true,
+          :type => Boolean,
+          :dynamic_name => true,
+          :allowed_from_server => false,
+          :description => 'If `true`, disables ActionDispatch instrumentation.'
+        },
         :disable_activejob => {
           :default => false,
           :public => true,

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -1144,7 +1144,6 @@ A map of error classes to a list of messages. When an error of one of the classe
           :default => false,
           :public => true,
           :type => Boolean,
-          :dynamic_name => true,
           :allowed_from_server => false,
           :description => 'If `true`, disables ActionDispatch instrumentation.'
         },

--- a/lib/new_relic/agent/instrumentation/action_dispatch.rb
+++ b/lib/new_relic/agent/instrumentation/action_dispatch.rb
@@ -21,7 +21,7 @@ DependencyDetection.defer do
   end
 
   executes do
-    ActiveSupport::Notifications.subscribe(/^process_middleware\.action_dispatch$/,
+    ActiveSupport::Notifications.subscribe(/\A[^\.]+\.action_dispatch\z/,
       NewRelic::Agent::Instrumentation::ActionDispatchSubscriber.new)
   end
 end

--- a/lib/new_relic/agent/instrumentation/action_dispatch.rb
+++ b/lib/new_relic/agent/instrumentation/action_dispatch.rb
@@ -1,0 +1,27 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+require 'new_relic/agent/instrumentation/action_dispatch_subscriber'
+
+DependencyDetection.defer do
+  named :action_dispatch
+
+  depends_on do
+    defined?(ActiveSupport) &&
+      defined?(ActionDispatch) &&
+      defined?(ActionPack) &&
+      ActionPack.respond_to?(:gem_version) &&
+      ActionPack.gem_version >= Gem::Version.new('6.0.0') && # notifications for dispatch added in Rails 6
+      !NewRelic::Agent::Instrumentation::ActionDispatchSubscriber.subscribed?
+  end
+
+  executes do
+    NewRelic::Agent.logger.info('Installing ActionDispatch instrumentation')
+  end
+
+  executes do
+    ActiveSupport::Notifications.subscribe(/^process_middleware\.action_dispatch$/,
+      NewRelic::Agent::Instrumentation::ActionDispatchSubscriber.new)
+  end
+end

--- a/lib/new_relic/agent/instrumentation/action_dispatch_subscriber.rb
+++ b/lib/new_relic/agent/instrumentation/action_dispatch_subscriber.rb
@@ -26,11 +26,6 @@ module NewRelic
 
         def start_segment(name, id, payload)
           segment = Tracer.start_segment(name: metric_name(name, payload))
-
-          # what's in payload?
-          binding.irb
-
-          segment.params[:middleware] = payload[:middleware]
           push_segment(id, segment)
         end
 

--- a/lib/new_relic/agent/instrumentation/action_dispatch_subscriber.rb
+++ b/lib/new_relic/agent/instrumentation/action_dispatch_subscriber.rb
@@ -26,8 +26,11 @@ module NewRelic
 
         def start_segment(name, id, payload)
           segment = Tracer.start_segment(name: metric_name(name, payload))
-          segment.params[:key] = payload[:key]
-          segment.params[:exist] = payload[:exist] if payload.key?(:exist)
+
+          # what's in payload?
+          binding.irb
+
+          segment.params[:middleware] = payload[:middleware]
           push_segment(id, segment)
         end
 
@@ -43,10 +46,10 @@ module NewRelic
         def metric_name(name, payload)
           middleware = payload[:middleware]
           method = method_from_name(name)
-          "Ruby/ActionDispatch/#{middleware}Middleware/#{method}"
+          "Ruby/ActionDispatch/#{middleware}/#{method}"
         end
 
-        PATTERN = /\Aprocess_middleware\.action_dispatch\z/
+        PATTERN = /\A([^\.]+)\.action_dispatch\z/
         UNKNOWN = 'unknown'.freeze
 
         METHOD_NAME_MAPPING = Hash.new do |h, k|

--- a/lib/new_relic/agent/instrumentation/action_dispatch_subscriber.rb
+++ b/lib/new_relic/agent/instrumentation/action_dispatch_subscriber.rb
@@ -1,0 +1,66 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+require 'new_relic/agent/instrumentation/notifications_subscriber'
+
+module NewRelic
+  module Agent
+    module Instrumentation
+      class ActionDispatchSubscriber < NotificationsSubscriber
+        def start(name, id, payload)
+          return unless state.is_execution_traced?
+
+          start_segment(name, id, payload)
+        rescue => e
+          log_notification_error(e, name, 'start')
+        end
+
+        def finish(name, id, payload)
+          return unless state.is_execution_traced?
+
+          finish_segment(id, payload)
+        rescue => e
+          log_notification_error(e, name, 'finish')
+        end
+
+        def start_segment(name, id, payload)
+          segment = Tracer.start_segment(name: metric_name(name, payload))
+          segment.params[:key] = payload[:key]
+          segment.params[:exist] = payload[:exist] if payload.key?(:exist)
+          push_segment(id, segment)
+        end
+
+        def finish_segment(id, payload)
+          if segment = pop_segment(id)
+            if exception = exception_object(payload)
+              segment.notice_error(exception)
+            end
+            segment.finish
+          end
+        end
+
+        def metric_name(name, payload)
+          middleware = payload[:middleware]
+          method = method_from_name(name)
+          "Ruby/ActionDispatch/#{middleware}Middleware/#{method}"
+        end
+
+        PATTERN = /\Aprocess_middleware\.action_dispatch\z/
+        UNKNOWN = 'unknown'.freeze
+
+        METHOD_NAME_MAPPING = Hash.new do |h, k|
+          if PATTERN =~ k
+            h[k] = $1
+          else
+            h[k] = UNKNOWN
+          end
+        end
+
+        def method_from_name(name)
+          METHOD_NAME_MAPPING[name]
+        end
+      end
+    end
+  end
+end

--- a/newrelic.yml
+++ b/newrelic.yml
@@ -169,6 +169,9 @@ common: &default_settings
   # If true, disables Action Cable instrumentation.
   # disable_action_cable_instrumentation: false
 
+  # If true, disables ActionDispatch instrumentation
+  # disable_action_dispatch: false
+
   # If true, disables instrumentation for Active Record 4, 5, and 6.
   # disable_active_record_notifications: false
 

--- a/newrelic.yml
+++ b/newrelic.yml
@@ -169,7 +169,7 @@ common: &default_settings
   # If true, disables Action Cable instrumentation.
   # disable_action_cable_instrumentation: false
 
-  # If true, disables ActionDispatch instrumentation
+  # If true, disables Action Dispatch instrumentation.
   # disable_action_dispatch: false
 
   # If true, disables Action Mailbox instrumentation.

--- a/test/new_relic/agent/instrumentation/action_dispatch_subscriber_test.rb
+++ b/test/new_relic/agent/instrumentation/action_dispatch_subscriber_test.rb
@@ -9,7 +9,7 @@ if defined?(ActiveSupport) &&
      defined?(ActionDispatch) &&
      defined?(ActionPack) &&
      ActionPack.respond_to?(:gem_version) &&
-     ActionPack.gem_version >= Gem::Version.new('6.0.0') && # notifications for dispatch added in Rails 6
+     ActionPack.gem_version >= Gem::Version.new('6.0.0') # notifications for dispatch added in Rails 6
   require_relative 'rails/action_dispatch_subscriber'
 else
   puts "Skipping tests in #{__FILE__} because ActionDispatch is unavailable or < 6.0"

--- a/test/new_relic/agent/instrumentation/action_dispatch_subscriber_test.rb
+++ b/test/new_relic/agent/instrumentation/action_dispatch_subscriber_test.rb
@@ -6,10 +6,10 @@ require_relative '../../../test_helper'
 require 'new_relic/agent/instrumentation/action_dispatch_subscriber'
 
 if defined?(ActiveSupport) &&
-     defined?(ActionDispatch) &&
-     defined?(ActionPack) &&
-     ActionPack.respond_to?(:gem_version) &&
-     ActionPack.gem_version >= Gem::Version.new('6.0.0') # notifications for dispatch added in Rails 6
+    defined?(ActionDispatch) &&
+    defined?(ActionPack) &&
+    ActionPack.respond_to?(:gem_version) &&
+    ActionPack.gem_version >= Gem::Version.new('6.0.0') # notifications for dispatch added in Rails 6
   require_relative 'rails/action_dispatch_subscriber'
 else
   puts "Skipping tests in #{__FILE__} because ActionDispatch is unavailable or < 6.0"

--- a/test/new_relic/agent/instrumentation/action_dispatch_subscriber_test.rb
+++ b/test/new_relic/agent/instrumentation/action_dispatch_subscriber_test.rb
@@ -1,0 +1,16 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+require_relative '../../../test_helper'
+require 'new_relic/agent/instrumentation/action_dispatch_subscriber'
+
+if defined?(ActiveSupport) &&
+     defined?(ActionDispatch) &&
+     defined?(ActionPack) &&
+     ActionPack.respond_to?(:gem_version) &&
+     ActionPack.gem_version >= Gem::Version.new('6.0.0') && # notifications for dispatch added in Rails 6
+  require_relative 'rails/action_dispatch_subscriber'
+else
+  puts "Skipping tests in #{__FILE__} because ActionDispatch is unavailable or < 6.0"
+end

--- a/test/new_relic/agent/instrumentation/rails/action_dispatch_subscriber.rb
+++ b/test/new_relic/agent/instrumentation/rails/action_dispatch_subscriber.rb
@@ -7,22 +7,28 @@ require 'new_relic/agent/instrumentation/action_dispatch_subscriber'
 
 module NewRelic::Agent::Instrumentation
   class TestMiddleware < ActionDispatch::MiddlewareStack::Middleware
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      @app.call(env)
+    end
   end
 
   class ActionDispatchSubscriberTest < Minitest::Test
     NAME = 'process_middleware.action_dispatch'
     ID = 1987 # 'Emperor of the Night'
     SUBSCRIBER = NewRelic::Agent::Instrumentation::ActionDispatchSubscriber.new
-    MIDDLEWARE = TestMiddleware.new
 
     def test_start
       in_transaction do |txn|
         time = Time.now.to_f
-        SUBSCRIBER.start(NAME, ID, {middleware: MIDDLEWARE.class.name})
+        SUBSCRIBER.start(NAME, ID, {middleware: TestMiddleware.name})
         segment = txn.segments.last
 
         assert_in_delta time, segment.start_time
-        assert_equal "Ruby/ActionDispatch/#{SERVICE}Service/#{SERVICE}", segment.name
+        assert_equal "Ruby/ActionDispatch/#{TestMiddleware.name}/process_middleware", segment.name
       end
     end
 
@@ -52,6 +58,11 @@ module NewRelic::Agent::Instrumentation
         end
       end
       logger.verify
+    end
+
+    def test_segment_naming_with_unknown_method
+      assert_equal "Ruby/ActionDispatch/#{TestMiddleware.name}/unknown",
+        SUBSCRIBER.send(:metric_name, 'indecipherable', {middleware: TestMiddleware.name})
     end
 
     def test_finish
@@ -100,13 +111,32 @@ module NewRelic::Agent::Instrumentation
       logger.verify
     end
 
-    def test_an_actual_mailbox_processing
-      in_transaction do |txn|
-        # mailbox = MAILBOX
-        # mailbox.perform_processing
+    def test_finish_when_not_tracing
+      state = MiniTest::Mock.new
+      state.expect :is_execution_traced?, false
 
-        assert_equal 2, txn.segments.size
-        assert_match %r{^Ruby/ActionDispatch}, txn.segments.last.name
+      SUBSCRIBER.stub :state, state do
+        assert_nil SUBSCRIBER.finish(NAME, ID, {})
+      end
+    end
+
+    def test_finish_segment_when_a_segment_does_not_exist
+      SUBSCRIBER.stub :pop_segment, nil, [ID] do
+        assert_nil SUBSCRIBER.send(:finish_segment, ID, {})
+      end
+    end
+
+    def test_an_actual_mailbox_processing
+      stack = ActionDispatch::MiddlewareStack.new
+      stack.use TestMiddleware
+      web_app = stack.build(proc { |env| [200, {}, []] })
+
+      in_transaction do |txn|
+        web_app.call({})
+        segment = txn.segments.detect { |s| s.name.start_with?('Ruby/ActionDispatch') }
+
+        assert segment
+        assert_equal segment.name, "Ruby/ActionDispatch/#{TestMiddleware.name}/process_middleware"
       end
     end
   end

--- a/test/new_relic/agent/instrumentation/rails/action_dispatch_subscriber.rb
+++ b/test/new_relic/agent/instrumentation/rails/action_dispatch_subscriber.rb
@@ -1,0 +1,110 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+require_relative '../../../../test_helper'
+require 'new_relic/agent/instrumentation/action_dispatch_subscriber'
+
+module NewRelic::Agent::Instrumentation
+  class ActionDispatchSubscriberTest < Minitest::Test
+    SERVICE = 'Emperor of the Night'
+    NAME = "service_#{SERVICE}.action_dispatch"
+    ID = 1987
+    SUBSCRIBER = NewRelic::Agent::Instrumentation::ActionDispatchSubscriber.new
+
+    def test_start
+      in_transaction do |txn|
+        time = Time.now.to_f
+        SUBSCRIBER.start(NAME, ID, {service: SERVICE})
+        segment = txn.segments.last
+
+        assert_in_delta time, segment.start_time
+        assert_equal "Ruby/ActionDispatch/#{SERVICE}Service/#{SERVICE}", segment.name
+      end
+    end
+
+    def test_start_when_not_traced
+      SUBSCRIBER.state.stub :is_execution_traced?, false do
+        in_transaction do |txn|
+          SUBSCRIBER.start(NAME, ID, {})
+
+          assert_empty txn.segments
+        end
+      end
+    end
+
+    def test_start_with_exception_raised
+      logger = MiniTest::Mock.new
+
+      NewRelic::Agent.stub :logger, logger do
+        logger.expect :error, nil, [/Error during .* callback/]
+        logger.expect :log_exception, nil, [:error, ArgumentError]
+
+        in_transaction do |txn|
+          SUBSCRIBER.stub :start_segment, -> { raise 'kaboom' } do
+            SUBSCRIBER.start(NAME, ID, {})
+          end
+
+          assert_equal 1, txn.segments.size
+        end
+      end
+      logger.verify
+    end
+
+    def test_finish
+      in_transaction do |txn|
+        started_segment = NewRelic::Agent::Tracer.start_transaction_or_segment(name: NAME, category: :testing)
+        SUBSCRIBER.push_segment(ID, started_segment)
+
+        time = Time.now.to_f
+        SUBSCRIBER.finish(NAME, ID, {})
+        segment = txn.segments.last
+
+        assert_in_delta time, segment.end_time
+        assert_predicate(segment, :finished?)
+      end
+    end
+
+    def test_finish_with_exception_payload
+      skip_unless_minitest5_or_above
+
+      exception_object = StandardError.new
+      noticed = false
+      segment = MiniTest::Mock.new
+      segment.expect :notice_error, nil, [exception_object]
+      SUBSCRIBER.stub(:pop_segment, segment, [ID]) do
+        SUBSCRIBER.finish(NAME, ID, {exception_object: exception_object})
+      end
+
+      segment.verify
+    end
+
+    def test_finish_with_exception_raised
+      logger = MiniTest::Mock.new
+
+      NewRelic::Agent.stub :logger, logger do
+        logger.expect :error, nil, [/Error during .* callback/]
+        logger.expect :log_exception, nil, [:error, RuntimeError]
+
+        in_transaction do |txn|
+          SUBSCRIBER.state.stub :is_execution_traced?, -> { raise 'kaboom' } do
+            SUBSCRIBER.finish(NAME, ID, {})
+          end
+
+          assert_equal 1, txn.segments.size
+        end
+      end
+      logger.verify
+    end
+
+    def test_an_actual_mailbox_processing
+      in_transaction do |txn|
+        # mailbox = MAILBOX
+        # mailbox.perform_processing
+
+        assert_equal 2, txn.segments.size
+        assert_match %r{^Ruby/ActionDispatch}, txn.segments.last.name
+      end
+    end
+  end
+end

--- a/test/new_relic/agent/instrumentation/rails/action_dispatch_subscriber.rb
+++ b/test/new_relic/agent/instrumentation/rails/action_dispatch_subscriber.rb
@@ -6,16 +6,19 @@ require_relative '../../../../test_helper'
 require 'new_relic/agent/instrumentation/action_dispatch_subscriber'
 
 module NewRelic::Agent::Instrumentation
+  class TestMiddleware < ActionDispatch::MiddlewareStack::Middleware
+  end
+
   class ActionDispatchSubscriberTest < Minitest::Test
-    SERVICE = 'Emperor of the Night'
-    NAME = "service_#{SERVICE}.action_dispatch"
-    ID = 1987
+    NAME = 'process_middleware.action_dispatch'
+    ID = 1987 # 'Emperor of the Night'
     SUBSCRIBER = NewRelic::Agent::Instrumentation::ActionDispatchSubscriber.new
+    MIDDLEWARE = TestMiddleware.new
 
     def test_start
       in_transaction do |txn|
         time = Time.now.to_f
-        SUBSCRIBER.start(NAME, ID, {service: SERVICE})
+        SUBSCRIBER.start(NAME, ID, {middleware: MIDDLEWARE.class.name})
         segment = txn.segments.last
 
         assert_in_delta time, segment.start_time

--- a/test/new_relic/agent/instrumentation/rails/action_dispatch_subscriber.rb
+++ b/test/new_relic/agent/instrumentation/rails/action_dispatch_subscriber.rb
@@ -126,7 +126,7 @@ module NewRelic::Agent::Instrumentation
       end
     end
 
-    def test_an_actual_mailbox_processing
+    def test_an_actual_middleware_call_based_event_processing
       stack = ActionDispatch::MiddlewareStack.new
       stack.use TestMiddleware
       web_app = stack.build(proc { |env| [200, {}, []] })


### PR DESCRIPTION
Provide instrumentation for Action Dispatch based middleware calls by subscribing to and creating segments for all related Active Support notifications based events.

addresses #1511 