### PR TITLE
Subscribe to additional Action View topic

### DIFF
--- a/lib/new_relic/agent/instrumentation/action_view_subscriber.rb
+++ b/lib/new_relic/agent/instrumentation/action_view_subscriber.rb
@@ -61,12 +61,14 @@ module NewRelic
         RENDER_TEMPLATE_EVENT_NAME = 'render_template.action_view'.freeze
         RENDER_PARTIAL_EVENT_NAME = 'render_partial.action_view'.freeze
         RENDER_COLLECTION_EVENT_NAME = 'render_collection.action_view'.freeze
+        RENDER_LAYOUT_EVENT_NAME = 'render_layout.action_view'.freeze
 
         def metric_action(name)
           case name
           when /#{RENDER_TEMPLATE_EVENT_NAME}$/o then 'Rendering'
           when RENDER_PARTIAL_EVENT_NAME then 'Partial'
           when RENDER_COLLECTION_EVENT_NAME then 'Partial'
+          when RENDER_LAYOUT_EVENT_NAME then 'Layout'
           end
         end
 

--- a/lib/new_relic/agent/instrumentation/action_view_subscriber.rb
+++ b/lib/new_relic/agent/instrumentation/action_view_subscriber.rb
@@ -66,6 +66,7 @@ module NewRelic
           when RENDER_PARTIAL_EVENT_NAME then 'Partial'
           when RENDER_COLLECTION_EVENT_NAME then 'Partial'
           when RENDER_LAYOUT_EVENT_NAME then 'Layout'
+          else 'Unknown'
           end
         end
 

--- a/test/new_relic/agent/instrumentation/rails/action_view_subscriber.rb
+++ b/test/new_relic/agent/instrumentation/rails/action_view_subscriber.rb
@@ -286,4 +286,12 @@ class NewRelic::Agent::Instrumentation::ActionViewSubscriberTest < Minitest::Tes
       assert_nil @subscriber.send(:finish_segment, :id, {})
     end
   end
+
+  def test_metric_action_nil_name
+    assert_equal 'Unknown', @subscriber.metric_action(nil)
+  end
+
+  def test_metric_action_unknown_name
+    assert_equal 'Unknown', @subscriber.metric_action('cheez-it')
+  end
 end

--- a/test/new_relic/agent/instrumentation/rails/action_view_subscriber.rb
+++ b/test/new_relic/agent/instrumentation/rails/action_view_subscriber.rb
@@ -280,4 +280,10 @@ class NewRelic::Agent::Instrumentation::ActionViewSubscriberTest < Minitest::Tes
   def test_metric_path_index_html_erb
     assert_equal('model/index.html.erb', @subscriber.metric_path('render_template.action_view', 'model/index.html.erb'))
   end
+
+  def test_finish_segment_when_no_segment
+    @subscriber.stub :pop_segment, nil do
+      assert_nil @subscriber.send(:finish_segment, :id, {})
+    end
+  end
 end

--- a/test/new_relic/agent/instrumentation/rails/action_view_subscriber.rb
+++ b/test/new_relic/agent/instrumentation/rails/action_view_subscriber.rb
@@ -110,6 +110,23 @@ class NewRelic::Agent::Instrumentation::ActionViewSubscriberTest < Minitest::Tes
     assert_metrics_recorded('View/model/_user.html.erb/Partial' => expected)
   end
 
+  def test_records_metrics_for_simple_layout
+    params = {:identifier => '/root/app/views/model/_layout.html.erb'}
+    nr_freeze_process_time
+    in_transaction do
+      @subscriber.start('render_layout.action_view', :id, params)
+      @subscriber.start('!render_layout.action_view', :id,
+        :virtual_path => 'model/_layout')
+      advance_process_time(2.0)
+      @subscriber.finish('!render_layout.action_view', :id,
+        :virtual_path => 'model/_layout')
+      @subscriber.finish('render_layout.action_view', :id, params)
+    end
+    expected = {:call_count => 1, :total_call_time => 2.0}
+
+    assert_metrics_recorded('View/model/_layout.html.erb/Layout' => expected)
+  end
+
   def test_records_metrics_for_layout
     nr_freeze_process_time
     in_transaction do


### PR DESCRIPTION
- subscribe to `render_layout.action_view`
- add test for `render_layout.action_view`
- refactor ActionViewSubscriber's `start` and `finish` to accommodate for new `start` and `finish` methods inherited from NotificationsSubscriber

closes #1512