### PR TITLE
Add broadcast instrumentation for Action Cable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The upcoming release of the agent introduces additional Ruby on Rails instrument
 
   The agent now newly supports or has updated support for the following libraries:
 
+  - Action Cable (for WebSockets) [PR#1749](https://github.com/newrelic/newrelic-ruby-agent/pull/1749)
   - Action Dispatch (for middleware) [PR#1745](https://github.com/newrelic/newrelic-ruby-agent/pull/1745)
   - Action Mailbox (for sending mail) [PR#1740](https://github.com/newrelic/newrelic-ruby-agent/pull/1740)
   - Action Mailer (for routing mail) [PR#1740](https://github.com/newrelic/newrelic-ruby-agent/pull/1740)
@@ -19,6 +20,7 @@ The upcoming release of the agent introduces additional Ruby on Rails instrument
 
   | Configuration name | Default | Behavior |
   | ----- | ----- | ----- |
+  | `disable_action_cable` | `false` | If `true`, disables Action Cable instrumentation. |
   | `disable_action_dispatch` | `false` | If `true`, disables Action Dispatch instrumentation. |
   | `disable_action_mailbox` | `false` | If `true`, disables Action Mailbox instrumentation. |
   | `disable_action_mailer` | `false` | If `true`, disables Action Mailer instrumentation. |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The upcoming release of the agent introduces additional Ruby on Rails instrument
   The agent now newly supports or has updated support for the following libraries:
 
   - Action Cable (for WebSockets) [PR#1749](https://github.com/newrelic/newrelic-ruby-agent/pull/1749)
-  - Action Controller [PR#1744](https://github.com/newrelic/newrelic-ruby-agent/pull/1744/)
+  - Action Controller (for the 'C' in MVC) [PR#1744](https://github.com/newrelic/newrelic-ruby-agent/pull/1744/)
   - Action Dispatch (for middleware) [PR#1745](https://github.com/newrelic/newrelic-ruby-agent/pull/1745)
   - Action Mailbox (for sending mail) [PR#1740](https://github.com/newrelic/newrelic-ruby-agent/pull/1740)
   - Action Mailer (for routing mail) [PR#1740](https://github.com/newrelic/newrelic-ruby-agent/pull/1740)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,10 @@ The upcoming release of the agent introduces additional Ruby on Rails instrument
   | Configuration name | Default | Behavior |
   | ----- | ----- | ----- |
   | `disable_action_cable` | `false` | If `true`, disables Action Cable instrumentation. |
+  | `disable_action_controller` | `false` | If `true`, disables Action Controller instrumentation. |
+  | `disable_action_dispatch` | `false` | If `true`, disables Action Dispatch instrumentation. |
   | `disable_action_mailbox` | `false` | If `true`, disables Action Mailbox instrumentation. |
+  | `disable_action_mailer` | `false` | If `true`, disables Action Mailer instrumentation. |
   | `disable_active_support` | `false` | If `true`, disables Active Support instrumentation. |
 
 ## 8.15.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This upcoming release of the agent adds instrumentation for Active Support cachi
 
 - **Add Active Support Instrumentation**
 
-  Active Support instruments caching-related operations. This change includes the instrumentation in the agent. A new segment is created when one of the operations is called. The key, store, and other attributes will be included on the segment as params. [PR#1742](https://github.com/newrelic/newrelic-ruby-agent/pull/1742)
+  Instrumentation is now automatically provided for all [Active Support caching](https://guides.rubyonrails.org/caching_with_rails.html) operations. Whenever a caching operation is performed, a New Relic segment is created that contains timing information as well as parameters for the cache key, store, and other relevant data. [PR#1742](https://github.com/newrelic/newrelic-ruby-agent/pull/1742)
 
   | Configuration name | Default | Behavior |
   | ----- | ----- | ----- |

--- a/lib/new_relic/agent/instrumentation/action_cable_subscriber.rb
+++ b/lib/new_relic/agent/instrumentation/action_cable_subscriber.rb
@@ -10,9 +10,7 @@ module NewRelic
       class ActionCableSubscriber < NotificationsSubscriber
         PERFORM_ACTION = 'perform_action.action_cable'.freeze
 
-        def start(name, id, payload) # THREAD_LOCAL_ACCESS
-          return unless state.is_execution_traced?
-
+        def start_segment(name, id, payload) # THREAD_LOCAL_ACCESS
           finishable = if name == PERFORM_ACTION
             Tracer.start_transaction_or_segment(
               name: transaction_name_from_payload(payload),
@@ -22,21 +20,6 @@ module NewRelic
             Tracer.start_segment(name: metric_name_from_payload(name, payload))
           end
           push_segment(id, finishable)
-        rescue => e
-          log_notification_error(e, name, 'start')
-        end
-
-        def finish(name, id, payload) # THREAD_LOCAL_ACCESS
-          return unless state.is_execution_traced?
-
-          if exception = exception_object(payload)
-            NewRelic::Agent.notice_error(exception)
-          end
-
-          finishable = pop_segment(id)
-          finishable.finish if finishable
-        rescue => e
-          log_notification_error(e, name, 'finish')
         end
 
         private

--- a/lib/new_relic/agent/instrumentation/action_cable_subscriber.rb
+++ b/lib/new_relic/agent/instrumentation/action_cable_subscriber.rb
@@ -46,7 +46,11 @@ module NewRelic
         end
 
         def metric_name_from_payload(name, payload)
-          "Ruby/ActionCable/#{payload[:channel_class]}/#{action_name(name)}"
+          "Ruby/ActionCable/#{metric_name(payload)}/#{action_name(name)}"
+        end
+
+        def metric_name(payload)
+          payload[:broadcasting] || payload[:channel_class]
         end
 
         DOT_ACTION_CABLE = '.action_cable'.freeze

--- a/lib/new_relic/agent/instrumentation/rails_notifications/action_cable.rb
+++ b/lib/new_relic/agent/instrumentation/rails_notifications/action_cable.rb
@@ -25,7 +25,7 @@ DependencyDetection.defer do
 
   executes do
     # enumerate the specific events we want so that we do not get unexpected additions in the future
-    ActiveSupport::Notifications.subscribe(/(perform_action|transmit)\.action_cable/,
+    ActiveSupport::Notifications.subscribe(/(perform_action|transmit|broadcast)\.action_cable/,
       NewRelic::Agent::Instrumentation::ActionCableSubscriber.new)
 
     ActiveSupport.on_load(:action_cable) do

--- a/lib/new_relic/agent/instrumentation/rails_notifications/action_cable.rb
+++ b/lib/new_relic/agent/instrumentation/rails_notifications/action_cable.rb
@@ -9,9 +9,9 @@ DependencyDetection.defer do
   @name = :action_cable_notifications
 
   depends_on do
-    defined?(Rails::VERSION::MAJOR) &&
-      Rails::VERSION::MAJOR.to_i >= 5 &&
-      defined?(ActionCable)
+    defined?(ActionCable::VERSION::MAJOR) &&
+      ActionCable::VERSION::MAJOR.to_i >= 5 &&
+      defined?(ActiveSupport)
   end
 
   depends_on do
@@ -25,7 +25,7 @@ DependencyDetection.defer do
 
   executes do
     # enumerate the specific events we want so that we do not get unexpected additions in the future
-    ActiveSupport::Notifications.subscribe(/(perform_action|transmit|broadcast)\.action_cable/,
+    ActiveSupport::Notifications.subscribe(/\A(?:perform_action|transmit|broadcast)\.action_cable\z/,
       NewRelic::Agent::Instrumentation::ActionCableSubscriber.new)
 
     ActiveSupport.on_load(:action_cable) do

--- a/test/new_relic/agent/instrumentation/rails/action_cable_subscriber.rb
+++ b/test/new_relic/agent/instrumentation/rails/action_cable_subscriber.rb
@@ -2,10 +2,18 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
+require_relative '../../../../../lib/new_relic/agent/instrumentation/rails_notifications/action_cable'
+
 module NewRelic
   module Agent
     module Instrumentation
       class ActionCableSubscriberTest < Minitest::Test
+        class TestConnection < ActionCable::Connection::Base; end
+
+        class TestChannel < ActionCable::Channel::Base
+          def do_it; end
+        end
+
         def setup
           nr_freeze_process_time
           @subscriber = ActionCableSubscriber.new
@@ -122,7 +130,56 @@ module NewRelic
         end
 
         def test_actual_call_to_broadcast_method_records_segment_in_txn
-          # write me!
+          in_transaction do |txn|
+            @subscriber.start('broadcast.action_cable', :id, payload_for_broadcast)
+            advance_process_time(1.0)
+            @subscriber.finish('broadcast.action_cable', :id, payload_for_broadcast)
+          end
+
+          metric_name = 'Ruby/ActionCable/TestBroadcasting/broadcast'
+
+          assert_metrics_recorded metric_name
+          assert find_node_with_name(last_transaction_trace, metric_name),
+            'Could not find a node with desired name.'
+        end
+
+        def test_metric_name_correctly_names_payload_for_broadcast
+          assert_equal 'TestBroadcasting', @subscriber.send(:metric_name, payload_for_broadcast)
+        end
+
+        def test_metric_name_correctly_names_payload_for_channel
+          assert_equal 'TestChannel', @subscriber.send(:metric_name, payload_for_perform_action)
+        end
+
+        def test_actual_call_to_action_cable
+          config = MiniTest::Mock.new
+          config.expect(:log_tags, {})
+
+          logger = ::Logger.new('/dev/null')
+
+          server = MiniTest::Mock.new
+          server.expect(:worker_pool, 'dinosaur')
+          server.expect(:config, config)
+          server.expect(:logger, logger)
+          server.expect(:event_loop, nil)
+
+          env = {}
+          connection = TestConnection.new(server, env)
+          identifier = nil
+
+          channel = TestChannel.new(connection, identifier)
+          data = {'action' => 'do_it'}
+
+          in_transaction do |txn|
+            channel.perform_action(data)
+          end
+
+          metric_name = "Nested/Controller/ActionCable/#{TestChannel.name}/do_it"
+
+          assert_metrics_recorded metric_name
+          assert find_node_with_name(last_transaction_trace, metric_name)
+          config.verify
+          server.verify
         end
 
         private

--- a/test/new_relic/agent/instrumentation/rails/active_support_subscriber.rb
+++ b/test/new_relic/agent/instrumentation/rails/active_support_subscriber.rb
@@ -102,8 +102,6 @@ module NewRelic
           trace = last_transaction_trace
           tt_node = find_node_with_name(trace, "#{METRIC_PREFIX}#{DEFAULT_STORE}/read")
 
-          puts txn.segments.last.inspect
-
           assert tt_node.params.key?(:hit)
           refute tt_node.params[:hit]
         end
@@ -115,8 +113,6 @@ module NewRelic
 
           trace = last_transaction_trace
           tt_node = find_node_with_name(trace, "#{METRIC_PREFIX}#{DEFAULT_STORE}/read")
-
-          puts txn.segments.last.inspect
 
           assert tt_node.params.key?(:super_operation)
           refute tt_node.params[:super_operation]


### PR DESCRIPTION
* Add `broadcast` to subscribe call
* Update metric name to use `broadcasting` if available
* Refactor ActionCable to use NotificationsSubscriber `start` and `finish` methods