### PR TITLE
Invalid multiverse method filter outputs warning instead of error

### DIFF
--- a/test/multiverse/lib/multiverse/runner.rb
+++ b/test/multiverse/lib/multiverse/runner.rb
@@ -58,7 +58,7 @@ module Multiverse
       execute_suites(filter, opts) do |suite|
         puts yellow(suite.execution_message)
         suite.each_instrumentation_method do |method|
-          if opts.key?(:method) && method != opts[:method]
+          if opts.key?(:method) && method != opts[:method] && suite.instrumentation_permutations.length > 1
             puts "Skipping method '#{method}' while focusing only on '#{opts[:method]}'"
             next
           end

--- a/test/multiverse/lib/multiverse/suite.rb
+++ b/test/multiverse/lib/multiverse/suite.rb
@@ -436,6 +436,10 @@ module Multiverse
       end
     end
 
+    def instrumentation_permutations
+      environments.instrumentation_permutations
+    end
+
     # Load the test suite's environment and execute it.
     #
     # Normally we fork to do this, and wait for the child to exit, to avoid
@@ -724,8 +728,9 @@ module Multiverse
       return environments.instrumentation_permutations unless opts.key?(:method)
 
       unless environments.instrumentation_permutations.include?(opts[:method])
-        raise "The :method filter specified a value of #{opts[:method]}, but the only possible methods are " \
-          "#{environments.instrumentation_permutations.join('|')}"
+        puts "Warning: The :method filter specified a value of #{opts[:method]}, but the only possible methods are " \
+        "#{environments.instrumentation_permutations.join('|')}. Ignoring :method filter."
+        return environments.instrumentation_permutations
       end
 
       [opts[:method]]


### PR DESCRIPTION
This PR just updates it so that if you pass in `method=prepend` to multiverse for a suite that it doesn't apply to, it will just emit a warning and then continue on as if no method was passed in. Just makes it a bit easier to make a bash alias that always run prepend/env=0 on all suites without having to deal with errors popping up because there is no prepend (like on rails). 