### PR TITLE
Enable `instrumentation.thread.tracing` by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ## v9.0.0
 
-- **Enabled Thread Instrumentation by default**
+  Version 9.0.0 of the agent enables thread tracing.
 
-  The configuration option `instrumentation.thread.tracing` is now enabled by default. Allowing the agent to properly monitor code that occurs inside of threads. If you are currently using custom instrumentation to start a new transaction inside of threads, this may be a breaking change, as it will no longer start a new transaction if one already exists.
+- **Enable Thread Instrumentation by default**
+
+  The configuration option `instrumentation.thread.tracing` is now enabled by default. This will allow the agent to properly monitor code that occurs inside of threads. If you are currently using custom instrumentation to start a new transaction inside of threads, this may be a breaking change, as it will no longer start a new transaction if one already exists.
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # New Relic Ruby Agent Release Notes
 
+## v9.0.0
+
+- **Enabled Thread Instrumentation by default**
+
+  The configuration option `instrumentation.thread.tracing` is now enabled by default. Allowing the agent to properly monitor code that occurs inside of threads. If you are currently using custom instrumentation to start a new transaction inside of threads, this may be a breaking change, as it will no longer start a new transaction if one already exists.
+
+
+
 ## Upcoming Release
 
 The upcoming release of the agent introduces additional Ruby on Rails instrumentation (especially for Rails 6 and 7) for various Action\*/Active\* libraries whose actions produce Active Support notifications events.

--- a/infinite_tracing/lib/infinite_tracing/client.rb
+++ b/infinite_tracing/lib/infinite_tracing/client.rb
@@ -133,9 +133,11 @@ module NewRelic::Agent
       end
 
       def restart
-        reset_connection
-        transfer_buffer
-        start_streaming
+        NewRelic::Agent.disable_all_tracing do
+          reset_connection
+          transfer_buffer
+          start_streaming
+        end
       end
 
       def stop
@@ -150,8 +152,10 @@ module NewRelic::Agent
       def start_streaming(exponential_backoff = true)
         return if suspended?
 
-        Connection.instance.wait_for_agent_connect
-        @lock.synchronize { response_handler(exponential_backoff) }
+        NewRelic::Agent.disable_all_tracing do
+          Connection.instance.wait_for_agent_connect
+          @lock.synchronize { response_handler(exponential_backoff) }
+        end
       end
 
       def record_spans(exponential_backoff)

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -1835,7 +1835,7 @@ If `true`, disables agent middleware for Sinatra. This middleware is responsible
           :description => "Controls auto-instrumentation of the Thread class at start up to allow the agent to correctly nest spans inside of an asynchronous transaction. This does not enable the agent to automatically trace all threads created (see `instrumentation.thread.tracing`). May be one of [auto|prepend|chain|disabled]."
         },
         :'instrumentation.thread.tracing' => {
-          :default => false,
+          :default => true,
           :public => true,
           :type => Boolean,
           :allowed_from_server => false,

--- a/lib/new_relic/agent/instrumentation/rake/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/rake/instrumentation.rb
@@ -82,11 +82,9 @@ module NewRelic
         def before_invoke_transaction(task)
           ensure_at_exit
 
+          instrument_execute_on_prereqs(task)
           if task.application.options.always_multitask
-            instrument_execute_on_prereqs(task)
             instrument_invoke_prerequisites_concurrently(task)
-          else
-            instrument_execute_on_prereqs(task)
           end
         rescue => e
           NewRelic::Agent.logger.error("Error during Rake task invoke", e)

--- a/lib/new_relic/agent/instrumentation/rake/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/rake/instrumentation.rb
@@ -82,8 +82,6 @@ module NewRelic
         def before_invoke_transaction(task)
           ensure_at_exit
 
-          # We can't represent overlapping operations yet, so if multitask just
-          # make one node and annotate with prereq task names
           if task.application.options.always_multitask
             instrument_execute_on_prereqs(task)
             instrument_invoke_prerequisites_concurrently(task)

--- a/lib/new_relic/agent/tracer.rb
+++ b/lib/new_relic/agent/tracer.rb
@@ -411,6 +411,7 @@ module NewRelic
         alias_method :tl_clear, :clear_state
 
         def thread_block_with_current_transaction(*args, segment_name:, parent: nil, &block)
+          parent ||= current_segment
           current_txn = ::Thread.current[:newrelic_tracer_state].current_transaction if ::Thread.current[:newrelic_tracer_state] && ::Thread.current[:newrelic_tracer_state].is_execution_traced?
           proc do
             begin

--- a/newrelic.yml
+++ b/newrelic.yml
@@ -447,7 +447,7 @@ common: &default_settings
   # instrumentation.thread: auto
 
   # Controls auto-instrumentation of the Thread class at start up to automatically add tracing to all Threads created in the application.
-  # instrumentation.thread.tracing: false
+  # instrumentation.thread.tracing: true
 
   # Controls auto-instrumentation of gRPC clients at start up.
   # May be one of [auto|prepend|chain|disabled].

--- a/test/multiverse/suites/concurrent_ruby/concurrent_ruby_instrumentation_test.rb
+++ b/test/multiverse/suites/concurrent_ruby/concurrent_ruby_instrumentation_test.rb
@@ -38,7 +38,11 @@ class ConcurrentRubyInstrumentationTest < Minitest::Test
     txn = future_in_transaction { 'time keeps on slipping' }
     expected_segment = 'Concurrent/Task'
 
-    assert_equal(2, txn.segments.length)
+    # concurrent ruby sometimes reuses threads, so in that case there would be no segment for the thread being created.
+    # this removes any thread segment since it may or may not exist, depending on what concurrent ruby decided to do
+    non_thread_segments = txn.segments.select { |seg| seg.name != 'Ruby/Thread' }
+
+    assert_equal(2, non_thread_segments.length)
     assert_includes txn.segments.map(&:name), expected_segment
   end
 

--- a/test/multiverse/suites/rake/Rakefile
+++ b/test/multiverse/suites/rake/Rakefile
@@ -45,14 +45,20 @@ namespace :named do
   task :all => [:'named:before', :'named:during', :'named:after']
 
   task :before do
+    a = NewRelic::Agent::Tracer.start_segment(name: 'custom_before')
     puts "named:before"
+    a.finish
   end
 
   task :during do
+    a = NewRelic::Agent::Tracer.start_segment(name: 'custom_during')
     puts "named:during"
+    a.finish
   end
 
   task :after do
+    a = NewRelic::Agent::Tracer.start_segment(name: 'custom_after')
     puts "named:after"
+    a.finish
   end
 end


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
Enabled the config option `instrumentation.thread.tracing` in the default config. 
Updates tests that aren't expecting this config to be enabled. 
closes https://github.com/newrelic/newrelic-ruby-agent/issues/1089 

Submitter Checklist:
- [ ] Include a link to the related GitHub issue, if applicable
- [ ] Include a security review link, if applicable

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
GitHub Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
