### PR TITLE
env tests: support --trace and other args

### DIFF
--- a/test/environments/lib/environments/runner.rb
+++ b/test/environments/lib/environments/runner.rb
@@ -100,7 +100,12 @@ module Environments
     def run(dir)
       puts "Starting tests for dir '#{dir}'..."
       cmd = String.new("cd #{dir} && bundle exec rake")
+      # if the shell running the original test:env rake task has a "file" env
+      # var, replicate it here in the subshell
       cmd << " file=#{ENV['file']}" if ENV["file"]
+      # if the shell running the original test:env rake task has CLI args (not
+      # Rake task args) such as '--trace', replicate them here in the subshell
+      cmd << " #{ARGV[1..-1].join(' ')}" if ARGV.size > 1
 
       IO.popen(cmd) do |io|
         until io.eof


### PR DESCRIPTION
For local dev, `bundle exec rake test:env` will cause an `IO.popen` subshell to spawn yet another instance of Rake. Any arguments passed to the outermost Rake task get ignored. Now they get sent to the subshell.

It is now possible to perform something like:

```shell
bundle exec rake test:env[railsedge] --trace
```

and have the `--trace` argument and any other take effect.

NOTE that the hack that applies this local dev only functionality assumes that arguments will always come after the Rake task arguments array and not before it.