### PR TITLE
Fix active job 6.0 failures when retry job

### DIFF
--- a/test/environments/norails/Rakefile
+++ b/test/environments/norails/Rakefile
@@ -5,6 +5,8 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
+require_relative '../../warning_test_helper'
+
 require 'rake'
 require 'tasks/all'
 

--- a/test/environments/rails32/Rakefile
+++ b/test/environments/rails32/Rakefile
@@ -5,6 +5,7 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
+require_relative '../../warning_test_helper'
 require_relative 'config/application'
 require 'rake'
 

--- a/test/environments/rails40/Rakefile
+++ b/test/environments/rails40/Rakefile
@@ -5,6 +5,8 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
+require_relative '../../warning_test_helper'
+
 require_relative 'config/application'
 require 'rake'
 

--- a/test/environments/rails41/Rakefile
+++ b/test/environments/rails41/Rakefile
@@ -5,6 +5,8 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
+require_relative '../../warning_test_helper'
+
 require_relative 'config/application'
 require 'rake'
 

--- a/test/environments/rails42/Rakefile
+++ b/test/environments/rails42/Rakefile
@@ -5,6 +5,8 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
+require_relative '../../warning_test_helper'
+
 require_relative 'config/application'
 require 'rake'
 

--- a/test/environments/rails50/Rakefile
+++ b/test/environments/rails50/Rakefile
@@ -5,6 +5,8 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
+require_relative '../../warning_test_helper'
+
 require_relative 'config/application'
 require 'rake'
 

--- a/test/environments/rails52/Rakefile
+++ b/test/environments/rails52/Rakefile
@@ -5,6 +5,8 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
+require_relative '../../warning_test_helper'
+
 require_relative 'config/application'
 require 'rake'
 

--- a/test/environments/rails60/Rakefile
+++ b/test/environments/rails60/Rakefile
@@ -5,6 +5,8 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
+require_relative '../../warning_test_helper'
+
 require_relative 'config/application'
 require 'rake'
 

--- a/test/environments/rails61/Rakefile
+++ b/test/environments/rails61/Rakefile
@@ -5,6 +5,8 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
+require_relative '../../warning_test_helper'
+
 require_relative 'config/application'
 require 'rake'
 

--- a/test/environments/rails70/Rakefile
+++ b/test/environments/rails70/Rakefile
@@ -5,6 +5,8 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
+require_relative '../../warning_test_helper'
+
 require_relative 'config/application'
 
 Rails.application.load_tasks

--- a/test/environments/railsedge/Rakefile
+++ b/test/environments/railsedge/Rakefile
@@ -5,6 +5,8 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
+require_relative '../../warning_test_helper'
+
 require_relative "config/application"
 
 Rails.application.load_tasks

--- a/test/new_relic/agent/instrumentation/active_job_subscriber_test.rb
+++ b/test/new_relic/agent/instrumentation/active_job_subscriber_test.rb
@@ -10,5 +10,5 @@ if defined?(ActiveJob) &&
     ActiveJob.gem_version >= Gem::Version.new('6.0.0')
   require_relative 'rails/active_job_subscriber'
 else
-  puts "Skipping tests in #{__FILE__} because ActiveJob is unavailable or < 6.0"
+  puts "Skipping tests in #{File.basename(__FILE__)} because ActiveJob is unavailable or < 6.0" if ENV['VERBOSE_TEST_OUPUT']
 end


### PR DESCRIPTION
# Overview
rails 6.0 seems to have issues retrying a job if the arg passed in is a class. it raises the error `ActiveJob::SerializationError: Unsupported argument type: Class`. However it's totally fine and works well if you aren't attempting to retry the job. It also works fine on 6.1+.
This works around the issue by using a string instead if on rails 6.0.

I also noticed some warnings when running the env tests because the warning helper was being called later when starting the env tests. I added it to the env test rake files so it will start working immediately instead. 

passing all: https://github.com/newrelic/newrelic-ruby-agent/actions/runs/4019560610