### PR TITLE
Pin webrick version to < 1.8.0 for multiverse

### DIFF
--- a/test/multiverse/lib/multiverse/envfile.rb
+++ b/test/multiverse/lib/multiverse/envfile.rb
@@ -62,10 +62,6 @@ module Multiverse
       @gemfiles.push(content) unless content.nil? || content.empty?
     end
 
-    def ruby3_gem_webrick
-      RUBY_VERSION >= "3.0.0" ? "gem 'webrick'" : ""
-    end
-
     def ruby3_gem_sorted_set
       RUBY_VERSION >= "3.0.0" ? "gem 'sorted_set'" : ""
     end

--- a/test/multiverse/lib/multiverse/suite.rb
+++ b/test/multiverse/lib/multiverse/suite.rb
@@ -268,6 +268,10 @@ module Multiverse
       raise "bundle command failed with (#{$?})" unless $? == 0
     end
 
+    def ruby3_gem_webrick
+      RUBY_VERSION >= "3.0.0" ? "gem 'webrick'" : ""
+    end
+
     def generate_gemfile(gemfile_text, env_index, local = true)
       gemfile = File.join(Dir.pwd, "Gemfile.#{env_index}")
       File.open(gemfile, 'w') do |f|
@@ -281,6 +285,10 @@ module Multiverse
 
         f.puts "gem 'mocha', '~> 1.9.0', require: false"
         f.puts "gem 'minitest-stub-const', '~> 0.6', require: false"
+
+        # pin webrick until we investigate why 1.8.1 breaks things
+        f.puts "gem 'webrick', '< 1.8.0'"
+        # f.puts ruby3_gem_webrick
 
         f.puts "gem 'warning'" if RUBY_VERSION >= '2.4.0'
 

--- a/test/multiverse/lib/multiverse/suite.rb
+++ b/test/multiverse/lib/multiverse/suite.rb
@@ -287,7 +287,7 @@ module Multiverse
         f.puts "gem 'minitest-stub-const', '~> 0.6', require: false"
 
         # pin webrick until we investigate why 1.8.1 breaks things
-        f.puts "gem 'webrick', '< 1.8.0'"
+        f.puts "gem 'webrick', '< 1.8.0'" if RUBY_VERSION > '2.3.0'
         # f.puts ruby3_gem_webrick
 
         f.puts "gem 'warning'" if RUBY_VERSION >= '2.4.0'

--- a/test/multiverse/suites/active_record_pg/Envfile
+++ b/test/multiverse/suites/active_record_pg/Envfile
@@ -20,7 +20,7 @@ def gem_list(activerecord_version = nil)
   <<-RB
     gem 'activerecord'#{activerecord_version}
     gem 'pg'
-    #{ruby3_gem_webrick}
+    
     gem 'rack'
     gem 'minitest', '~> 5.2.3'
   RB

--- a/test/multiverse/suites/activemerchant/Envfile
+++ b/test/multiverse/suites/activemerchant/Envfile
@@ -14,7 +14,7 @@ def gem_list(activemerchant_version = nil)
     gem 'activemerchant'#{activemerchant_version}
     gem 'rack'
     gem 'rexml' if RUBY_VERSION >= '3.0.0'
-    #{ruby3_gem_webrick}
+    
     gem 'activesupport'
     gem 'nokogiri'
     gem 'minitest', '~> 5.1.0' if RUBY_VERSION > '2.2.0'

--- a/test/multiverse/suites/agent_only/Envfile
+++ b/test/multiverse/suites/agent_only/Envfile
@@ -6,5 +6,5 @@ gemfile <<-RB
   gem 'minitest', "#{RUBY_VERSION >= '3.0.0' ? '5.3.3' : '4.7.5'}"
   gem 'rack', '< 2.1.0'
   gem 'rack-test', '>= 0.8.0'
-  #{ruby3_gem_webrick}
+  
 RB

--- a/test/multiverse/suites/bunny/Envfile
+++ b/test/multiverse/suites/bunny/Envfile
@@ -19,7 +19,7 @@ def gem_list(bunny_version = nil)
     gem 'rack'
     gem 'bunny'#{bunny_version}
     gem 'amq-protocol'
-    #{ruby3_gem_webrick}
+    
   RB
 end
 

--- a/test/multiverse/suites/capistrano/Envfile
+++ b/test/multiverse/suites/capistrano/Envfile
@@ -15,7 +15,7 @@ def gem_list(capistrano_version = nil)
   <<-RB
     gem 'sshkit', '1.16.0'
     gem 'rack'
-    #{ruby3_gem_webrick}
+    
     gem 'capistrano'#{capistrano_version}
   RB
 end

--- a/test/multiverse/suites/capistrano2/Envfile
+++ b/test/multiverse/suites/capistrano2/Envfile
@@ -9,5 +9,5 @@ end
 gemfile <<-RB
   gem 'capistrano', '~> 2.15.5'
   gem 'rack'
-  #{ruby3_gem_webrick}
+  
 RB

--- a/test/multiverse/suites/curb/Envfile
+++ b/test/multiverse/suites/curb/Envfile
@@ -41,12 +41,12 @@ gemfile <<-RB
   gem 'rack'
   gem 'json', :platforms => [:rbx, :mri_18]
 
-  #{ruby3_gem_webrick}
+  
 RB
 
 gemfile <<-RB
   gem 'curb', '#{curb_gem_version}'
   gem 'rack'
   gem 'json', :platforms => [:rbx, :mri_18]
-  #{ruby3_gem_webrick}
+  
 RB

--- a/test/multiverse/suites/deferred_instrumentation/Envfile
+++ b/test/multiverse/suites/deferred_instrumentation/Envfile
@@ -14,7 +14,7 @@ def gem_list(sinatra_version = nil)
   <<-RB
     gem 'sinatra'#{sinatra_version}, :require => false
     gem 'rack-test', '>= 0.8.0', :require => 'rack/test'
-    #{ruby3_gem_webrick}
+    
   RB
 end
 

--- a/test/multiverse/suites/delayed_job/Envfile
+++ b/test/multiverse/suites/delayed_job/Envfile
@@ -28,7 +28,7 @@ boilerplate_gems = <<-SQLITE
   gem 'rack'
   #{sqlite}
   #{bigdecimal}
-  #{ruby3_gem_webrick}
+  
 SQLITE
 
 if RUBY_VERSION >= '2.6.0'

--- a/test/multiverse/suites/elasticsearch/Envfile
+++ b/test/multiverse/suites/elasticsearch/Envfile
@@ -12,7 +12,7 @@ ELASTICSEARCH_VERSIONS = [
 def gem_list(elasticsearch_version = nil)
   <<-RB
     gem 'elasticsearch'#{elasticsearch_version}
-    #{ruby3_gem_webrick}
+    
   RB
 end
 

--- a/test/multiverse/suites/excon/Envfile
+++ b/test/multiverse/suites/excon/Envfile
@@ -12,7 +12,7 @@ def gem_list(excon_version = nil)
   <<-RB
     gem 'excon'#{excon_version}
     gem 'rack'
-    #{ruby3_gem_webrick}
+    
   RB
 end
 

--- a/test/multiverse/suites/grape/Envfile
+++ b/test/multiverse/suites/grape/Envfile
@@ -15,7 +15,7 @@ def gem_list(grape_version = nil)
     gem 'rack'
     gem 'rack-test', '>= 0.8.0'
     gem 'grape'#{grape_version}
-    #{ruby3_gem_webrick}
+    
     gem 'activesupport'
   RB
 end

--- a/test/multiverse/suites/high_security/Envfile
+++ b/test/multiverse/suites/high_security/Envfile
@@ -4,5 +4,5 @@
 
 gemfile <<-RB
   gem 'rack'
-  #{ruby3_gem_webrick}
+  
 RB

--- a/test/multiverse/suites/httpclient/Envfile
+++ b/test/multiverse/suites/httpclient/Envfile
@@ -17,7 +17,7 @@ def gem_list(httpclient_version = nil)
   <<-RB
     gem 'httpclient'#{httpclient_version}
     gem 'rack'
-    #{ruby3_gem_webrick}
+    
   RB
 end
 

--- a/test/multiverse/suites/httprb/Envfile
+++ b/test/multiverse/suites/httprb/Envfile
@@ -27,7 +27,7 @@ def gem_list(httprb_version = nil)
   <<-RB
     gem 'http'#{httprb_version}
     gem 'rack'
-    #{ruby3_gem_webrick}
+    
   RB
 end
 

--- a/test/multiverse/suites/json/Envfile
+++ b/test/multiverse/suites/json/Envfile
@@ -4,5 +4,5 @@
 
 gemfile <<-RB
   gem 'rack'
-  #{ruby3_gem_webrick}
+  
 RB

--- a/test/multiverse/suites/marshalling/Envfile
+++ b/test/multiverse/suites/marshalling/Envfile
@@ -4,5 +4,5 @@
 
 gemfile <<-RB
   gem 'rack'
-  #{ruby3_gem_webrick}
+  
 RB

--- a/test/multiverse/suites/net_http/Envfile
+++ b/test/multiverse/suites/net_http/Envfile
@@ -6,5 +6,5 @@ instrumentation_methods :chain, :prepend
 
 gemfile <<-RB
   gem 'rack'
-  #{ruby3_gem_webrick}
+  
 RB

--- a/test/multiverse/suites/padrino/Envfile
+++ b/test/multiverse/suites/padrino/Envfile
@@ -10,7 +10,6 @@ gemfile <<-RB
   gem 'padrino'
   gem 'rack-test'
   gem 'sinatra'
-  gem 'webrick' if RUBY_VERSION >= '2.7.0'
 RB
 
 # Sinatra <3
@@ -19,5 +18,4 @@ gemfile <<-RB
   gem 'padrino', '0.15.1'
   gem 'rack-test', '>= 0.8.0', :require => 'rack/test'
   gem 'sinatra', '< 3'
-  gem 'webrick' if RUBY_VERSION >= '2.7.0'
 RB

--- a/test/multiverse/suites/rack/Envfile
+++ b/test/multiverse/suites/rack/Envfile
@@ -21,7 +21,7 @@ def gem_list(puma_version = nil)
     gem 'puma'#{puma_version}
     gem 'rack'#{rack_version}
     gem 'rack-test'
-    #{ruby3_gem_webrick}
+    
   RB
 end
 
@@ -31,13 +31,13 @@ if RUBY_VERSION >= '2.3.0'
   gemfile <<-RB
     gem 'rack'
     gem 'rack-test'
-    #{ruby3_gem_webrick}
+    
   RB
 
   gemfile <<-RB
     gem 'rack', '2.2.4'
     gem 'rack-test'
-    #{ruby3_gem_webrick}
+    
   RB
 end
 
@@ -45,6 +45,6 @@ if RUBY_VERSION < '3.2.0'
   gemfile <<-RB
     gem 'rack', '1.6.13'
     gem 'rack-test'
-    #{ruby3_gem_webrick}
+    
   RB
 end

--- a/test/multiverse/suites/rails/Envfile
+++ b/test/multiverse/suites/rails/Envfile
@@ -53,7 +53,7 @@ def gem_list(rails_version = nil)
     #{haml_rails(rails_version)}
     gem 'minitest', '#{minitest_rails_version(rails_version)}'
     gem 'erubis' if RUBY_PLATFORM.eql?('java')
-    #{ruby3_gem_webrick}
+    
   RB
 end
 

--- a/test/multiverse/suites/rake/Envfile
+++ b/test/multiverse/suites/rake/Envfile
@@ -36,7 +36,7 @@ def gem_list(rake_version = nil)
   <<-RB
     gem 'rack'
     gem 'rake'#{rake_version}
-    #{ruby3_gem_webrick}
+    
   RB
 end
 
@@ -51,7 +51,7 @@ end
 gemfile <<-RB
   gem 'rack', "~> #{rack_version}"
   gem 'rake'
-  #{ruby3_gem_webrick}
+  
   gem 'rails'
   gem 'minitest', '5.2.3'
 RB

--- a/test/multiverse/suites/redis/Envfile
+++ b/test/multiverse/suites/redis/Envfile
@@ -14,7 +14,7 @@ def gem_list(redis_version = nil)
   <<-RB
     gem 'rack'
     gem 'redis'#{redis_version}
-    #{ruby3_gem_webrick}
+    
   RB
 end
 

--- a/test/multiverse/suites/resque/Envfile
+++ b/test/multiverse/suites/resque/Envfile
@@ -11,7 +11,7 @@ RESQUE_VERSIONS = [
 def gem_list(resque_version = nil)
   <<-RB
   gem 'resque'#{resque_version}
-  #{ruby3_gem_webrick}
+  
   RB
 end
 

--- a/test/multiverse/suites/sidekiq/Envfile
+++ b/test/multiverse/suites/sidekiq/Envfile
@@ -22,7 +22,7 @@ def gem_list(sidekiq_version = nil)
     gem 'json'
     #{gem_connection_pool}
     #{gem_redis}
-    #{ruby3_gem_webrick}
+    
     #{ruby3_gem_sorted_set}
     gem 'sidekiq'#{sidekiq_version}
     gem 'newrelic_rpm', :require => false, :path => File.expand_path('../../../../')

--- a/test/multiverse/suites/sinatra/Envfile
+++ b/test/multiverse/suites/sinatra/Envfile
@@ -25,7 +25,7 @@ def gem_list(sinatra_version = nil)
     gem 'sinatra'#{sinatra_version}
     gem 'rack', '#{rack_version(sinatra_version)}'
     gem 'rack-test', '#{rack_test_version}', :require => 'rack/test'
-    #{ruby3_gem_webrick}
+    
   RB
 end
 

--- a/test/multiverse/suites/sinatra_agent_disabled/Envfile
+++ b/test/multiverse/suites/sinatra_agent_disabled/Envfile
@@ -23,7 +23,7 @@ def gem_list(sinatra_version = nil)
     gem 'sinatra'#{sinatra_version}
     gem 'rack', '#{rack_version(sinatra_version)}'
     gem 'rack-test', '#{rack_test_version}', :require => 'rack/test'
-    #{ruby3_gem_webrick}
+    
   RB
 end
 

--- a/test/multiverse/suites/tilt/Envfile
+++ b/test/multiverse/suites/tilt/Envfile
@@ -19,7 +19,7 @@ def gem_list(tilt_version = nil)
   <<-RB
     gem 'tilt'#{tilt_version}
     gem 'haml'#{haml_version(tilt_version)}
-    #{ruby3_gem_webrick}
+    
   RB
 end
 

--- a/test/multiverse/suites/typhoeus/Envfile
+++ b/test/multiverse/suites/typhoeus/Envfile
@@ -23,7 +23,7 @@ def gem_list(typhoeus_version = nil)
     gem 'typhoeus'#{typhoeus_version}
     gem 'ethon' if RUBY_PLATFORM == 'java'
     gem 'rack'
-    #{ruby3_gem_webrick}
+    
   RB
 end
 

--- a/test/multiverse/suites/yajl/Envfile
+++ b/test/multiverse/suites/yajl/Envfile
@@ -18,7 +18,7 @@ def gem_list(yajl_version = nil)
   <<-RB
     gem 'rack'
     gem 'yajl-ruby'#{yajl_version}, require: ['yajl', 'yajl/json_gem']
-    #{ruby3_gem_webrick}
+    
   RB
 end
 


### PR DESCRIPTION
This pins the webrick version to < 1.8.0.
Webrick released 1.8.0 and 1.8.1 last night which breaks many of our multiverse suites. Until we investigate what is going on with that and resolve it, we'll be limiting our webrick versions to 1.7.0.

I also noticed like all of our multiverse envfiles were calling a method to add webrick if it was ruby 3.0+, so I also decided to move that into the method that adds all the shared gems for all multiverse suites.