### PR TITLE
Increase jruby CI attempts

### DIFF
--- a/.github/workflows/ci_jruby.yml
+++ b/.github/workflows/ci_jruby.yml
@@ -151,7 +151,7 @@ jobs:
         env: 
           TEST_CMD: "bundle exec rake test:multiverse[group=${{ matrix.multiverse }}]"
           VERBOSE_TEST_OUTPUT: true
-          RETRY_ATTEMPS: 2
+          RETRY_ATTEMPS: 5
           SERIALIZE: 1
           DB_PORT: ${{ job.services.mysql.ports[3306] }}
           JRUBY_OPTS: --dev --debug

--- a/.github/workflows/scripts/retry_command
+++ b/.github/workflows/scripts/retry_command
@@ -10,6 +10,11 @@ while [[ $return_val != 0  && $count -le $RETRY_ATTEMPTS ]]; do
   $TEST_CMD
   return_val=$?
   count+=1
+  if [[ $return_val != 0 ]]; then
+    echo $'\n*************************************************************************************************************\n'
+    echo "FAILURE ON ATTEMPT $((count+1)) of $((RETRY_ATTEMPTS+1))"
+    echo $'\n*************************************************************************************************************\n'
+  fi
 done
 
 exit $return_val


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

I noticed the jruby intermittent multiverse failures seem to still end up failing, so I've increased the retry count. Since we don't have to wait on this CI for our PRs, increasing to 5 doesn't seem like it should be too much of a problem in the case of real failures, because at least hopefully now we'll stop seeing the intermittent failures constantly. 

 I also added an extra output from the retry script to state failure.

Submitter Checklist:
- [ ] Include a link to the related GitHub issue, if applicable
- [ ] Include a security review link, if applicable

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
GitHub Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
