### PR TITLE
Attempt to resolve mysql not starting intermittently in github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,8 +223,18 @@ jobs:
         env:
           RUBY_VERSION: ${{ matrix.ruby-version }}
 
-      - name: Test MySQL
-        run: mysql --host 127.0.0.1 --port ${{ job.services.mysql.ports[3306] }} -uroot -proot -e "SHOW GRANTS FOR 'root'@'localhost'"
+
+      - name: Wait for/Check Mysql
+        uses: nick-fields/retry@v2.8.2
+        with:
+          timeout_minutes: 1
+          max_attempts: 20
+          command: |
+            mysql --host 127.0.0.1 --port ${{ job.services.mysql.ports[3306] }} -uroot -proot -e "SHOW GRANTS FOR 'root'@'localhost'";
+            if [[ $? != 0 ]]; then
+              sleep 1;
+            fi
+
 
       - name: Run Multiverse Tests
         uses: nick-fields/retry@v2.8.2

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -241,8 +241,18 @@ jobs:
         env:
           RUBY_VERSION: ${{ matrix.ruby-version }}
 
-      - name: Test MySQL
-        run: mysql --host 127.0.0.1 --port ${{ job.services.mysql.ports[3306] }} -uroot -proot -e "SHOW GRANTS FOR 'root'@'localhost'"
+
+      - name: Wait for/Check Mysql
+        uses: nick-fields/retry@v2.8.2
+        with:
+          timeout_minutes: 1
+          max_attempts: 20
+          command: |
+            mysql --host 127.0.0.1 --port ${{ job.services.mysql.ports[3306] }} -uroot -proot -e "SHOW GRANTS FOR 'root'@'localhost'";
+            if [[ $? != 0 ]]; then
+              sleep 1;
+            fi
+
 
       - name: Run Multiverse Tests
         uses: nick-fields/retry@v2.8.2


### PR DESCRIPTION
Lately we keep getting a job failing due to mysql not being started when we check it before running our multiverse tests. 
```
Run mysql --host 127.0.0.1 --port 32768 -uroot -proot -e "SHOW GRANTS FOR 'root'@'localhost'"
Warning: arning] Using a password on the command line interface can be insecure.
ERROR 2003 (HY000): Can't connect to MySQL server on '127.0.0.1:32768' (111)
Error: Process completed with exit code 1.
```
This PR should retry this command several times and sleep in between if each failure. Hopefully this should give mysql enough time to get started and able to respond to our command. 