### PR TITLE
disable, make private ActionDispatch notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ Version 8.16.0 of the agent introduces additional Ruby on Rails instrumentation 
 
   - Action Cable (for WebSockets) [PR#1749](https://github.com/newrelic/newrelic-ruby-agent/pull/1749)
   - Action Controller (for the 'C' in MVC) [PR#1744](https://github.com/newrelic/newrelic-ruby-agent/pull/1744/)
-  - Action Dispatch (for middleware) [PR#1745](https://github.com/newrelic/newrelic-ruby-agent/pull/1745)
   - Action Mailbox (for sending mail) [PR#1740](https://github.com/newrelic/newrelic-ruby-agent/pull/1740)
   - Action Mailer (for routing mail) [PR#1740](https://github.com/newrelic/newrelic-ruby-agent/pull/1740)
   - Active Job (for background jobs) [PR#1742](https://github.com/newrelic/newrelic-ruby-agent/pull/1761)
@@ -24,7 +23,6 @@ Version 8.16.0 of the agent introduces additional Ruby on Rails instrumentation 
   | ----- | ----- | ----- |
   | `disable_action_cable` | `false` | If `true`, disables Action Cable instrumentation. |
   | `disable_action_controller` | `false` | If `true`, disables Action Controller instrumentation. |
-  | `disable_action_dispatch` | `false` | If `true`, disables Action Dispatch instrumentation. |
   | `disable_action_mailbox` | `false` | If `true`, disables Action Mailbox instrumentation. |
   | `disable_action_mailer` | `false` | If `true`, disables Action Mailer instrumentation. |
   | `disable_activejob` | `false` | If `true`, disables Active Job instrumentation. |

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -1140,9 +1140,17 @@ A map of error classes to a list of messages. When an error of one of the classe
           :allowed_from_server => false,
           :description => 'If `true`, disables Action Cable instrumentation.'
         },
+        # TODO: by subscribing to process_middleware.action_dispatch events,
+        #       we duplicate the efforts already performed by non-notifications
+        #       based instrumentation. In future, we ought to determine the
+        #       extent of the overlap and duplication and end up with only this
+        #       notifications based approach existing and the monkey patching
+        #       approach removed entirely. NOTE that we will likely not want to
+        #       do so until we are okay with dropping support for Rails < v6,
+        #       given that these events are available only for v6+.
         :disable_action_dispatch => {
-          :default => false,
-          :public => true,
+          :default => true,
+          :public => false,
           :type => Boolean,
           :allowed_from_server => false,
           :description => 'If `true`, disables Action Dispatch instrumentation.'

--- a/newrelic.yml
+++ b/newrelic.yml
@@ -169,9 +169,6 @@ common: &default_settings
   # If true, disables Action Cable instrumentation.
   # disable_action_cable_instrumentation: false
 
-  # If true, disables Action Dispatch instrumentation.
-  # disable_action_dispatch: false
-
   # If true, disables Action Mailbox instrumentation.
   # disable_action_mailbox: false
 

--- a/test/new_relic/agent/instrumentation/rails/action_dispatch_subscriber.rb
+++ b/test/new_relic/agent/instrumentation/rails/action_dispatch_subscriber.rb
@@ -126,18 +126,22 @@ module NewRelic::Agent::Instrumentation
       end
     end
 
-    def test_an_actual_middleware_call_based_event_processing
-      stack = ActionDispatch::MiddlewareStack.new
-      stack.use TestMiddleware
-      web_app = stack.build(proc { |env| [200, {}, []] })
+    # TODO: uncomment after the :disable_action_dispatch TODO comment in
+    #       default_source.rb has been satisfied
+    # def test_an_actual_middleware_call_based_event_processing
+    #   with_config(disable_action_dispatch: false) do
+    #     stack = ActionDispatch::MiddlewareStack.new
+    #     stack.use TestMiddleware
+    #     web_app = stack.build(proc { |env| [200, {}, []] })
 
-      in_transaction do |txn|
-        web_app.call({})
-        segment = txn.segments.detect { |s| s.name.start_with?('Ruby/ActionDispatch') }
+    #     in_transaction do |txn|
+    #       web_app.call({})
+    #       segment = txn.segments.detect { |s| s.name.start_with?('Ruby/ActionDispatch') }
 
-        assert segment
-        assert_equal segment.name, "Ruby/ActionDispatch/#{TestMiddleware.name}/process_middleware"
-      end
-    end
+    #       assert segment
+    #       assert_equal segment.name, "Ruby/ActionDispatch/#{TestMiddleware.name}/process_middleware"
+    #     end
+    #   end
+    # end
   end
 end


### PR DESCRIPTION
the ActiveSupport event notifications based instrumentation for ActionDispatch overlaps too greatly with our existing Rails middleware instrumentation, leading to confusing and potentially costly overlap for Rails users.

ideally, we'd like to standardize on leveraging Rails notifications for all Rails instrumentation and remove any custom Rails instrumentation that overlaps. But in this case with ActionDispatch the notifications aren't available until Rails v6, and we aren't prepared at this time to stop supporting earlier Rails versions.

so for now, retain the notifications based instrumentation for ActionDispatch but have it configured - privately - to be disabled by default.