### PR TITLE
Fix jruby retry script

### DIFF
--- a/.github/workflows/scripts/retry_command
+++ b/.github/workflows/scripts/retry_command
@@ -6,13 +6,13 @@
 count=0
 return_val=1
 
-while [[ $return_val != 0  && $count -le $RETRY_ATTEMPTS ]]; do
+while [[ $return_val != 0  && $count -lt $RETRY_ATTEMPTS ]]; do
   $TEST_CMD
   return_val=$?
-  count+=1
+  count=$((count + 1))
   if [[ $return_val != 0 ]]; then
     echo $'\n*************************************************************************************************************\n'
-    echo "FAILURE ON ATTEMPT $((count+1)) of $((RETRY_ATTEMPTS+1))"
+    echo "FAILURE ON ATTEMPT $((count)) of $((RETRY_ATTEMPTS))"
     echo $'\n*************************************************************************************************************\n'
   fi
 done


### PR DESCRIPTION
I noticed the jruby CI failed again and it looks like the script is still only ever trying twice. Turns out `count+=1` just appends 1 to the end like a string, not actually doing math! So that is now fixed. Previously I had only tested it with a retry attempt of 2, so I never caught that, this time I tried a few different values to make sure it's working as expected