### PR TITLE
Remove support for `disable_transaction_tracing`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@
     - Rainbows
     - Sunspot
 
+- **Dropped method: `NewRelic::Agent.disable_transaction_tracing`**
+
+  Support for `NewRelic::Agent.disable_transaction_tracing` has been dropped. Users are encouraged to use `NewRelic::Agent.disable_all_tracing` or `NewRelic::Agent.ignore_transaction`.
+
 ## 8.16.0
 
 Version 8.16.0 introduces more Ruby on Rails instrumentation (especially for Rails 6 and 7) for various Action\*/Active\* libraries whose actions produce [Active Support notifications events](https://guides.rubyonrails.org/active_support_instrumentation.html).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 
 - **Dropped method: `NewRelic::Agent.disable_transaction_tracing`**
 
-  Support for `NewRelic::Agent.disable_transaction_tracing` has been dropped. Users are encouraged to use `NewRelic::Agent.disable_all_tracing` or `NewRelic::Agent.ignore_transaction`.
+  The previously deprecated `NewRelic::Agent.disable_transaction_tracing` method has been removed. Users are encouraged to use `NewRelic::Agent.disable_all_tracing` or `NewRelic::Agent.ignore_transaction`.
 
 ## 8.16.0
 

--- a/lib/new_relic/agent.rb
+++ b/lib/new_relic/agent.rb
@@ -511,18 +511,6 @@ module NewRelic
       end
     end
 
-    # This method disables the recording of transaction traces in the given
-    # block.  See also #disable_all_tracing
-    #
-    # @api public
-    #
-    def disable_transaction_tracing
-      Deprecator.deprecate(:disable_transaction_tracing,
-        'disable_all_tracing or ignore_transaction')
-      record_api_supportability_metric(:disable_transaction_tracing)
-      yield
-    end
-
     # This method sets the state of sql recording in the transaction
     # sampler feature. Within the given block, no sql will be recorded
     #

--- a/lib/new_relic/supportability_helper.rb
+++ b/lib/new_relic/supportability_helper.rb
@@ -21,7 +21,6 @@ module NewRelic
       :browser_timing_header,
       :disable_all_tracing,
       :disable_sql_recording,
-      :disable_transaction_tracing,
       :drop_buffered_data,
       :get_request_metadata,
       :get_response_metadata,

--- a/test/multiverse/suites/agent_only/script/public_api_when_disabled.rb
+++ b/test/multiverse/suites/agent_only/script/public_api_when_disabled.rb
@@ -32,9 +32,6 @@ NewRelic::Agent.ignore_enduser
 NewRelic::Agent.disable_all_tracing do
 end
 
-NewRelic::Agent.disable_transaction_tracing do
-end
-
 NewRelic::Agent.disable_sql_recording do
 end
 

--- a/test/new_relic/agent/supportability_test.rb
+++ b/test/new_relic/agent/supportability_test.rb
@@ -113,12 +113,6 @@ class APISupportabilityMetricsTest < Minitest::Test
     assert_api_supportability_metric_recorded(:disable_sql_recording)
   end
 
-  def test_disable_transaction_tracing_records_supportability_metric
-    NewRelic::Agent.disable_transaction_tracing {}
-
-    assert_api_supportability_metric_recorded(:disable_transaction_tracing)
-  end
-
   def test_ignore_apdex_records_supportability_metric
     NewRelic::Agent.ignore_apdex
 

--- a/test/new_relic/agent_test.rb
+++ b/test/new_relic/agent_test.rb
@@ -464,19 +464,6 @@ module NewRelic
       end
     end
 
-    def test_disable_transaction_tracing_deprecated
-      log = with_array_logger(:warn) do
-        NewRelic::Agent.disable_transaction_tracing do
-          in_transaction do |txn|
-            # no-op
-          end
-        end
-      end
-
-      assert log.array.any? { |msg| msg.include?('The method disable_transaction_tracing is deprecated.') }
-      assert log.array.any? { |msg| msg.include?('Please use disable_all_tracing or ignore_transaction instead.') }
-    end
-
     def test_eventing_helpers
       called = false
       NewRelic::Agent.subscribe(:boo) { called = true }


### PR DESCRIPTION
This PR removes references to `NewRelic::Agent.disable_transaction_tracing`, which was deprecated in Ruby agent 5.4.0. 

Users are encouraged to use `NewRelic::Agent.disable_all_tracing` or `NewRelic::Agent.ignore_transaction` instead.

Related to #745 