### PR TITLE
Remove orphaned constant MYSQL_EXPLAIN_COLUMNS

### DIFF
--- a/lib/new_relic/agent/database.rb
+++ b/lib/new_relic/agent/database.rb
@@ -7,20 +7,6 @@ require 'new_relic/agent/database/explain_plan_helpers'
 require 'new_relic/agent/database/obfuscator'
 
 module NewRelic
-  # columns for a mysql explain plan
-  MYSQL_EXPLAIN_COLUMNS = [
-    "Id",
-    "Select Type",
-    "Table",
-    "Type",
-    "Possible Keys",
-    "Key",
-    "Key Length",
-    "Ref",
-    "Rows",
-    "Extra"
-  ].freeze
-
   module Agent
     module Database
       MAX_QUERY_LENGTH = 16384


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview

Removing an unused constant.

- [newrelic/newrelic-ruby-agent/issues/1130] 

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
GitHub Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
