### PR TITLE
Allow `set_transaction_name` to change name and category of current transaction.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,7 @@
 
 - **Changes how the API method `set_transaction_name` works**
 
-  When the method `NewRelic::Agent.set_transaction_name` is called, it will now always change the name and category of the currently running transaction to what is passed in to the method. This is a change from how it functioned in previous agent versions. Previously, if set_transaction_name was called with a new transaction name and a new category that did not match the category that was already assignd to a transaction, neither the new name nor category would be saved to the transaction. 
+  When the method `NewRelic::Agent.set_transaction_name` is called, it will now always change the name and category of the currently running transaction to what is passed in to the method. This is a change from how it functioned in previous agent versions. Previously, if `set_transaction_name` was called with a new transaction name and a new category that did not match the category that was already assigned to a transaction, neither the new name nor category would be saved to the transaction. 
 
 
 - **Dropped method: `NewRelic::Agent.disable_transaction_tracing`**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v9.0.0
 
-  Version 9.0.0 of the agent enables thread tracing, removes several deprecated configuration options, and removes support for Ruby versions 2.2 and 2.3.
+  Version 9.0.0 of the agent enables thread tracing, removes several deprecated configuration options, removes support for Ruby versions 2.2 and 2.3, and changes how the API method `set_transaction_name` works..
 
 
 - **Remove Deprecated Configuration Options**
@@ -69,6 +69,12 @@
     - DataMapper
     - Rainbows
     - Sunspot
+
+
+- **Changes how the API method `set_transaction_name` works**
+
+  When the method `NewRelic::Agent.set_transaction_name` is called, it will now always change the name and category of the currently running transaction to what is passed in to the method. This is a change from how it functioned in previous agent versions. Previously, if set_transaction_name was called with a new transaction name and a new category that did not match the category that was already assignd to a transaction, neither the new name nor category would be saved to the transaction. 
+
 
 - **Dropped method: `NewRelic::Agent.disable_transaction_tracing`**
 

--- a/lib/new_relic/agent/transaction.rb
+++ b/lib/new_relic/agent/transaction.rb
@@ -359,10 +359,8 @@ module NewRelic
       def set_overriding_transaction_name(name, category)
         return log_frozen_name(name) if name_frozen?
 
-        if influences_transaction_name?(category)
-          self.overridden_name = name
-          @category = category if category
-        end
+        self.overridden_name = name
+        @category = category if category
       end
 
       def log_frozen_name(name)

--- a/test/multiverse/suites/agent_only/set_transaction_name_test.rb
+++ b/test/multiverse/suites/agent_only/set_transaction_name_test.rb
@@ -41,11 +41,12 @@ class SetTransactionNameTest < Minitest::Test
   def test_metric_names_when_child_has_different_category
     TestTransactor.new.parent_txn(:task)
 
+    # background task does not record apdex
     assert_metrics_recorded([
-      'Controller/TestTransactor/parent',
+      'OtherTransaction/Background/TestTransactor/child',
       'Nested/Controller/SetTransactionNameTest::TestTransactor/child_txn',
-      ['Nested/Controller/SetTransactionNameTest::TestTransactor/child_txn', 'Controller/TestTransactor/parent'],
-      'Apdex/TestTransactor/parent'
+      ['Nested/Controller/SetTransactionNameTest::TestTransactor/child_txn', 'OtherTransaction/Background/TestTransactor/child'], # check child method segment metric still exists
+      ['Nested/Controller/SetTransactionNameTest::TestTransactor/parent_txn', 'OtherTransaction/Background/TestTransactor/child'] # check parent segment metric still exists
     ])
   end
 


### PR DESCRIPTION
This updates how `set_transaction_name` works so it functions more as expected and accomplishes what customers have expected it to do. Now, when set_transaction_name is called with a different category that is already assigned, the category and name will be changed to what is passed in. Previously, nothing would happen if the category was different. 

The `set_transaction_name` api docs did not need to be updated because the way it is worded already implies that this is how it was supposed to work in the first place. 

closes #1064