### PR TITLE
remove NewRelic::Agent.tl_is_sql_recorded?

### DIFF
--- a/lib/new_relic/agent.rb
+++ b/lib/new_relic/agent.rb
@@ -554,12 +554,6 @@ module NewRelic
       NewRelic::Agent::Tracer.state.is_execution_traced?
     end
 
-    # helper method to check the thread local to determine whether sql
-    # is being recorded or not
-    def tl_is_sql_recorded?
-      NewRelic::Agent::Tracer.state.is_sql_recorded?
-    end
-
     # @!group Adding custom attributes to traces
 
     # Add attributes to the transaction trace, Insights Transaction event, and

--- a/test/new_relic/agent/rpm_agent_test.rb
+++ b/test/new_relic/agent/rpm_agent_test.rb
@@ -78,17 +78,17 @@ class NewRelic::Agent::RpmAgentTest < Minitest::Test
   def test_set_record_sql
     @agent.set_record_sql(false)
 
-    refute NewRelic::Agent.tl_is_sql_recorded?
+    refute NewRelic::Agent::Tracer.state.is_sql_recorded?
     NewRelic::Agent.disable_sql_recording do
-      refute NewRelic::Agent.tl_is_sql_recorded?
+      refute NewRelic::Agent::Tracer.state.is_sql_recorded?
       NewRelic::Agent.disable_sql_recording do
-        refute NewRelic::Agent.tl_is_sql_recorded?
+        refute NewRelic::Agent::Tracer.state.is_sql_recorded?
       end
 
-      refute NewRelic::Agent.tl_is_sql_recorded?
+      refute NewRelic::Agent::Tracer.state.is_sql_recorded?
     end
 
-    refute NewRelic::Agent.tl_is_sql_recorded?
+    refute NewRelic::Agent::Tracer.state.is_sql_recorded?
     @agent.set_record_sql(nil)
   end
 

--- a/test/new_relic/agent_test.rb
+++ b/test/new_relic/agent_test.rb
@@ -142,19 +142,19 @@ module NewRelic
     def test_is_sql_recorded_true
       NewRelic::Agent::Tracer.state.record_sql = true
 
-      assert_predicate(NewRelic::Agent, :tl_is_sql_recorded?, 'should be true since the thread local is set')
+      assert_predicate(NewRelic::Agent::Tracer.state, :is_sql_recorded?, 'should be true since the thread local is set')
     end
 
     def test_is_sql_recorded_blank
       NewRelic::Agent::Tracer.state.record_sql = nil
 
-      assert_predicate(NewRelic::Agent, :tl_is_sql_recorded?, 'should be true since the thread local is not set')
+      assert_predicate(NewRelic::Agent::Tracer.state, :is_sql_recorded?, 'should be true since the thread local is not set')
     end
 
     def test_is_sql_recorded_false
       NewRelic::Agent::Tracer.state.record_sql = false
 
-      refute(NewRelic::Agent.tl_is_sql_recorded?, 'should be false since the thread local is false')
+      refute(NewRelic::Agent::Tracer.state.is_sql_recorded?, 'should be false since the thread local is false')
     end
 
     def test_is_execution_traced_true


### PR DESCRIPTION
We have a `NewRelic::Agent.tl_is_sql_recorded?` helper method that isn't used by any code outside of the `test` directory.

Remove that orphaned code and refactor the affected tests accordingly.