### PR TITLE
Fix jruby retry script issue

### DIFF
--- a/.github/workflows/ci_jruby.yml
+++ b/.github/workflows/ci_jruby.yml
@@ -151,7 +151,7 @@ jobs:
         env: 
           TEST_CMD: "bundle exec rake test:multiverse[group=${{ matrix.multiverse }}]"
           VERBOSE_TEST_OUTPUT: true
-          RETRY_ATTEMPS: 5
+          RETRY_ATTEMPTS: 5
           SERIALIZE: 1
           DB_PORT: ${{ job.services.mysql.ports[3306] }}
           JRUBY_OPTS: --dev --debug


### PR DESCRIPTION
Fix the typo on RETRY_ATTEMPTS env variable for the retry script for jruby multiverse

multiverse agent group running: https://github.com/newrelic/newrelic-ruby-agent/actions/runs/4127424807/jobs/7130617406