### PR TITLE
Pin rubocop versions

### DIFF
--- a/newrelic_rpm.gemspec
+++ b/newrelic_rpm.gemspec
@@ -54,10 +54,13 @@ https://github.com/newrelic/newrelic-ruby-agent/
   s.add_development_dependency 'mocha', '~> 1.16'
   s.add_development_dependency 'pry' unless ENV['CI']
   s.add_development_dependency 'rake', '12.3.3'
-  s.add_development_dependency 'rubocop' unless ENV['CI'] && RUBY_VERSION < '3.0.0'
-  s.add_development_dependency 'rubocop-minitest' unless ENV['CI'] && RUBY_VERSION < '3.0.0'
-  s.add_development_dependency 'rubocop-performance' unless ENV['CI'] && RUBY_VERSION < '3.0.0'
-  s.add_development_dependency 'rubocop-rake' unless ENV['CI'] && RUBY_VERSION < '3.0.0'
+
+  s.add_development_dependency 'rubocop', '1.44.1' unless ENV['CI'] && RUBY_VERSION < '3.0.0'
+  s.add_development_dependency 'rubocop-ast', '1.24.1' unless ENV['CI'] && RUBY_VERSION < '3.0.0'
+  s.add_development_dependency 'rubocop-minitest', '0.27.0' unless ENV['CI'] && RUBY_VERSION < '3.0.0'
+  s.add_development_dependency 'rubocop-performance', '1.16.0' unless ENV['CI'] && RUBY_VERSION < '3.0.0'
+  s.add_development_dependency 'rubocop-rake', '0.6.0' unless ENV['CI'] && RUBY_VERSION < '3.0.0'
+
   s.add_development_dependency 'simplecov' if RUBY_VERSION >= '2.7.0'
   s.add_development_dependency 'thor' unless ENV['CI']
   s.add_development_dependency 'warning' if RUBY_VERSION >= '2.4.0'


### PR DESCRIPTION
When rubocop releases a new version that changes how a cop works, it breaks our CI, which isn't great. Now we'll have control over when our rubocop versions get upgraded so we can make the changes necessary to satisfy the changes to rubocop. The versions I chose were just the ones that ran last night.