### PR TITLE
Remove MessageBroker metric for ActiveJob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,10 @@
 
   The previously deprecated `NewRelic::Agent.disable_transaction_tracing` method has been removed. Users are encouraged to use `NewRelic::Agent.disable_all_tracing` or `NewRelic::Agent.ignore_transaction`.
 
+- **Renamed ActiveJob metrics**
+
+  Previously, ActiveJob was cateterogized as a message broker, which is inaccurate. We've updated the naming of ActiveJob traces from leading with `MessageBroker/ActiveJob` to simply leading with `ActiveJob`.
+
 - **Code cleanup**
 
   Thank you to community member [@esquith](https://github.com/esquith) for contributing some cleanup of orphaned constants in our code base. [PR#1793](https://github.com/newrelic/newrelic-ruby-agent/pull/1793) [PR#1794](https://github.com/newrelic/newrelic-ruby-agent/pull/1794)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,7 +87,7 @@
 
 - **Renamed ActiveJob metrics**
 
-  Previously, ActiveJob was cateterogized as a message broker, which is inaccurate. We've updated the naming of ActiveJob traces from leading with `MessageBroker/ActiveJob` to simply leading with `ActiveJob`.
+  Previously, ActiveJob was categorized as a message broker, which is inaccurate. We've updated the naming of ActiveJob traces from leading with `MessageBroker/ActiveJob` to simply leading with `ActiveJob`.
 
 - **Code cleanup**
 

--- a/lib/new_relic/agent/instrumentation/active_job.rb
+++ b/lib/new_relic/agent/instrumentation/active_job.rb
@@ -71,7 +71,7 @@ module NewRelic
         end
 
         def self.run_in_trace(job, block, event)
-          trace_execution_scoped("ActiveJob/#{adapter}/Queue/#{event}/Named/#{job.queue_name}",
+          trace_execution_scoped("ActiveJob/#{adapter.sub(/^ActiveJob::/, '')}/Queue/#{event}/Named/#{job.queue_name}",
             code_information: code_information_for_job(job)) do
             block.call
           end

--- a/lib/new_relic/agent/instrumentation/active_job.rb
+++ b/lib/new_relic/agent/instrumentation/active_job.rb
@@ -71,7 +71,7 @@ module NewRelic
         end
 
         def self.run_in_trace(job, block, event)
-          trace_execution_scoped("MessageBroker/#{adapter}/Queue/#{event}/Named/#{job.queue_name}",
+          trace_execution_scoped("ActiveJob/#{adapter}/Queue/#{event}/Named/#{job.queue_name}",
             code_information: code_information_for_job(job)) do
             block.call
           end

--- a/test/multiverse/suites/rails/activejob_test.rb
+++ b/test/multiverse/suites/rails/activejob_test.rb
@@ -60,8 +60,8 @@ if Rails::VERSION::STRING >= "4.2.0"
       end
     end
 
-    ENQUEUE_PREFIX = "ActiveJob/ActiveJob::Inline/Queue/Produce/Named"
-    PERFORM_PREFIX = "ActiveJob/ActiveJob::Inline/Queue/Consume/Named"
+    ENQUEUE_PREFIX = "ActiveJob/Inline/Queue/Produce/Named"
+    PERFORM_PREFIX = "ActiveJob/Inline/Queue/Consume/Named"
 
     PERFORM_TRANSACTION_NAME = 'OtherTransaction/ActiveJob::Inline/MyJob/execute'
     PERFORM_TRANSACTION_ROLLUP = 'OtherTransaction/ActiveJob::Inline/all'

--- a/test/multiverse/suites/rails/activejob_test.rb
+++ b/test/multiverse/suites/rails/activejob_test.rb
@@ -60,8 +60,8 @@ if Rails::VERSION::STRING >= "4.2.0"
       end
     end
 
-    ENQUEUE_PREFIX = "MessageBroker/ActiveJob::Inline/Queue/Produce/Named"
-    PERFORM_PREFIX = "MessageBroker/ActiveJob::Inline/Queue/Consume/Named"
+    ENQUEUE_PREFIX = "ActiveJob/ActiveJob::Inline/Queue/Produce/Named"
+    PERFORM_PREFIX = "ActiveJob/ActiveJob::Inline/Queue/Consume/Named"
 
     PERFORM_TRANSACTION_NAME = 'OtherTransaction/ActiveJob::Inline/MyJob/execute'
     PERFORM_TRANSACTION_ROLLUP = 'OtherTransaction/ActiveJob::Inline/all'


### PR DESCRIPTION
ActiveJob isn't considered a MessageBroker. This PR cleans up naming and associated tests.

Closes #1151 