### PR TITLE
Add alt text to main paragraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ to help you improve the customer experience and make data-driven business decisi
 The New Relic Ruby agent is dual-purposed as either a Gem or a Rails plugin,
 hosted on [github](https://github.com/newrelic/newrelic-ruby-agent).
 
-This code is currently maintained by New Relic engineering teams and delivered here in GitHub. See the README for troubleshooting and defect reporting instructions.
+This code is actively maintained by New Relic engineering teams and delivered here in GitHub. See below for troubleshooting and defect reporting instructions.
 
 [![Gem Version](https://badge.fury.io/rb/newrelic_rpm.svg)](https://badge.fury.io/rb/newrelic_rpm)
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ to help you improve the customer experience and make data-driven business decisi
 The New Relic Ruby agent is dual-purposed as either a Gem or a Rails plugin,
 hosted on [github](https://github.com/newrelic/newrelic-ruby-agent).
 
+This code is currently maintained by New Relic engineering teams and delivered here in GitHub. See the README for troubleshooting and defect reporting instructions.
+
 [![Gem Version](https://badge.fury.io/rb/newrelic_rpm.svg)](https://badge.fury.io/rb/newrelic_rpm)
 
 ## Supported Environments


### PR DESCRIPTION
The header image on our README was [updated](https://github.com/newrelic/newrelic-ruby-agent/pull/1815) to be in compliance with [open source policy](https://github.com/newrelic/newrelic-ruby-agent/issues/1720). We removed the image alt text but wanted to keep it for accessibility, and so the text was moved into the README directly.