### PR TITLE
Remove unncessary TODO

### DIFF
--- a/test/multiverse/lib/multiverse/envfile.rb
+++ b/test/multiverse/lib/multiverse/envfile.rb
@@ -27,7 +27,6 @@ module Multiverse
       @condition = block
     end
 
-    # TODO: create_gemfiles doesn't need gem_list as arg. Refactor all callers of create_gemfiles
     def create_gemfiles(versions, gem_list)
       versions.each do |version|
         if version.is_a?(Array)


### PR DESCRIPTION
A TODO was introduced to refactor a method to remove an unused argument, but it appears that argument is being used by the method. Remove the TODO.

Closes #1440