### PR TITLE
MaxPayloadSizeLimit supportability metric rename

### DIFF
--- a/lib/new_relic/agent/new_relic_service.rb
+++ b/lib/new_relic/agent/new_relic_service.rb
@@ -595,7 +595,7 @@ module NewRelic
         return if post_string.size < Agent.config[:max_payload_size_in_bytes]
 
         ::NewRelic::Agent.logger.debug("Tried to send too much data: #{post_string.size} bytes")
-        NewRelic::Agent.increment_metric("Supportability/Agent/Collector/#{endpoint}/MaxPayloadSizeLimit")
+        NewRelic::Agent.increment_metric("Supportability/Ruby/Collector/#{endpoint}/MaxPayloadSizeLimit")
         raise UnrecoverableServerException.new('413 Request Entity Too Large')
       end
 

--- a/test/new_relic/agent/new_relic_service_test.rb
+++ b/test/new_relic/agent/new_relic_service_test.rb
@@ -921,7 +921,7 @@ class NewRelicServiceTest < Minitest::Test
     end
 
     assert_metrics_recorded(
-      "Supportability/Agent/Collector/foobar/MaxPayloadSizeLimit" => {:call_count => 1}
+      "Supportability/Ruby/Collector/foobar/MaxPayloadSizeLimit" => {:call_count => 1}
     )
   end
 


### PR DESCRIPTION
As per internal agent specs PR 585, make sure the `MaxPayloadSizeLimit` supportability metric includes the agent language name ("Ruby").

NOTE that the `MaxPayloadSizeLimit` part of the name itself isn't great, but we've decided to keep it as-is for now. The metric actually keeps a running tally of violations of the size limit and doesn't actually report what the configured limit is.