### PR TITLE
Update grpc gemlist

### DIFF
--- a/test/multiverse/suites/grpc/Envfile
+++ b/test/multiverse/suites/grpc/Envfile
@@ -16,6 +16,7 @@ GRPC_VERSIONS = [
 def gem_list(grpc_version = nil)
   <<~RB
     gem 'grpc'#{grpc_version}
+    gem 'google-protobuf', '3.21.12' if RUBY_VERSION <= '2.5.9'
   RB
 end
 


### PR DESCRIPTION
Lock grpc dependency `google-protobuf` to 3.21.12 for Rubies less than 2.5.9. 

google-protobuf 3.22 depends on ruby >=2.6, so we need to pin the version. 