### PR TITLE
Remove DT warnings for sidekiq

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## dev
 
-  Upcoming version removes distributed tracing warnings from agent logs when using sidekiq.
+  Upcoming version removes Distributed Tracing warnings from agent logs when using Sidekiq.
 
 
 - **Removes Distributed Tracing related warnings from agent logs when headers are not present in Sidekiq**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # New Relic Ruby Agent Release Notes
 
+## dev
+
+  Upcoming version removes distributed tracing warnings from agent logs when using sidekiq.
+
+
+- **Removes Distributed Tracing related warnings from agent logs when headers are not present in Sidekiq**
+
+  Previously, the agent would log a warning in the newrelic_agent.log every time it attempted to accept empty distributed tracing headers from sidekiq jobs which could result in an excessive number of warnings. Now the agent will no longer create these warnings when using sidekiq. [PR#1834](https://github.com/newrelic/newrelic-ruby-agent/pull/1834)
+
 ## v9.0.0
 
   Version 9.0.0 of the agent removes several deprecated configuration options and API methods, enables Thread tracing by default, adds Fiber instrumentation, removes support for Ruby versions 2.2 and 2.3, removes instrumentation for several deprecated gems, changes how the API method `set_transaction_name` works, and updates `rails_defer_initialization` to be an environment variable only configuration option.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 - **Removes Distributed Tracing related warnings from agent logs when headers are not present in Sidekiq**
 
-  Previously, the agent would log a warning in the newrelic_agent.log every time it attempted to accept empty distributed tracing headers from sidekiq jobs which could result in an excessive number of warnings. Now the agent will no longer create these warnings when using sidekiq. [PR#1834](https://github.com/newrelic/newrelic-ruby-agent/pull/1834)
+  Previously, the agent would log a warning to `newrelic_agent.log` every time it attempted to accept empty Distributed Tracing headers from Sidekiq jobs which could result in an excessive number of warnings. Now the agent will no longer create these warnings when using Sidekiq. [PR#1834](https://github.com/newrelic/newrelic-ruby-agent/pull/1834)
 
 ## v9.0.0
 

--- a/lib/new_relic/agent/instrumentation/sidekiq/server.rb
+++ b/lib/new_relic/agent/instrumentation/sidekiq/server.rb
@@ -21,7 +21,7 @@ module NewRelic::Agent::Instrumentation::Sidekiq
         NewRelic::Agent::Transaction.merge_untrusted_agent_attributes(msg['args'], :'job.sidekiq.args',
           NewRelic::Agent::AttributeFilter::DST_NONE)
 
-        ::NewRelic::Agent::DistributedTracing::accept_distributed_trace_headers(trace_headers, "Other") if ::NewRelic::Agent.config[:'distributed_tracing.enabled']
+        ::NewRelic::Agent::DistributedTracing::accept_distributed_trace_headers(trace_headers, "Other") if ::NewRelic::Agent.config[:'distributed_tracing.enabled'] && trace_headers
         yield
       end
     end

--- a/lib/new_relic/agent/instrumentation/sidekiq/server.rb
+++ b/lib/new_relic/agent/instrumentation/sidekiq/server.rb
@@ -21,7 +21,7 @@ module NewRelic::Agent::Instrumentation::Sidekiq
         NewRelic::Agent::Transaction.merge_untrusted_agent_attributes(msg['args'], :'job.sidekiq.args',
           NewRelic::Agent::AttributeFilter::DST_NONE)
 
-        ::NewRelic::Agent::DistributedTracing::accept_distributed_trace_headers(trace_headers, "Other") if ::NewRelic::Agent.config[:'distributed_tracing.enabled'] && trace_headers
+        ::NewRelic::Agent::DistributedTracing::accept_distributed_trace_headers(trace_headers, "Other") if ::NewRelic::Agent.config[:'distributed_tracing.enabled'] && trace_headers&.any?
         yield
       end
     end

--- a/test/multiverse/suites/sidekiq/sidekiq_instrumentation_test.rb
+++ b/test/multiverse/suites/sidekiq/sidekiq_instrumentation_test.rb
@@ -182,6 +182,14 @@ class SidekiqTest < Minitest::Test
     Sidekiq::CLI.instance.handle_exception(exception)
   end
 
+  def test_accept_dt_headers_not_called_if_headers_nil
+    NewRelic::Agent::DistributedTracing.stubs(:insert_distributed_trace_headers)
+    NewRelic::Agent::DistributedTracing.expects(:accept_distributed_trace_headers).never
+    in_transaction do
+      run_jobs
+    end
+  end
+
   def assert_metric_and_call_count(name, expected_call_count)
     metric_data = $collector.calls_for('metric_data')
 


### PR DESCRIPTION
The agent attempts to accept dt headers from sidekiq jobs if distributed tracing is enabled. If the jobs are not being created with an agent that also has dt enabled, then this can result in an excessive number of warnings in the agent logs. This change will make it so that we will only attempt to accept the headers if it is not empty.

closes #1725