### PR TITLE
Rubocops compatible with Ruby 2.4+

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -142,6 +142,8 @@ Performance/StringIdentifierArgument: # new in 1.13
   Enabled: true
 Performance/StringInclude: # new in 1.7
   Enabled: true
+Performance/Sum: # new in 1.8
+  Enabled: true
 
 
 # Old cops

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1731,6 +1731,9 @@ Style/RescueStandardError:
 Style/ReturnNil:
   Enabled: false
 
+Style/SafeNavigation:
+  Enabled: true
+
 Style/Sample:
   Enabled: true
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -130,6 +130,8 @@ Performance/RedundantSplitRegexpArgument: # new in 1.10
   Enabled: true
 Performance/RedundantStringChars: # new in 1.7
   Enabled: true
+Performance/RegexpMatch:
+  Enabled: true
 Performance/ReverseFirst: # new in 1.7
   Enabled: true
 Performance/SortReverse: # new in 1.7

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -144,8 +144,9 @@ Performance/StringInclude: # new in 1.7
   Enabled: true
 Performance/Sum: # new in 1.8
   Enabled: true
-
-
+Performance/UnfreezeString:
+  Enabled: true
+  
 # Old cops
 
 Bundler/DuplicatedGem:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -146,7 +146,7 @@ Performance/Sum: # new in 1.8
   Enabled: true
 Performance/UnfreezeString:
   Enabled: true
-  
+
 # Old cops
 
 Bundler/DuplicatedGem:
@@ -1321,6 +1321,9 @@ Style/ExplicitBlockArgument:
   Enabled: false
 
 Style/ExponentialNotation:
+  Enabled: false
+
+Style/FetchEnvVar:
   Enabled: false
 
 Style/FloatDivision:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -66,7 +66,7 @@ Style/RedundantEach: # new in 1.38
   Enabled: true
 Style/RedundantInitialize: # new in 1.27
   Enabled: true
-Style/RedundantStringEscape: # new in 1.37
+Style/RedundantStringEscape: # new in 1.37, 'pending' by default so enabled to make sure it's applied
   Enabled: true
 Style/YodaExpression: # new in 1.42
   Enabled: true
@@ -130,8 +130,6 @@ Performance/RedundantSplitRegexpArgument: # new in 1.10
   Enabled: true
 Performance/RedundantStringChars: # new in 1.7
   Enabled: true
-Performance/RegexpMatch:
-  Enabled: true
 Performance/ReverseFirst: # new in 1.7
   Enabled: true
 Performance/SortReverse: # new in 1.7
@@ -142,9 +140,7 @@ Performance/StringIdentifierArgument: # new in 1.13
   Enabled: true
 Performance/StringInclude: # new in 1.7
   Enabled: true
-Performance/Sum: # new in 1.8
-  Enabled: true
-Performance/UnfreezeString:
+Performance/Sum: # new in 1.8, pending so left enabled explicitly until 2.0
   Enabled: true
 
 # Old cops
@@ -1730,9 +1726,6 @@ Style/RescueStandardError:
 
 Style/ReturnNil:
   Enabled: false
-
-Style/SafeNavigation:
-  Enabled: true
 
 Style/Sample:
   Enabled: true

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -63,11 +63,6 @@ Minitest/EmptyLineBeforeAssertionMethods:
     - 'test/new_relic/agent_test.rb'
     - 'test/new_relic/cli/commands/deployments_test.rb'
 
-# Offense count: 23
-# This cop supports safe autocorrection (--autocorrect).
-Performance/RegexpMatch:
-  Enabled: false
-
 # Offense count: 1
 # This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: OnlySumOrWithInitialValue.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -65,12 +65,6 @@ Minitest/RefuteRespondTo:
 Style/FetchEnvVar:
   Enabled: true
 
-# Offense count: 1
-# This cop supports safe autocorrection (--autocorrect).
-Style/RedundantStringEscape:
-  Exclude:
-    - 'test/new_relic/agent/logging_test.rb'
-
 # Offense count: 115
 # This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: ConvertCodeThatCanStartToReturnNil, AllowedMethods, MaxChainLength.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -63,11 +63,6 @@ Minitest/EmptyLineBeforeAssertionMethods:
     - 'test/new_relic/agent_test.rb'
     - 'test/new_relic/cli/commands/deployments_test.rb'
 
-# Offense count: 72
-# This cop supports unsafe autocorrection (--autocorrect-all).
-Performance/UnfreezeString:
-  Enabled: false
-
 # Offense count: 21
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: AllowedVars.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -58,10 +58,3 @@ Style/ConcatArrayLiterals:
 Minitest/RefuteRespondTo:
   Exclude:
     - 'test/new_relic/cli/commands/deployments_test.rb'
-
-# Offense count: 115
-# This cop supports unsafe autocorrection (--autocorrect-all).
-# Configuration parameters: ConvertCodeThatCanStartToReturnNil, AllowedMethods, MaxChainLength.
-# AllowedMethods: present?, blank?, presence, try, try!
-Style/SafeNavigation:
-  Enabled: false

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -36,6 +36,7 @@ Minitest/DuplicateTestRun:
 Minitest/EmptyLineBeforeAssertionMethods:
   Exclude:
     - 'test/new_relic/agent_test.rb'
+    - 'test/new_relic/cli/commands/deployments_test.rb'
 
 # Offense count: 269
 Minitest/MultipleAssertions:
@@ -56,11 +57,6 @@ Style/ConcatArrayLiterals:
 
 Minitest/RefuteRespondTo:
   Exclude:
-    - 'test/new_relic/cli/commands/deployments_test.rb'
-
-Minitest/EmptyLineBeforeAssertionMethods:
-  Exclude:
-    - 'test/new_relic/agent_test.rb'
     - 'test/new_relic/cli/commands/deployments_test.rb'
 
 # Offense count: 21

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -67,7 +67,7 @@ Minitest/EmptyLineBeforeAssertionMethods:
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: AllowedVars.
 Style/FetchEnvVar:
-  Enabled: false
+  Enabled: true
 
 # Offense count: 1
 # This cop supports safe autocorrection (--autocorrect).

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -59,12 +59,6 @@ Minitest/RefuteRespondTo:
   Exclude:
     - 'test/new_relic/cli/commands/deployments_test.rb'
 
-# Offense count: 21
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: AllowedVars.
-Style/FetchEnvVar:
-  Enabled: true
-
 # Offense count: 115
 # This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: ConvertCodeThatCanStartToReturnNil, AllowedMethods, MaxChainLength.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -63,13 +63,6 @@ Minitest/EmptyLineBeforeAssertionMethods:
     - 'test/new_relic/agent_test.rb'
     - 'test/new_relic/cli/commands/deployments_test.rb'
 
-# Offense count: 1
-# This cop supports unsafe autocorrection (--autocorrect-all).
-# Configuration parameters: OnlySumOrWithInitialValue.
-Performance/Sum:
-  Exclude:
-    - 'lib/new_relic/agent/system_info.rb'
-
 # Offense count: 72
 # This cop supports unsafe autocorrection (--autocorrect-all).
 Performance/UnfreezeString:

--- a/bin/nrdebug
+++ b/bin/nrdebug
@@ -216,7 +216,7 @@ class ProcessReport
 
       section(f) do
         c_backtraces, ruby_backtraces = @target.gather_backtraces
-        if c_backtraces =~ /could not attach/i
+        if /could not attach/i.match?(c_backtraces)
           fail("Failed to attach to target process. Please try again with sudo.")
         end
 

--- a/infinite_tracing/lib/infinite_tracing/agent_integrations/agent.rb
+++ b/infinite_tracing/lib/infinite_tracing/agent_integrations/agent.rb
@@ -23,7 +23,7 @@ module NewRelic::Agent
     def handle_force_restart(error)
       ::NewRelic::Agent.logger.debug(error.message)
       drop_buffered_data
-      @service.force_restart if @service
+      @service&.force_restart
       @connect_state = :pending
       close_infinite_tracer
       sleep(30)

--- a/infinite_tracing/lib/infinite_tracing/config.rb
+++ b/infinite_tracing/lib/infinite_tracing/config.rb
@@ -64,7 +64,7 @@ module NewRelic::Agent
       # is overridden by the presence of the port on the host entry.
       def port_from_host_entry
         port_str = NewRelic::Agent.config[:'infinite_tracing.trace_observer.host'].scan(%r{:(\d+)$}).flatten
-        if port = (port_str[0] and port_str[0].to_i)
+        if port = (port_str[0]&.to_i)
           NewRelic::Agent.logger.warn(":'infinite_tracing.trace_observer.port' is ignored if present because :'infinite_tracing.trace_observer.host' specifies the port")
           return port
         end

--- a/infinite_tracing/lib/infinite_tracing/config.rb
+++ b/infinite_tracing/lib/infinite_tracing/config.rb
@@ -64,7 +64,7 @@ module NewRelic::Agent
       # is overridden by the presence of the port on the host entry.
       def port_from_host_entry
         port_str = NewRelic::Agent.config[:'infinite_tracing.trace_observer.host'].scan(%r{:(\d+)$}).flatten
-        if port = (port_str[0]&.to_i)
+        if port = port_str[0]&.to_i
           NewRelic::Agent.logger.warn(":'infinite_tracing.trace_observer.port' is ignored if present because :'infinite_tracing.trace_observer.host' specifies the port")
           return port
         end

--- a/infinite_tracing/test/support/fake_trace_observer_helpers.rb
+++ b/infinite_tracing/test/support/fake_trace_observer_helpers.rb
@@ -52,7 +52,7 @@ if NewRelic::Agent::InfiniteTracing::Config.should_load?
           end
 
           def teardown
-            @mock_thread.kill if @mock_thread
+            @mock_thread&.kill
             @mock_thread = nil
             @server_response_enum = nil
             reset_buffers_and_caches
@@ -170,7 +170,7 @@ if NewRelic::Agent::InfiniteTracing::Config.should_load?
               end
             end
           ensure
-            client.stop unless client.nil?
+            client&.stop
           end
 
           # when the server responds with an error that should stop the server
@@ -215,7 +215,7 @@ if NewRelic::Agent::InfiniteTracing::Config.should_load?
           end
 
           def join_grpc_mock
-            @mock_thread.join if @mock_thread
+            @mock_thread&.join
           end
 
           # Simulates a Messages seen response from the mock grpc server

--- a/lib/new_relic/agent.rb
+++ b/lib/new_relic/agent.rb
@@ -386,7 +386,7 @@ module NewRelic
     #
     def after_fork(options = {})
       record_api_supportability_metric(:after_fork)
-      agent.after_fork(options) if agent
+      agent&.after_fork(options)
     end
 
     # Shutdown the agent.  Call this before exiting.  Sends any queued data
@@ -398,7 +398,7 @@ module NewRelic
     #
     def shutdown(options = {})
       record_api_supportability_metric(:shutdown)
-      agent.shutdown if agent
+      agent&.shutdown
     end
 
     # Clear out any data the agent has buffered but has not yet transmitted
@@ -406,7 +406,7 @@ module NewRelic
     #
     # @api public
     def drop_buffered_data
-      agent.drop_buffered_data if agent
+      agent&.drop_buffered_data
       record_api_supportability_metric(:drop_buffered_data)
     end
 
@@ -465,8 +465,7 @@ module NewRelic
     #
     def ignore_transaction
       record_api_supportability_metric(:ignore_transaction)
-      txn = NewRelic::Agent::Transaction.tl_current
-      txn.ignore! if txn
+      NewRelic::Agent::Transaction.tl_current&.ignore!
     end
 
     # This method disables the recording of Apdex metrics in the current
@@ -476,8 +475,7 @@ module NewRelic
     #
     def ignore_apdex
       record_api_supportability_metric(:ignore_apdex)
-      txn = NewRelic::Agent::Transaction.tl_current
-      txn.ignore_apdex! if txn
+      NewRelic::Agent::Transaction.tl_current&.ignore_apdex!
     end
 
     # This method disables browser monitoring javascript injection in the
@@ -487,8 +485,7 @@ module NewRelic
     #
     def ignore_enduser
       record_api_supportability_metric(:ignore_enduser)
-      txn = NewRelic::Agent::Transaction.tl_current
-      txn.ignore_enduser! if txn
+      NewRelic::Agent::Transaction.tl_current&.ignore_enduser!
     end
 
     # Yield to the block without collecting any metrics or traces in
@@ -564,8 +561,7 @@ module NewRelic
       record_api_supportability_metric(:add_custom_attributes)
 
       if params.is_a?(Hash)
-        txn = Transaction.tl_current
-        txn.add_custom_attributes(params) if txn
+        Transaction.tl_current&.add_custom_attributes(params)
 
         segment = ::NewRelic::Agent::Tracer.current_segment
         if segment

--- a/lib/new_relic/agent.rb
+++ b/lib/new_relic/agent.rb
@@ -386,7 +386,8 @@ module NewRelic
     #
     def after_fork(options = {})
       record_api_supportability_metric(:after_fork)
-      agent&.after_fork(options)
+      # the following line needs else branch coverage
+      agent.after_fork(options) if agent # rubocop:disable Style/SafeNavigation
     end
 
     # Shutdown the agent.  Call this before exiting.  Sends any queued data
@@ -406,7 +407,8 @@ module NewRelic
     #
     # @api public
     def drop_buffered_data
-      agent&.drop_buffered_data
+      # the following line needs else branch coverage
+      agent.drop_buffered_data if agent # rubocop:disable Style/SafeNavigation
       record_api_supportability_metric(:drop_buffered_data)
     end
 

--- a/lib/new_relic/agent/agent_helpers/connect.rb
+++ b/lib/new_relic/agent/agent_helpers/connect.rb
@@ -115,7 +115,7 @@ module NewRelic
           ::NewRelic::Agent.logger.debug("Connected to NewRelic Service at #{@service.collector.name}")
           ::NewRelic::Agent.logger.debug("Agent Run       = #{@service.agent_id}.")
           ::NewRelic::Agent.logger.debug("Connection data = #{config_data.inspect}")
-          if config_data['messages'] && config_data['messages'].any?
+          if config_data['messages']&.any?
             log_collector_messages(config_data['messages'])
           end
         end

--- a/lib/new_relic/agent/agent_helpers/start_worker_thread.rb
+++ b/lib/new_relic/agent/agent_helpers/start_worker_thread.rb
@@ -42,7 +42,7 @@ module NewRelic
         # The use-case where this typically arises is in cronjob scheduled rake tasks where there's
         # also some network stability/latency issues happening.
         def stop_event_loop
-          @event_loop.stop if @event_loop
+          @event_loop&.stop
           # Wait the end of the event loop thread.
           if @worker_thread
             unless @worker_thread.join(3)
@@ -100,7 +100,7 @@ module NewRelic
         def handle_force_restart(error)
           ::NewRelic::Agent.logger.debug(error.message)
           drop_buffered_data
-          @service.force_restart if @service
+          @service&.force_restart
           @connect_state = :pending
           sleep(30)
         end

--- a/lib/new_relic/agent/commands/agent_command_router.rb
+++ b/lib/new_relic/agent/commands/agent_command_router.rb
@@ -29,9 +29,7 @@ module NewRelic
           @handlers['start_profiler'] = proc { |cmd| thread_profiler_session.handle_start_command(cmd) }
           @handlers['stop_profiler'] = proc { |cmd| thread_profiler_session.handle_stop_command(cmd) }
 
-          if event_listener
-            event_listener.subscribe(:before_shutdown, &method(:on_before_shutdown))
-          end
+          event_listener&.subscribe(:before_shutdown, &method(:on_before_shutdown))
         end
 
         def new_relic_service

--- a/lib/new_relic/agent/commands/agent_command_router.rb
+++ b/lib/new_relic/agent/commands/agent_command_router.rb
@@ -30,6 +30,10 @@ module NewRelic
           @handlers['stop_profiler'] = proc { |cmd| thread_profiler_session.handle_stop_command(cmd) }
 
           event_listener&.subscribe(:before_shutdown, &method(:on_before_shutdown))
+          # the following statement needs else branch coverage
+          if event_listener # rubocop:disable Style/SafeNavigation
+            event_listener.subscribe(:before_shutdown, &method(:on_before_shutdown))
+          end
         end
 
         def new_relic_service

--- a/lib/new_relic/agent/commands/agent_command_router.rb
+++ b/lib/new_relic/agent/commands/agent_command_router.rb
@@ -29,7 +29,6 @@ module NewRelic
           @handlers['start_profiler'] = proc { |cmd| thread_profiler_session.handle_start_command(cmd) }
           @handlers['stop_profiler'] = proc { |cmd| thread_profiler_session.handle_stop_command(cmd) }
 
-          event_listener&.subscribe(:before_shutdown, &method(:on_before_shutdown))
           # the following statement needs else branch coverage
           if event_listener # rubocop:disable Style/SafeNavigation
             event_listener.subscribe(:before_shutdown, &method(:on_before_shutdown))

--- a/lib/new_relic/agent/commands/thread_profiler_session.rb
+++ b/lib/new_relic/agent/commands/thread_profiler_session.rb
@@ -51,7 +51,7 @@ module NewRelic
 
         def harvest
           NewRelic::Agent.logger.debug(
-            "Harvesting from Thread Profiler #{@finished_profile.to_log_description unless @finished_profile.nil?}"
+            "Harvesting from Thread Profiler #{@finished_profile&.to_log_description}"
           )
           profile = @finished_profile
           @backtrace_service.profile_agent_code = false

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -104,7 +104,8 @@ module NewRelic
             end
 
             # If we're packaged for warbler, we can tell from GEM_HOME
-            if ENV["GEM_HOME"]&.end_with?(".jar!")
+            # the following line needs else branch coverage
+            if ENV["GEM_HOME"] && ENV["GEM_HOME"].end_with?(".jar!") # rubocop:disable Style/SafeNavigation
               app_name = File.basename(ENV["GEM_HOME"], ".jar!")
               paths << File.join(ENV["GEM_HOME"], app_name, "config", "newrelic.yml")
               paths << File.join(ENV["GEM_HOME"], app_name, "config", "newrelic.yml.erb")

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -104,7 +104,7 @@ module NewRelic
             end
 
             # If we're packaged for warbler, we can tell from GEM_HOME
-            if ENV["GEM_HOME"] && ENV["GEM_HOME"].end_with?(".jar!")
+            if ENV["GEM_HOME"]&.end_with?(".jar!")
               app_name = File.basename(ENV["GEM_HOME"], ".jar!")
               paths << File.join(ENV["GEM_HOME"], app_name, "config", "newrelic.yml")
               paths << File.join(ENV["GEM_HOME"], app_name, "config", "newrelic.yml.erb")

--- a/lib/new_relic/agent/configuration/environment_source.rb
+++ b/lib/new_relic/agent/configuration/environment_source.rb
@@ -94,7 +94,7 @@ module NewRelic
           elsif type == Array
             self[config_key] = value.split(/\s*,\s*/)
           elsif type == NewRelic::Agent::Configuration::Boolean
-            if value =~ /false|off|no/i
+            if /false|off|no/i.match?(value)
               self[config_key] = false
             elsif !value.nil?
               self[config_key] = true

--- a/lib/new_relic/agent/configuration/server_source.rb
+++ b/lib/new_relic/agent/configuration/server_source.rb
@@ -70,7 +70,7 @@ module NewRelic
 
         def fix_transaction_threshold(merged_settings)
           # when value is "apdex_f" remove the config and defer to default
-          if merged_settings['transaction_tracer.transaction_threshold'].to_s =~ /apdex_f/i
+          if /apdex_f/i.match?(merged_settings['transaction_tracer.transaction_threshold'].to_s)
             merged_settings.delete('transaction_tracer.transaction_threshold')
           end
         end

--- a/lib/new_relic/agent/configuration/yaml_source.rb
+++ b/lib/new_relic/agent/configuration/yaml_source.rb
@@ -124,7 +124,7 @@ module NewRelic
               config['transaction_tracer']['transaction_threshold'].to_s =~ /apdex_f/i
             # when value is "apdex_f" remove the config and defer to default
             config['transaction_tracer'].delete('transaction_threshold')
-          elsif config['transaction_tracer.transaction_threshold'].to_s =~ /apdex_f/i
+          elsif /apdex_f/i.match?(config['transaction_tracer.transaction_threshold'].to_s)
             config.delete('transaction_tracer.transaction_threshold')
           end
         end

--- a/lib/new_relic/agent/connect/request_builder.rb
+++ b/lib/new_relic/agent/connect/request_builder.rb
@@ -48,7 +48,7 @@ module NewRelic
 
         def environment_metadata
           env_copy = {}
-          ENV.keys.each { |k| env_copy[k] = ENV[k] if k =~ /^NEW_RELIC_METADATA_/ }
+          ENV.keys.each { |k| env_copy[k] = ENV[k] if /^NEW_RELIC_METADATA_/.match?(k) }
           env_copy
         end
 

--- a/lib/new_relic/agent/custom_event_aggregator.rb
+++ b/lib/new_relic/agent/custom_event_aggregator.rb
@@ -27,7 +27,7 @@ module NewRelic
         return unless enabled?
 
         type = @type_strings[type]
-        unless type =~ EVENT_TYPE_REGEX
+        unless EVENT_TYPE_REGEX.match?(type)
           note_dropped_event(type)
           return false
         end

--- a/lib/new_relic/agent/database/obfuscation_helpers.rb
+++ b/lib/new_relic/agent/database/obfuscation_helpers.rb
@@ -52,7 +52,7 @@ module NewRelic
         FAILED_TO_OBFUSCATE_MESSAGE = "Failed to obfuscate SQL query - quote characters remained after obfuscation".freeze
 
         def obfuscate_single_quote_literals(sql)
-          return sql unless sql =~ COMPONENTS_REGEX_MAP[:single_quotes]
+          return sql unless sql&.match?(COMPONENTS_REGEX_MAP[:single_quotes])
 
           sql.gsub(COMPONENTS_REGEX_MAP[:single_quotes], PLACEHOLDER)
         end

--- a/lib/new_relic/agent/datastores/redis.rb
+++ b/lib/new_relic/agent/datastores/redis.rb
@@ -25,7 +25,7 @@ module NewRelic
 
         def self.format_command(command_with_args)
           if Agent.config[:'transaction_tracer.record_redis_arguments']
-            result = String.new('')
+            result = +''
 
             append_command_with_args(result, command_with_args)
 
@@ -36,7 +36,7 @@ module NewRelic
         end
 
         def self.format_pipeline_commands(commands_with_args)
-          result = String.new('')
+          result = +''
 
           commands_with_args.each do |command|
             if result.length >= MAXIMUM_COMMAND_LENGTH

--- a/lib/new_relic/agent/distributed_tracing/cross_app_tracing.rb
+++ b/lib/new_relic/agent/distributed_tracing/cross_app_tracing.rb
@@ -36,7 +36,7 @@ module NewRelic
       end
 
       def cat_trip_id
-        cross_app_payload && cross_app_payload.referring_trip_id || transaction.guid
+        cross_app_payload&.referring_trip_id || transaction.guid
       end
 
       def cross_app_monitor
@@ -74,7 +74,7 @@ module NewRelic
       end
 
       def record_cross_app_metrics
-        if (id = cross_app_payload && cross_app_payload.id)
+        if (id = cross_app_payload&.id)
           app_time_in_seconds = [
             Process.clock_gettime(Process::CLOCK_REALTIME) - transaction.start_time,
             0.0
@@ -104,11 +104,11 @@ module NewRelic
       end
 
       def cat_referring_path_hash
-        cross_app_payload && cross_app_payload.referring_path_hash
+        cross_app_payload&.referring_path_hash
       end
 
       def append_cat_info(payload)
-        if (referring_guid = cross_app_payload && cross_app_payload.referring_guid)
+        if (referring_guid = cross_app_payload&.referring_guid)
           payload[:referring_transaction_guid] = referring_guid
         end
 

--- a/lib/new_relic/agent/distributed_tracing/trace_context.rb
+++ b/lib/new_relic/agent/distributed_tracing/trace_context.rb
@@ -78,7 +78,7 @@ module NewRelic
           end
 
           def create_trace_state_entry(entry_key, payload)
-            "#{entry_key}=#{payload}".dup
+            +"#{entry_key}=#{payload}"
           end
 
           private
@@ -138,7 +138,7 @@ module NewRelic
 
             payload = nil
             trace_state_size = 0
-            trace_state_vendors = String.new
+            trace_state_vendors = +''
             trace_state = header.split(COMMA).map(&:strip)
             trace_state.reject! do |entry|
               if entry == NewRelic::EMPTY_STR
@@ -223,7 +223,7 @@ module NewRelic
             max_size = MAX_TRACE_STATE_SIZE - trace_state_entry_size
             return @trace_state_entries.join(COMMA).prepend(COMMA) if @trace_state_size < max_size
 
-            joined_trace_state = ''.dup
+            joined_trace_state = +''
 
             used_size = 0
 

--- a/lib/new_relic/agent/error_collector.rb
+++ b/lib/new_relic/agent/error_collector.rb
@@ -227,7 +227,7 @@ module NewRelic
       def notice_error(exception, options = {}, span_id = nil)
         state = ::NewRelic::Agent::Tracer.state
         transaction = state.current_transaction
-        status_code = transaction ? transaction.http_response_code : nil
+        status_code = transaction&.http_response_code
 
         return if skip_notice_error?(exception, status_code)
 
@@ -242,8 +242,8 @@ module NewRelic
         noticed_error = create_noticed_error(exception, options)
         error_trace_aggregator.add_to_error_queue(noticed_error)
         transaction = state.current_transaction
-        payload = transaction ? transaction.payload : nil
-        span_id ||= transaction && transaction.current_segment ? transaction.current_segment.guid : nil
+        payload = transaction&.payload
+        span_id ||= transaction&.current_segment ? transaction.current_segment.guid : nil
         error_event_aggregator.record(noticed_error, payload, span_id)
         exception
       rescue => e

--- a/lib/new_relic/agent/error_filter.rb
+++ b/lib/new_relic/agent/error_filter.rb
@@ -80,7 +80,7 @@ module NewRelic
             @ignore_messages.update(errors)
             log_filter(:ignore_messages, errors)
           when String
-            if errors =~ /^[\d\,\-]+$/
+            if /^[\d\,\-]+$/.match?(errors)
               @ignore_status_codes |= parse_status_codes(errors)
               log_filter(:ignore_status_codes, errors)
             else
@@ -104,7 +104,7 @@ module NewRelic
             @expected_messages.update(errors)
             log_filter(:expected_messages, errors)
           when String
-            if errors =~ /^[\d\,\-]+$/
+            if /^[\d\,\-]+$/.match?(errors)
               @expected_status_codes |= parse_status_codes(errors)
               log_filter(:expected_status_codes, errors)
             else

--- a/lib/new_relic/agent/event_loop.rb
+++ b/lib/new_relic/agent/event_loop.rb
@@ -161,7 +161,7 @@ module NewRelic
       end
 
       def reschedule_timer_for_event(e)
-        @timers[e].reschedule if @timers[e]
+        @timers[e]&.reschedule
       end
 
       def on(event, &blk)

--- a/lib/new_relic/agent/harvester.rb
+++ b/lib/new_relic/agent/harvester.rb
@@ -14,9 +14,7 @@ module NewRelic
         @starting_pid = nil
         @after_forker = after_forker
 
-        if events
-          events.subscribe(:start_transaction, &method(:on_transaction))
-        end
+        events&.subscribe(:start_transaction, &method(:on_transaction))
       end
 
       def on_transaction(*_)

--- a/lib/new_relic/agent/heap.rb
+++ b/lib/new_relic/agent/heap.rb
@@ -26,7 +26,7 @@ module NewRelic
       def initialize(items = nil, &priority_fn)
         @items = []
         @priority_fn = priority_fn || ->(x) { x }
-        items.each { |item| push(item) } if items
+        items&.each { |item| push(item) }
       end
 
       def [](index)

--- a/lib/new_relic/agent/heap.rb
+++ b/lib/new_relic/agent/heap.rb
@@ -26,7 +26,8 @@ module NewRelic
       def initialize(items = nil, &priority_fn)
         @items = []
         @priority_fn = priority_fn || ->(x) { x }
-        items&.each { |item| push(item) }
+        # the following line needs else branch coverage
+        items.each { |item| push(item) } if items # rubocop:disable Style/SafeNavigation
       end
 
       def [](index)

--- a/lib/new_relic/agent/http_clients/curb_wrappers.rb
+++ b/lib/new_relic/agent/http_clients/curb_wrappers.rb
@@ -62,7 +62,7 @@ module NewRelic
         def append_header_data(data)
           key, value = data.split(/:\s*/, 2)
           @headers[key.downcase] = value
-          @wrapped_response._nr_header_str ||= String.new
+          @wrapped_response._nr_header_str ||= +''
           @wrapped_response._nr_header_str << data
         end
 

--- a/lib/new_relic/agent/http_clients/net_http_wrappers.rb
+++ b/lib/new_relic/agent/http_clients/net_http_wrappers.rb
@@ -61,7 +61,7 @@ module NewRelic
             ::NewRelic::Agent::HTTPClients::URIUtil.parse_and_normalize_url(@request.path)
           else
             connection_address = @connection.address
-            if connection_address =~ Resolv::IPv6::Regex
+            if Resolv::IPv6::Regex.match?(connection_address)
               connection_address = "[#{connection_address}]"
             end
 

--- a/lib/new_relic/agent/http_clients/uri_util.rb
+++ b/lib/new_relic/agent/http_clients/uri_util.rb
@@ -36,7 +36,7 @@ module NewRelic
               uri = ::URI.parse(url)
             end
           end
-          uri.host.downcase! unless uri.host.nil?
+          uri.host&.downcase!
           uri
         end
 

--- a/lib/new_relic/agent/instrumentation/action_controller_other_subscriber.rb
+++ b/lib/new_relic/agent/instrumentation/action_controller_other_subscriber.rb
@@ -28,7 +28,7 @@ module NewRelic
 
         def controller_name_for_metric(payload)
           # redirect_to
-          return payload[:request].controller_class.controller_path if payload[:request] && payload[:request].controller_class
+          return payload[:request].controller_class.controller_path if payload[:request]&.controller_class
 
           # unpermitted_parameters
           ::NewRelic::LanguageSupport.constantize(payload[:context][:controller]).controller_path if payload[:context] && payload[:context][:controller]

--- a/lib/new_relic/agent/instrumentation/action_controller_subscriber.rb
+++ b/lib/new_relic/agent/instrumentation/action_controller_subscriber.rb
@@ -90,7 +90,8 @@ module NewRelic
         end
 
         def queue_start(request)
-          if request&.respond_to?(:env)
+          # the following line needs else branch coverage 
+          if request && request.respond_to?(:env) # rubocop:disable Style/SafeNavigation
             QueueTime.parse_frontend_timestamp(request.env, Process.clock_gettime(Process::CLOCK_REALTIME))
           end
         end

--- a/lib/new_relic/agent/instrumentation/action_controller_subscriber.rb
+++ b/lib/new_relic/agent/instrumentation/action_controller_subscriber.rb
@@ -90,7 +90,7 @@ module NewRelic
         end
 
         def queue_start(request)
-          # the following line needs else branch coverage 
+          # the following line needs else branch coverage
           if request && request.respond_to?(:env) # rubocop:disable Style/SafeNavigation
             QueueTime.parse_frontend_timestamp(request.env, Process.clock_gettime(Process::CLOCK_REALTIME))
           end

--- a/lib/new_relic/agent/instrumentation/action_controller_subscriber.rb
+++ b/lib/new_relic/agent/instrumentation/action_controller_subscriber.rb
@@ -19,7 +19,7 @@ module NewRelic
           else
             # if this transaction is ignored, make sure child
             # transaction are also ignored
-            state.current_transaction.ignore! if state.current_transaction
+            state.current_transaction&.ignore!
             NewRelic::Agent.instance.push_trace_execution_flag(false)
           end
         rescue => e
@@ -90,7 +90,7 @@ module NewRelic
         end
 
         def queue_start(request)
-          if request && request.respond_to?(:env)
+          if request&.respond_to?(:env)
             QueueTime.parse_frontend_timestamp(request.env, Process.clock_gettime(Process::CLOCK_REALTIME))
           end
         end

--- a/lib/new_relic/agent/instrumentation/action_view_subscriber.rb
+++ b/lib/new_relic/agent/instrumentation/action_view_subscriber.rb
@@ -75,7 +75,7 @@ module NewRelic
           # so do not mistake rendering a collection for rendering a file.
           if identifier.nil? && name != RENDER_COLLECTION_EVENT_NAME
             'file'
-          elsif identifier =~ /template$/
+          elsif /template$/.match?(identifier)
             identifier
           elsif identifier && (parts = identifier.split('/')).size > 1
             parts[-2..-1].join('/')

--- a/lib/new_relic/agent/instrumentation/action_view_subscriber.rb
+++ b/lib/new_relic/agent/instrumentation/action_view_subscriber.rb
@@ -99,11 +99,11 @@ module NewRelic
         end
 
         def finish
-          @finishable.finish if @finishable
+          @finishable&.finish
         end
 
         def notice_error(error)
-          @finishable.notice_error(error) if @finishable
+          @finishable&.notice_error(error)
         end
       end
     end

--- a/lib/new_relic/agent/instrumentation/active_job.rb
+++ b/lib/new_relic/agent/instrumentation/active_job.rb
@@ -57,7 +57,7 @@ module NewRelic
 
           # Don't nest transactions if we're already in a web transaction.
           # Probably inline processing the job if that happens, so just trace.
-          if txn && txn.recording_web_transaction?
+          if txn&.recording_web_transaction?
             run_in_trace(job, block, :Consume)
           elsif txn && !txn.recording_web_transaction?
             ::NewRelic::Agent::Transaction.set_default_transaction_name(

--- a/lib/new_relic/agent/instrumentation/active_record.rb
+++ b/lib/new_relic/agent/instrumentation/active_record.rb
@@ -13,7 +13,7 @@ module NewRelic
             ::ActiveRecord::Base.send("#{statement.config[:adapter]}_connection",
               statement.config)
           end
-          if connection && connection.respond_to?(:execute)
+          if connection&.respond_to?(:execute)
             return connection.execute("EXPLAIN #{statement.sql}")
           end
         end

--- a/lib/new_relic/agent/instrumentation/active_record.rb
+++ b/lib/new_relic/agent/instrumentation/active_record.rb
@@ -13,7 +13,8 @@ module NewRelic
             ::ActiveRecord::Base.send("#{statement.config[:adapter]}_connection",
               statement.config)
           end
-          if connection&.respond_to?(:execute)
+          # the following line needs else branch coverage
+          if connection && connection.respond_to?(:execute) # rubocop:disable Style/SafeNavigation
             return connection.execute("EXPLAIN #{statement.sql}")
           end
         end

--- a/lib/new_relic/agent/instrumentation/active_record_helper.rb
+++ b/lib/new_relic/agent/instrumentation/active_record_helper.rb
@@ -102,7 +102,7 @@ module NewRelic
           # TODO: OLD RUBIES - RUBY_VERSION < 2.5
           # With Ruby 2.5+ we could use #delete_suffix instead of #chomp for a
           # potential speed boost
-          return adapter_name.chomp(MAKARA_SUFFIX) if adapter_name && adapter_name.end_with?(MAKARA_SUFFIX)
+          return adapter_name.chomp(MAKARA_SUFFIX) if adapter_name&.end_with?(MAKARA_SUFFIX)
 
           adapter_name
         end
@@ -118,7 +118,7 @@ module NewRelic
         SPACE = ' '.freeze
 
         def split_name(name)
-          if name && name.respond_to?(:split)
+          if name&.respond_to?(:split)
             name.split(SPACE)
           else
             NewRelic::EMPTY_ARRAY

--- a/lib/new_relic/agent/instrumentation/active_record_subscriber.rb
+++ b/lib/new_relic/agent/instrumentation/active_record_subscriber.rb
@@ -74,7 +74,7 @@ module NewRelic
             ::ActiveRecord::Base.send("#{statement.config[:adapter]}_connection",
               statement.config)
           end
-          # the following line needs else branch coverage 
+          # the following line needs else branch coverage
           if connection && connection.respond_to?(:exec_query) # rubocop:disable Style/SafeNavigation
             return connection.exec_query("EXPLAIN #{statement.sql}",
               "Explain #{statement.name}",

--- a/lib/new_relic/agent/instrumentation/active_record_subscriber.rb
+++ b/lib/new_relic/agent/instrumentation/active_record_subscriber.rb
@@ -74,7 +74,8 @@ module NewRelic
             ::ActiveRecord::Base.send("#{statement.config[:adapter]}_connection",
               statement.config)
           end
-          if connection&.respond_to?(:exec_query)
+          # the following line needs else branch coverage 
+          if connection && connection.respond_to?(:exec_query) # rubocop:disable Style/SafeNavigation
             return connection.exec_query("EXPLAIN #{statement.sql}",
               "Explain #{statement.name}",
               statement.binds)

--- a/lib/new_relic/agent/instrumentation/active_record_subscriber.rb
+++ b/lib/new_relic/agent/instrumentation/active_record_subscriber.rb
@@ -74,7 +74,7 @@ module NewRelic
             ::ActiveRecord::Base.send("#{statement.config[:adapter]}_connection",
               statement.config)
           end
-          if connection && connection.respond_to?(:exec_query)
+          if connection&.respond_to?(:exec_query)
             return connection.exec_query("EXPLAIN #{statement.sql}",
               "Explain #{statement.name}",
               statement.binds)

--- a/lib/new_relic/agent/instrumentation/controller_instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/controller_instrumentation.rb
@@ -236,7 +236,8 @@ module NewRelic
           end
 
           def self.prefix_for_category(txn, category = nil)
-            category ||= (txn&.category)
+            # the following line needs else branch coverage
+            category ||= (txn && txn.category) # rubocop:disable Style/SafeNavigation
             case category
             when :controller then ::NewRelic::Agent::Transaction::CONTROLLER_PREFIX
             when :web then ::NewRelic::Agent::Transaction::CONTROLLER_PREFIX
@@ -386,7 +387,8 @@ module NewRelic
               raise
             end
           ensure
-            finishable&.finish
+            # the following line needs else branch coverage
+            finishable.finish if finishable # rubocop:disable Style/SafeNavigation
           end
         end
 

--- a/lib/new_relic/agent/instrumentation/controller_instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/controller_instrumentation.rb
@@ -236,7 +236,7 @@ module NewRelic
           end
 
           def self.prefix_for_category(txn, category = nil)
-            category ||= (txn && txn.category)
+            category ||= (txn&.category)
             case category
             when :controller then ::NewRelic::Agent::Transaction::CONTROLLER_PREFIX
             when :web then ::NewRelic::Agent::Transaction::CONTROLLER_PREFIX
@@ -360,7 +360,7 @@ module NewRelic
           skip_tracing = do_not_trace? || !state.is_execution_traced?
 
           if skip_tracing
-            state.current_transaction.ignore! if state.current_transaction
+            state.current_transaction&.ignore!
             NewRelic::Agent.disable_all_tracing { return yield }
           end
 
@@ -386,7 +386,7 @@ module NewRelic
               raise
             end
           ensure
-            finishable.finish if finishable
+            finishable&.finish
           end
         end
 

--- a/lib/new_relic/agent/instrumentation/curb/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/curb/instrumentation.rb
@@ -141,12 +141,12 @@ module NewRelic
             request._nr_original_on_complete = original_callback
             request.on_complete do |finished_request|
               begin
-                segment.process_response_headers(wrapped_response) if segment
+                segment&.process_response_headers(wrapped_response)
               ensure
                 ::NewRelic::Agent::Transaction::Segment.finish(segment)
                 # Make sure the existing completion callback is run, and restore the
                 # on_complete callback to how it was before.
-                original_callback.call(finished_request) if original_callback
+                original_callback&.call(finished_request)
                 remove_instrumentation_callbacks(request)
               end
             end
@@ -173,7 +173,7 @@ module NewRelic
                   segment.notice_error(noticeable_error)
                 end
               ensure
-                original_callback.call(failed_request, error) if original_callback
+                original_callback&.call(failed_request, error)
                 remove_failure_callback(failed_request)
               end
             end

--- a/lib/new_relic/agent/instrumentation/custom_events_subscriber.rb
+++ b/lib/new_relic/agent/instrumentation/custom_events_subscriber.rb
@@ -23,7 +23,8 @@ module NewRelic::Agent::Instrumentation
       NewRelic::Agent.notice_error(payload[:exception_object]) if payload.key?(:exception_object)
 
       finishable = pop_segment(id)
-      finishable&.finish
+      # the following line needs else branch coverage
+      finishable.finish if finishable # rubocop:disable Style/SafeNavigation
     rescue => e
       log_notification_error(e, name, 'finish')
     end

--- a/lib/new_relic/agent/instrumentation/custom_events_subscriber.rb
+++ b/lib/new_relic/agent/instrumentation/custom_events_subscriber.rb
@@ -23,7 +23,7 @@ module NewRelic::Agent::Instrumentation
       NewRelic::Agent.notice_error(payload[:exception_object]) if payload.key?(:exception_object)
 
       finishable = pop_segment(id)
-      finishable.finish if finishable
+      finishable&.finish
     rescue => e
       log_notification_error(e, name, 'finish')
     end

--- a/lib/new_relic/agent/instrumentation/delayed_job_instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/delayed_job_instrumentation.rb
@@ -109,6 +109,6 @@ DependencyDetection.defer do
   end
 
   def delayed_job_version
-    Gem.loaded_specs['delayed_job'].version if Gem.loaded_specs['delayed_job']
+    Gem.loaded_specs['delayed_job']&.version
   end
 end

--- a/lib/new_relic/agent/instrumentation/delayed_job_instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/delayed_job_instrumentation.rb
@@ -109,6 +109,7 @@ DependencyDetection.defer do
   end
 
   def delayed_job_version
-    Gem.loaded_specs['delayed_job']&.version
+    # the following line needs else branch coverage
+    Gem.loaded_specs['delayed_job'].version if Gem.loaded_specs['delayed_job'] # rubocop:disable Style/SafeNavigation
   end
 end

--- a/lib/new_relic/agent/instrumentation/excon/middleware.rb
+++ b/lib/new_relic/agent/instrumentation/excon/middleware.rb
@@ -46,7 +46,8 @@ module ::Excon
       end
 
       def finish_trace(datum) # THREAD_LOCAL_ACCESS
-        segment = datum[:connection]&.instance_variable_get(TRACE_DATA_IVAR)
+        # The following line needs else branch coverage
+        segment = datum[:connection] && datum[:connection].instance_variable_get(TRACE_DATA_IVAR)(TRACE_DATA_IVAR) # rubocop:disable Style/SafeNavigation
         if segment
           begin
             segment.notice_error(datum[:error]) if datum[:error]

--- a/lib/new_relic/agent/instrumentation/excon/middleware.rb
+++ b/lib/new_relic/agent/instrumentation/excon/middleware.rb
@@ -46,7 +46,7 @@ module ::Excon
       end
 
       def finish_trace(datum) # THREAD_LOCAL_ACCESS
-        segment = datum[:connection] && datum[:connection].instance_variable_get(TRACE_DATA_IVAR)
+        segment = datum[:connection]&.instance_variable_get(TRACE_DATA_IVAR)
         if segment
           begin
             segment.notice_error(datum[:error]) if datum[:error]

--- a/lib/new_relic/agent/instrumentation/excon/middleware.rb
+++ b/lib/new_relic/agent/instrumentation/excon/middleware.rb
@@ -47,7 +47,7 @@ module ::Excon
 
       def finish_trace(datum) # THREAD_LOCAL_ACCESS
         # The following line needs else branch coverage
-        segment = datum[:connection] && datum[:connection].instance_variable_get(TRACE_DATA_IVAR)(TRACE_DATA_IVAR) # rubocop:disable Style/SafeNavigation
+        segment = datum[:connection] && datum[:connection].instance_variable_get(TRACE_DATA_IVAR) # rubocop:disable Style/SafeNavigation
         if segment
           begin
             segment.notice_error(datum[:error]) if datum[:error]

--- a/lib/new_relic/agent/instrumentation/grpc/server/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/grpc/server/instrumentation.rb
@@ -37,7 +37,7 @@ module NewRelic
               raise
             end
           ensure
-            txn.finish if txn
+            txn&.finish
           end
 
           def add_http2_port_with_tracing(*args)
@@ -55,12 +55,12 @@ module NewRelic
           def add_attributes(txn, metadata, streamer_type)
             grpc_params(metadata, streamer_type).each do |attr, value|
               txn.add_agent_attribute(attr, value, DESTINATIONS)
-              txn.current_segment.add_agent_attribute(attr, value) if txn.current_segment
+              txn.current_segment&.add_agent_attribute(attr, value)
             end
           end
 
           def metadata_for_call(active_call)
-            return NewRelic::EMPTY_HASH unless active_call && active_call.metadata
+            return NewRelic::EMPTY_HASH unless active_call&.metadata
 
             active_call.metadata
           end

--- a/lib/new_relic/agent/instrumentation/middleware_tracing.rb
+++ b/lib/new_relic/agent/instrumentation/middleware_tracing.rb
@@ -108,7 +108,7 @@ module NewRelic
             NewRelic::Agent.notice_error(e)
             raise e
           ensure
-            finishable.finish if finishable
+            finishable&.finish
           end
         end
 

--- a/lib/new_relic/agent/instrumentation/rails3/action_controller.rb
+++ b/lib/new_relic/agent/instrumentation/rails3/action_controller.rb
@@ -112,7 +112,7 @@ DependencyDetection.defer do
       def render_with_newrelic(context, options)
         # This is needed for rails 3.2 compatibility
         @details = extract_details(options) if respond_to?(:extract_details, true)
-        identifier = determine_template(options) ? determine_template(options).identifier : nil
+        identifier = determine_template(options)&.identifier
         scope_name = "View/#{NewRelic::Agent::Instrumentation::Rails3::ActionView::NewRelic.template_metric(identifier, options)}/Rendering"
         trace_execution_scoped(scope_name) do
           render_without_newrelic(context, options)

--- a/lib/new_relic/agent/instrumentation/rails3/action_controller.rb
+++ b/lib/new_relic/agent/instrumentation/rails3/action_controller.rb
@@ -112,7 +112,8 @@ DependencyDetection.defer do
       def render_with_newrelic(context, options)
         # This is needed for rails 3.2 compatibility
         @details = extract_details(options) if respond_to?(:extract_details, true)
-        identifier = determine_template(options)&.identifier
+        # this file can't be found in SimpleCov, need to check test coverage
+        identifier = determine_template(options) ? determine_template(options).identifier : nil # rubocop:disable Style/SafeNavigation
         scope_name = "View/#{NewRelic::Agent::Instrumentation::Rails3::ActionView::NewRelic.template_metric(identifier, options)}/Rendering"
         trace_execution_scoped(scope_name) do
           render_without_newrelic(context, options)

--- a/lib/new_relic/agent/instrumentation/redis/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/redis/instrumentation.rb
@@ -79,7 +79,7 @@ module NewRelic::Agent::Instrumentation
           self
         # redis-client gem v0.11+ (self is a RedisClient::Middlewares)
         elsif respond_to?(:client)
-          client && client.config
+          client&.config
         # redis-client gem <0.11 (self is a RedisClient::Middlewares)
         elsif defined?(::RedisClient)
           ::RedisClient.config if ::RedisClient.respond_to?(:config)

--- a/lib/new_relic/agent/instrumentation/redis/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/redis/instrumentation.rb
@@ -79,7 +79,8 @@ module NewRelic::Agent::Instrumentation
           self
         # redis-client gem v0.11+ (self is a RedisClient::Middlewares)
         elsif respond_to?(:client)
-          client&.config
+          # The following line needs else branch coverage
+          client && client.config # rubocop:disable Style/SafeNavigation
         # redis-client gem <0.11 (self is a RedisClient::Middlewares)
         elsif defined?(::RedisClient)
           ::RedisClient.config if ::RedisClient.respond_to?(:config)

--- a/lib/new_relic/agent/instrumentation/sinatra/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/sinatra/instrumentation.rb
@@ -45,7 +45,7 @@ module NewRelic::Agent::Instrumentation
 
       def try_to_use(app, clazz)
         install_lock.synchronize do
-          has_middleware = app.middleware && app.middleware.any? { |info| info && info[0] == clazz }
+          has_middleware = app.middleware&.any? { |info| info && info[0] == clazz }
           app.use(clazz) unless has_middleware
         end
       end

--- a/lib/new_relic/agent/instrumentation/sinatra/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/sinatra/instrumentation.rb
@@ -45,7 +45,8 @@ module NewRelic::Agent::Instrumentation
 
       def try_to_use(app, clazz)
         install_lock.synchronize do
-          has_middleware = app.middleware&.any? { |info| info && info[0] == clazz }
+          # The following line needs else branch coverage
+          has_middleware = app.middleware && app.middleware.any? { |info| info && info[0] == clazz } # rubocop:disable Style/SafeNavigation
           app.use(clazz) unless has_middleware
         end
       end

--- a/lib/new_relic/agent/instrumentation/tilt/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/tilt/instrumentation.rb
@@ -32,7 +32,8 @@ module NewRelic
               raise
             end
           ensure
-            finishable&.finish
+            # The following line needs else branch coverage
+            finishable.finish if finishable # rubocop:disable Style/SafeNavigation
           end
         end
       end

--- a/lib/new_relic/agent/instrumentation/tilt/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/tilt/instrumentation.rb
@@ -32,7 +32,7 @@ module NewRelic
               raise
             end
           ensure
-            finishable.finish if finishable
+            finishable&.finish
           end
         end
       end

--- a/lib/new_relic/agent/logging.rb
+++ b/lib/new_relic/agent/logging.rb
@@ -41,7 +41,7 @@ module NewRelic
         end
 
         def call(severity, time, progname, msg)
-          message = String.new('{')
+          message = +'{'
           if app_name
             add_key_value(message, ENTITY_NAME_KEY, app_name)
             message << COMMA

--- a/lib/new_relic/agent/messaging.rb
+++ b/lib/new_relic/agent/messaging.rb
@@ -148,7 +148,7 @@ module NewRelic
         yield
       ensure
         begin
-          txn.finish if txn
+          txn&.finish
         rescue => e
           NewRelic::Agent.logger.error("Error stopping Message Broker consume transaction", e)
         end
@@ -190,7 +190,7 @@ module NewRelic
 
         raise ArgumentError, 'missing required argument: headers' if headers.nil? && CrossAppTracing.cross_app_enabled?
 
-        original_headers = headers.nil? ? nil : headers.dup
+        original_headers = headers&.dup
 
         segment = Tracer.start_message_broker_segment(
           action: :produce,

--- a/lib/new_relic/agent/messaging.rb
+++ b/lib/new_relic/agent/messaging.rb
@@ -148,7 +148,8 @@ module NewRelic
         yield
       ensure
         begin
-          txn&.finish
+          # the following line needs else branch coverage
+          txn.finish if txn # rubocop:disable Style/SafeNavigation
         rescue => e
           NewRelic::Agent.logger.error("Error stopping Message Broker consume transaction", e)
         end
@@ -190,7 +191,8 @@ module NewRelic
 
         raise ArgumentError, 'missing required argument: headers' if headers.nil? && CrossAppTracing.cross_app_enabled?
 
-        original_headers = headers&.dup
+        # The following line needs else branch coverage
+        original_headers = headers.nil? ? nil : headers.dup # rubocop:disable Style/SafeNavigation
 
         segment = Tracer.start_message_broker_segment(
           action: :produce,

--- a/lib/new_relic/agent/new_relic_service.rb
+++ b/lib/new_relic/agent/new_relic_service.rb
@@ -521,7 +521,7 @@ module NewRelic
           # ruled out; see the initializer
         }
 
-        uri = String.new('/agent_listener/invoke_raw_method?')
+        uri = +'/agent_listener/invoke_raw_method?'
         uri << params.map do |k, v|
           next unless v
 

--- a/lib/new_relic/agent/obfuscator.rb
+++ b/lib/new_relic/agent/obfuscator.rb
@@ -33,7 +33,7 @@ module NewRelic
       def encode(text)
         return text unless key_bytes
 
-        encoded = String.new('')
+        encoded = +''
         encoded.force_encoding('binary') if encoded.respond_to?(:force_encoding)
         index = 0
         text.each_byte do |byte|

--- a/lib/new_relic/agent/parameter_filtering.rb
+++ b/lib/new_relic/agent/parameter_filtering.rb
@@ -42,7 +42,7 @@ module NewRelic
 
       def filter_rack_file_data(env, params)
         content_type = env["CONTENT_TYPE"]
-        multipart = content_type && content_type.start_with?("multipart")
+        multipart = content_type&.start_with?("multipart")
 
         params.inject({}) do |memo, (k, v)|
           if multipart && v.is_a?(Hash) && v[:tempfile]

--- a/lib/new_relic/agent/pipe_channel_manager.rb
+++ b/lib/new_relic/agent/pipe_channel_manager.rb
@@ -218,7 +218,8 @@ module NewRelic
         def close_all_pipes
           @pipes_lock.synchronize do
             @pipes.each do |id, pipe|
-              pipe&.close
+              # Needs else branch coverage
+              pipe.close if pipe # rubocop:disable Style/SafeNavigation
             end
             @pipes = {}
           end

--- a/lib/new_relic/agent/pipe_channel_manager.rb
+++ b/lib/new_relic/agent/pipe_channel_manager.rb
@@ -218,7 +218,7 @@ module NewRelic
         def close_all_pipes
           @pipes_lock.synchronize do
             @pipes.each do |id, pipe|
-              pipe.close if pipe
+              pipe&.close
             end
             @pipes = {}
           end

--- a/lib/new_relic/agent/pipe_service.rb
+++ b/lib/new_relic/agent/pipe_service.rb
@@ -65,7 +65,8 @@ module NewRelic
       end
 
       def shutdown
-        @pipe&.close
+        # no else branch coverage
+        @pipe.close if @pipe # rubocop:disable Style/SafeNavigation
       end
 
       # Invokes the block it is passed.  This is used to implement HTTP
@@ -82,7 +83,8 @@ module NewRelic
       end
 
       def write_to_pipe(endpoint, data)
-        @pipe&.write(marshal_payload([endpoint, data]))
+        # the following line needs else branch coverage
+        @pipe.write(marshal_payload([endpoint, data])) if @pipe # rubocop:disable Style/SafeNavigation
       end
     end
   end

--- a/lib/new_relic/agent/pipe_service.rb
+++ b/lib/new_relic/agent/pipe_service.rb
@@ -65,7 +65,7 @@ module NewRelic
       end
 
       def shutdown
-        @pipe.close if @pipe
+        @pipe&.close
       end
 
       # Invokes the block it is passed.  This is used to implement HTTP
@@ -82,7 +82,7 @@ module NewRelic
       end
 
       def write_to_pipe(endpoint, data)
-        @pipe.write(marshal_payload([endpoint, data])) if @pipe
+        @pipe&.write(marshal_payload([endpoint, data]))
       end
     end
   end

--- a/lib/new_relic/agent/samplers/memory_sampler.rb
+++ b/lib/new_relic/agent/samplers/memory_sampler.rb
@@ -29,7 +29,7 @@ module NewRelic
             end
           elsif platform.include?('darwin9') # 10.5
             @sampler = ShellPS.new("ps -o rsz")
-          elsif platform =~ /darwin(1|2)\d+/ # >= 10.6
+          elsif /darwin(1|2)\d+/.match?(platform) # >= 10.6
             @sampler = ShellPS.new("ps -o rss")
           elsif platform.include?('freebsd')
             @sampler = ShellPS.new("ps -o rss")

--- a/lib/new_relic/agent/sql_sampler.rb
+++ b/lib/new_relic/agent/sql_sampler.rb
@@ -159,7 +159,7 @@ module NewRelic
       def distributed_trace_attributes(state)
         transaction = state.current_transaction
         params = nil
-        if transaction && transaction.distributed_tracer.distributed_trace_payload
+        if transaction&.distributed_tracer&.distributed_trace_payload
           params = {}
           payload = transaction.distributed_tracer.distributed_trace_payload
           DistributedTraceAttributes.copy_from_transaction(transaction, payload, params)

--- a/lib/new_relic/agent/system_info.rb
+++ b/lib/new_relic/agent/system_info.rb
@@ -128,7 +128,7 @@ module NewRelic
 
         num_physical_packages = cores.keys.map(&:first).uniq.size
         num_physical_cores = cores.size
-        num_logical_processors = cores.values.reduce(0, :+)
+        num_logical_processors = cores.values.sum
 
         if num_physical_cores == 0
           num_logical_processors = total_processors

--- a/lib/new_relic/agent/system_info.rb
+++ b/lib/new_relic/agent/system_info.rb
@@ -242,7 +242,7 @@ module NewRelic
       def self.proc_try_read(path)
         return nil unless File.exist?(path)
 
-        content = String.new('')
+        content = +''
         File.open(path) do |f|
           loop do
             begin

--- a/lib/new_relic/agent/threading/agent_thread.rb
+++ b/lib/new_relic/agent/threading/agent_thread.rb
@@ -45,7 +45,7 @@ module NewRelic
 
             if txn && !txn.recording_web_transaction?
               :background
-            elsif txn && txn.recording_web_transaction?
+            elsif txn&.recording_web_transaction?
               :request
             else
               :other

--- a/lib/new_relic/agent/threading/backtrace_node.rb
+++ b/lib/new_relic/agent/threading/backtrace_node.rb
@@ -70,7 +70,7 @@ module NewRelic
         end
 
         def dump_string
-          result = String.new("#<BacktraceRoot:#{object_id}>")
+          result = +"#<BacktraceRoot:#{object_id}>"
           child_results = @children.map { |c| c.dump_string(2) }.join("\n")
           result << "\n" unless child_results.empty?
           result << child_results
@@ -116,8 +116,8 @@ module NewRelic
         def dump_string(indent = 0)
           @file, @method, @line_no = parse_backtrace_frame(@raw_line)
           indentation = ' ' * indent
-          result = String.new("#{indentation}#<BacktraceNode:#{object_id} ) + \
-                              [#{@runnable_count}] #{@file}:#{@line_no} in #{@method}>")
+          result = +"#{indentation}#<BacktraceNode:#{object_id} ) + \
+                              [#{@runnable_count}] #{@file}:#{@line_no} in #{@method}>"
           child_results = @children.map { |c| c.dump_string(indent + 2) }.join("\n")
           result << "\n" unless child_results.empty?
           result << child_results

--- a/lib/new_relic/agent/threading/backtrace_service.rb
+++ b/lib/new_relic/agent/threading/backtrace_service.rb
@@ -41,9 +41,7 @@ module NewRelic
             @overhead_percent_threshold = new_value
           end
 
-          if event_listener
-            event_listener.subscribe(:transaction_finished, &method(:on_transaction_finished))
-          end
+          event_listener&.subscribe(:transaction_finished, &method(:on_transaction_finished))
         end
 
         # Public interface
@@ -221,9 +219,7 @@ module NewRelic
 
         # This method is expected to be called with @lock held.
         def aggregate_global_backtrace(backtrace, bucket, thread)
-          if @profiles[ALL_TRANSACTIONS]
-            @profiles[ALL_TRANSACTIONS].aggregate(backtrace, bucket, thread)
-          end
+          @profiles[ALL_TRANSACTIONS]&.aggregate(backtrace, bucket, thread)
         end
 
         # This method is expected to be called with @lock held.

--- a/lib/new_relic/agent/tracer.rb
+++ b/lib/new_relic/agent/tracer.rb
@@ -107,7 +107,7 @@ module NewRelic
             current_transaction.notice_error(exception)
             raise
           ensure
-            finishable.finish if finishable
+            finishable&.finish
           end
         end
 
@@ -355,7 +355,7 @@ module NewRelic
 
           yield
         rescue => exception
-          if segment && segment.is_a?(Transaction::AbstractSegment)
+          if segment&.is_a?(Transaction::AbstractSegment)
             segment.notice_error(exception)
           end
           raise
@@ -487,7 +487,7 @@ module NewRelic
         end
 
         def pop_traced
-          @untraced.pop if @untraced
+          @untraced&.pop
         end
 
         def is_execution_traced?

--- a/lib/new_relic/agent/tracer.rb
+++ b/lib/new_relic/agent/tracer.rb
@@ -355,7 +355,8 @@ module NewRelic
 
           yield
         rescue => exception
-          if segment&.is_a?(Transaction::AbstractSegment)
+          # needs else branch coverage
+          if segment && segment.is_a?(Transaction::AbstractSegment) # rubocop:disable Style/SafeNavigation
             segment.notice_error(exception)
           end
           raise
@@ -487,7 +488,8 @@ module NewRelic
         end
 
         def pop_traced
-          @untraced&.pop
+          # needs else branch coverage
+          @untraced.pop if @untraced # rubocop:disable Style/SafeNavigation
         end
 
         def is_execution_traced?

--- a/lib/new_relic/agent/transaction.rb
+++ b/lib/new_relic/agent/transaction.rb
@@ -155,7 +155,7 @@ module NewRelic
         NewRelic::Agent.record_api_supportability_metric(:recording_web_transaction?)
 
         txn = tl_current
-        txn && txn.recording_web_transaction?
+        txn&.recording_web_transaction?
       end
 
       def self.apdex_bucket(duration, failed, apdex_t)
@@ -181,7 +181,7 @@ module NewRelic
 
       def add_agent_attribute(key, value, default_destinations)
         @attributes.add_agent_attribute(key, value, default_destinations)
-        current_segment.add_agent_attribute(key, value) if current_segment
+        current_segment&.add_agent_attribute(key, value)
       end
 
       def self.merge_untrusted_agent_attributes(attributes, prefix, default_destinations)
@@ -194,7 +194,7 @@ module NewRelic
 
       def merge_untrusted_agent_attributes(attributes, prefix, default_destinations)
         @attributes.merge_untrusted_agent_attributes(attributes, prefix, default_destinations)
-        current_segment.merge_untrusted_agent_attributes(attributes, prefix, default_destinations) if current_segment
+        current_segment&.merge_untrusted_agent_attributes(attributes, prefix, default_destinations)
       end
 
       @@java_classes_loaded = false
@@ -309,15 +309,15 @@ module NewRelic
       end
 
       def referer
-        @request_attributes && @request_attributes.referer
+        @request_attributes&.referer
       end
 
       def request_path
-        @request_attributes && @request_attributes.request_path
+        @request_attributes&.request_path
       end
 
       def request_port
-        @request_attributes && @request_attributes.port
+        @request_attributes&.port
       end
 
       # This transaction-local hash may be used as temporary storage by
@@ -594,9 +594,7 @@ module NewRelic
           add_agent_attribute(:'response.headers.contentType', response_content_type, default_destinations)
         end
 
-        if @request_attributes
-          @request_attributes.assign_agent_attributes(self)
-        end
+        @request_attributes&.assign_agent_attributes(self)
 
         display_host = Agent.config[:'process_host.display_name']
         unless display_host == NewRelic::Agent::Hostname.get

--- a/lib/new_relic/agent/transaction.rb
+++ b/lib/new_relic/agent/transaction.rb
@@ -181,7 +181,8 @@ module NewRelic
 
       def add_agent_attribute(key, value, default_destinations)
         @attributes.add_agent_attribute(key, value, default_destinations)
-        current_segment&.add_agent_attribute(key, value)
+        # the following line needs else branch coverage
+        current_segment.add_agent_attribute(key, value) if current_segment # rubocop:disable Style/SafeNavigation
       end
 
       def self.merge_untrusted_agent_attributes(attributes, prefix, default_destinations)

--- a/lib/new_relic/agent/transaction/abstract_segment.rb
+++ b/lib/new_relic/agent/transaction/abstract_segment.rb
@@ -56,7 +56,7 @@ module NewRelic
           @start_time ||= Process.clock_gettime(Process::CLOCK_REALTIME)
           return unless transaction
 
-          parent.child_start(self) if parent
+          parent&.child_start(self)
         end
 
         def finish
@@ -228,7 +228,7 @@ module NewRelic
 
           if finished?
             transaction.async = true
-            parent.descendant_complete(self, segment) if parent
+            parent&.descendant_complete(self, segment)
           end
         end
 
@@ -269,7 +269,7 @@ module NewRelic
 
         def run_complete_callbacks
           segment_complete
-          parent.child_complete(self) if parent
+          parent&.child_complete(self)
           transaction.segment_complete(self)
         end
 

--- a/lib/new_relic/agent/transaction/datastore_segment.rb
+++ b/lib/new_relic/agent/transaction/datastore_segment.rb
@@ -24,7 +24,7 @@ module NewRelic
           @nosql_statement = nil
           @record_sql = true
           set_instance_info(host, port_path_or_id)
-          @database_name = database_name ? database_name.to_s : nil
+          @database_name = database_name&.to_s
           super(Datastores::MetricHelper.scoped_metric_for(product, operation, collection),
                 nil,
                 start_time)

--- a/lib/new_relic/agent/transaction/external_request_segment.rb
+++ b/lib/new_relic/agent/transaction/external_request_segment.rb
@@ -62,7 +62,7 @@ module NewRelic
         # @api public
         def add_request_headers(request)
           process_host_header(request)
-          synthetics_header = transaction && transaction.raw_synthetics_header
+          synthetics_header = transaction&.raw_synthetics_header
           insert_synthetics_header(request, synthetics_header) if synthetics_header
 
           return unless record_metrics?

--- a/lib/new_relic/agent/transaction/trace_node.rb
+++ b/lib/new_relic/agent/transaction/trace_node.rb
@@ -58,7 +58,7 @@ module NewRelic
         end
 
         def to_s_compact
-          str = String.new('')
+          str = +''
           str << metric_name
           if children.any?
             str << "{#{children.map { |cs| cs.to_s_compact }.join(',')}}"
@@ -67,7 +67,7 @@ module NewRelic
         end
 
         def to_debug_str(depth)
-          tab = String.new('  ') * depth
+          tab = (+'  ') * depth
           s = tab.clone
           s << ">> #{'%3i ms' % (@entry_timestamp * 1000)} [#{self.class.name.split("::").last}] #{metric_name} \n"
           unless params.empty?

--- a/lib/new_relic/agent/transaction/trace_node.rb
+++ b/lib/new_relic/agent/transaction/trace_node.rb
@@ -136,10 +136,8 @@ module NewRelic
         def each_node(&block)
           yield(self)
 
-          if @children
-            @children.each do |node|
-              node.each_node(&block)
-            end
+          @children&.each do |node|
+            node.each_node(&block)
           end
         end
 
@@ -149,10 +147,8 @@ module NewRelic
           summary = yield(self)
           summary.current_nest_count += 1 if summary
 
-          if @children
-            @children.each do |node|
-              node.each_node_with_nest_tracking(&block)
-            end
+          @children&.each do |node|
+            node.each_node_with_nest_tracking(&block)
           end
 
           summary.current_nest_count -= 1 if summary

--- a/lib/new_relic/agent/transaction/trace_node.rb
+++ b/lib/new_relic/agent/transaction/trace_node.rb
@@ -147,9 +147,14 @@ module NewRelic
           summary = yield(self)
           summary.current_nest_count += 1 if summary
 
-          @children&.each do |node|
-            node.each_node_with_nest_tracking(&block)
+          # no then branch coverage 
+          # rubocop:disable Style/SafeNavigation
+          if @children
+            @children.each do |node|
+              node.each_node_with_nest_tracking(&block)
+            end
           end
+          # rubocop:enable Style/SafeNavigation
 
           summary.current_nest_count -= 1 if summary
         end

--- a/lib/new_relic/agent/transaction/trace_node.rb
+++ b/lib/new_relic/agent/transaction/trace_node.rb
@@ -147,7 +147,7 @@ module NewRelic
           summary = yield(self)
           summary.current_nest_count += 1 if summary
 
-          # no then branch coverage 
+          # no then branch coverage
           # rubocop:disable Style/SafeNavigation
           if @children
             @children.each do |node|

--- a/lib/new_relic/agent/transaction_time_aggregator.rb
+++ b/lib/new_relic/agent/transaction_time_aggregator.rb
@@ -149,8 +149,8 @@ module NewRelic
         def log_missing_elapsed_transaction_time
           # rubocop:disable Style/SafeNavigation
           transaction_name = transaction_name = Tracer.current_transaction &&
-          Tracer.current_transaction.best_name ||
-          "unknown"
+            Tracer.current_transaction.best_name ||
+            "unknown"
           # rubocop:enable Style/SafeNavigation
           NewRelic::Agent.logger.warn("Unable to calculate elapsed transaction time for #{transaction_name}")
         end

--- a/lib/new_relic/agent/transaction_time_aggregator.rb
+++ b/lib/new_relic/agent/transaction_time_aggregator.rb
@@ -101,7 +101,8 @@ module NewRelic
 
         def thread_is_alive?(thread_id)
           thread = thread_by_id(thread_id)
-          thread&.alive?
+          # needs else branch coverage
+          thread && thread.alive? # rubocop:disable Style/SafeNavigation
         rescue StandardError
           false
         end
@@ -144,9 +145,13 @@ module NewRelic
           elapsed
         end
 
+        # this method has no test coverage
         def log_missing_elapsed_transaction_time
-          transaction_name = Tracer.current_transaction&.best_name ||
-            "unknown"
+          # rubocop:disable Style/SafeNavigation
+          transaction_name = transaction_name = Tracer.current_transaction &&
+          Tracer.current_transaction.best_name ||
+          "unknown"
+          # rubocop:enable Style/SafeNavigation
           NewRelic::Agent.logger.warn("Unable to calculate elapsed transaction time for #{transaction_name}")
         end
       end

--- a/lib/new_relic/agent/transaction_time_aggregator.rb
+++ b/lib/new_relic/agent/transaction_time_aggregator.rb
@@ -101,7 +101,7 @@ module NewRelic
 
         def thread_is_alive?(thread_id)
           thread = thread_by_id(thread_id)
-          thread && thread.alive?
+          thread&.alive?
         rescue StandardError
           false
         end
@@ -145,8 +145,7 @@ module NewRelic
         end
 
         def log_missing_elapsed_transaction_time
-          transaction_name = Tracer.current_transaction &&
-            Tracer.current_transaction.best_name ||
+          transaction_name = Tracer.current_transaction&.best_name ||
             "unknown"
           NewRelic::Agent.logger.warn("Unable to calculate elapsed transaction time for #{transaction_name}")
         end

--- a/lib/new_relic/agent/utilization/vendor.rb
+++ b/lib/new_relic/agent/utilization/vendor.rb
@@ -133,7 +133,7 @@ module NewRelic
 
         def valid_chars?(value)
           value.each_char do |ch|
-            next if ch =~ VALID_CHARS
+            next if VALID_CHARS.match?(ch)
 
             code_point = ch[0].ord # this works in Ruby 1.8.7 - 2.1.2
             next if code_point >= 0x80

--- a/lib/new_relic/cli/command.rb
+++ b/lib/new_relic/cli/command.rb
@@ -60,7 +60,7 @@ module NewRelic
         extra = []
         options = ARGV.options do |opts|
           script_name = File.basename($0)
-          if script_name =~ /newrelic_cmd$/
+          if /newrelic_cmd$/.match?(script_name)
             $stdout.puts "warning: the 'newrelic_cmd' script has been renamed 'newrelic'"
             script_name = 'newrelic'
           end

--- a/lib/new_relic/cli/commands/deployments.rb
+++ b/lib/new_relic/cli/commands/deployments.rb
@@ -33,7 +33,7 @@ class NewRelic::Cli::Deployments < NewRelic::Cli::Command
     @changelog = nil
     @user = nil
     super(command_line_args)
-    @description ||= @leftover && @leftover.join(" ")
+    @description ||= @leftover&.join(" ")
     @user ||= ENV['USER']
     control.env = @environment if @environment
 

--- a/lib/new_relic/cli/commands/deployments.rb
+++ b/lib/new_relic/cli/commands/deployments.rb
@@ -33,7 +33,8 @@ class NewRelic::Cli::Deployments < NewRelic::Cli::Command
     @changelog = nil
     @user = nil
     super(command_line_args)
-    @description ||= @leftover&.join(" ")
+    # needs else branch coverage
+    @description ||= @leftover && @leftover.join(" ") # rubocop:disable Style/SafeNavigation
     @user ||= ENV['USER']
     control.env = @environment if @environment
 

--- a/lib/new_relic/collection_helper.rb
+++ b/lib/new_relic/collection_helper.rb
@@ -40,7 +40,7 @@ module NewRelic
         when nil then ''
         when object.instance_of?(String) then object
         when String then String.new(object) # convert string subclasses to strings
-        else String.new("#<#{object.class}>")
+        else +"#<#{object.class}>"
       end
     end
 

--- a/lib/new_relic/dependency_detection.rb
+++ b/lib/new_relic/dependency_detection.rb
@@ -37,7 +37,7 @@ module DependencyDetection
 
   def installed?(name)
     item = dependency_by_name(name)
-    # needs test coverage 
+    # needs test coverage
     item && item.executed # rubocop:disable Style/SafeNavigation
   end
 

--- a/lib/new_relic/dependency_detection.rb
+++ b/lib/new_relic/dependency_detection.rb
@@ -37,7 +37,7 @@ module DependencyDetection
 
   def installed?(name)
     item = dependency_by_name(name)
-    item && item.executed
+    item&.executed
   end
 
   def items

--- a/lib/new_relic/dependency_detection.rb
+++ b/lib/new_relic/dependency_detection.rb
@@ -37,7 +37,8 @@ module DependencyDetection
 
   def installed?(name)
     item = dependency_by_name(name)
-    item&.executed
+    # needs test coverage 
+    item && item.executed # rubocop:disable Style/SafeNavigation
   end
 
   def items

--- a/lib/new_relic/helper.rb
+++ b/lib/new_relic/helper.rb
@@ -63,7 +63,8 @@ module NewRelic
         raise NewRelic::CommandRunFailedError.new("Failed to run command '#{command}': #{message}")
       end
 
-      output&.chomp
+      # needs else branch coverage 
+      output.chomp if output # rubocop:disable Style/SafeNavigation
     end
 
     # TODO: Open3 defers the actual execution of a binary to Process.spawn,

--- a/lib/new_relic/helper.rb
+++ b/lib/new_relic/helper.rb
@@ -63,7 +63,7 @@ module NewRelic
         raise NewRelic::CommandRunFailedError.new("Failed to run command '#{command}': #{message}")
       end
 
-      # needs else branch coverage 
+      # needs else branch coverage
       output.chomp if output # rubocop:disable Style/SafeNavigation
     end
 

--- a/lib/new_relic/helper.rb
+++ b/lib/new_relic/helper.rb
@@ -63,7 +63,7 @@ module NewRelic
         raise NewRelic::CommandRunFailedError.new("Failed to run command '#{command}': #{message}")
       end
 
-      output.chomp if output
+      output&.chomp
     end
 
     # TODO: Open3 defers the actual execution of a binary to Process.spawn,

--- a/lib/new_relic/latest_changes.rb
+++ b/lib/new_relic/latest_changes.rb
@@ -30,8 +30,8 @@ EOS
 
       current_item = nil
       latest.each do |line|
-        if line =~ /^\s*\*.*/
-          if line =~ /\(#{patch_level}\)/
+        if /^\s*\*.*/.match?(line)
+          if /\(#{patch_level}\)/.match?(line)
             # Found a patch level item, so start tracking the lines!
             current_item = line
           else
@@ -52,7 +52,7 @@ EOS
       changes = []
       version_count = 0
       contents.each_line do |line|
-        if line =~ /##\s+v[\d.]+/
+        if /##\s+v[\d.]+/.match?(line)
           version_count += 1
         end
         break if version_count >= 2

--- a/lib/new_relic/rack/browser_monitoring.rb
+++ b/lib/new_relic/rack/browser_monitoring.rb
@@ -96,11 +96,11 @@ module NewRelic
       end
 
       def html?(headers)
-        headers[CONTENT_TYPE] && headers[CONTENT_TYPE].include?(TEXT_HTML)
+        headers[CONTENT_TYPE]&.include?(TEXT_HTML)
       end
 
       def attachment?(headers)
-        headers[CONTENT_DISPOSITION] && headers[CONTENT_DISPOSITION].include?(ATTACHMENT)
+        headers[CONTENT_DISPOSITION]&.include?(ATTACHMENT)
       end
 
       def streaming?(env, headers)
@@ -150,12 +150,12 @@ module NewRelic
 
       def find_x_ua_compatible_position(beginning_of_source)
         match = X_UA_COMPATIBLE_RE.match(beginning_of_source)
-        match.end(0) if match
+        match&.end(0)
       end
 
       def find_charset_position(beginning_of_source)
         match = CHARSET_RE.match(beginning_of_source)
-        match.end(0) if match
+        match&.end(0)
       end
 
       def find_end_of_head_open(beginning_of_source)

--- a/lib/new_relic/rack/browser_monitoring.rb
+++ b/lib/new_relic/rack/browser_monitoring.rb
@@ -96,7 +96,7 @@ module NewRelic
       end
 
       def html?(headers)
-        # needs else branch coverage 
+        # needs else branch coverage
         headers[CONTENT_TYPE] && headers[CONTENT_TYPE].include?(TEXT_HTML) # rubocop:disable Style/SafeNavigation
       end
 

--- a/lib/new_relic/rack/browser_monitoring.rb
+++ b/lib/new_relic/rack/browser_monitoring.rb
@@ -96,7 +96,8 @@ module NewRelic
       end
 
       def html?(headers)
-        headers[CONTENT_TYPE]&.include?(TEXT_HTML)
+        # needs else branch coverage 
+        headers[CONTENT_TYPE] && headers[CONTENT_TYPE].include?(TEXT_HTML) # rubocop:disable Style/SafeNavigation
       end
 
       def attachment?(headers)

--- a/lib/tasks/helpers/format.rb
+++ b/lib/tasks/helpers/format.rb
@@ -110,7 +110,7 @@ module Format
   end
 
   def section_key(key, components)
-    if key =~ /^disable_/ # "disable_httpclient"
+    if /^disable_/.match?(key) # "disable_httpclient"
       DISABLING
     elsif components.length >= 2 && !(components[1] == "attributes") # "analytics_events.enabled"
       components.first

--- a/test/agent_helper.rb
+++ b/test/agent_helper.rb
@@ -379,8 +379,8 @@ end
 #   in_transaction('foobar', :category => :controller) { ... }
 #
 def in_transaction(*args, &blk)
-  opts = args.last && args.last.is_a?(Hash) ? args.pop : {}
-  category = (opts && opts.delete(:category)) || :other
+  opts = args.last&.is_a?(Hash) ? args.pop : {}
+  category = (opts&.delete(:category)) || :other
 
   # At least one test passes `:transaction_name => nil`, so handle it gently
   name = opts.key?(:transaction_name) ? opts.delete(:transaction_name) : args.first || 'dummy'
@@ -671,7 +671,7 @@ def undefine_constant(constant_symbol)
   const_str = constant_symbol.to_s
   parent = get_parent(const_str)
   const_name = const_str.gsub(/.*::/, '')
-  return yield unless parent && parent.constants.include?(const_name.to_sym)
+  return yield unless parent&.constants&.include?(const_name.to_sym)
 
   removed_constant = parent.send(:remove_const, const_name)
   yield

--- a/test/agent_helper.rb
+++ b/test/agent_helper.rb
@@ -182,7 +182,7 @@ def _normalize_metric_expectations(expectations)
 end
 
 def dump_stats(stats)
-  str = String.new("  Call count:           #{stats.call_count}\n")
+  str = +"  Call count:           #{stats.call_count}\n"
   str << "  Total call time:      #{stats.total_call_time}\n"
   str << "  Total exclusive time: #{stats.total_exclusive_time}\n"
   str << "  Min call time:        #{stats.min_call_time}\n"
@@ -891,7 +891,7 @@ def assert_event_attributes(event, test_name, expected_attributes, non_expected_
     incorrect_attributes << name unless actual_value == expected_value
   end
 
-  msg = String.new("Found missing or incorrect attribute values in #{test_name}:\n")
+  msg = +"Found missing or incorrect attribute values in #{test_name}:\n"
 
   incorrect_attributes.each do |name|
     msg << "  #{name}: expected = #{expected_attributes[name].inspect}, actual = #{event_attrs[name].inspect}\n"

--- a/test/environments/lib/environments/runner.rb
+++ b/test/environments/lib/environments/runner.rb
@@ -99,7 +99,7 @@ module Environments
 
     def run(dir)
       puts "Starting tests for dir '#{dir}'..." if ENV['VERBOSE_TEST_OUTPUT']
-      cmd = String.new("cd #{dir} && bundle exec rake")
+      cmd = +"cd #{dir} && bundle exec rake"
       # if the shell running the original test:env rake task has a "file" env
       # var, replicate it here in the subshell
       cmd << " file=#{ENV['file']}" if ENV["file"]

--- a/test/environments/rails60/config/psych4_monkeypatch.rb
+++ b/test/environments/rails60/config/psych4_monkeypatch.rb
@@ -17,7 +17,7 @@ module Rails
         path = paths["config/database"].existent.first
         yaml = Pathname.new(path) if path
 
-        config = if yaml && yaml.exist?
+        config = if yaml&.exist?
           require "yaml"
           require "erb"
 

--- a/test/helpers/misc.rb
+++ b/test/helpers/misc.rb
@@ -48,7 +48,7 @@ def fixture_tcp_socket(response)
 
     stubs(:check_write) { self.write_checker = Proc.new }
     stubs(:write) do |buf|
-      self.write_checker.call(buf) if self.write_checker
+      self.write_checker&.call(buf)
       buf.length
     end
 

--- a/test/multiverse/lib/multiverse/envfile.rb
+++ b/test/multiverse/lib/multiverse/envfile.rb
@@ -37,7 +37,7 @@ module Multiverse
           )
         end
 
-        version = if version && version.start_with?('=')
+        version = if version&.start_with?('=')
           add_version(version.sub('= ', ''), false) # don't twiddle wakka
         else
           add_version(version)

--- a/test/multiverse/lib/multiverse/output_collector.rb
+++ b/test/multiverse/lib/multiverse/output_collector.rb
@@ -26,7 +26,7 @@ module Multiverse
       key = [suite, env]
       @buffer_lock.synchronize do
         @buffers ||= {}
-        @buffers[key] ||= String.new('')
+        @buffers[key] ||= +''
         @buffers[key]
       end
     end

--- a/test/multiverse/lib/multiverse/suite.rb
+++ b/test/multiverse/lib/multiverse/suite.rb
@@ -462,13 +462,13 @@ module Multiverse
 
       configure_instrumentation_method(instrumentation_method)
 
-      environments.before.call if environments.before
+      environments.before&.call
       if should_serialize?
         execute_serial(instrumentation_method)
       else
         execute_parallel(instrumentation_method)
       end
-      environments.after.call if environments.after
+      environments.after&.call
     rescue => e
       puts e.backtrace
       puts red("Failure during execution of suite #{directory.inspect}.")

--- a/test/multiverse/lib/multiverse/suite.rb
+++ b/test/multiverse/lib/multiverse/suite.rb
@@ -275,8 +275,8 @@ module Multiverse
       File.open(gemfile, 'w') do |f|
         f.puts 'source "https://rubygems.org"'
         f.print gemfile_text
-        f.puts newrelic_gemfile_line unless gemfile_text =~ /^\s*gem .newrelic_rpm./
-        f.puts minitest_line unless gemfile_text =~ /^\s*gem .minitest[^_]./
+        f.puts newrelic_gemfile_line unless /^\s*gem .newrelic_rpm./.match?(gemfile_text)
+        f.puts minitest_line unless /^\s*gem .minitest[^_]./.match?(gemfile_text)
         f.puts "gem 'rake'" unless gemfile_text =~ /^\s*gem .rake[^_]./ || suite == 'rake'
 
         f.puts "gem 'rackup'" if need_rackup?(gemfile_text)

--- a/test/multiverse/suites/agent_only/start_up_test.rb
+++ b/test/multiverse/suites/agent_only/start_up_test.rb
@@ -100,7 +100,7 @@ RUBY
             NewRelic::Agent.after_fork
 
             txn = NewRelic::Agent::Tracer.current_transaction
-            txn_name = txn ? txn.best_name : nil
+            txn_name = txn&.best_name
             Marshal.dump(txn_name, write)
           end
           write.close

--- a/test/multiverse/suites/agent_only/thread_profiling_test.rb
+++ b/test/multiverse/suites/agent_only/thread_profiling_test.rb
@@ -115,11 +115,9 @@ class ThreadProfilingTest < Minitest::Test
   end
 
   def join_background_threads
-    if @threads
-      @threads.each do |thread|
-        thread.run
-        thread.join
-      end
+    @threads&.each do |thread|
+      thread.run
+      thread.join
     end
   end
 

--- a/test/multiverse/suites/agent_only/utilization_data_collection_test.rb
+++ b/test/multiverse/suites/agent_only/utilization_data_collection_test.rb
@@ -87,7 +87,7 @@ class UtilizationDataCollectionTest < Minitest::Test
 
     yield(metadata_service)
   ensure
-    metadata_service.stop if metadata_service
+    metadata_service&.stop
     unredirect_link_local_address
   end
 

--- a/test/multiverse/suites/excon/excon_test.rb
+++ b/test/multiverse/suites/excon/excon_test.rb
@@ -47,11 +47,11 @@ class ExconTest < Minitest::Test
   end
 
   def post_response
-    Excon.post(default_url, body: String.new)
+    Excon.post(default_url, body: +'')
   end
 
   def put_response
-    Excon.put(default_url, body: String.new)
+    Excon.put(default_url, body: +'')
   end
 
   def delete_response

--- a/test/multiverse/suites/rails/view_instrumentation_test.rb
+++ b/test/multiverse/suites/rails/view_instrumentation_test.rb
@@ -9,17 +9,17 @@ ActionController::Base.view_paths = ['app/views']
 
 class ViewsController < ApplicationController
   def template_render_with_3_partial_renders
-    render(String.new('index'))
+    render((+'index'))
   end
 
   def render_with_delays
     nr_freeze_process_time
     @delay = 1
-    render(String.new('index'))
+    render((+'index'))
   end
 
   def deep_partial_render
-    render(String.new('deep_partial'))
+    render((+'deep_partial'))
   end
 
   def text_render
@@ -54,7 +54,7 @@ class ViewsController < ApplicationController
   end
 
   def haml_render
-    render(String.new('haml_view'))
+    render((+'haml_view'))
   end
 
   def no_template

--- a/test/new_relic/agent/agent_logger_test.rb
+++ b/test/new_relic/agent/agent_logger_test.rb
@@ -297,7 +297,7 @@ class AgentLoggerTest < Minitest::Test
 
   def test_should_cache_hostname
     NewRelic::Agent::Hostname.instance_variable_set(:@hostname, nil)
-    hostname = String.new('cachey-mccaherson')
+    hostname = +'cachey-mccaherson'
     Socket.expects(:gethostname).once.returns(hostname)
     logger = create_basic_logger
     logger.warn('one')

--- a/test/new_relic/agent/attribute_filter_test.rb
+++ b/test/new_relic/agent/attribute_filter_test.rb
@@ -23,7 +23,7 @@ module NewRelic::Agent
           expected_destinations = to_bitfield(test_case['expected_destinations'])
 
           assert_equal(to_names(expected_destinations), to_names(actual_destinations),
-            PP.pp(test_case, String.new('')) + PP.pp(filter.rules, String.new('')))
+            PP.pp(test_case, (+'')) + PP.pp(filter.rules, (+'')))
         end
       end
     end

--- a/test/new_relic/agent/audit_logger_test.rb
+++ b/test/new_relic/agent/audit_logger_test.rb
@@ -68,7 +68,7 @@ class AuditLoggerTest < Minitest::Test
 
   def test_log_formatter
     NewRelic::Agent::Hostname.instance_variable_set(:@hostname, nil)
-    Socket.stubs(:gethostname).returns(String.new('dummyhost'))
+    Socket.stubs(:gethostname).returns((+'dummyhost'))
     formatter = NewRelic::Agent::AuditLogger.new.create_log_formatter
     time = '2012-01-01 00:00:00'
     msg = 'hello'
@@ -81,7 +81,7 @@ class AuditLoggerTest < Minitest::Test
   def test_log_formatter_to_stdout
     with_config(:'audit_log.path' => "STDOUT") do
       NewRelic::Agent::Hostname.instance_variable_set(:@hostname, nil)
-      Socket.stubs(:gethostname).returns(String.new('dummyhost'))
+      Socket.stubs(:gethostname).returns((+'dummyhost'))
       formatter = NewRelic::Agent::AuditLogger.new.create_log_formatter
       time = '2012-01-01 00:00:00'
       msg = 'hello'
@@ -164,7 +164,7 @@ class AuditLoggerTest < Minitest::Test
 
   def test_should_cache_hostname
     NewRelic::Agent::Hostname.instance_variable_set(:@hostname, nil)
-    hostname = String.new('cachey-mccaherson')
+    hostname = +'cachey-mccaherson'
     Socket.expects(:gethostname).once.returns(hostname)
     setup_fake_logger
     3.times do
@@ -231,7 +231,7 @@ class AuditLoggerTest < Minitest::Test
 
   def capturing_stdout
     orig = $stdout.dup
-    output = String.new('')
+    output = +''
     $stdout = StringIO.new(output)
     yield
     output

--- a/test/new_relic/agent/commands/agent_command_router_test.rb
+++ b/test/new_relic/agent/commands/agent_command_router_test.rb
@@ -43,7 +43,7 @@ class AgentCommandRouterTest < Minitest::Test
   end
 
   def teardown
-    agent_commands.backtrace_service.worker_thread.join if agent_commands.backtrace_service.worker_thread
+    agent_commands.backtrace_service.worker_thread&.join
   end
 
   # Helpers for DataContainerTests
@@ -59,7 +59,7 @@ class AgentCommandRouterTest < Minitest::Test
   def populate_container(container, n)
     start_profile('duration' => 1.0)
     advance_process_time(1.1)
-    agent_commands.backtrace_service.worker_thread.join if agent_commands.backtrace_service.worker_thread
+    agent_commands.backtrace_service.worker_thread&.join
   end
 
   # General command routing

--- a/test/new_relic/agent/configuration/manager_test.rb
+++ b/test/new_relic/agent/configuration/manager_test.rb
@@ -342,7 +342,7 @@ module NewRelic::Agent::Configuration
     end
 
     def test_parse_labels_from_string_with_hard_failure
-      bad_string = String.new('baaaad')
+      bad_string = +'baaaad'
       bad_string.stubs(:strip).raises('Booom')
       @manager.add_config_for_testing(:labels => bad_string)
 

--- a/test/new_relic/agent/database/sql_obfuscation_test.rb
+++ b/test/new_relic/agent/database/sql_obfuscation_test.rb
@@ -13,7 +13,7 @@ module NewRelic::Agent::Database
     end
 
     def build_failure_message(statement, acceptable_outputs, actual_output)
-      msg = String.new("Failed to obfuscate #{statement.adapter} query correctly.\n")
+      msg = +"Failed to obfuscate #{statement.adapter} query correctly.\n"
       msg << "Input:    #{statement.inspect}\n"
       if acceptable_outputs.size == 1
         msg << "Expected: #{acceptable_outputs.first}\n"

--- a/test/new_relic/agent/database_test.rb
+++ b/test/new_relic/agent/database_test.rb
@@ -191,9 +191,9 @@ class NewRelic::Agent::DatabaseTest < Minitest::Test
     config = {:adapter => 'postgresql'}
     sql = 'select count(id) from blogs limit 1'
 
-    plan = String.new("Limit  (cost=11.75..11.76 rows=1 width=4)
+    plan = +"Limit  (cost=11.75..11.76 rows=1 width=4)
   ->  Aggregate  (cost=11.75..11.76 rows=1 width=4)
-        ->  Seq Scan on blogs  (cost=0.00..11.40 rows=140 width=4)")
+        ->  Seq Scan on blogs  (cost=0.00..11.40 rows=140 width=4)"
     explainer = lambda { |statement| plan }
 
     statement = NewRelic::Agent::Database::Statement.new(sql, config, explainer)
@@ -481,7 +481,7 @@ class NewRelic::Agent::DatabaseTest < Minitest::Test
     assert_equal('a' * (NewRelic::Agent::Database::MAX_QUERY_LENGTH - 3) + '...', truncated_query)
   end
 
-  INVALID_UTF8_STRING = String.new("select \x80").force_encoding('UTF-8')
+  INVALID_UTF8_STRING = (+"select \x80").force_encoding('UTF-8')
 
   def test_capture_query_mis_encoded
     query = INVALID_UTF8_STRING

--- a/test/new_relic/agent/datastores/redis_test.rb
+++ b/test/new_relic/agent/datastores/redis_test.rb
@@ -62,7 +62,7 @@ class NewRelic::Agent::Datastores::RedisTest < Minitest::Test
     expected = 'set ?'
 
     with_config(:'transaction_tracer.record_redis_arguments' => false) do
-      result = String.new('')
+      result = +''
       NewRelic::Agent::Datastores::Redis.append_pipeline_command(result, [:set, 'foo', 'bar'])
 
       assert_equal expected, result
@@ -73,7 +73,7 @@ class NewRelic::Agent::Datastores::RedisTest < Minitest::Test
     expected = 'multi'
 
     with_config(:'transaction_tracer.record_redis_arguments' => true) do
-      result = String.new('')
+      result = +''
       NewRelic::Agent::Datastores::Redis.append_pipeline_command(result, [:multi])
 
       assert_equal expected, result
@@ -84,7 +84,7 @@ class NewRelic::Agent::Datastores::RedisTest < Minitest::Test
     expected = 'multi'
 
     with_config(:'transaction_tracer.record_redis_arguments' => false) do
-      result = String.new('')
+      result = +''
       NewRelic::Agent::Datastores::Redis.append_pipeline_command(result, [:multi])
 
       assert_equal expected, result

--- a/test/new_relic/agent/encoding_normalizer_test.rb
+++ b/test/new_relic/agent/encoding_normalizer_test.rb
@@ -66,7 +66,7 @@ class EncodingNormalizerTest < Minitest::Test
     # Encoding::ConverterNotFoundError, which is what we're trying to
     # replicate for this test case.
     # The following UTF-7 string decodes to 'Jyväskylä', a city in Finland
-    string = String.new('Jyv+AOQ-skyl+AOQ-')
+    string = +'Jyv+AOQ-skyl+AOQ-'
     input = string.dup.force_encoding('UTF-7')
 
     assert_predicate input, :valid_encoding?

--- a/test/new_relic/agent/error_trace_aggregator_test.rb
+++ b/test/new_relic/agent/error_trace_aggregator_test.rb
@@ -25,7 +25,7 @@ module NewRelic
 
       def populate_container(aggregator, n)
         n.times do |i|
-          error = NewRelic::NoticedError.new(String.new('path'), String.new('yay errors'))
+          error = NewRelic::NoticedError.new((+'path'), (+'yay errors'))
           aggregator.add_to_error_queue(error)
         end
       end

--- a/test/new_relic/agent/hostname_test.rb
+++ b/test/new_relic/agent/hostname_test.rb
@@ -10,7 +10,7 @@ module NewRelic
     class HostnameTest < Minitest::Test
       def setup
         NewRelic::Agent::Hostname.instance_variable_set(:@hostname, nil)
-        Socket.stubs(:gethostname).returns(String.new('Rivendell'))
+        Socket.stubs(:gethostname).returns((+'Rivendell'))
       end
 
       def teardown
@@ -22,7 +22,7 @@ module NewRelic
       end
 
       def test_get_returns_socket_hostname_converted_to_utf8
-        computer = String.new('Elronds’s-Computer')
+        computer = +'Elronds’s-Computer'
         Socket.stubs(:gethostname).returns(computer.force_encoding(Encoding::ASCII_8BIT))
 
         assert_equal 'Elronds’s-Computer', NewRelic::Agent::Hostname.get
@@ -48,7 +48,7 @@ module NewRelic
 
       def test_does_not_shorten_if_not_using_dyno_names
         with_dyno_name('Imladris', :'heroku.use_dyno_names' => false, :'heroku.dyno_name_prefixes_to_shorten' => ['Rivendell']) do
-          Socket.stubs(:gethostname).returns(String.new('Rivendell.1'))
+          Socket.stubs(:gethostname).returns((+'Rivendell.1'))
 
           assert_equal 'Rivendell.1', NewRelic::Agent::Hostname.get
         end
@@ -133,7 +133,7 @@ module NewRelic
 
       # 'hostname -f' succeeds
       def test_get_fqdn_hostname_f
-        stubbed = String.new('Rivendell.Eriador.MiddleEarth')
+        stubbed = +'Rivendell.Eriador.MiddleEarth'
         NewRelic::Helper.stubs('run_command').with('hostname -f').returns(stubbed)
         fqdn = NewRelic::Agent::Hostname.get_fqdn
 
@@ -142,7 +142,7 @@ module NewRelic
 
       # 'hostname -f' fails, 'hostname' succeeds
       def test_get_fqdn_hostname
-        stubbed = String.new('Lauterbrunnen.Switzerland.Earth')
+        stubbed = +'Lauterbrunnen.Switzerland.Earth'
         NewRelic::Helper.stubs('run_command').with('hostname -f').raises(NewRelic::CommandRunFailedError)
         NewRelic::Helper.stubs('run_command').with('hostname').returns(stubbed)
         fqdn = NewRelic::Agent::Hostname.get_fqdn

--- a/test/new_relic/agent/logging_test.rb
+++ b/test/new_relic/agent/logging_test.rb
@@ -71,7 +71,7 @@ module NewRelic
         messages_to_escape = {
           'quote' => 'message with a quote "',
           'escaped_quote' => 'message with an escaped quote \"',
-          'backslash' => "message with a backslash \ ",
+          'backslash' => "message with a backslash \ ", # rubocop:disable Style/RedundantStringEscape
           'forward_slash' => "message with a forward slash / ",
           'backspace' => 'message with a backspace \b ',
           'form_feed' => "message with a form feed \f ",

--- a/test/new_relic/agent/logging_test.rb
+++ b/test/new_relic/agent/logging_test.rb
@@ -103,7 +103,7 @@ module NewRelic
 
         def test_to_replace_ascii_8bit_chars
           message = 'message with an ASCII-8BIT character'
-          char = String.new('č')
+          char = +'č'
           input = "#{message} #{char.force_encoding(Encoding::ASCII_8BIT)}"
           expectation = "#{message} #{DecoratingFormatter::REPLACEMENT_CHAR}#{DecoratingFormatter::REPLACEMENT_CHAR}"
           logger = DecoratingLogger.new(@output)

--- a/test/new_relic/agent/new_relic_service_test.rb
+++ b/test/new_relic/agent/new_relic_service_test.rb
@@ -1220,7 +1220,7 @@ class NewRelicServiceTest < Minitest::Test
     end
 
     def last_request_payload
-      return nil unless @last_request && @last_request.body
+      return nil unless @last_request&.body
 
       content_encoding = @last_request['Content-Encoding']
       body = if content_encoding == 'deflate'

--- a/test/new_relic/agent/pipe_channel_manager_test.rb
+++ b/test/new_relic/agent/pipe_channel_manager_test.rb
@@ -317,7 +317,7 @@ class NewRelic::Agent::PipeChannelManagerTest < Minitest::Test
     wake_mock = MiniTest::Mock.new
     out_mock = MiniTest::Mock.new
     4.times { wake_mock.expect(:out, out_mock) }
-    error_stub = proc { |msg| desired_error_messages_seen += 1 if msg =~ /^(?:Issue while|Ready pipes)/ }
+    error_stub = proc { |msg| desired_error_messages_seen += 1 if /^(?:Issue while|Ready pipes)/.match?(msg) }
     ready_pipes_mock = MiniTest::Mock.new
 
     ::IO.stub(:select, [ready_pipes_mock]) do

--- a/test/new_relic/agent/stats_engine/gc_profiler_test.rb
+++ b/test/new_relic/agent/stats_engine/gc_profiler_test.rb
@@ -78,7 +78,7 @@ class NewRelic::Agent::StatsEngine
         GC::Profiler.enable
 
         count_before_allocations = GC.count
-        100000.times { String.new }
+        100000.times { +'' }
         GC.start
         count_after_allocations = GC.count
         GC::Profiler.clear

--- a/test/new_relic/agent/system_info_test.rb
+++ b/test/new_relic/agent/system_info_test.rb
@@ -306,7 +306,7 @@ class NewRelic::Agent::SystemInfoTest < Minitest::Test
     assert_metrics_recorded "Supportability/utilization/docker/error"
   end
 
-  VALID_UUID = String.new('eb26a240-5535-0135-e727-745c89b5accd')
+  VALID_UUID = +'eb26a240-5535-0135-e727-745c89b5accd'
 
   def test_valid_boot_id
     NewRelic::Agent::SystemInfo.stubs(:ruby_os_identifier).returns("linux")
@@ -336,7 +336,7 @@ class NewRelic::Agent::SystemInfoTest < Minitest::Test
 
   def test_non_ascii_boot_id
     NewRelic::Agent::SystemInfo.stubs(:ruby_os_identifier).returns("linux")
-    panda = String.new('🐼')
+    panda = +'🐼'
     NewRelic::Agent::SystemInfo.expects(:proc_try_read).with('/proc/sys/kernel/random/boot_id').returns(panda)
 
     assert_nil NewRelic::Agent::SystemInfo.boot_id
@@ -345,7 +345,7 @@ class NewRelic::Agent::SystemInfoTest < Minitest::Test
 
   def test_empty_boot_id
     NewRelic::Agent::SystemInfo.stubs(:ruby_os_identifier).returns("linux")
-    empty = String.new('')
+    empty = +''
     NewRelic::Agent::SystemInfo.expects(:proc_try_read).with('/proc/sys/kernel/random/boot_id').returns(empty)
 
     assert_nil NewRelic::Agent::SystemInfo.boot_id

--- a/test/new_relic/agent/threading/backtrace_node_test.rb
+++ b/test/new_relic/agent/threading/backtrace_node_test.rb
@@ -19,7 +19,7 @@ module NewRelic::Agent::Threading
     end
 
     def assert_backtrace_trees_equal(a, b, original_a = a, original_b = b)
-      message = String.new("Thread profiles did not match.\n\n")
+      message = +"Thread profiles did not match.\n\n"
       message << "Expected tree:\n#{original_a.dump_string}\n\n"
       message << "Actual tree:\n#{original_b.dump_string}\n"
 

--- a/test/new_relic/agent/threading/backtrace_node_test.rb
+++ b/test/new_relic/agent/threading/backtrace_node_test.rb
@@ -32,7 +32,7 @@ module NewRelic::Agent::Threading
 
     def create_node(frame, parent = nil, runnable_count = 0)
       node = BacktraceNode.new(frame)
-      parent.add_child_unless_present(node) if parent
+      parent&.add_child_unless_present(node)
       node.runnable_count = runnable_count
       node
     end

--- a/test/new_relic/agent/utilization/aws_test.rb
+++ b/test/new_relic/agent/utilization/aws_test.rb
@@ -106,20 +106,18 @@ module NewRelic
 
               assert_equal expected, {aws: @vendor.metadata}
 
-              if test_case[:expected_metrics]
-                test_case[:expected_metrics].each do |metric, v|
-                  if v[:call_count] == 0
-                    if uri_obj[:timeout]
-                      refute detection, '@vendor.detect should have returned false'
-                    else
-                      assert detection, '@vendor.detect should have returned truthy'
-                    end
-
-                    assert_metrics_not_recorded [metric.to_s]
-                  else
+              test_case[:expected_metrics]&.each do |metric, v|
+                if v[:call_count] == 0
+                  if uri_obj[:timeout]
                     refute detection, '@vendor.detect should have returned false'
-                    assert_metrics_recorded [metric.to_s]
+                  else
+                    assert detection, '@vendor.detect should have returned truthy'
                   end
+
+                  assert_metrics_not_recorded [metric.to_s]
+                else
+                  refute detection, '@vendor.detect should have returned false'
+                  assert_metrics_recorded [metric.to_s]
                 end
               end
             end

--- a/test/new_relic/agent/utilization/azure_test.rb
+++ b/test/new_relic/agent/utilization/azure_test.rb
@@ -95,20 +95,18 @@ module NewRelic
 
               assert_equal expected, {azure: @vendor.metadata}
 
-              if test_case[:expected_metrics]
-                test_case[:expected_metrics].each do |metric, v|
-                  if v[:call_count] == 0
-                    if uri_obj[:timeout]
-                      refute detection, '@vendor.detect should have returned false'
-                    else
-                      assert detection, '@vendor.detect should have returned truthy'
-                    end
-
-                    assert_metrics_not_recorded [metric.to_s]
-                  else
+              test_case[:expected_metrics]&.each do |metric, v|
+                if v[:call_count] == 0
+                  if uri_obj[:timeout]
                     refute detection, '@vendor.detect should have returned false'
-                    assert_metrics_recorded [metric.to_s]
+                  else
+                    assert detection, '@vendor.detect should have returned truthy'
                   end
+
+                  assert_metrics_not_recorded [metric.to_s]
+                else
+                  refute detection, '@vendor.detect should have returned false'
+                  assert_metrics_recorded [metric.to_s]
                 end
               end
             end

--- a/test/new_relic/agent/utilization/gcp_test.rb
+++ b/test/new_relic/agent/utilization/gcp_test.rb
@@ -95,20 +95,18 @@ module NewRelic
 
               assert_equal expected, {gcp: @vendor.metadata}
 
-              if test_case[:expected_metrics]
-                test_case[:expected_metrics].each do |metric, v|
-                  if v[:call_count] == 0
-                    if uri_obj[:timeout]
-                      refute detection, '@vendor.detect should have returned false'
-                    else
-                      assert detection, '@vendor.detect should have returned truthy'
-                    end
-
-                    assert_metrics_not_recorded [metric.to_s]
-                  else
+              test_case[:expected_metrics]&.each do |metric, v|
+                if v[:call_count] == 0
+                  if uri_obj[:timeout]
                     refute detection, '@vendor.detect should have returned false'
-                    assert_metrics_recorded [metric.to_s]
+                  else
+                    assert detection, '@vendor.detect should have returned truthy'
                   end
+
+                  assert_metrics_not_recorded [metric.to_s]
+                else
+                  refute detection, '@vendor.detect should have returned false'
+                  assert_metrics_recorded [metric.to_s]
                 end
               end
             end

--- a/test/new_relic/agent/utilization/pcf_test.rb
+++ b/test/new_relic/agent/utilization/pcf_test.rb
@@ -80,20 +80,18 @@ module NewRelic
 
                 assert_equal expected, {pcf: @vendor.metadata}
 
-                if test_case[:expected_metrics]
-                  test_case[:expected_metrics].each do |metric, v|
-                    if v[:call_count] == 0
-                      if timeout
-                        refute detection, '@vendor.detect should have returned false'
-                      else
-                        assert detection, '@vendor.detect should have returned truthy'
-                      end
-
-                      assert_metrics_not_recorded [metric.to_s]
-                    else
+                test_case[:expected_metrics]&.each do |metric, v|
+                  if v[:call_count] == 0
+                    if timeout
                       refute detection, '@vendor.detect should have returned false'
-                      assert_metrics_recorded [metric.to_s]
+                    else
+                      assert detection, '@vendor.detect should have returned truthy'
                     end
+
+                    assert_metrics_not_recorded [metric.to_s]
+                  else
+                    refute detection, '@vendor.detect should have returned false'
+                    assert_metrics_recorded [metric.to_s]
                   end
                 end
               end

--- a/test/new_relic/agent/utilization_data_test.rb
+++ b/test/new_relic/agent/utilization_data_test.rb
@@ -145,7 +145,7 @@ module NewRelic::Agent
     def test_logged_when_docker_container_id_is_unrecognized
       NewRelic::Agent::SystemInfo.stubs(:ruby_os_identifier).returns('linux')
       NewRelic::Agent::SystemInfo.stubs(:ram_in_mib).returns(128)
-      NewRelic::Agent::SystemInfo.stubs(:proc_try_read).returns(String.new('whatever'))
+      NewRelic::Agent::SystemInfo.stubs(:proc_try_read).returns((+'whatever'))
       NewRelic::Agent::SystemInfo.stubs(:parse_cgroup_ids).returns('cpu' => "*****YOLO*******")
 
       expects_logging(:debug, includes("YOLO"))

--- a/test/new_relic/collection_helper_test.rb
+++ b/test/new_relic/collection_helper_test.rb
@@ -38,7 +38,7 @@ class NewRelic::CollectionHelperTest < Minitest::Test
   end
 
   def test_string__singleton
-    val = String.new('This String')
+    val = +'This String'
     def val.hello; end
 
     assert_equal 'This String', normalize_params(val)

--- a/test/new_relic/evil_server.rb
+++ b/test/new_relic/evil_server.rb
@@ -34,7 +34,7 @@ module NewRelic
     end
 
     def start
-      return if @thread && @thread.alive?
+      return if @thread&.alive?
 
       @requests = []
       @server = TCPServer.new(0)

--- a/test/new_relic/fake_server.rb
+++ b/test/new_relic/fake_server.rb
@@ -57,7 +57,7 @@ module NewRelic
     end
 
     def running?
-      @thread && @thread.alive?
+      @thread&.alive?
     end
 
     def run

--- a/test/new_relic/fake_server.rb
+++ b/test/new_relic/fake_server.rb
@@ -5,7 +5,7 @@
 require 'webrick'
 require 'webrick/https'
 require 'rack'
-require 'rackup/handler' unless Rack.release =~ /^1|2/
+require 'rackup/handler' unless /^1|2/.match?(Rack.release)
 require 'timeout'
 require 'json'
 

--- a/test/new_relic/fake_server.rb
+++ b/test/new_relic/fake_server.rb
@@ -16,20 +16,20 @@ module NewRelic
 
     # Default server options
     DEFAULT_OPTIONS = {
-      :Logger => ::WEBrick::Log.new(String.new('/dev/null')),
-      :AccessLog => [[String.new('/dev/null'), '']]
+      :Logger => ::WEBrick::Log.new((+'/dev/null')),
+      :AccessLog => [[+'/dev/null', '']]
     }
 
     CONFIG_PATH = String.new(File.join(File.dirname(__FILE__), '..', 'config'))
-    FAKE_SSL_CERT_PATH = File.join(CONFIG_PATH, String.new('test.cert.crt'))
-    FAKE_SSL_KEY_PATH = File.join(CONFIG_PATH, String.new('test.cert.key'))
+    FAKE_SSL_CERT_PATH = File.join(CONFIG_PATH, (+'test.cert.crt'))
+    FAKE_SSL_KEY_PATH = File.join(CONFIG_PATH, (+'test.cert.key'))
 
     SSL_OPTIONS = {
       :SSLEnable => true,
       :SSLVerifyClient => OpenSSL::SSL::VERIFY_NONE,
       :SSLPrivateKey => OpenSSL::PKey::RSA.new(File.read(FAKE_SSL_KEY_PATH)),
       :SSLCertificate => OpenSSL::X509::Certificate.new(File.read(FAKE_SSL_CERT_PATH)),
-      :SSLCertName => [[String.new('CN'), String.new('newrelic.com')]]
+      :SSLCertName => [[+'CN', +'newrelic.com']]
     }
 
     def initialize(port = DEFAULT_PORT)
@@ -66,7 +66,7 @@ module NewRelic
       @started_options = build_webrick_options
 
       @server = WEBrick::HTTPServer.new(@started_options)
-      @server.mount(String.new('/'), webrick_handler, app)
+      @server.mount((+'/'), webrick_handler, app)
 
       @thread = Thread.new(&self.method(:run_server)).tap { |t| t.abort_on_exception = true }
     end
@@ -114,7 +114,7 @@ module NewRelic
       req = ::Rack::Request.new(env)
       res = ::Rack::Response.new
       res.status = 403
-      res.body = [String.new("Forbidden\n")]
+      res.body = [+"Forbidden\n"]
       res.finish
     end
 
@@ -130,7 +130,7 @@ module NewRelic
     end
 
     def call(env)
-      raise String.new('something went wrong!')
+      raise (+'something went wrong!')
     end
 
     def app

--- a/test/new_relic/framework_test.rb
+++ b/test/new_relic/framework_test.rb
@@ -35,7 +35,7 @@ class FrameworkTest < Minitest::Test
     end
 
     # does the path match "rails\d" (ex: rails7) or "railsedge"?
-    if ENV['BUNDLE_GEMFILE'] =~ /rails(?:\d|edge)/
+    if /rails(?:\d|edge)/.match?(ENV['BUNDLE_GEMFILE'])
       # rubocop:disable Performance/StringInclude
       assert_truthy NewRelic::Agent.config[:framework].match(/rails/)
       # rubocop:enable Performance/StringInclude

--- a/test/new_relic/rack/browser_monitoring_test.rb
+++ b/test/new_relic/rack/browser_monitoring_test.rb
@@ -166,7 +166,7 @@ if defined?(Rack::Test)
     end
 
     def test_with_invalid_us_ascii_encoding
-      response = String.new('<html><body>Jürgen</body></html>')
+      response = +'<html><body>Jürgen</body></html>'
       response.force_encoding(Encoding.find("US-ASCII"))
       TestApp.next_response = Rack::Response.new(response)
 

--- a/test/performance/lib/performance/test_case.rb
+++ b/test/performance/lib/performance/test_case.rb
@@ -44,9 +44,7 @@ module Performance
     end
 
     def fire(event, *args)
-      if @callbacks[event]
-        @callbacks[event].each { |cb| cb.arity > 0 ? cb.call(*args) : cb.call }
-      end
+      @callbacks[event]&.each { |cb| cb.arity > 0 ? cb.call(*args) : cb.call }
     end
 
     def runnable_test_methods

--- a/test/performance/suites/marshalling.rb
+++ b/test/performance/suites/marshalling.rb
@@ -120,16 +120,16 @@ class Marshalling < Performance::TestCase
     1000.times do
       event = {
         'timestamp' => Process.clock_gettime(Process::CLOCK_REALTIME),
-        'name' => String.new('Controller/foo/bar'),
-        'type' => String.new('Transaction'),
+        'name' => +'Controller/foo/bar',
+        'type' => +'Transaction',
         'duration' => rand,
         'databaseDuration' => rand,
         'databaseCallCount' => rand,
         'gcCumulative' => rand,
-        'host' => String.new('lo-calhost'),
-        'color' => String.new('blue-green'),
-        'shape' => String.new('squarish'),
-        'texture' => String.new('sort of lumpy like a bag of frozen peas')
+        'host' => +'lo-calhost',
+        'color' => +'blue-green',
+        'shape' => +'squarish',
+        'texture' => +'sort of lumpy like a bag of frozen peas'
       }
       events << [event, {}]
     end


### PR DESCRIPTION
# Overview

Our agent's previous support of Ruby 2.2 and 2.3 prevented some Rubocop linters from being enabled. This PR enables the following:
* [Performance/RegexpMatch](https://docs.rubocop.org/rubocop-performance/cops_performance.html#performanceregexpmatch) - safe
* [Performance/Sum](https://docs.rubocop.org/rubocop-performance/cops_performance.html#performancesum) - unsafe autocorrection; covered by tests 
* [Performance/UnfreezeString](https://docs.rubocop.org/rubocop-performance/cops_performance.html#performanceunfreezestring) - unsafe autocorrection; covered by tests
* [Style/RedundantStringEscape](https://docs.rubocop.org/rubocop/1.46/cops_style.html#styleredundantstringescape) - safe 
* [Style/SafeNavigation](https://docs.rubocop.org/rubocop/1.46/cops_style.html#stylesafenavigation) - unsafe autocorrection

It disables Style/FetchEnvVar. When `ENV.fetch` fails, a `KeyError` or the explicitly specified default
value is returned. We don't want to raise an unexpected error in a customer's environment. Also, fetch is slightly less performant than `ENV[]` when there is not a non-nil replacement value.

Resolves: https://github.com/newrelic/newrelic-ruby-agent/issues/1787 
Resolves: https://github.com/newrelic/newrelic-ruby-agent/issues/1246 