### PR TITLE
Multiverse: always show options, fix 'not found'

### DIFF
--- a/test/multiverse/lib/multiverse/suite.rb
+++ b/test/multiverse/lib/multiverse/suite.rb
@@ -575,9 +575,9 @@ module Multiverse
 
       # MiniTest 5.0 moved things around, so choose which way to run it
       if ::MiniTest.respond_to?(:run)
-        test_run = ::MiniTest.run(options)
+        passed = ::MiniTest.run(options)
       else
-        test_run = ::MiniTest::Unit.new.run(options)
+        passed = ::MiniTest::Unit.new.run(options)
       end
 
       load(@after_file) if @after_file
@@ -593,13 +593,9 @@ module Multiverse
         end
       end
 
-      if test_run
-        exit(test_run)
-      else
-        puts "No tests found with those options."
-        puts "options: #{original_options}"
-        exit(1)
-      end
+      puts 'One or more failures or errors were seen!' unless passed
+      puts "Options used: #{original_options}"
+      exit(passed) # `exit true` returns 0, `exit false` returns 1
     end
 
     def configure_before_bundling


### PR DESCRIPTION
Multiverse CI tests:

- Always report the options used, pass or fail
- Don't report "No tests found with those options." just because a test failed or errored out.
- Rename "run_test" to "passed" to better convey that it contains the boolean result of the tests having been performed

Unfortunately given that the v5.x `run` method instantiates its own reporter that falls out of scope as soon as the method completes, all we are left with is a boolean result of the run. We can't make a determination as to whether or not 0 tests were found and force that condition to be an error condition with a non-zero exit code. Perhaps in future we could hook into the reporter chain with our own plugin to relay the test count back to us at the end.