### PR TITLE
Prevent undfined method error in Action Controller instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 - **Bugfix: Undefined method `controller_path` logged in Action Controller Instrumentation**
 
-  Previously, agent could log an error when trying to determine the metric name in the Action Controller instrumentation if the contrller class did not respond to `controller_path`. This has been resolved and the agent will no longer call this method unless the class responds to it. Thank you to @ for letting us know about this issue [PR#1844](https://github.com/newrelic/newrelic-ruby-agent/pull/1844)
+  Previously, the agent could log an error when trying to determine the metric name in the Action Controller instrumentation if the controller class did not respond to `controller_path`. This has been resolved and the agent will no longer call this method unless the class responds to it. Thank you to [@gsar](https://github.com/gsar) for letting us know about this issue. [PR#1844](https://github.com/newrelic/newrelic-ruby-agent/pull/1844)
 
 
 ## v9.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 
   Previously, the agent sometimes received children of the `NewRelic::Agent::HTTPClients::AbstractRequest` class as an argument when `NewRelic::Agent::Transaction::DistributedTracers#log_request_headers` was called. This caused debug-level log messages that print the request headers to show human-readable Objects (ex. `#<NewRelic::Agent::HTTPClients::HTTPClientRequest:0x00007fd0dda983e0>`) instead of the request headers. Now, the hash of the request headers should always be logged. [PR#1839](https://github.com/newrelic/newrelic-ruby-agent/pull/1839)
 
-- **Bugfix: Undefined method `controller_path` logged when Action Controller Instrumentation**
+- **Bugfix: Undefined method `controller_path` logged in Action Controller Instrumentation**
 
   Previously, agent could log an error when trying to determine the metric name in the Action Controller instrumentation if the contrller class did not respond to `controller_path`. This has been resolved and the agent will no longer call this method unless the class responds to it. Thank you to @ for letting us know about this issue [PR#1844](https://github.com/newrelic/newrelic-ruby-agent/pull/1844)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@
 
   Previously, the agent sometimes received children of the `NewRelic::Agent::HTTPClients::AbstractRequest` class as an argument when `NewRelic::Agent::Transaction::DistributedTracers#log_request_headers` was called. This caused debug-level log messages that print the request headers to show human-readable Objects (ex. `#<NewRelic::Agent::HTTPClients::HTTPClientRequest:0x00007fd0dda983e0>`) instead of the request headers. Now, the hash of the request headers should always be logged. [PR#1839](https://github.com/newrelic/newrelic-ruby-agent/pull/1839)
 
+- **Bugfix: Undefined method `controller_path` logged when Action Controller Instrumentation**
+
+  Previously, agent could log an error when trying to determine the metric name in the Action Controller instrumentation if the contrller class did not respond to `controller_path`. This has been resolved and the agent will no longer call this method unless the class responds to it. Thank you to @ for letting us know about this issue [PR#1844](https://github.com/newrelic/newrelic-ruby-agent/pull/1844)
+
+
 ## v9.0.0
 
   Version 9.0.0 of the agent removes several deprecated configuration options and API methods, enables Thread tracing by default, adds Fiber instrumentation, removes support for Ruby versions 2.2 and 2.3, removes instrumentation for several deprecated gems, changes how the API method `set_transaction_name` works, and updates `rails_defer_initialization` to be an environment variable only configuration option.

--- a/lib/new_relic/agent/instrumentation/action_controller_other_subscriber.rb
+++ b/lib/new_relic/agent/instrumentation/action_controller_other_subscriber.rb
@@ -27,8 +27,9 @@ module NewRelic
         end
 
         def controller_name_for_metric(payload)
+          return unless payload
           # redirect_to
-          return payload[:request].controller_class.controller_path if payload[:request]&.controller_class&.respond_to?(:controller_path)
+          return payload[:request].controller_class.controller_path if payload[:request].respond_to?(:controller_class) && payload[:request]&.controller_class&.respond_to?(:controller_path)
 
           # unpermitted_parameters
           if payload[:context]&.[](:controller) && constantized_class = ::NewRelic::LanguageSupport.constantize(payload[:context][:controller])

--- a/lib/new_relic/agent/instrumentation/action_controller_other_subscriber.rb
+++ b/lib/new_relic/agent/instrumentation/action_controller_other_subscriber.rb
@@ -29,7 +29,7 @@ module NewRelic
         def controller_name_for_metric(payload)
           return unless payload
           # redirect_to
-          return payload[:request].controller_class.controller_path if payload[:request].respond_to?(:controller_class) && payload[:request]&.controller_class&.respond_to?(:controller_path)
+          return payload[:request].controller_class.controller_path if payload[:request].respond_to?(:controller_class) && payload[:request].controller_class&.respond_to?(:controller_path)
 
           # unpermitted_parameters
           if payload[:context]&.[](:controller) && constantized_class = ::NewRelic::LanguageSupport.constantize(payload[:context][:controller])

--- a/lib/new_relic/agent/instrumentation/action_controller_other_subscriber.rb
+++ b/lib/new_relic/agent/instrumentation/action_controller_other_subscriber.rb
@@ -28,10 +28,12 @@ module NewRelic
 
         def controller_name_for_metric(payload)
           # redirect_to
-          return payload[:request].controller_class.controller_path if payload[:request] && payload[:request].controller_class
+          return payload[:request].controller_class.controller_path if payload[:request]&.controller_class&.respond_to?(:controller_path)
 
           # unpermitted_parameters
-          ::NewRelic::LanguageSupport.constantize(payload[:context][:controller]).controller_path if payload[:context] && payload[:context][:controller]
+          if payload[:context]&.[](:controller) && constantized_class = ::NewRelic::LanguageSupport.constantize(payload[:context][:controller])
+            constantized_class.respond_to?(:controller_path) ? constantized_class.controller_path : nil
+          end
         end
       end
     end

--- a/test/multiverse/suites/rails/action_controller_other_test.rb
+++ b/test/multiverse/suites/rails/action_controller_other_test.rb
@@ -108,5 +108,26 @@ if defined?(ActionController::Live)
 
       assert_metrics_recorded(['Controller/data/not_allowed', segment_name])
     end
+
+    class TestClassActionController; end
+    def test_no_metric_naming_error
+      payloads = [
+        {request: "Not gonna respond to controller_class"},
+        {request: Class.new do
+          def controller_class
+            "not gonna respond to controller_path"
+          end
+        end},
+        {context: {}},
+        {context: {controller: TestClassActionController.name}},
+        {},
+        nil
+      ]
+
+      payloads.each do |payload|
+        # make sure no error is raised
+        NewRelic::Agent::Instrumentation::ActionControllerOtherSubscriber.new.controller_name_for_metric(payload)
+      end
+    end
   end
 end


### PR DESCRIPTION
If the action controller instrumentation was being called for a class that didn't respond to `controller_path`, the agent would error when trying to create the metric name for the segment. Now it will always check to make sure that method will work before calling it. I also updated this section to use the safe navigation operator now that we only support ruby 2.4+.

closes #1842