### PR TITLE
Use !value.nil? instead of nil != value

### DIFF
--- a/lib/new_relic/agent/distributed_tracing/cross_app_tracing.rb
+++ b/lib/new_relic/agent/distributed_tracing/cross_app_tracing.rb
@@ -27,7 +27,7 @@ module NewRelic
       end
 
       def is_cross_app_callee?
-        cross_app_payload != nil
+        !cross_app_payload.nil?
       end
 
       def is_cross_app?

--- a/lib/new_relic/agent/transaction/synthetics_sample_buffer.rb
+++ b/lib/new_relic/agent/transaction/synthetics_sample_buffer.rb
@@ -13,7 +13,7 @@ module NewRelic
         end
 
         def allow_sample?(sample)
-          sample.synthetics_resource_id != nil
+          !sample.synthetics_resource_id.nil?
         end
 
         def truncate_samples


### PR DESCRIPTION
This change supports microbenchmarking tests on Ruby 3.0 and Ruby 2.7