### PR TITLE
Fix warnings in unit tests

### DIFF
--- a/test/new_relic/agent/method_tracer_helpers_test.rb
+++ b/test/new_relic/agent/method_tracer_helpers_test.rb
@@ -91,7 +91,7 @@ class NewRelic::Agent::MethodTracerHelpersTest < Minitest::Test
     end
   end
 
-  def test_provides_accurate_info_for_an_instance_method
+  def test_provides_accurate_info_for_a_private_instance_method
     with_config(:'code_level_metrics.enabled' => true) do
       info = NewRelic::Agent::MethodTracerHelpers.code_information(::The::Example, :private_method)
 

--- a/test/new_relic/agent/tracer_test.rb
+++ b/test/new_relic/agent/tracer_test.rb
@@ -400,7 +400,7 @@ module NewRelic
             Thread.new { 'woof' }.join
           end
 
-          assert_match (/Ruby\/Thread\/Thread\d+\/Fiber\d+/), txn.segments.last.name
+          assert_match %r{Ruby/Thread/Thread\d+/Fiber\d+}, txn.segments.last.name
         end
       end
 
@@ -413,7 +413,7 @@ module NewRelic
             Thread.new { 'woof' }.join
           end
 
-          assert_match (/Ruby\/Thread$/), txn.segments.last.name
+          assert_match %r{Ruby/Thread$}, txn.segments.last.name
         end
       end
 

--- a/test/new_relic/agent/tracer_test.rb
+++ b/test/new_relic/agent/tracer_test.rb
@@ -400,7 +400,7 @@ module NewRelic
             Thread.new { 'woof' }.join
           end
 
-          assert_match /Ruby\/Thread\/Thread\d+\/Fiber\d+/, txn.segments.last.name
+          assert_match (/Ruby\/Thread\/Thread\d+\/Fiber\d+/), txn.segments.last.name
         end
       end
 
@@ -413,7 +413,7 @@ module NewRelic
             Thread.new { 'woof' }.join
           end
 
-          assert_match /Ruby\/Thread$/, txn.segments.last.name
+          assert_match (/Ruby\/Thread$/), txn.segments.last.name
         end
       end
 


### PR DESCRIPTION
Fixes a couple of warnings related to the way our tests were written

There was a test that was the same name as another test (test_provides_accurate_info_for_an_instance_method)
```
/Users/tmcclure/projects/ruby-agent/test/new_relic/agent/method_tracer_helpers_test.rb:94: warning: method redefined; discarding old test_provides_accurate_info_for_an_instance_method
/Users/tmcclure/projects/ruby-agent/test/new_relic/agent/method_tracer_helpers_test.rb:82: warning: previous definition of test_provides_accurate_info_for_an_instance_method was here
```

There were 2 regexs used in tests that wanted it surrounded by parens 
```
/Users/tmcclure/projects/ruby-agent/test/new_relic/agent/tracer_test.rb:403: warning: ambiguity between regexp and two divisions: wrap regexp in parentheses or add a space after `/' operator
/Users/tmcclure/projects/ruby-agent/test/new_relic/agent/tracer_test.rb:416: warning: ambiguity between regexp and two divisions: wrap regexp in parentheses or add a space after `/' operator
```