### PR TITLE
errors inbox fingerprinting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # New Relic Ruby Agent Release Notes
 
+## error_fingerprinting_and_user_tracking
+  
+  Version x.x.x of the agent delivers support for two new [errors inbox](https://docs.newrelic.com/docs/errors-inbox/errors-inbox/) features: error fingerprinting and user tracking.
+
+- **Error fingerprinting**
+
+  A new `set_error_group_callback` public API method now exists that will accept a user defined proc. The proc will be invoked for each noticed error and whenever it returns a string, that string will be used as the error group name for the error and will take precedence over any server-side grouping that takes place with the New Relic errors inbox. This gives users much greater control over the grouping of their errors.
+
+  The customer defined proc will be expected to receive exactly one input argument, a hash. The hash contains the following:
+
+  |  Key                 | Value                                                                        |
+  | ---------------------| ---------------------------------------------------------------------------- |
+  | `:error`             | The Ruby error class instance. Offers `#class`, `#message`, and `#backtrace` |
+  | `:customAttributes`  | Any customer defined customed attributed for the current transaction         |
+  | `:'request.uri'`     | The current requeset URI if available                                        |
+  | `:'http.statusCode'` | The HTTP status code (200, 404, etc.) if available                           |
+  | `:'http.method'`     | The HTTP method (GET, PUT, etc.) if available                                |
+  | `:'error.expected'`  | Whether (true) or not (false) the error was expected                         |
+  | `:'options'`         | The options hash passed to `NewRelic::Agent.notice_error                     |
+
+  The callback only needs to be set once per initialization of the New Relic agent.
+
+  Example usage:
+
+  ```
+  proc = proc { |hash| "Access" if hash[:'http.statusCode'].to_s == '401' }
+  NewRelic::Agent.set_error_group_callback(proc)
+  ```
+
+- **User tracking**
+
+  A new `set_user_id` public API method now exists that will accept a string representation of a user id and associate that user id with the current transaction. Transactions and errors will then have a new `enduser.id` agent attribute associated with them. This will allow agent users to tag transactions and errors as belonging to given user ids in support of greater filtering and alerting capabilities.
+
+
 ## dev
 
   Upcoming version removes Distributed Tracing warnings from agent logs when using Sidekiq, fixes a bug regarding logged request headers, and is tested against the recently released JRuby 9.4.2.0.

--- a/lib/new_relic/agent.rb
+++ b/lib/new_relic/agent.rb
@@ -333,6 +333,7 @@ module NewRelic
         return
       end
 
+      record_api_supportability_metric(:set_error_group_callback)
       @error_group_callback = callback_proc
     end
 

--- a/lib/new_relic/agent.rb
+++ b/lib/new_relic/agent.rb
@@ -105,6 +105,8 @@ module NewRelic
     # placeholder name used when we cannot determine a transaction's name
     UNKNOWN_METRIC = '(unknown)'.freeze
 
+    attr_reader :error_group_callback
+
     @agent = nil
     @error_group_callback = nil
     @logger = nil

--- a/lib/new_relic/agent.rb
+++ b/lib/new_relic/agent.rb
@@ -106,6 +106,7 @@ module NewRelic
     UNKNOWN_METRIC = '(unknown)'.freeze
 
     @agent = nil
+    @error_group_callback = nil
     @logger = nil
     @tracer_lock = Mutex.new
     @tracer_queue = []
@@ -291,6 +292,46 @@ module NewRelic
 
       Transaction.notice_error(exception, options)
       nil # don't return a noticed error data structure. it can only hurt.
+    end
+
+    # Set a callback proc for determining an error's error group name
+    #
+    # @param [Proc] the callback proc
+    #
+    # Typically this method should be called only once to set a callback for
+    # use with all noticed errors. If it is called multiple times, each new
+    # callback given will replace the old one.
+    #
+    # The proc will be called with a single hash as its input argument and is
+    # expected to return a string representing the desired error group.
+    #
+    # see https://docs.newrelic.com/docs/errors-inbox/errors-inbox/#groups
+    #
+    # The hash passed to the customer defined callback proc has the following
+    # keys:
+    #
+    # :error => The Ruby error class instance, likely inheriting from
+    #           StandardError. Call `#class`, `#message`, and `#backtrace` on
+    #           the error object to retrieve the error's class, message, and
+    #           backtrace.
+    # :customAttributes => Any customer defined custom attributes that have been
+    #                      associated with the current transaction.
+    # :'request.uri' => The current request URI if available
+    # :'http.statusCode' => The HTTP status code (200, 404, etc.) if available
+    # :'http.method' => The HTTP method (GET, PUT, etc.) if available
+    # :'error.expected' => Whether (true) or not (false) the error was expected
+    # :options => The options hash passed to `NewRelic::Agent.notice_error`
+    #
+    # @api public
+    #
+    def set_error_group_callback(callback_proc)
+      unless callback_proc.is_a?(Proc)
+        NewRelic::Agent.logger.error('The error group callback proc must be an instance of Proc, ' \
+                                     "got #{callback_proc.class}")
+        return
+      end
+
+      @error_group_callback = callback_proc
     end
 
     # @!endgroup

--- a/lib/new_relic/agent.rb
+++ b/lib/new_relic/agent.rb
@@ -326,7 +326,7 @@ module NewRelic
     #
     def set_error_group_callback(callback_proc)
       unless callback_proc.is_a?(Proc)
-        NewRelic::Agent.logger.error('The error group callback proc must be an instance of Proc, ' \
+        NewRelic::Agent.logger.error("#{self}.#{__method__}: expected an argument of type Proc, " \
                                      "got #{callback_proc.class}")
         return
       end

--- a/lib/new_relic/agent/error_collector.rb
+++ b/lib/new_relic/agent/error_collector.rb
@@ -312,10 +312,10 @@ module NewRelic
       private
 
       def update_error_group_name(noticed_error, exception, options)
-        return unless customer_error_group_callback
+        return unless error_group_callback
 
         callback_hash = build_customer_callback_hash(noticed_error, exception, options)
-        result = customer_error_group_callback.call(callback_hash)
+        result = error_group_callback.call(callback_hash)
         noticed_error.error_group = result
       rescue StandardError => e
         NewRelic::Agent.logger.error("Failed to obtain error group from customer callback: #{e.class} - #{e.message}")
@@ -326,13 +326,13 @@ module NewRelic
          customAttributes: noticed_error.custom_attributes,
          'request.uri': noticed_error.request_uri,
          'http.statusCode': noticed_error.agent_attributes[:'http.statusCode'],
-         'http.method': noticed_error.instrinsic_attributes[:'http.method'],
+         'http.method': noticed_error.intrinsic_attributes[:'http.method'],
          'error.expected': noticed_error.expected,
          options: options}
       end
 
-      def customer_error_group_callback
-        NewRelic::Agent.customer_error_group_callback
+      def error_group_callback
+        NewRelic::Agent.error_group_callback
       end
     end
   end

--- a/lib/new_relic/agent/error_collector.rb
+++ b/lib/new_relic/agent/error_collector.rb
@@ -285,6 +285,8 @@ module NewRelic
         # get treated as custom attributes, so merge them into that hash.
         noticed_error.attributes_from_notice_error.merge!(options)
 
+        update_error_group_name(noticed_error, exception, options)
+
         noticed_error
       end
 
@@ -305,6 +307,32 @@ module NewRelic
         @error_trace_aggregator.reset!
         @error_event_aggregator.reset!
         nil
+      end
+
+      private
+
+      def update_error_group_name(noticed_error, exception, options)
+        return unless customer_error_group_callback
+
+        callback_hash = build_customer_callback_hash(noticed_error, exception, options)
+        result = customer_error_group_callback.call(callback_hash)
+        noticed_error.error_group = result
+      rescue StandardError => e
+        NewRelic::Agent.logger.error("Failed to obtain error group from customer callback: #{e.class} - #{e.message}")
+      end
+
+      def build_customer_callback_hash(noticed_error, exception, options)
+        {error: exception,
+         customAttributes: noticed_error.custom_attributes,
+         'request.uri': noticed_error.request_uri,
+         'http.statusCode': noticed_error.agent_attributes[:'http.statusCode'],
+         'http.method': noticed_error.instrinsic_attributes[:'http.method'],
+         'error.expected': noticed_error.expected,
+         options: options}
+      end
+
+      def customer_error_group_callback
+        NewRelic::Agent.customer_error_group_callback
       end
     end
   end

--- a/lib/new_relic/agent/error_trace_aggregator.rb
+++ b/lib/new_relic/agent/error_trace_aggregator.rb
@@ -81,9 +81,10 @@ module NewRelic
           # Already seen this class once? Bail!
           return if @errors.any? { |err| err.exception_class_name == exception.class.name }
 
-          trace = exception.backtrace || caller.dup
-          noticed_error = NewRelic::NoticedError.new('NewRelic/AgentError', exception)
-          noticed_error.stack_trace = trace
+          noticed_error = NewRelic::Agent.instance.error_collector.create_noticed_error(exception,
+            {metric: 'NewRelic/AgentError'})
+          noticed_error.stack_trace ||= caller.dup
+
           @errors << noticed_error
         end
       rescue => e

--- a/lib/new_relic/agent/error_trace_aggregator.rb
+++ b/lib/new_relic/agent/error_trace_aggregator.rb
@@ -83,7 +83,7 @@ module NewRelic
 
           noticed_error = NewRelic::Agent.instance.error_collector.create_noticed_error(exception,
             {metric: 'NewRelic/AgentError'})
-          noticed_error.stack_trace ||= caller.dup
+          noticed_error.stack_trace = caller.dup unless exception.backtrace
 
           @errors << noticed_error
         end

--- a/lib/new_relic/noticed_error.rb
+++ b/lib/new_relic/noticed_error.rb
@@ -144,10 +144,6 @@ class NewRelic::NoticedError
   end
 
   def build_agent_attributes(merged_attributes)
-
-    # when does this get called?
-
-
     agent_attributes = if @attributes
       @attributes.agent_attributes_for(DESTINATION)
     else

--- a/lib/new_relic/noticed_error.rb
+++ b/lib/new_relic/noticed_error.rb
@@ -158,7 +158,7 @@ class NewRelic::NoticedError
       next unless value
 
       merged_attributes.add_agent_attribute(name, value, DESTINATION)
-      agent_attributes.merge(merged_attributes.agent_attributes_for(DESTINATION))
+      agent_attributes = agent_attributes.merge(merged_attributes.agent_attributes_for(DESTINATION))
     end
 
     agent_attributes

--- a/lib/new_relic/noticed_error.rb
+++ b/lib/new_relic/noticed_error.rb
@@ -205,7 +205,7 @@ class NewRelic::NoticedError
   end
 
   def error_group=(name)
-    return unless name.nil? || name.empty?
+    return if name.nil? || name.empty?
 
     @error_group = name
   end

--- a/lib/new_relic/noticed_error.rb
+++ b/lib/new_relic/noticed_error.rb
@@ -143,12 +143,15 @@ class NewRelic::NoticedError
   end
 
   def build_agent_attributes(merged_attributes)
-    return NewRelic::EMPTY_HASH unless @attributes || error_group
-
-    error_group_hash = {AGENT_ATTRIBUTE_ERROR_GROUP => error_group}
     return error_group_hash unless @attributes
 
     @attributes.agent_attributes_for(DESTINATION).merge(error_group_hash)
+  end
+
+  def error_group_hash
+    return NewRelic::EMPTY_HASH unless error_group
+
+    {AGENT_ATTRIBUTE_ERROR_GROUP => error_group}
   end
 
   def build_intrinsic_attributes

--- a/lib/new_relic/noticed_error.rb
+++ b/lib/new_relic/noticed_error.rb
@@ -28,7 +28,7 @@ class NewRelic::NoticedError
   DESTINATION = NewRelic::Agent::AttributeFilter::DST_ERROR_COLLECTOR
 
   AGENT_ATTRIBUTE_REQUEST_URI = :'request.uri'
-  AGENT_ATTRIBUTE_ERROR_GRUP = :'error.group.name'
+  AGENT_ATTRIBUTE_ERROR_GROUP = :'error.group.name'
 
   ERROR_PREFIX_KEY = 'error'
   ERROR_MESSAGE_KEY = "#{ERROR_PREFIX_KEY}.message"

--- a/lib/new_relic/noticed_error.rb
+++ b/lib/new_relic/noticed_error.rb
@@ -150,15 +150,14 @@ class NewRelic::NoticedError
       NewRelic::EMPTY_HASH
     end
 
-    # It's possible to override the request_uri from the transaction attributes
-    # with a uri passed to notice_error. Add it to merged_attributes filter and
-    # merge with the transaction attributes, possibly overriding the request_uri
+    # If we have a local value for one of these properties, use it as the
+    # agent attribute value; possibly overwriting an existing value
     {AGENT_ATTRIBUTE_REQUEST_URI => request_uri,
      AGENT_ATTRIBUTE_ERROR_GROUP => error_group}.each do |name, value|
       next unless value
 
       merged_attributes.add_agent_attribute(name, value, DESTINATION)
-      agent_attributes = agent_attributes.merge(merged_attributes.agent_attributes_for(DESTINATION))
+      agent_attributes.merge(merged_attributes.agent_attributes_for(DESTINATION))
     end
 
     agent_attributes

--- a/lib/new_relic/supportability_helper.rb
+++ b/lib/new_relic/supportability_helper.rb
@@ -44,7 +44,7 @@ module NewRelic
       :record_metric,
       :recording_web_transaction?,
       :require_test_helper,
-      :set_error_group_callabck,
+      :set_error_group_callback,
       :set_sql_obfuscator,
       :set_transaction_name,
       :shutdown,

--- a/lib/new_relic/supportability_helper.rb
+++ b/lib/new_relic/supportability_helper.rb
@@ -44,6 +44,7 @@ module NewRelic
       :record_metric,
       :recording_web_transaction?,
       :require_test_helper,
+      :set_error_group_callabck,
       :set_sql_obfuscator,
       :set_transaction_name,
       :shutdown,

--- a/test/new_relic/agent/error_collector_test.rb
+++ b/test/new_relic/agent/error_collector_test.rb
@@ -600,6 +600,72 @@ module NewRelic::Agent
         assert_nothing_harvested_for_segment_errors
       end
 
+      def test_build_customer_callback_hash
+        custom_attributes = {billie_eilish: :bored}
+        agent_attributes = {'http.statusCode': :bleachers__dont_take_the_money}
+        intrinsic_attributes = {'http.method': :walk_the_moon__anna_sun}
+        request_uri = :alternative_music
+        options = {taylor_swift: :maroon}
+        expected = true
+        error = StandardError.new
+
+        noticed_error = NewRelic::NoticedError.new(:watermelon, error)
+        noticed_error.instance_variable_set(:@processed_attributes,
+          {NewRelic::NoticedError::USER_ATTRIBUTES => custom_attributes,
+           NewRelic::NoticedError::AGENT_ATTRIBUTES => agent_attributes,
+           NewRelic::NoticedError::INTRINSIC_ATTRIBUTES => intrinsic_attributes})
+        noticed_error.request_uri = request_uri
+        noticed_error.expected = expected
+        hash = @error_collector.send(:build_customer_callback_hash, noticed_error, error, options)
+
+        assert_equal hash[:error], error
+        assert_equal hash[:customAttributes], custom_attributes
+        assert_equal hash[:'request.uri'], request_uri
+        assert_equal hash[:'http.statusCode'], agent_attributes[:'http.statusCode']
+        assert_equal hash[:'http.method'], intrinsic_attributes[:'http.method']
+        assert_equal hash[:'error.expected'], expected
+        assert_equal hash[:options], options
+      end
+
+      def test_update_error_group_name_returns_nil_unless_a_callback_has_been_registered
+        # because the build_customer_callback_hash method will call
+        # #custom_attributes on the noticed error object, and we're passing in
+        # nil for it, it would error out if the early return we're testing for
+        # did not return
+        @error_collector.stub(:error_group_callback, nil) do
+          assert_nil @error_collector.send(:update_error_group_name, nil, nil, nil)
+        end
+      end
+
+      def test_update_error_group_name_updates_the_error_group_name
+        error = ArgumentError.new
+        error_group = 'lucky tiger'
+        noticed_error = NewRelic::NoticedError.new(:watermelon, error)
+        NewRelic::Agent.set_error_group_callback(proc { |hash| error_group if error.is_a?(ArgumentError) })
+        @error_collector.send(:update_error_group_name, noticed_error, error, {})
+
+        assert_equal error_group, noticed_error.error_group
+      ensure
+        NewRelic::Agent.remove_instance_variable(:@error_group_callback)
+      end
+
+      def test_update_error_group_logs_if_an_error_is_rescued
+        skip_unless_minitest5_or_above
+
+        logger = MiniTest::Mock.new
+        # have #error return a phony value just for the purpose of being able
+        # to supply this test with at least 1 assertion. really, the #verify
+        # call to the mock should suffice, but it's nice to have assertions
+        phony_return = :yep_i_was_indeed_called
+        logger.expect :error, phony_return, [/Failed to obtain/]
+        @error_collector.stub(:error_group_callback, -> { raise 'kaboom' }) do
+          NewRelic::Agent.stub :logger, logger do
+            assert_equal phony_return, @error_collector.send(:update_error_group_name, nil, nil, nil)
+          end
+        end
+        logger.verify
+      end
+
       private
 
       # Segment errors utilize the error_collector's filtering for LASP

--- a/test/new_relic/agent_test.rb
+++ b/test/new_relic/agent_test.rb
@@ -572,6 +572,15 @@ module NewRelic
       NewRelic::Agent.remove_instance_variable(:@error_group_callback)
     end
 
+    def test_successful_set_error_group_callback_api_invocation_produces_supportability_metrics
+      called = false
+      verification_proc = proc { |name| called = true if name == :set_error_group_callback }
+      NewRelic::Agent.stub :record_api_supportability_metric, verification_proc do
+        NewRelic::Agent.set_error_group_callback(proc {})
+      end
+      assert called
+    end
+
     private
 
     def with_unstarted_agent

--- a/test/new_relic/agent_test.rb
+++ b/test/new_relic/agent_test.rb
@@ -553,7 +553,7 @@ module NewRelic
       NewRelic::Agent.instance_variable_set(:@error_group_callback, nil)
 
       mock_logger = MiniTest::Mock.new
-      mock_logger.expect :error, nil, [/must be an instance of Proc/]
+      mock_logger.expect :error, nil, [/expected an argument of type Proc/]
 
       NewRelic::Agent.stub(:logger, mock_logger) do
         NewRelic::Agent.set_error_group_callback([])
@@ -561,6 +561,15 @@ module NewRelic
 
       mock_logger.verify
       assert_nil NewRelic::Agent.instance_variable_get(:@error_group_callback)
+    end
+
+    def test_error_group_callback_is_exposed
+      callback = 'lucky tiger'
+      NewRelic::Agent.instance_variable_set(:@error_group_callback, callback)
+
+      assert_equal callback, NewRelic::Agent.error_group_callback
+    ensure
+      NewRelic::Agent.remove_instance_variable(:@error_group_callback)
     end
 
     private

--- a/test/new_relic/noticed_error_test.rb
+++ b/test/new_relic/noticed_error_test.rb
@@ -306,6 +306,15 @@ class NewRelic::Agent::NoticedErrorTest < Minitest::Test
     assert_equal error_group, error.error_group
   end
 
+  def test_error_group_name_agent_attribute_is_set
+    error_group = 'spicy lavender'
+    error = NewRelic::NoticedError.new(@path, StandardError.new)
+    error.error_group = error_group
+    agent_attributes = error.agent_attributes
+
+    assert_equal error_group, agent_attributes[:'error.group.name']
+  end
+
   private
 
   def create_error(exception = StandardError.new)

--- a/test/new_relic/noticed_error_test.rb
+++ b/test/new_relic/noticed_error_test.rb
@@ -271,6 +271,43 @@ class NewRelic::Agent::NoticedErrorTest < Minitest::Test
     end
   end
 
+  def test_error_group_can_be_read
+    error_group = 'lucky tiger'
+    error = NewRelic::NoticedError.new(@path, StandardError.new)
+    error.instance_variable_set(:@error_group, error_group)
+
+    assert_equal error_group, error.error_group
+  end
+
+  def test_error_group_can_be_set
+    error_group = 'lucky tiger'
+    error = NewRelic::NoticedError.new(@path, StandardError.new)
+    error.error_group = error_group
+
+    assert_equal error_group, error.error_group
+  end
+
+  def test_error_group_setting_ignores_empty_strings
+    error = NewRelic::NoticedError.new(@path, StandardError.new)
+
+    assert_nil error.error_group
+
+    error.error_group = ''
+
+    assert_nil error.error_group
+  end
+
+  def test_error_group_setting_ignores_nil
+    error = NewRelic::NoticedError.new(@path, StandardError.new)
+    error_group = 'lucky tiger'
+    error.instance_variable_set(:@error_group, error_group)
+    error.error_group = nil
+
+    assert_equal error_group, error.error_group
+  end
+
+  private
+
   def create_error(exception = StandardError.new)
     noticed_error = NewRelic::NoticedError.new(@path, exception, @time)
     noticed_error.attributes = @attributes


### PR DESCRIPTION
Allow the customer to register a proc to be invoked on each noticed error in order to associate each noticed error with an error group

Changes made:

- A new public `set_error_group_callback` API method exists. It must be given a Ruby proc or lambda (must be of type `Proc`)
- When a noticed error is created by the error collector, it will invoke the callback with a hash of information about the error, and apply the resulting error group string (if returned) as the error group.
- Any noticed error with an error group property set will have that error group name present in its agent attributes with the key `error.group.name`.
- Internal errors (of which we only have a single stats hash related type currently) will now be routed through the error collector's method for creating a noticed error, thus ensuring the error group callback is invoked for the error.

resolves #1845 