### PR TITLE
Error inbox add set_user_id API method

### DIFF
--- a/lib/new_relic/agent.rb
+++ b/lib/new_relic/agent.rb
@@ -605,7 +605,7 @@ module NewRelic
       end
     end
 
-    # Set the user id for the current transaction
+    # Set the user id for the current transaction. When present, this value will be included in the agent attributes for transaction and error events as 'enduser.id'.
     #
     # @param [String] user_id    The user id to add to the current transaction attributes
     #

--- a/lib/new_relic/agent.rb
+++ b/lib/new_relic/agent.rb
@@ -605,6 +605,26 @@ module NewRelic
       end
     end
 
+    # Set the user id for the current transaction
+    #
+    # @param [String] user_id    The user id to add to the current transaction attributes
+    #
+    # @api public
+    def set_user_id(user_id)
+      record_api_supportability_metric(:set_user_id)
+
+      if user_id.nil? || user_id.empty?
+        ::NewRelic::Agent.logger.warn('NewRelic::Agent.set_user_id called with a nil or empty user id.')
+        return
+      end
+
+      default_destinations = NewRelic::Agent::AttributeFilter::DST_TRANSACTION_TRACER |
+        NewRelic::Agent::AttributeFilter::DST_TRANSACTION_EVENTS |
+        NewRelic::Agent::AttributeFilter::DST_ERROR_COLLECTOR
+
+      NewRelic::Agent::Transaction.add_agent_attribute('enduser.id', user_id, default_destinations)
+    end
+
     # @!endgroup
 
     # @!group Transaction naming

--- a/lib/new_relic/agent.rb
+++ b/lib/new_relic/agent.rb
@@ -622,7 +622,7 @@ module NewRelic
         NewRelic::Agent::AttributeFilter::DST_TRANSACTION_EVENTS |
         NewRelic::Agent::AttributeFilter::DST_ERROR_COLLECTOR
 
-      NewRelic::Agent::Transaction.add_agent_attribute('enduser.id', user_id, default_destinations)
+      NewRelic::Agent::Transaction.add_agent_attribute(:'enduser.id', user_id, default_destinations)
     end
 
     # @!endgroup

--- a/lib/new_relic/supportability_helper.rb
+++ b/lib/new_relic/supportability_helper.rb
@@ -46,6 +46,7 @@ module NewRelic
       :require_test_helper,
       :set_sql_obfuscator,
       :set_transaction_name,
+      :set_user_id,
       :shutdown,
       :start_segment,
       :trace,

--- a/test/new_relic/agent_test.rb
+++ b/test/new_relic/agent_test.rb
@@ -73,6 +73,9 @@ module NewRelic
         refute NewRelic::Agent.config[:'transaction_tracer.enabled']
         refute NewRelic::Agent.config[:'error_collector.enabled']
       end
+
+      # resets the SSC to empty
+      NewRelic::Agent.config.replace_or_add_config(NewRelic::Agent::Configuration::ServerSource.new({}))
     end
 
     def test_after_fork
@@ -526,6 +529,33 @@ module NewRelic
         end
 
         break if stack.empty?
+      end
+    end
+
+    def test_set_user_id_attribute
+      test_user = 'test_user_id'
+
+      reset_error_traces!
+      in_transaction do |txn|
+        NewRelic::Agent.set_user_id(test_user)
+        NewRelic::Agent.notice_error(NewRelic::TestHelpers::Exceptions::TestError.new)
+      end
+
+      [harvest_transaction_events!, harvest_error_events!].each do |events|
+        assert_equal events[1][0][2]['enduser.id'], test_user
+      end
+    end
+
+    def test_set_user_id_nil_or_empty_error
+      [nil, ''].each do |test_user_id|
+        in_transaction do |txn|
+          NewRelic::Agent.set_user_id(nil)
+          NewRelic::Agent.notice_error(NewRelic::TestHelpers::Exceptions::TestError.new)
+        end
+
+        [harvest_transaction_events!, harvest_error_events!].each do |events|
+          refute events[1][0][2].key?('enduser.id')
+        end
       end
     end
 

--- a/test/new_relic/agent_test.rb
+++ b/test/new_relic/agent_test.rb
@@ -553,7 +553,7 @@ module NewRelic
         end
 
         [harvest_transaction_events!, harvest_error_events!].each do |events|
-          refute events[1][0][2].key?('enduser.id')
+          refute events[1][0][2].key?(:'enduser.id')
         end
       end
     end

--- a/test/new_relic/agent_test.rb
+++ b/test/new_relic/agent_test.rb
@@ -548,7 +548,7 @@ module NewRelic
     def test_set_user_id_nil_or_empty_error
       [nil, ''].each do |test_user_id|
         in_transaction do |txn|
-          NewRelic::Agent.set_user_id(nil)
+          NewRelic::Agent.set_user_id(test_user_id)
           NewRelic::Agent.notice_error(NewRelic::TestHelpers::Exceptions::TestError.new)
         end
 

--- a/test/new_relic/agent_test.rb
+++ b/test/new_relic/agent_test.rb
@@ -535,7 +535,6 @@ module NewRelic
     def test_set_user_id_attribute
       test_user = 'test_user_id'
 
-      reset_error_traces!
       in_transaction do |txn|
         NewRelic::Agent.set_user_id(test_user)
         NewRelic::Agent.notice_error(NewRelic::TestHelpers::Exceptions::TestError.new)

--- a/test/new_relic/agent_test.rb
+++ b/test/new_relic/agent_test.rb
@@ -541,7 +541,7 @@ module NewRelic
       end
 
       [harvest_transaction_events!, harvest_error_events!].each do |events|
-        assert_equal events[1][0][2]['enduser.id'], test_user
+        assert_equal events[1][0][2][:'enduser.id'], test_user
       end
     end
 


### PR DESCRIPTION
Adds the api method `NewRelic::Agent.set_user_id`.

closes https://github.com/newrelic/newrelic-ruby-agent/issues/1847