### PR TITLE
NoticedError: remove defunct request.uri feature

### DIFF
--- a/lib/new_relic/noticed_error.rb
+++ b/lib/new_relic/noticed_error.rb
@@ -141,21 +141,9 @@ class NewRelic::NoticedError
   end
 
   def build_agent_attributes(merged_attributes)
-    agent_attributes = if @attributes
-      @attributes.agent_attributes_for(DESTINATION)
-    else
-      NewRelic::EMPTY_HASH
-    end
+    return NewRelic::EMPTY_HASH unless @attributes
 
-    # It's possible to override the request_uri from the transaction attributes
-    # with a uri passed to notice_error. Add it to merged_attributes filter and
-    # merge with the transaction attributes, possibly overriding the request_uri
-    if request_uri
-      merged_attributes.add_agent_attribute(:'request.uri', request_uri, DESTINATION)
-      agent_attributes.merge(merged_attributes.agent_attributes_for(DESTINATION))
-    end
-
-    agent_attributes
+    @attributes.agent_attributes_for(DESTINATION)
   end
 
   def build_intrinsic_attributes


### PR DESCRIPTION
[1fcfbdd2f7970b68182895c5c792a8c288a01b53](https://github.com/newrelic/newrelic-ruby-agent/commit/1fcfbdd2f7970b68182895c5c792a8c288a01b53) introduced some custom logic to `NoticedError` to treat the request URI in a special manner.

[9f7636e5072db0c5d63257be59ec4701e16348de](https://github.com/newrelic/newrelic-ruby-agent/commit/9f7636e5072db0c5d63257be59ec4701e16348de) removed this custom logic, but did not do enough clean up. A comment and a code block remained that will no longer effect the noticed error's agent attributes hash.

Removed the defunct code.