### PR TITLE
Adds Amazon Timestream ActiveRecord Adapter

### DIFF
--- a/lib/new_relic/agent/instrumentation/active_record_helper.rb
+++ b/lib/new_relic/agent/instrumentation/active_record_helper.rb
@@ -200,7 +200,10 @@ module NewRelic
           'odbc' => 'ODBC',
 
           # https://rubygems.org/gems/activerecord-oracle_enhanced-adapter
-          'oracle_enhanced' => 'Oracle'
+          'oracle_enhanced' => 'Oracle',
+
+          # https://rubygems.org/gems/activerecord-amazon-timestream-adapter
+          'amazon_timestream' => 'Timestream'
         }.freeze
 
         ACTIVE_RECORD_DEFAULT_PRODUCT_NAME = 'ActiveRecord'.freeze


### PR DESCRIPTION
# Overview
This pull request adds the [Amazon Timestream ActiveRecord Adapter](https://rubygems.org/gems/activerecord-amazon-timestream-adapter) to the list of known AR adapters. I don't know which are the requirements for relevance here, but if this gem doesn't meet them, let me know.

Submitter Checklist:
- ~[ ] Include a link to the related GitHub issue, if applicable~ N/A
- ~[ ] Include a security review link, if applicable~ N/A

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
