### PR TITLE
Add safe navigation to parent.name in warn message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,14 @@
 
 ## dev
 
-  Upcoming version identifies the Amazon Timesteam data store, removes Distributed Tracing warnings from agent logs when using Sidekiq, fixes a bug regarding logged request headers, and is tested against the recently released JRuby 9.4.2.0.
+  Upcoming version identifies the Amazon Timesteam data store, removes Distributed Tracing warnings from agent logs when using Sidekiq, fixes bugs, and is tested against the recently released JRuby 9.4.2.0.
 
 
 - **Identify Amazon Timestream when the amazon_timestream AR adapter is used**
 
   When the agent sees the [activerecord-amazon-timestream-adapter](https://rubygems.org/gems/activerecord-amazon-timestream-adapter) gem being used, it will now identify the data store as "Timestream". Thanks very much to [@wagner](https://github.com/wagner) for contributing this enhancement! [PR#1872](https://github.com/newrelic/newrelic-ruby-agent/pull/1872)
 
-- **Bugfix: Removes Distributed Tracing related warnings from agent logs when headers are not present in Sidekiq**
+- **Bugfix: Remove Distributed Tracing related warnings from agent logs when headers are not present in Sidekiq**
 
   Previously, the agent would log a warning to `newrelic_agent.log` every time it attempted to accept empty Distributed Tracing headers from Sidekiq jobs which could result in an excessive number of warnings. Now the agent will no longer create these warnings when using Sidekiq. [PR#1834](https://github.com/newrelic/newrelic-ruby-agent/pull/1834)
 
@@ -17,11 +17,15 @@
 
   Previously, the agent sometimes received children of the `NewRelic::Agent::HTTPClients::AbstractRequest` class as an argument when `NewRelic::Agent::Transaction::DistributedTracers#log_request_headers` was called. This caused debug-level log messages that print the request headers to show human-readable Objects (ex. `#<NewRelic::Agent::HTTPClients::HTTPClientRequest:0x00007fd0dda983e0>`) instead of the request headers. Now, the hash of the request headers should always be logged. [PR#1839](https://github.com/newrelic/newrelic-ruby-agent/pull/1839)
 
-- **Bugfix: Undefined method `controller_path` logged in Action Controller Instrumentation**
+- **Bugfix: Fix undefined method `controller_path` logged in Action Controller Instrumentation**
 
   Previously, the agent could log an error when trying to determine the metric name in the Action Controller instrumentation if the controller class did not respond to `controller_path`. This has been resolved and the agent will no longer call this method unless the class responds to it. Thank you to [@gsar](https://github.com/gsar) for letting us know about this issue. [PR#1844](https://github.com/newrelic/newrelic-ruby-agent/pull/1844)
 
-- **CI: target JRuby 9.4.2.0**
+- **Bugfix: Fix Transaction#finish exception and decrease log level for related warning during async transactions**
+
+  Previously, the agent would raise a non-fatal error when a segment without a parent was unfinished when the transaction completed. This error was raised while constructing a `warn`-level log message. Now that Thread instrumentatation is on by default, this log message emits more frequently and is less concerning. In cases where we see a Thread, Fiber, or concurrent-ruby segment in a transaction, the message will be degraded to a `debug`-level. Thanks to [@NielsKSchjoedt](https://github.com/NielsKSchjoedt) for creating the issue and [@boomer196](https://github.com/boomer196) for testing solutions. [PR#1876](https://github.com/newrelic/newrelic-ruby-agent/pull/1876)
+
+- **CI: Target JRuby 9.4.2.0**
 
   The agent is now actively being tested against JRuby 9.4.2.0. NOTE that this release does not contain any non-CI related changes for JRuby. Old agent versions are still expected to work with newer JRubies and the newest agent version is still expected to work with older JRubies.
 

--- a/lib/new_relic/agent/tracer.rb
+++ b/lib/new_relic/agent/tracer.rb
@@ -426,6 +426,7 @@ module NewRelic
             begin
               if current_txn
                 NewRelic::Agent::Tracer.state.current_transaction = current_txn
+                transaction.async = true
                 segment_name += "/Thread#{::Thread.current.object_id}/Fiber#{::Fiber.current.object_id}" if NewRelic::Agent.config[:'thread_ids_enabled']
                 segment = NewRelic::Agent::Tracer.start_segment(name: segment_name, parent: parent)
               end

--- a/lib/new_relic/agent/tracer.rb
+++ b/lib/new_relic/agent/tracer.rb
@@ -426,7 +426,7 @@ module NewRelic
             begin
               if current_txn
                 NewRelic::Agent::Tracer.state.current_transaction = current_txn
-                transaction.async = true
+                current_txn.async = true
                 segment_name += "/Thread#{::Thread.current.object_id}/Fiber#{::Fiber.current.object_id}" if NewRelic::Agent.config[:'thread_ids_enabled']
                 segment = NewRelic::Agent::Tracer.start_segment(name: segment_name, parent: parent)
               end

--- a/lib/new_relic/agent/transaction/abstract_segment.rb
+++ b/lib/new_relic/agent/transaction/abstract_segment.rb
@@ -262,10 +262,9 @@ module NewRelic
 
         def force_finish
           finish
-          message = "Segment: #{name} was unfinished at " \
+          NewRelic::Agent.logger.send(transaction.async? ? :debug : :warn, "Segment: #{name} was unfinished at " \
             "the end of transaction. Timing information for this segment's " \
-            "parent #{parent&.name} in #{transaction.best_name} may be inaccurate."
-          transaction.async? ? NewRelic::Agent.logger.debug(message) : NewRelic::Agent.logger.warn(message)
+            "parent #{parent&.name} in #{transaction.best_name} may be inaccurate.")
         end
 
         def run_complete_callbacks

--- a/lib/new_relic/agent/transaction/abstract_segment.rb
+++ b/lib/new_relic/agent/transaction/abstract_segment.rb
@@ -262,7 +262,7 @@ module NewRelic
 
         def force_finish
           finish
-          NewRelic::Agent.logger.warn("Segment: #{name} was unfinished at " \
+          NewRelic::Agent.logger.debug("Segment: #{name} was unfinished at " \
             "the end of transaction. Timing information for this segment's " \
             "parent #{parent&.name} in #{transaction.best_name} may be inaccurate.")
         end

--- a/lib/new_relic/agent/transaction/abstract_segment.rb
+++ b/lib/new_relic/agent/transaction/abstract_segment.rb
@@ -262,9 +262,10 @@ module NewRelic
 
         def force_finish
           finish
-          NewRelic::Agent.logger.debug("Segment: #{name} was unfinished at " \
+          message = "Segment: #{name} was unfinished at " \
             "the end of transaction. Timing information for this segment's " \
-            "parent #{parent&.name} in #{transaction.best_name} may be inaccurate.")
+            "parent #{parent&.name} in #{transaction.best_name} may be inaccurate."
+          transaction.async? ? NewRelic::Agent.logger.debug(message) : NewRelic::Agent.logger.warn(message)
         end
 
         def run_complete_callbacks

--- a/lib/new_relic/agent/transaction/abstract_segment.rb
+++ b/lib/new_relic/agent/transaction/abstract_segment.rb
@@ -263,8 +263,8 @@ module NewRelic
         def force_finish
           finish
           NewRelic::Agent.logger.warn("Segment: #{name} was unfinished at " \
-            "the end of transaction. Timing information for this segment's " \
-            "parent #{parent.name} in #{transaction.best_name} may be inaccurate.")
+            "the end of transaction. Timing information for this segment's" \
+            "parent #{parent&.name} in #{transaction.best_name} may be inaccurate.")
         end
 
         def run_complete_callbacks

--- a/lib/new_relic/agent/transaction/abstract_segment.rb
+++ b/lib/new_relic/agent/transaction/abstract_segment.rb
@@ -263,7 +263,7 @@ module NewRelic
         def force_finish
           finish
           NewRelic::Agent.logger.warn("Segment: #{name} was unfinished at " \
-            "the end of transaction. Timing information for this segment's" \
+            "the end of transaction. Timing information for this segment's " \
             "parent #{parent&.name} in #{transaction.best_name} may be inaccurate.")
         end
 


### PR DESCRIPTION
# Overview

Asynchronous segments may not be finished before the current transaction finishes. This can cause segments to have inaccurate timing information. In Ruby agent 9.0.0, a `NoMethodError` may be raised in these scenarios while a transaction finishes: 

  ```
  [2023-03-06 15:13:18 +0100 web-01 (8675309)] ERROR : Exception during Transaction#finish
  [2023-03-06 15:13:18 +0100 web-01 (8675309)] ERROR : NoMethodError: undefined method `name' for nil:NilClass
  ```

This exception is thrown while issuing a `warn`-level log stating a segment without a parent was unfinished when the transaction finished. This exception should not stop transactions from being harvested.

We've issued a fix that does two things: 
  1. Make sure the `NoMethodError` is not raised by adding a safe navigation operator to the nil object 
  2. Decrease the severity of the logged messages to `debug` level instead of `warn` level when a transaction contains a Thread, Fiber, or concurrent-ruby segment

Closes #1859