### PR TITLE
NoticedError: update attr cache for error group

### DIFF
--- a/lib/new_relic/noticed_error.rb
+++ b/lib/new_relic/noticed_error.rb
@@ -143,15 +143,9 @@ class NewRelic::NoticedError
   end
 
   def build_agent_attributes(merged_attributes)
-    return error_group_hash unless @attributes
+    return NewRelic::EMPTY_HASH unless @attributes
 
-    @attributes.agent_attributes_for(DESTINATION).merge(error_group_hash)
-  end
-
-  def error_group_hash
-    return NewRelic::EMPTY_HASH unless error_group
-
-    {AGENT_ATTRIBUTE_ERROR_GROUP => error_group}
+    @attributes.agent_attributes_for(DESTINATION)
   end
 
   def build_intrinsic_attributes
@@ -196,6 +190,13 @@ class NewRelic::NoticedError
 
   def error_group=(name)
     return if name.nil? || name.empty?
+
+    if processed_attributes[AGENT_ATTRIBUTES].frozen?
+      processed_attributes[AGENT_ATTRIBUTES] =
+        processed_attributes[AGENT_ATTRIBUTES].merge(AGENT_ATTRIBUTE_ERROR_GROUP => name)
+    else
+      processed_attributes[AGENT_ATTRIBUTES] = name
+    end
 
     @error_group = name
   end

--- a/test/new_relic/agent_test.rb
+++ b/test/new_relic/agent_test.rb
@@ -592,9 +592,8 @@ module NewRelic
         NewRelic::Agent.notice_error(NewRelic::TestHelpers::Exceptions::TestError.new)
       end
 
-      [harvest_transaction_events!, harvest_error_events!].each do |events|
-        assert_equal events[1][0][2][:'enduser.id'], test_user
-      end
+      assert_equal test_user, harvest_transaction_events![1][0][2][:'enduser.id']
+      assert_equal test_user, harvest_error_events![1][0][2][:'enduser.id']
     end
 
     def test_set_user_id_nil_or_empty_error


### PR DESCRIPTION
`NewRelic::Agent::ErrorCollector#create_noticed_error`, which is the sole consumer of `NoticedError#error_group=`, ends up calling `NoticedError#processed_attributes` fully 3 times in order to build the hash that is passed to the customer error group callback.

As a result, the agent attributes for the noticed error end up being memoized. Because of the memoization, the agent attributes hash is not rebuilt later on when it comes time to submit those attributes to the collector.

Updated `NoticedError#error_group=` to effectively bust the memoization cache and ensure that the error group name makes it into the agent attributes hash.