### PR TITLE
Move constant above RDoc

### DIFF
--- a/lib/new_relic/agent.rb
+++ b/lib/new_relic/agent.rb
@@ -210,6 +210,8 @@ module NewRelic
       record_metric(metric_name, value)
     end
 
+    SUPPORTABILITY_INCREMENT_METRIC = 'Supportability/API/increment_metric'.freeze
+
     # Increment a simple counter metric.
     #
     # +metric_name+ should follow a slash separated path convention. Application
@@ -218,9 +220,7 @@ module NewRelic
     # This method is safe to use from any thread.
     #
     # @api public
-
-    SUPPORTABILITY_INCREMENT_METRIC = 'Supportability/API/increment_metric'.freeze
-
+    #
     def increment_metric(metric_name, amount = 1) # THREAD_LOCAL_ACCESS
       return unless agent
 


### PR DESCRIPTION
The current location of this constant displays its content instead of the method definition in RDoc.

I haven't been able to test this, so it may not fix the problem. 

Here's a link to the page: https://rubydoc.info/github/newrelic/newrelic-ruby-agent/NewRelic/Agent

See the heading "Recording custom metrics"