### PR TITLE
What if agent attributes isn't frozen

### DIFF
--- a/lib/new_relic/noticed_error.rb
+++ b/lib/new_relic/noticed_error.rb
@@ -191,11 +191,10 @@ class NewRelic::NoticedError
   def error_group=(name)
     return if name.nil? || name.empty?
 
-    if processed_attributes[AGENT_ATTRIBUTES].frozen?
-      processed_attributes[AGENT_ATTRIBUTES] =
-        processed_attributes[AGENT_ATTRIBUTES].merge(AGENT_ATTRIBUTE_ERROR_GROUP => name)
+    if agent_attributes.frozen?
+      processed_attributes[AGENT_ATTRIBUTES] = agent_attributes.merge(AGENT_ATTRIBUTE_ERROR_GROUP => name)
     else
-      processed_attributes[AGENT_ATTRIBUTES] = name
+      agent_attributes[AGENT_ATTRIBUTE_ERROR_GROUP] = name
     end
 
     @error_group = name

--- a/test/new_relic/noticed_error_test.rb
+++ b/test/new_relic/noticed_error_test.rb
@@ -315,6 +315,16 @@ class NewRelic::Agent::NoticedErrorTest < Minitest::Test
     assert_equal error_group, agent_attributes[:'error.group.name']
   end
 
+  def test_noticed_errors_group_is_not_frozen
+    error_group = 'mint tea'
+    exception = RuntimeError.new
+    noticed_error = ::NewRelic::NoticedError.new('www.mint_tea.com', exception)
+    noticed_error.instance_variable_set(:@processed_attributes, {noticed_error.class::AGENT_ATTRIBUTES => {}})
+    noticed_error.send(:error_group=, error_group)
+
+    assert_equal error_group, noticed_error.agent_attributes[::NewRelic::NoticedError::AGENT_ATTRIBUTE_ERROR_GROUP]
+  end
+
   private
 
   def create_error(exception = StandardError.new)


### PR DESCRIPTION
Previously, we were incorrectly adding error_group to agent attributes in the case of an unfrozen attributes hash. We are now correctly doing this and added a corresponding test!