### PR TITLE
Skip errored Sidekiq/Redis test for Ruby 3.1

### DIFF
--- a/test/multiverse/suites/sidekiq/sidekiq_with_redis_test.rb
+++ b/test/multiverse/suites/sidekiq/sidekiq_with_redis_test.rb
@@ -34,7 +34,8 @@ class SidekiqWithRedisTest < MiniTest::Test
   # NOTE: Because Sidekiq v7.0+ can use `redis-client` without `redis`, this
   #       test brings in the `redis` gem directly via `bundler/inline`
   def test_redis_client_pipelined_calls_work
-    skip 'Testing conducted only using Sidekiq v7.0+ with redis not yet bundled' unless sidekiq_without_redis?
+    skip 'The CI fails when trying to run this test because of a Bundler error' if RUBY_VERSION.match?(/^3\.1/)
+    # skip 'Testing conducted only using Sidekiq v7.0+ with redis not yet bundled' unless sidekiq_without_redis?
 
     gemfile do
       source 'https://rubygems.org'

--- a/test/multiverse/suites/sidekiq/sidekiq_with_redis_test.rb
+++ b/test/multiverse/suites/sidekiq/sidekiq_with_redis_test.rb
@@ -35,7 +35,7 @@ class SidekiqWithRedisTest < MiniTest::Test
   #       test brings in the `redis` gem directly via `bundler/inline`
   def test_redis_client_pipelined_calls_work
     skip 'The CI fails when trying to run this test because of a Bundler error' if RUBY_VERSION.match?(/^3\.1/)
-    # skip 'Testing conducted only using Sidekiq v7.0+ with redis not yet bundled' unless sidekiq_without_redis?
+    skip 'Testing conducted only using Sidekiq v7.0+ with redis not yet bundled' unless sidekiq_without_redis?
 
     gemfile do
       source 'https://rubygems.org'


### PR DESCRIPTION
The error showed up on the CI last night for only Ruby 3.1

```
SidekiqWithRedisTest#test_redis_client_pipelined_calls_work:
Bundler::InstallError: Bundler::DirectoryRemovalError: Could not delete previous installation of `/opt/hostedtoolcache/Ruby/3.1.3/x64/lib/ruby/gems/3.1.0/gems/redis-5.0.6`.
The underlying error was ArgumentError: parent directory is world writable, Bundler::FileUtils#remove_entry_secure does not work
```

This PR skips the test for Ruby 3.1

There's a separate issue to fix the error: #1894 