### PR TITLE
restore railsedge testing

### DIFF
--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -54,7 +54,6 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby-version }}
 
-        # ,railsedge goes in 2.7+
       - name: Set up mini-envs for ruby version
         uses: kanga333/variable-mapper@master
         with:
@@ -71,16 +70,16 @@ jobs:
                 "rails": "norails,rails61,rails60,rails52,rails51,rails42"
               },
               "2.7.7": {
-                "rails": "norails,rails61,rails60,rails70"
+                "rails": "norails,rails61,rails60,rails70,railsedge"
               },
               "3.0.5": {
-                "rails": "norails,rails61,rails60,rails70"
+                "rails": "norails,rails61,rails60,rails70,railsedge"
               },
               "3.1.3": {
-                "rails": "norails,rails61,rails70"
+                "rails": "norails,rails61,rails70,railsedge"
               },
               "3.2.1": {
-                "rails": "norails,rails61,rails70"
+                "rails": "norails,rails61,rails70,railsedge"
               }
             }
 


### PR DESCRIPTION
test Rails EDGE with Ruby 2.7+ on nightly CI runs

issue 1775 seems to have been addressed in the Rails code itself or possibly in a dependent gem update