### PR TITLE
Dalli: update TODOs, test fewer versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # New Relic Ruby Agent Release Notes
 
+## dev
+
+- **Feature: Deprecate memcached and memcache-client instrumentation**
+
+  Instrumentation for the memcached and memcache-client libraries is deprecated and will be removed during the next major release.
+
 ## v9.1.0
 
   Version 9.1.0 of the agent delivers support for two new [errors inbox](https://docs.newrelic.com/docs/errors-inbox/errors-inbox/) features: error fingerprinting and user tracking, identifies the Amazon Timestream data store, removes Distributed Tracing warnings from agent logs when using Sidekiq, fixes bugs, and is tested against the recently released JRuby 9.4.2.0.

--- a/lib/new_relic/agent/instrumentation/memcache/dalli.rb
+++ b/lib/new_relic/agent/instrumentation/memcache/dalli.rb
@@ -58,7 +58,9 @@ module NewRelic
             end.class_eval do
               include NewRelic::Agent::Instrumentation::Memcache::Tracer
 
-              # TODO: Dalli - 3.1.0 renamed send_multiget to pipelined_get, but the method is otherwise the same
+              # TODO: MAJOR VERSION
+              # Dalli - 3.1.0 renamed send_multiget to pipelined_get, but the method is otherwise the same
+              # Once we no longer support Dalli < 3.1.0, remove this conditional logic
               if Gem::Version.new(::Dalli::VERSION) >= Gem::Version.new('3.1.0')
                 alias_method(:pipelined_get_without_newrelic_trace, :pipelined_get)
                 def pipelined_get(keys)

--- a/lib/new_relic/agent/instrumentation/memcache/prepend.rb
+++ b/lib/new_relic/agent/instrumentation/memcache/prepend.rb
@@ -84,7 +84,9 @@ module NewRelic::Agent::Instrumentation
           extend Helper
           include NewRelic::Agent::Instrumentation::Memcache::Tracer
 
-          # TODO: Dalli - 3.1.0 renamed send_multiget to pipelined_get, but the method is otherwise the same
+          # TODO: MAJOR VERSION
+          # Dalli - 3.1.0 renamed send_multiget to pipelined_get, but the method is otherwise the same
+          # Once we no longer support Dalli < 3.1.0, remove this conditional logic
           if Gem::Version.new(::Dalli::VERSION) >= Gem::Version.new('3.1.0')
             def pipelined_get(keys)
               send_multiget_with_newrelic_tracing(keys) { super }

--- a/test/multiverse/suites/memcache/Envfile
+++ b/test/multiverse/suites/memcache/Envfile
@@ -2,41 +2,23 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
-require File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "..", "helpers", "docker"))
+require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..', 'helpers', 'docker'))
 
-if RUBY_VERSION >= '2.6.0'
-  gemfile <<~RB
-    gem 'dalli'
-  RB
-
-  gemfile <<~RB
-    gem 'dalli', '3.2.0'
-  RB
-
-  # 3.1.1 to 3.1.6 behave similarly
-  gemfile <<~RB
-    gem 'dalli', '3.1.6'
-  RB
-
-  # this version is a breaking change from the previous versions and also different from versions after it
-  gemfile <<~RB
-    gem 'dalli', '3.1.0'
-  RB
+# Dalli
+# TODO: MAJOR VERSION - drop support for versions older than 3.2.1
+DALLI_VERSIONS = [
+  [nil, 2.6],
+  ['= 3.1.0', 2.6],
+  ['3.0.2', 2.5],
+  ['= 2.7.11', 2.4],
+]
+def gem_list(version = nil)
+  "gem 'dalli'#{version}"
 end
+create_gemfiles(DALLI_VERSIONS)
 
-if RUBY_VERSION >= '2.5.0'
-  # TODO: MAJOR VERSION - Bump lowest version to 3.2.1 in version 9.0.0
-  gemfile <<~RB
-    gem 'dalli', '~> 3.0.2'
-  RB
-end
-
-%w(2.7.6 2.7.8 2.7.11).each do |version|
-  gemfile <<~RB
-    gem 'dalli', '~> #{version}'
-  RB
-end
-
+# memcache-client
+# TODO: MAJOR VERSION - drop support for memcache-client gem (defunct)
 %w(1.8.5 1.5.0).each do |version|
   # v 1.5.0 uses `timeout`, which does not exist in Ruby 3.1
   next if RUBY_VERSION >= '3.1.0' && version == '1.5.0'
@@ -45,6 +27,8 @@ end
   RB
 end
 
+# memcached
+# TODO: MAJOR VERSION - drop support for memcached gem (defunct)
 unless RUBY_PLATFORM == 'java' || RUBY_VERSION >= '3.2.0'
   gemfile <<~RB
     gem 'memcached', '~> 1.8.0'


### PR DESCRIPTION
For the Dalli (memcached client) instrumentation:

* Update the TODO comments to remind us of what needs doing for the next major release.
* Test fewer individual Dalli versions

addresses #1439 