### PR TITLE
Add ::Chain to end of instrumentation class names

### DIFF
--- a/lib/new_relic/agent/instrumentation/bunny.rb
+++ b/lib/new_relic/agent/instrumentation/bunny.rb
@@ -26,7 +26,7 @@ DependencyDetection.defer do
       prepend_instrument Bunny::Queue, NewRelic::Agent::Instrumentation::Bunny::Prepend::Queue
       prepend_instrument Bunny::Consumer, NewRelic::Agent::Instrumentation::Bunny::Prepend::Consumer
     else
-      chain_instrument NewRelic::Agent::Instrumentation::Bunny
+      chain_instrument NewRelic::Agent::Instrumentation::Bunny::Chain
     end
   end
 end

--- a/lib/new_relic/agent/instrumentation/bunny/chain.rb
+++ b/lib/new_relic/agent/instrumentation/bunny/chain.rb
@@ -3,7 +3,7 @@
 # frozen_string_literal: true
 
 module NewRelic::Agent::Instrumentation
-  module Bunny
+  module Bunny::Chain
     def self.instrument!
       ::Bunny::Exchange.class_eval do
         include NewRelic::Agent::Instrumentation::Bunny::Exchange

--- a/lib/new_relic/agent/instrumentation/elasticsearch.rb
+++ b/lib/new_relic/agent/instrumentation/elasticsearch.rb
@@ -25,7 +25,7 @@ DependencyDetection.defer do
     if use_prepend?
       prepend_instrument to_instrument, NewRelic::Agent::Instrumentation::Elasticsearch::Prepend
     else
-      chain_instrument NewRelic::Agent::Instrumentation::Elasticsearch
+      chain_instrument NewRelic::Agent::Instrumentation::Elasticsearch::Chain
     end
   end
 end

--- a/lib/new_relic/agent/instrumentation/elasticsearch/chain.rb
+++ b/lib/new_relic/agent/instrumentation/elasticsearch/chain.rb
@@ -3,7 +3,7 @@
 # frozen_string_literal: true
 
 module NewRelic::Agent::Instrumentation
-  module Elasticsearch
+  module Elasticsearch::Chain
     def self.instrument!
       to_instrument = if ::Gem::Version.create(::Elasticsearch::VERSION) <
           ::Gem::Version.create('8.0.0')

--- a/lib/new_relic/agent/instrumentation/fiber.rb
+++ b/lib/new_relic/agent/instrumentation/fiber.rb
@@ -19,7 +19,7 @@ DependencyDetection.defer do
     if use_prepend?
       prepend_instrument Fiber, NewRelic::Agent::Instrumentation::MonitoredFiber::Prepend
     else
-      chain_instrument NewRelic::Agent::Instrumentation::MonitoredFiber
+      chain_instrument NewRelic::Agent::Instrumentation::MonitoredFiber::Chain
     end
   end
 end

--- a/lib/new_relic/agent/instrumentation/fiber/chain.rb
+++ b/lib/new_relic/agent/instrumentation/fiber/chain.rb
@@ -3,7 +3,7 @@
 # frozen_string_literal: true
 
 module NewRelic::Agent::Instrumentation
-  module MonitoredFiber
+  module MonitoredFiber::Chain
     def self.instrument!
       ::Fiber.class_eval do
         include NewRelic::Agent::Instrumentation::MonitoredFiber

--- a/lib/new_relic/agent/instrumentation/memcache.rb
+++ b/lib/new_relic/agent/instrumentation/memcache.rb
@@ -58,7 +58,7 @@ DependencyDetection.defer do
         prepend_instrument client_class, instrumenting_module, 'MemcachedDalli'
       end
     else
-      chain_instrument NewRelic::Agent::Instrumentation::Memcache::Dalli
+      chain_instrument NewRelic::Agent::Instrumentation::Memcache::Dalli, 'MemcachedDalli'
     end
   end
 end
@@ -81,7 +81,7 @@ DependencyDetection.defer do
         prepend_instrument client_class, instrumenting_module, 'MemcachedDalliCAS'
       end
     else
-      chain_instrument NewRelic::Agent::Instrumentation::Memcache::DalliCAS
+      chain_instrument NewRelic::Agent::Instrumentation::Memcache::DalliCAS, 'MemcachedDalliCAS'
     end
   end
 end

--- a/lib/tasks/instrumentation_generator/templates/chain.tt
+++ b/lib/tasks/instrumentation_generator/templates/chain.tt
@@ -3,7 +3,7 @@
 # frozen_string_literal: true
 
 module NewRelic::Agent::Instrumentation
-  module <%= @class_name %>
+  module <%= @class_name %>::Chain
     def self.instrument!
       ::<%= @class_name %>.class_eval do
         include NewRelic::Agent::Instrumentation::<%= @class_name %>

--- a/lib/tasks/instrumentation_generator/templates/dependency_detection.tt
+++ b/lib/tasks/instrumentation_generator/templates/dependency_detection.tt
@@ -23,7 +23,7 @@ DependencyDetection.defer do
     if use_prepend?
       prepend_instrument ::<%= @class_name %>, NewRelic::Agent::Instrumentation::<%= @class_name %>::Prepend
     else
-      chain_instrument NewRelic::Agent::Instrumentation::<%= @class_name %>
+      chain_instrument NewRelic::Agent::Instrumentation::<%= @class_name %>::Chain
     end
   end
 end


### PR DESCRIPTION
`DependencyDetection#log_and_instrument` takes the second to last namespace and uses it in the
`Supportability/instrumention/#{supportability_name}/#{chain|prepend}` metrics

This was common in new instrumentation because the instrumentation generator templates didn't include `::Chain` (and the class I based the generator off of didn't have this either!)