### PR TITLE
Slack notification update

### DIFF
--- a/.github/workflows/slack_notifications.yml
+++ b/.github/workflows/slack_notifications.yml
@@ -8,7 +8,7 @@ jobs:
   gem_notifications:
     runs-on: ubuntu-22.04
     steps:
-      - uses: ruby/setup-ruby@v1.90.0
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.2
       - uses: actions/checkout@v2
@@ -40,7 +40,7 @@ jobs:
   cve_notifications:
     runs-on: ubuntu-22.04
     steps:
-      - uses: ruby/setup-ruby@v1.90.0
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.2
       - uses: actions/checkout@v2


### PR DESCRIPTION
Update Ruby setup.

From [setup-ruby docs](https://github.com/ruby/setup-ruby):
> Important: Prefer ruby/setup-ruby@v1. If you pin to a commit or release, only the Ruby versions available at the time of the commit will be available, and you will need to update it to use newer Ruby versions, see [Versioning](https://github.com/ruby/setup-ruby#versioning).

To keep up-to-date with new ruby versions, we stick to using us setup-ruby@v1