### PR TITLE
Update all GHA to use SHAs

### DIFF
--- a/.github/workflows/assignproj.yml
+++ b/.github/workflows/assignproj.yml
@@ -14,7 +14,7 @@ jobs:
     name: Assign to One Project
     steps:
     - name: Assign NEW issues and NEW pull requests to project 2
-      uses: srggrs/assign-one-project-github-action@1.2.0
+      uses: srggrs/assign-one-project-github-action@65a8ddab497df42ef268001e67bbf976f8fd39e1 # tag v1.3.1
       if: github.event.action == 'opened'
       with:
         project: 'https://github.com/orgs/newrelic/projects/17'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,8 @@ jobs:
     steps:
       - name: Configure git
         run: 'git config --global init.defaultBranch main'
-      - uses: actions/checkout@v3
-      - uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # tag v3.5.0
+      - uses: ruby/setup-ruby@55283cc23133118229fd3f97f9336ee23a179fcf # tag v1.146.0
         with:
           ruby-version: '3.2'
       - run: bundle
@@ -35,7 +35,7 @@ jobs:
     steps:
       - name: Configure git
         run: 'git config --global init.defaultBranch main'
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # tag v3.5.0
 
         # - curl is needed for Curb
         # - xslt is needed for older Nokogiris, RUBY_VERSION < 2.5
@@ -44,12 +44,12 @@ jobs:
         run: sudo apt-get update; sudo apt-get install -y --no-install-recommends libcurl4-nss-dev libsasl2-dev libxslt1-dev
 
       - name: Install Ruby ${{ matrix.ruby-version }}
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@55283cc23133118229fd3f97f9336ee23a179fcf # tag v1.146.0
         with:
           ruby-version: ${{ matrix.ruby-version }}
 
       - name: Set up mini-envs for ruby version
-        uses: kanga333/variable-mapper@master
+        uses: kanga333/variable-mapper@3681b75f5c6c00162721168fb91ab74925eaebcb # tag v0.3.0
         with:
           key: ${{ matrix.ruby-version }}
           map: |
@@ -69,7 +69,7 @@ jobs:
       - if: matrix.ruby-version == '2.4.10'
         name: Cache mysql55
         id: mysql55-cache
-        uses: actions/cache@v3.2.2
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # tag v3.3.1
         with:
           path: /usr/local/mysql55
           key: mysql55-install
@@ -85,7 +85,7 @@ jobs:
           RAILS_VERSION: ${{ env.rails }}
 
       - name: Run Unit Tests
-        uses: nick-fields/retry@v2.8.2
+        uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd # tag v2.8.3
         with:
           timeout_minutes: 30
           max_attempts: 2
@@ -96,7 +96,7 @@ jobs:
           COVERAGE: true
 
       - name: Save coverage results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # tag v3.1.2
         with:
           name: coverage-report-unit-tests
           path: lib/coverage_*/.resultset.json
@@ -188,7 +188,7 @@ jobs:
     steps:
       - name: Configure git
         run: 'git config --global init.defaultBranch main'
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # tag v3.5.0
 
         # - curl is needed for Curb
         # - xslt is needed for older Nokogiris, RUBY_VERSION < 2.5
@@ -197,7 +197,7 @@ jobs:
         run: sudo apt-get update; sudo apt-get install -y --no-install-recommends libcurl4-nss-dev libsasl2-dev libxslt1-dev
 
       - name: Install Ruby ${{ matrix.ruby-version }}
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@55283cc23133118229fd3f97f9336ee23a179fcf # tag v1.146.0
         with:
           ruby-version: ${{ matrix.ruby-version }}
 
@@ -209,7 +209,7 @@ jobs:
       - if: matrix.ruby-version == '2.4.10'
         name: Cache mysql55
         id: mysql55-cache
-        uses: actions/cache@v3.2.2
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # tag v3.3.1
         with:
           path: /usr/local/mysql55
           key: mysql55-install
@@ -225,7 +225,7 @@ jobs:
 
 
       - name: Wait for/Check Mysql
-        uses: nick-fields/retry@v2.8.2
+        uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd # tag v2.8.3
         with:
           timeout_minutes: 1
           max_attempts: 20
@@ -237,7 +237,7 @@ jobs:
 
 
       - name: Run Multiverse Tests
-        uses: nick-fields/retry@v2.8.2
+        uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd # tag v2.8.3
         with:
           timeout_minutes: 60
           max_attempts: 2
@@ -259,7 +259,7 @@ jobs:
         uses: ./.github/actions/annotate
 
       - name: Save coverage results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # tag v3.1.2
         with:
           name: coverage-report-multiverse
           path: lib/coverage_*/.resultset.json
@@ -269,7 +269,7 @@ jobs:
         run: rake test:multiverse:gem_manifest
 
       - name: Save gem manifest
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # tag v3.1.2
         with:
           name: gem_manifest_${{ matrix.ruby-version }}.json
           path: gem_manifest_${{ matrix.ruby-version }}.json
@@ -286,10 +286,10 @@ jobs:
     steps:
       - name: Configure git
         run: 'git config --global init.defaultBranch main'
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # tag v3.5.0
 
       - name: Install Ruby ${{ matrix.ruby-version }}
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@55283cc23133118229fd3f97f9336ee23a179fcf # tag v1.146.0
         with:
           ruby-version: ${{ matrix.ruby-version }}
 
@@ -297,7 +297,7 @@ jobs:
         run: bundle install
 
       - name: Run Multiverse Tests
-        uses: nick-fields/retry@v2.8.2
+        uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd # tag v2.8.3
         with:
           timeout_minutes: 15
           max_attempts: 2
@@ -312,7 +312,7 @@ jobs:
         uses: ./.github/actions/annotate
 
       - name: Save coverage results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # tag v3.1.2
         with:
           name: coverage-report-infinite-tracing
           path: lib/coverage_*/.resultset.json
@@ -325,17 +325,17 @@ jobs:
     steps:
       - name: Configure git
         run: 'git config --global init.defaultBranch main'
-      - uses: actions/checkout@v3
-      - uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # tag v3.5.0
+      - uses: ruby/setup-ruby@55283cc23133118229fd3f97f9336ee23a179fcf # tag v1.146.0
         with:
           ruby-version: '3.1'
       - run: bundle
       - name: Download all workflow run artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # tag v3.0.2
       - name: Collate Coverage Results
         run: bundle exec rake coverage:report
       - name: Upload coverage results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # tag v3.1.2
         with:
           name: coverage-report-combined
           path: lib/coverage_results

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -15,8 +15,8 @@ jobs:
     steps:
       - name: Configure git
         run: 'git config --global init.defaultBranch main'
-      - uses: actions/checkout@v3
-      - uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # tag v3.5.0
+      - uses: ruby/setup-ruby@55283cc23133118229fd3f97f9336ee23a179fcf # tag v1.146.0
         with:
           ruby-version: '3.2'
       - run: bundle
@@ -41,7 +41,7 @@ jobs:
     steps:
       - name: Configure git
         run: 'git config --global init.defaultBranch main'
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # tag v3.5.0
 
         # - curl is needed for Curb
         # - xslt is needed for older Nokogiris, RUBY_VERSION < 2.5
@@ -50,12 +50,12 @@ jobs:
         run: sudo apt-get update; sudo apt-get install -y --no-install-recommends libcurl4-nss-dev libsasl2-dev libxslt1-dev
 
       - name: Install Ruby ${{ matrix.ruby-version }}
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@55283cc23133118229fd3f97f9336ee23a179fcf # tag v1.146.0
         with:
           ruby-version: ${{ matrix.ruby-version }}
 
       - name: Set up mini-envs for ruby version
-        uses: kanga333/variable-mapper@master
+        uses: kanga333/variable-mapper@3681b75f5c6c00162721168fb91ab74925eaebcb # tag v0.3.0
         with:
           key: ${{ matrix.ruby-version }}
           map: |
@@ -90,7 +90,7 @@ jobs:
       - if: matrix.ruby-version == '2.4.10' || matrix.ruby-version == '2.5.9' || matrix.ruby-version == '2.6.10'
         name: Cache mysql55
         id: mysql55-cache
-        uses: actions/cache@v3.2.2
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # tag v3.3.1
         with:
           path: /usr/local/mysql55
           key: mysql55-install
@@ -106,7 +106,7 @@ jobs:
           RAILS_VERSION: ${{ env.rails }}
 
       - name: Run Unit Tests
-        uses: nick-fields/retry@v2.8.2
+        uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd # tag v2.8.3
         with:
           timeout_minutes: 30
           max_attempts: 2
@@ -200,7 +200,7 @@ jobs:
     steps:
       - name: Configure git
         run: 'git config --global init.defaultBranch main'
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # tag v3.5.0
 
         # - curl is needed for Curb
         # - xslt is needed for older Nokogiris, RUBY_VERSION < 2.5
@@ -209,7 +209,7 @@ jobs:
         run: sudo apt-get update; sudo apt-get install -y --no-install-recommends libcurl4-nss-dev libsasl2-dev libxslt1-dev
 
       - name: Install Ruby ${{ matrix.ruby-version }}
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@55283cc23133118229fd3f97f9336ee23a179fcf # tag v1.146.0
         with:
           ruby-version: ${{ matrix.ruby-version }}
 
@@ -220,7 +220,7 @@ jobs:
       - if: matrix.ruby-version == '2.4.10'
         name: Cache mysql55
         id: mysql55-cache
-        uses: actions/cache@v3.2.2
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # tag v3.3.1
         with:
           path: /usr/local/mysql55
           key: mysql55-install
@@ -236,7 +236,7 @@ jobs:
 
 
       - name: Wait for/Check Mysql
-        uses: nick-fields/retry@v2.8.2
+        uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd # tag v2.8.3
         with:
           timeout_minutes: 1
           max_attempts: 20
@@ -248,7 +248,7 @@ jobs:
 
 
       - name: Run Multiverse Tests
-        uses: nick-fields/retry@v2.8.2
+        uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd # tag v2.8.3
         with:
           timeout_minutes: 60
           max_attempts: 2
@@ -278,10 +278,10 @@ jobs:
     steps:
       - name: Configure git
         run: 'git config --global init.defaultBranch main'
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # tag v3.5.0
 
       - name: Install Ruby ${{ matrix.ruby-version }}
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@55283cc23133118229fd3f97f9336ee23a179fcf # tag v1.146.0
         with:
           ruby-version: ${{ matrix.ruby-version }}
 
@@ -289,7 +289,7 @@ jobs:
         run: bundle install
 
       - name: Run Multiverse Tests
-        uses: nick-fields/retry@v2.8.2
+        uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd # tag v2.8.3
         with:
           timeout_minutes: 15
           max_attempts: 2
@@ -309,8 +309,8 @@ jobs:
     runs-on: ubuntu-22.04
     if: always()
     steps:
-      - uses: technote-space/workflow-conclusion-action@v3
-      - uses: voxmedia/github-action-slack-notify-build@v1
+      - uses: technote-space/workflow-conclusion-action@45ce8e0eb155657ab8ccf346ade734257fd196a5 # tag v3.0.3
+      - uses: voxmedia/github-action-slack-notify-build@3665186a8c1a022b28a1dbe0954e73aa9081ea9e # v1.6.0
         if: ${{ env.WORKFLOW_CONCLUSION == 'failure' && github.event_name != 'workflow_dispatch' }}
         env:
           SLACK_BOT_TOKEN: ${{ secrets.RUBY_GITHUB_ACTIONS_BOT_WEBHOOK }}
@@ -326,13 +326,13 @@ jobs:
     runs-on: ubuntu-22.04
     if: always()
     steps:
-      - uses: technote-space/workflow-conclusion-action@v3
+      - uses: technote-space/workflow-conclusion-action@45ce8e0eb155657ab8ccf346ade734257fd196a5 # tag v3.0.3
       - run: echo ${{ github.event_name }}
-      - uses: Mercymeilya/last-workflow-status@v0.3.2
+      - uses: Mercymeilya/last-workflow-status@3418710aefe8556d73b6f173a0564d38bcfd9a43 # tag v0.3.3
         id: last_status
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: voxmedia/github-action-slack-notify-build@v1
+      - uses: voxmedia/github-action-slack-notify-build@3665186a8c1a022b28a1dbe0954e73aa9081ea9e # v1.6.0
         if: ${{ env.WORKFLOW_CONCLUSION == 'success' && steps.last_status.outputs.last_status == 'failure' && github.event_name != 'workflow_dispatch' }}
         env:
           SLACK_BOT_TOKEN: ${{ secrets.RUBY_GITHUB_ACTIONS_BOT_WEBHOOK }}

--- a/.github/workflows/ci_jruby.yml
+++ b/.github/workflows/ci_jruby.yml
@@ -21,10 +21,10 @@ jobs:
     steps:
       - name: Configure git
         run: 'git config --global init.defaultBranch main'
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # tag v3.5.0
 
       - name: Install Ruby jruby-9.4.2.0
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@55283cc23133118229fd3f97f9336ee23a179fcf # tag v1.146.0
         with:
           ruby-version: jruby-9.4.2.0
 
@@ -32,7 +32,7 @@ jobs:
         run: bundle install
 
       - name: Run Unit Tests
-        uses: nick-fields/retry@v2.8.2
+        uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd # tag v2.8.3
         with:
           timeout_minutes: 30
           max_attempts: 2
@@ -120,10 +120,10 @@ jobs:
         run: 'git config --global init.defaultBranch main'
 
       - name: Check out the source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # tag v3.5.0
 
       - name: Install JRuby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@55283cc23133118229fd3f97f9336ee23a179fcf # tag v1.146.0
         with:
           ruby-version: jruby-9.4.2.0
 

--- a/.github/workflows/label_community_cards.yml
+++ b/.github/workflows/label_community_cards.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Label community issue
-        uses: actions/github-script@v5
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # tag v6.4.1
         with:
          script: |
            github.rest.issues.addLabels({

--- a/.github/workflows/performance_tests.yml
+++ b/.github/workflows/performance_tests.yml
@@ -14,10 +14,10 @@ jobs:
     outputs:
       changed: ${{ steps.branch_change_output.outputs.has-new-commits }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # tag v3.5.0
       - name: check branch changes
         id: branch_change_output
-        uses: adriangl/check-new-commits-action@v1
+        uses: adriangl/check-new-commits-action@6556947ca20c2047ed733894258186619b84d282 # tag v1.0.6
         with:
           seconds: 604800
           branch: 'dev'
@@ -30,24 +30,24 @@ jobs:
       run:
         working-directory: ./test/performance
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # tag v3.5.0
         with:
           ref: 'main'
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@55283cc23133118229fd3f97f9336ee23a179fcf # tag v1.146.0
         with:
           ruby-version: '3.2'
       - run: bundle
       - run: script/runner -B
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # tag v3.5.0
       - run: bundle
       - run: script/runner -C -M > performance_results.md
       - name: Save performance results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # tag v3.1.2
         with:
           name: performance-test-results
           path: ./test/performance/performance_results.md
       - name: Slack results
-        uses: adrey/slack-file-upload-action@1.0.5
+        uses: adrey/slack-file-upload-action@903be3678c88966c762193f06530c39178b44d68 # tag v1.0.5
         with:
           token: ${{ secrets.RUBY_GITHUB_ACTIONS_BOT_WEBHOOK }}
           path: ./test/performance/performance_results.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,11 +9,11 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # tag v3.5.0
       with:
         fetch-depth: 0
 
-    - uses: ruby/setup-ruby@v1.90.0
+    - uses: ruby/setup-ruby@55283cc23133118229fd3f97f9336ee23a179fcf # tag v1.146.0
       with:
         ruby-version: 3.2
 
@@ -39,7 +39,7 @@ jobs:
         echo "VERSION=$(ls newrelic_rpm-*.gem | ruby -pe 'sub(/newrelic_rpm\-(.*).gem/, "\\1")')" >> $GITHUB_ENV
 
     - name: Create github release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # tag v0.1.15
       if: $(git tag -l ${{ env.VERSION }}) == false
       with:
         tag_name: ${{ env.VERSION }}

--- a/.github/workflows/release_notes.yml
+++ b/.github/workflows/release_notes.yml
@@ -9,11 +9,11 @@ jobs:
   send-pull-requests:
     runs-on: ubuntu-latest
     steps:
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@55283cc23133118229fd3f97f9336ee23a179fcf # tag v1.146.0
         with:
           ruby-version: 3.2
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # tag v3.5.0
 
       - name: Generate release notes and environment variables
         run: |
@@ -24,7 +24,7 @@ jobs:
         run: echo "source_file=$PWD/$(ruby -r $PWD/.github/workflows/scripts/generate_release_notes.rb -e GenerateReleaseNotes.new.file_name)" >> $GITHUB_ENV
 
       - name: Create branch
-        uses: dmnemec/copy_file_to_another_repo_action@main
+        uses: dmnemec/copy_file_to_another_repo_action@c93037aa10fa8893de271f19978c980d0c1a9b37 # tag v1.1.1
         env:
           API_TOKEN_GITHUB: ${{ secrets.NEWRELIC_RUBY_AGENT_BOT_TOKEN }}
         with:
@@ -38,7 +38,7 @@ jobs:
           commit_message: 'chore(ruby agent): add release notes'
 
       - name: Make pull request
-        uses: repo-sync/pull-request@v2
+        uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5 # tag v2.12.1
         with:
           github_token: ${{ secrets.NEWRELIC_RUBY_AGENT_BOT_TOKEN }}
           source_branch: ${{env.branch_name}}

--- a/.github/workflows/repolinter.yml
+++ b/.github/workflows/repolinter.yml
@@ -15,17 +15,17 @@ jobs:
     steps:
       - name: Test Default Branch
         id: default-branch
-        uses: actions/github-script@v2
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # tag v6.4.1
         with:
           script: |
-            const data = await github.repos.get(context.repo)
+            const data = await github.rest.repos.get(context.repo)
             return data.data && data.data.default_branch === context.ref.split('/').slice(-1)[0]
       - name: Checkout Self
         if: ${{ steps.default-branch.outputs.result == 'true' }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # tag v3.5.0
       - name: Run Repolinter
         if: ${{ steps.default-branch.outputs.result == 'true' }}
-        uses: newrelic/repolinter-action@v1
+        uses: newrelic/repolinter-action@3f4448f855c351e9695b24524a4111c7847b84cb # tag v1.7.0
         with:
           config_url: https://raw.githubusercontent.com/newrelic/.github/main/repolinter-rulesets/community-plus.yml
           output_type: issue

--- a/.github/workflows/slack_notifications.yml
+++ b/.github/workflows/slack_notifications.yml
@@ -8,10 +8,10 @@ jobs:
   gem_notifications:
     runs-on: ubuntu-22.04
     steps:
-      - uses: ruby/setup-ruby@v1.90.0
+      - uses: ruby/setup-ruby@55283cc23133118229fd3f97f9336ee23a179fcf # tag v1.146.0
         with:
           ruby-version: 3.2
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # tag v3.5.0
       - run: gem install httparty
       - name: Check for outdated gems 
         run: ruby .github/workflows/scripts/slack_notifications/gem_notifier.rb ${{ env.gems }}
@@ -40,10 +40,10 @@ jobs:
   cve_notifications:
     runs-on: ubuntu-22.04
     steps:
-      - uses: ruby/setup-ruby@v1.90.0
+      - uses: ruby/setup-ruby@55283cc23133118229fd3f97f9336ee23a179fcf # tag v1.146.0
         with:
           ruby-version: 3.2
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # tag v3.5.0
       - run: gem install httparty
       - run: gem install feedjira
       - name: Check for CVEs

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -12,15 +12,15 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # tag v3.5.0
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1.90.0
+        uses: ruby/setup-ruby@55283cc23133118229fd3f97f9336ee23a179fcf # tag v1.146.0
         with:
           ruby-version: 3.2
       - name: Bundle
         run: bundle install
       - name: Run Snyk
-        uses: snyk/actions/ruby@master
+        uses: snyk/actions/ruby@7fad562681122205233d1242c3bb39598c5393da # tag v.3.0
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:


### PR DESCRIPTION
As part of security updates, all Actions versions now use a full-length SHA. 

Each one is using the latest stable version.

closes #1901 