### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Ruby agent code owners:
+*       @fallwith @hannahramadan @kaylareopelle @tannalynn


### PR DESCRIPTION
Add CODEOWNERS file. The presence of this file means that any changes to the newrelic-ruby-agent repository need to be reviewed by at least one code owner. This feature automatically requests reviews from the code owners when a PR changes any owned file (in this case, all of them).

Closes #1906