### PR TITLE
Add permissions to GITHUB_TOKEN

### DIFF
--- a/.github/workflows/assignproj.yml
+++ b/.github/workflows/assignproj.yml
@@ -4,8 +4,11 @@ on:
   issues:
     types: [opened]
 
+permissions:
+  issues: write
+
 env:
-  MY_GITHUB_TOKEN: ${{ secrets.RUBY_GITHUB_TOKEN }}
+  MY_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   assign_one_project:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,6 +322,8 @@ jobs:
     needs: [unit_tests, multiverse, infinite_tracing]
     runs-on: ubuntu-22.04
     if: github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      pull-requests: write
     steps:
       - name: Configure git
         run: 'git config --global init.defaultBranch main'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,8 @@ jobs:
     - name: Create github release
       uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # tag v0.1.15
       if: $(git tag -l ${{ env.VERSION }}) == false
+      permissions:
+        contents: write
       with:
         tag_name: ${{ env.VERSION }}
       env:


### PR DESCRIPTION
Actions that use `GITHUB_TOKEN` will be affected when GHA permissions are set to read-only (#1904) as a part of security updates. To allow these actions to continue working properly (write), we need to add `permissions` to the job. 

`GITHUB_TOKEN` exists in the following places: 

- `release.yml` - updated
- `ci.yml` - updated
- `assignproj.yml` - updated
- `ci_cron.yml` - NOT updated. The job that uses this is only reading the results of the last run.

Closes #1904