### PR TITLE
Make explicitly unexpected errors unexpected again

### DIFF
--- a/lib/new_relic/agent/error_collector.rb
+++ b/lib/new_relic/agent/error_collector.rb
@@ -277,7 +277,7 @@ module NewRelic
         noticed_error.line_number = sense_method(exception, :line_number)
         noticed_error.stack_trace = truncate_trace(extract_stack_trace(exception))
 
-        noticed_error.expected = !options.delete(:expected).nil? || expected?(exception)
+        noticed_error.expected = !!options.delete(:expected) || expected?(exception) # rubocop:disable Style/DoubleNegation
 
         noticed_error.attributes_from_notice_error = options.delete(:custom_params) || {}
 

--- a/test/new_relic/agent/error_collector_test.rb
+++ b/test/new_relic/agent/error_collector_test.rb
@@ -453,7 +453,22 @@ module NewRelic::Agent
         assert trace_attrs[:'error.expected'], "Trace attributes should have 'error.expected' set to true"
       end
 
-      def test_unexpected_error_sets_expected_attribute_to_false
+      def test_explicitly_unexpected_error_sets_expected_attribute_to_false
+        in_transaction do
+          @error_collector.notice_error(StandardError.new, :expected => false)
+        end
+        traces = harvest_error_traces
+        events = harvest_error_events
+        event_attrs = events[0][0]
+        trace_attrs = traces[0].to_collector_array[4]
+
+        refute event_attrs['error.expected'],
+          "Intrinsic attributes should have 'error.expected' set to false when it's explicitly passed as false"
+        refute trace_attrs[:'error.expected'],
+          "Trace attributes should have 'error.expected' set to false when it's explicitly passed as false"
+      end
+
+      def test_implicitly_unexpected_error_sets_expected_attribute_to_false
         in_transaction do
           @error_collector.notice_error(StandardError.new)
         end


### PR DESCRIPTION
# Overview
`newrelic_rpm` 9.1.0 introduced an inconsistency in `NewRelic::Agent.notice_error` method that wasn't fixed in 9.2.0 either. 

Previously, when `false` was passed at `expected` key, e.g

```ruby
NewRelic::Agent.notice_error(error, expected: false)
```

an error was marked as unexpected in NewRelic. But fixes for Rubocop's `Style/DoubleNegation` done in https://github.com/newrelic/newrelic-ruby-agent/commit/589d9c12db300276939336bb61c8d2aae2cd2d31 (specifically [THIS LINE](https://github.com/newrelic/newrelic-ruby-agent/commit/589d9c12db300276939336bb61c8d2aae2cd2d31#diff-5d01d1fe7521ba113d127ae244e73bb33f3f71cb47e54e17aa79bf8d84b1fc75R280)) introduced an issue with doing so, it started checking for passed option like so:

```ruby
!options.delete(:expected).nil?
```

it obviously evaluates to `true`, when `false` was actually passed as `false.nil?` is `false`. Rubocop has a special note for such case [here](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/DoubleNegation):

> NOTE: when 'something' is a boolean value `!!something` and `!something.nil?` are not the same thing

So there are a couple of ways to achieve previous behaviour, but actually double negation seems like the cleanest solution in this case as I want to preserve old behaviour not to break anyone's else errors reporting as I'm not sure what users can pass here as a value for `expected` key. 

Included `test_explicitly_unexpected_error_sets_expected_attribute_to_false` test fails without the change in `lib/new_relic/agent/error_collector.rb`

Submitter Checklist:
- [ ] Include a link to the related GitHub issue, if applicable
- [ ] Include a security review link, if applicable

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
GitHub Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
