### PR TITLE
Pin onetimepass

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         ruby-version: 3.2
 
     - name: Install onetimepass
-      run: pip install onetimepass
+      run: pip install onetimepass==1.0.1
 
     - name: Configure gem credentials
       run: |


### PR DESCRIPTION
Pin onetimepass to v1.0.1 and resolve a [security alert](https://github.com/newrelic/newrelic-ruby-agent/security/code-scanning/3). 