### PR TITLE
Add permission to write to repository project

### DIFF
--- a/.github/workflows/assignproj.yml
+++ b/.github/workflows/assignproj.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   issues: write
+  repository-projects: write
 
 env:
   MY_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This workflow requires another permission to add issues to repository projects.
Closes #1951