### PR TITLE
Bugfix Thread instrumentation continuing to use finished transactions on other threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 # New Relic Ruby Agent Release Notes
 
 ## dev
-  Version ___ fixes a bug preventing errors from being expected.
+  Version ___ fixes a bug causing the agent to continue storing data on finished transaction, and a bug preventing errors from being expected.
+
+- **Bugfix: Finished transactions continue to store data on different threads**
+
+  Previously, when a new thread was spawned the agent would continue using the current transaction to record data on, even if this transaction had finished already in a different thread. Now the agent will only use the current transaction in the new thread if it is not yet finished. Thank you to [@fcheung](https://github.com/fcheung) for reporting this bug and providing us with an extremely helpful reproduction to debug. [PR#1969](https://github.com/newrelic/newrelic-ruby-agent/pull/1969)
+
 
 - **Bugfix: Expected Errors passed to notice_error are expected again**
 

--- a/lib/new_relic/agent/tracer.rb
+++ b/lib/new_relic/agent/tracer.rb
@@ -424,7 +424,7 @@ module NewRelic
           current_txn = ::Thread.current[:newrelic_tracer_state]&.current_transaction if ::Thread.current[:newrelic_tracer_state]&.is_execution_traced?
           proc do
             begin
-              if current_txn && !current_txn.initial_segment.finished?
+              if current_txn && !current_txn.finished?
                 NewRelic::Agent::Tracer.state.current_transaction = current_txn
                 current_txn.async = true
                 segment_name += "/Thread#{::Thread.current.object_id}/Fiber#{::Fiber.current.object_id}" if NewRelic::Agent.config[:'thread_ids_enabled']

--- a/lib/new_relic/agent/tracer.rb
+++ b/lib/new_relic/agent/tracer.rb
@@ -424,7 +424,7 @@ module NewRelic
           current_txn = ::Thread.current[:newrelic_tracer_state]&.current_transaction if ::Thread.current[:newrelic_tracer_state]&.is_execution_traced?
           proc do
             begin
-              if current_txn
+              if current_txn && !current_txn.initial_segment.finished?
                 NewRelic::Agent::Tracer.state.current_transaction = current_txn
                 current_txn.async = true
                 segment_name += "/Thread#{::Thread.current.object_id}/Fiber#{::Fiber.current.object_id}" if NewRelic::Agent.config[:'thread_ids_enabled']

--- a/lib/new_relic/agent/transaction.rb
+++ b/lib/new_relic/agent/transaction.rb
@@ -439,6 +439,10 @@ module NewRelic
         segments.first
       end
 
+      def finished?
+        initial_segment.finished?
+      end
+
       def create_initial_segment(options = {})
         segment = create_segment(@default_name, options)
         segment.record_scoped_metric = false

--- a/lib/new_relic/agent/transaction/tracing.rb
+++ b/lib/new_relic/agent/transaction/tracing.rb
@@ -29,6 +29,11 @@ module NewRelic
           else
             segment.record_on_finish = true
             ::NewRelic::Agent.logger.debug("Segment limit of #{segment_limit} reached, ceasing collection.")
+
+            if initial_segment&.finished?
+              ::NewRelic::Agent.logger.debug("Transaction #{best_name} has finished but segments still being created, resetting state.")
+              NewRelic::Agent::Tracer.state.reset
+            end
           end
           segment.transaction_assigned
         end

--- a/lib/new_relic/agent/transaction/tracing.rb
+++ b/lib/new_relic/agent/transaction/tracing.rb
@@ -30,7 +30,7 @@ module NewRelic
             segment.record_on_finish = true
             ::NewRelic::Agent.logger.debug("Segment limit of #{segment_limit} reached, ceasing collection.")
 
-            if initial_segment&.finished?
+            if finished?
               ::NewRelic::Agent.logger.debug("Transaction #{best_name} has finished but segments still being created, resetting state.")
               NewRelic::Agent::Tracer.state.reset
             end

--- a/lib/new_relic/agent/transaction/tracing.rb
+++ b/lib/new_relic/agent/transaction/tracing.rb
@@ -33,6 +33,7 @@ module NewRelic
             if finished?
               ::NewRelic::Agent.logger.debug("Transaction #{best_name} has finished but segments still being created, resetting state.")
               NewRelic::Agent::Tracer.state.reset
+              NewRelic::Agent.record_metric('Supportability/Transaction/SegmentLimitReachedAfterFinished/ResetState', 1)
             end
           end
           segment.transaction_assigned

--- a/test/new_relic/agent/tracer_test.rb
+++ b/test/new_relic/agent/tracer_test.rb
@@ -312,6 +312,7 @@ module NewRelic
             assert_nil Tracer.current_transaction
           end
         end
+        sleep(0.01) until txn.segments.size >= 2
         txn.finish
         threads.each(&:join)
       end


### PR DESCRIPTION
This fixes a bug where the agent would continue to record segments on transactions that were already finished in another thread. This would lead to increased memory usage over time because the agent would continue to copy over the finished transaction as the still current transaction in the thread instrumentation, causing the agent to think it was still supposed to continue recording data on the actually finished transaction. Now the agent will check the finished state of a transaction before using it when a new thread is spawned. 
Additionally, if a transaction reaches the segment limit but the transaction is actually already finished on some other thread, the state will now reset, preventing future segments from being created and a supportability metric will be recorded.

#1936