### PR TITLE
Run active_record_pg suite in serial

### DIFF
--- a/test/multiverse/lib/multiverse/suite.rb
+++ b/test/multiverse/lib/multiverse/suite.rb
@@ -412,9 +412,10 @@ module Multiverse
     def log_test_running_process
       puts yellow("Starting tests in child PID #{Process.pid} at #{Time.now}\n")
     end
-
+    
+    # active_record_pg test suite runs in serialize to prevent database conflicts
     def should_serialize?
-      ENV['SERIALIZE'] || debug || environments.file_path.include?('active_record_pg')
+      ENV['SERIALIZE'] || debug || self.directory.include?('active_record_pg')
     end
 
     def check_environment_condition

--- a/test/multiverse/lib/multiverse/suite.rb
+++ b/test/multiverse/lib/multiverse/suite.rb
@@ -415,6 +415,7 @@ module Multiverse
 
     # active_record_pg test suite runs in serial to prevent database conflicts
     def should_serialize?
+      # TODO: Devise a way for an individual suite to express that it doesn't support parallel
       ENV['SERIALIZE'] || debug || self.directory.include?('active_record_pg')
     end
 

--- a/test/multiverse/lib/multiverse/suite.rb
+++ b/test/multiverse/lib/multiverse/suite.rb
@@ -413,7 +413,7 @@ module Multiverse
       puts yellow("Starting tests in child PID #{Process.pid} at #{Time.now}\n")
     end
 
-    # active_record_pg test suite runs in serialize to prevent database conflicts
+    # active_record_pg test suite runs in serial to prevent database conflicts
     def should_serialize?
       ENV['SERIALIZE'] || debug || self.directory.include?('active_record_pg')
     end

--- a/test/multiverse/lib/multiverse/suite.rb
+++ b/test/multiverse/lib/multiverse/suite.rb
@@ -412,7 +412,7 @@ module Multiverse
     def log_test_running_process
       puts yellow("Starting tests in child PID #{Process.pid} at #{Time.now}\n")
     end
-    
+
     # active_record_pg test suite runs in serialize to prevent database conflicts
     def should_serialize?
       ENV['SERIALIZE'] || debug || self.directory.include?('active_record_pg')

--- a/test/multiverse/lib/multiverse/suite.rb
+++ b/test/multiverse/lib/multiverse/suite.rb
@@ -414,7 +414,7 @@ module Multiverse
     end
 
     def should_serialize?
-      ENV['SERIALIZE'] || debug
+      ENV['SERIALIZE'] || debug || environments.file_path.include?('active_record_pg')
     end
 
     def check_environment_condition


### PR DESCRIPTION
The active_record_pg test suite intermittently fails when running in parallel due to multiple processes attempting to access/manipulate the same database. Running this suite in serial prevents this from occurring.

Closes #1979 
