### PR TITLE
Add test for #finished? on txn without segments

### DIFF
--- a/test/new_relic/agent/transaction_test.rb
+++ b/test/new_relic/agent/transaction_test.rb
@@ -1732,5 +1732,13 @@ module NewRelic::Agent
         end
       end
     end
+
+    def test_transaction_finished_works_when_inital_segment_nil
+      txn = Transaction.new(:web, {})
+
+      assert_empty txn.segments
+      assert_nil txn.initial_segment
+      refute txn.finished?
+    end
   end
 end


### PR DESCRIPTION
This test is a fast follow to support the change for version 9.2.2

Relates to #1981 