### PR TITLE
Specify nokogiri version for Ruby 2.6 Rails environments

### DIFF
--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -61,13 +61,13 @@ jobs:
           map: |
             {
               "2.4.10": {
-                "rails": "norails,rails52,rails51,rails42"
+                "rails": "norails,rails52,rails51,rails50,rails42"
               },
               "2.5.9": {
-                "rails": "norails,rails61,rails60,rails52,rails51,rails42"
+                "rails": "norails,rails61,rails60,rails52,rails51,rails50,rails42"
               },
               "2.6.10": {
-                "rails": "norails,rails61,rails60,rails52,rails51,rails42"
+                "rails": "norails,rails61,rails60,rails52,rails51,rails50,rails42"
               },
               "2.7.8": {
                 "rails": "norails,rails61,rails60,rails70,railsedge"

--- a/test/environments/rails42/Gemfile
+++ b/test/environments/rails42/Gemfile
@@ -27,3 +27,7 @@ gem 'newrelic_rpm', :path => '../../..'
 gem 'pry', '~> 0.12.2'
 gem 'pry-nav'
 gem 'warning' if RUBY_VERSION >= '2.4.0'
+
+if RUBY_VERSION == '2.6.10'
+  gem 'nokogiri', '~> 1.13', '>= 1.13.10'
+end

--- a/test/environments/rails50/Gemfile
+++ b/test/environments/rails50/Gemfile
@@ -28,3 +28,7 @@ gem 'newrelic_rpm', :path => '../../..'
 gem 'pry', '~> 0.12.2'
 gem 'pry-nav'
 gem 'warning' if RUBY_VERSION >= '2.4.0'
+
+if RUBY_VERSION == '2.6.10'
+  gem 'nokogiri', '~> 1.13', '>= 1.13.10'
+end

--- a/test/environments/rails51/Gemfile
+++ b/test/environments/rails51/Gemfile
@@ -27,3 +27,7 @@ gem 'newrelic_rpm', :path => '../../..'
 gem 'pry', '~> 0.12.2'
 gem 'pry-nav'
 gem 'warning' if RUBY_VERSION >= '2.4.0'
+
+if RUBY_VERSION == '2.6.10'
+  gem 'nokogiri', '~> 1.13', '>= 1.13.10'
+end

--- a/test/environments/rails52/Gemfile
+++ b/test/environments/rails52/Gemfile
@@ -27,3 +27,7 @@ gem 'newrelic_rpm', :path => '../../..'
 gem 'pry', '~> 0.12.2'
 gem 'pry-nav'
 gem 'warning' if RUBY_VERSION >= '2.4.0'
+
+if RUBY_VERSION == '2.6.10'
+  gem 'nokogiri', '~> 1.13', '>= 1.13.10'
+end

--- a/test/environments/rails60/Gemfile
+++ b/test/environments/rails60/Gemfile
@@ -35,3 +35,7 @@ gem 'pry', '~> 0.14.1'
 gem 'pry-nav'
 gem 'simplecov' if ENV['VERBOSE_TEST_OUTPUT']
 gem 'warning' if RUBY_VERSION >= '2.4.0'
+
+if RUBY_VERSION == '2.6.10'
+  gem 'nokogiri', '~> 1.13', '>= 1.13.10'
+end

--- a/test/environments/rails61/Gemfile
+++ b/test/environments/rails61/Gemfile
@@ -34,3 +34,7 @@ gem 'pry', '~> 0.14.1'
 gem 'pry-nav'
 gem 'simplecov' if ENV['VERBOSE_TEST_OUTPUT']
 gem 'warning' if RUBY_VERSION >= '2.4.0'
+
+if RUBY_VERSION == '2.6.10'
+  gem 'nokogiri', '~> 1.13', '>= 1.13.10'
+end


### PR DESCRIPTION
Specify the Nokogiri version range for Ruby 2.6 in Rails test environments. This gives Bundler a little extra help in hopes of preventing this [CI failure](https://github.com/newrelic/newrelic-ruby-agent/actions/runs/4924326199/jobs/8797231901#step:12:107)

This PR also reactivates Rails 5.0 testing. 