### PR TITLE
Add rails40, -41, -50 versions to ci_cron matrix

### DIFF
--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -61,13 +61,13 @@ jobs:
           map: |
             {
               "2.4.10": {
-                "rails": "norails,rails52,rails51,rails42"
+                "rails": "norails,rails52,rails51,rails50,rails42,rails41,rails40"
               },
               "2.5.9": {
-                "rails": "norails,rails61,rails60,rails52,rails51,rails42"
+                "rails": "norails,rails61,rails60,rails52,rails51,rails50,rails42"
               },
               "2.6.10": {
-                "rails": "norails,rails61,rails60,rails52,rails51,rails42"
+                "rails": "norails,rails61,rails60,rails52,rails51,rails50,rails42"
               },
               "2.7.8": {
                 "rails": "norails,rails61,rails60,rails70,railsedge"


### PR DESCRIPTION
We support these versions and they weren't being tested
