### PR TITLE
instrumentation config: use :unsatisfied

### DIFF
--- a/lib/new_relic/agent/configuration/manager.rb
+++ b/lib/new_relic/agent/configuration/manager.rb
@@ -15,7 +15,7 @@ module NewRelic
   module Agent
     module Configuration
       class Manager
-        DEPENDENCY_DETECTION_VALUES = %i[prepend chain].freeze
+        DEPENDENCY_DETECTION_VALUES = %i[prepend chain unsatisfied].freeze
 
         # Defining these explicitly saves object allocations that we incur
         # if we use Forwardable and def_delegators.
@@ -366,7 +366,8 @@ module NewRelic
 
           preserved = @cache.select { |_k, v| DEPENDENCY_DETECTION_VALUES.include?(v) }
           new_cache
-          preserved.each { |k, v| @cache[k] = v unless @cache[k] && @cache[k] != 'auto' }
+          preserved.each { |k, v| @cache[k] = v }
+
           @cache
         end
 

--- a/lib/new_relic/dependency_detection.rb
+++ b/lib/new_relic/dependency_detection.rb
@@ -27,6 +27,8 @@ module DependencyDetection
     @items.each do |item|
       if item.dependencies_satisfied?
         item.execute
+      else
+        item.configure_as_unsatisfied unless item.disabled_configured?
       end
     end
   end
@@ -60,6 +62,10 @@ module DependencyDetection
 
     def dependencies_satisfied?
       !executed and check_dependencies
+    end
+
+    def configure_as_unsatisfied
+      NewRelic::Agent.config.instance_variable_get(:@cache)[config_key] = :unsatisfied
     end
 
     def source_location_for(klass, method_name)

--- a/test/new_relic/agent/local_log_decorator_test.rb
+++ b/test/new_relic/agent/local_log_decorator_test.rb
@@ -20,6 +20,7 @@ module NewRelic::Agent
           :'instrumentation.logger' => 'auto'
         }
         NewRelic::Agent.config.add_config_for_testing(@enabled_config)
+        NewRelic::Agent.config.send(:new_cache)
       end
 
       def teardown


### PR DESCRIPTION
With [1930](https://github.com/newrelic/newrelic-ruby-agent/pull/1930/) the agent will now automatically convert any configured instrumentation value of `:auto` into either `:prepend` or `:chain` once the determination of which approach to take has been dynamically determined.

This will allow the agent's config to be inspected after the `:prepend` / `:chain` determination is made to see what `:auto` actually becomes under the hood.

But 1930 left an edge case gap open in the form of not allowing the configuration to convey instrumentation with unsatisfied dependencies. If a config value is set to `:prepend` or `:chain` in the configuration (overriding the default `:auto` value) and a dependency is unsatisfied (the library to instrument is not found on the system, it is of an unsupported version, etc.) then the value would end up staying as `:prepend` or `:chain` and incorrectly convey to anyone inspecting the config that a certain method of instrumentation was used when in actuality no instrumentation was performed at all.

Now, if an instrumentation's dependencies are unsatisfied, the corresponding configuration value will be updated with a value of `:unsatisfied`.