### PR TITLE
Use rackup >=2.0.0

### DIFF
--- a/test/multiverse/lib/multiverse/suite.rb
+++ b/test/multiverse/lib/multiverse/suite.rb
@@ -279,7 +279,7 @@ module Multiverse
         f.puts minitest_line unless /^\s*gem .minitest[^_]./.match?(gemfile_text)
         f.puts "gem 'rake'" unless gemfile_text =~ /^\s*gem .rake[^_]./ || suite == 'rake'
 
-        f.puts "gem 'rackup'" if need_rackup?(gemfile_text)
+        f.puts "gem 'rackup', '>=2.0.0'" if need_rackup?(gemfile_text)
 
         f.puts "gem 'mocha', '~> 1.9.0', require: false"
         f.puts "gem 'minitest-stub-const', '~> 0.6', require: false"

--- a/test/multiverse/suites/grape/Envfile
+++ b/test/multiverse/suites/grape/Envfile
@@ -5,7 +5,7 @@
 instrumentation_methods :chain, :prepend
 
 GRAPE_VERSIONS = [
-  [nil, 2.5],
+  [1.7.0, 2.5],
   ['1.6', 2.5],
   ['1.5.3', 2.4, 3.0],
 ]

--- a/test/multiverse/suites/grape/Envfile
+++ b/test/multiverse/suites/grape/Envfile
@@ -5,7 +5,7 @@
 instrumentation_methods :chain, :prepend
 
 GRAPE_VERSIONS = [
-  [1.7.0, 2.5],
+  ['1.7.0', 2.5],
   ['1.6', 2.5],
   ['1.5.3', 2.4, 3.0],
 ]

--- a/test/multiverse/suites/grape/Envfile
+++ b/test/multiverse/suites/grape/Envfile
@@ -5,9 +5,9 @@
 instrumentation_methods :chain, :prepend
 
 GRAPE_VERSIONS = [
-  ['1.7.0', 2.5],
+  [nil, 2.5],
   ['1.6', 2.5],
-  ['1.5.3', 2.4, 3.0],
+  ['1.5.3', 2.4, 3.0]
 ]
 
 def gem_list(grape_version = nil)


### PR DESCRIPTION
We need to require `rackup` when using `rack` >=v3. 

The Rackup v1.0.0 release was missing an important file, Rackup v2.0.0 was released the same day with [the fix](https://github.com/rack/rackup/commit/ce660d517ed82158108c905c28269f415190b2ef). We should only ever use Rackup >=v2.0.0