### PR TITLE
CI fix: Rails40 and Rails41

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,10 +63,6 @@ jobs:
             }
 
       - if: matrix.ruby-version == '2.4.10'
-        name: Prepare mysql dirextory
-        run: sudo chown -R $USER /usr/local
-
-      - if: matrix.ruby-version == '2.4.10'
         name: Cache mysql55
         id: mysql55-cache
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # tag v3.3.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,10 @@ jobs:
             }
 
       - if: matrix.ruby-version == '2.4.10'
+        name: Prepare mysql dirextory
+        run: sudo chown -R $USER /usr/local
+
+      - if: matrix.ruby-version == '2.4.10'
         name: Cache mysql55
         id: mysql55-cache
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # tag v3.3.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
             }
 
       - if: matrix.ruby-version == '2.4.10'
-        name: Prepare mysql dirextory
+        name: Prepare mysql directory
         run: sudo chown -R $USER /usr/local
 
       - if: matrix.ruby-version == '2.4.10'

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -218,6 +218,10 @@ jobs:
         run: sudo chown -R $USER /usr/local
 
       - if: matrix.ruby-version == '2.4.10'
+        name: Install mysql-client
+        run: sudo apt-get install mysql-client libmysqlclient-dev
+
+      - if: matrix.ruby-version == '2.4.10'
         name: Cache mysql55
         id: mysql55-cache
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # tag v3.3.1
@@ -228,10 +232,6 @@ jobs:
       - if: steps.mysql55-cache.outputs.cache-hit != 'true' && ( matrix.ruby-version == '2.4.10')
         name: Install mysql55
         run: sudo ./test/script/install_mysql55
-
-      - if: matrix.ruby-version == '2.4.10'
-        name: Install mysql-client
-        run: sudo apt-get install mysql-client libmysqlclient-dev
 
       - name: Setup bundler
         run: ./.github/workflows/scripts/setup_bundler

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -98,10 +98,10 @@ jobs:
       - if: steps.mysql55-cache.outputs.cache-hit != 'true' && ( matrix.ruby-version == '2.4.10' || matrix.ruby-version == '2.5.9' || matrix.ruby-version == '2.6.10')
         name: Install mysql55
         run: sudo ./test/script/install_mysql55
-      
+
       - if: matrix.ruby-version == '2.4.10'
-        name: Prepare mysql dirextory
-        run: sudo chown -R $USER /usr/local
+        name: Install mysql-client TEST
+        run: sudo apt-get install mysql-client libmysqlclient-dev
 
       - name: Setup bundler
         run: ./.github/workflows/scripts/setup_bundler
@@ -220,10 +220,6 @@ jobs:
       - if: matrix.ruby-version == '2.4.10'
         name: Prepare mysql dirextory
         run: sudo chown -R $USER /usr/local
-
-      - if: matrix.ruby-version == '2.4.10'
-        name: Install mysql-client TEST
-        run: sudo apt-get install mysql-client libmysqlclient-dev
 
       - if: matrix.ruby-version == '2.4.10'
         name: Cache mysql55

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -84,7 +84,7 @@ jobs:
             }
 
       - if: matrix.ruby-version == '2.4.10' || matrix.ruby-version == '2.5.9' || matrix.ruby-version == '2.6.10'
-        name: Prepare mysql dirextory
+        name: Prepare mysql directory
         run: sudo chown -R $USER /usr/local
 
       - if: matrix.ruby-version == '2.4.10' || matrix.ruby-version == '2.5.9' || matrix.ruby-version == '2.6.10'
@@ -98,14 +98,6 @@ jobs:
       - if: steps.mysql55-cache.outputs.cache-hit != 'true' && ( matrix.ruby-version == '2.4.10' || matrix.ruby-version == '2.5.9' || matrix.ruby-version == '2.6.10')
         name: Install mysql55
         run: sudo ./test/script/install_mysql55
-
-      - if: matrix.ruby-version == '2.4.10'
-        name: Install mysql-client TEST
-        run: sudo apt-get install mysql-client libmysqlclient-dev
-
-      - if: matrix.ruby-version == '2.4.10'
-        name: Install mysql2 TEST
-        run: sudo gem install mysql2
 
       - name: Setup bundler
         run: ./.github/workflows/scripts/setup_bundler

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -222,7 +222,7 @@ jobs:
         run: sudo chown -R $USER /usr/local
 
       - if: matrix.ruby-version == '2.4.10'
-        name: Install mysql-client
+        name: Install mysql-client TEST
         run: sudo apt-get install mysql-client libmysqlclient-dev
 
       - if: matrix.ruby-version == '2.4.10'

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -103,6 +103,10 @@ jobs:
         name: Install mysql-client TEST
         run: sudo apt-get install mysql-client libmysqlclient-dev
 
+      - if: matrix.ruby-version == '2.4.10'
+        name: Install mysql2 TEST
+        run: sudo gem install mysql2
+
       - name: Setup bundler
         run: ./.github/workflows/scripts/setup_bundler
         env:

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -229,6 +229,10 @@ jobs:
         name: Install mysql55
         run: sudo ./test/script/install_mysql55
 
+      - if: matrix.ruby-version == '2.4.10'
+        name: Install mysql-client
+        run: sudo apt-get install mysql-client libmysqlclient-dev
+
       - name: Setup bundler
         run: ./.github/workflows/scripts/setup_bundler
         env:

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -98,6 +98,10 @@ jobs:
       - if: steps.mysql55-cache.outputs.cache-hit != 'true' && ( matrix.ruby-version == '2.4.10' || matrix.ruby-version == '2.5.9' || matrix.ruby-version == '2.6.10')
         name: Install mysql55
         run: sudo ./test/script/install_mysql55
+      
+      - if: matrix.ruby-version == '2.4.10'
+        name: Prepare mysql dirextory
+        run: sudo chown -R $USER /usr/local
 
       - name: Setup bundler
         run: ./.github/workflows/scripts/setup_bundler

--- a/.github/workflows/scripts/setup_bundler
+++ b/.github/workflows/scripts/setup_bundler
@@ -57,6 +57,17 @@ function install_desired_bundler_version {
   gem list bundler
 }
 
+function configure_bundler {
+  if ! [[ $RUBY_VERSION =~ 2.4 ]]; then
+    echo "DEBUG: Ruby is not at version 2.4.x, skipping 'bundler config'"
+    return
+  fi
+
+  # add mysql specific config for bundler when we are using older mysql
+  echo "DEBUG: running 'bundle config'"
+  bundle config --global build.mysql2 --with-mysql-config=/usr/local/mysql55/bin/mysql_config
+}
+
 function install_ruby_version_specific_gems {
   if using_jruby; then
     echo "DEBUG: Skipping specific gem installation, as JRuby is in use"
@@ -90,6 +101,7 @@ function set_up_bundler {
 
   update_to_desired_rubygems_version
   install_desired_bundler_version
+  configure_bundler
 }
 
 echo "DEBUG: setting up Bundler"

--- a/test/environments/rails40/Gemfile
+++ b/test/environments/rails40/Gemfile
@@ -17,7 +17,7 @@ platforms :jruby do
 end
 
 platforms :ruby, :rbx do
-  gem 'mysql2'
+  gem 'mysql2', '~> 0.3.18'
   gem 'sqlite3', '~> 1.3.13'
 end
 

--- a/test/environments/rails40/Gemfile
+++ b/test/environments/rails40/Gemfile
@@ -17,7 +17,7 @@ platforms :jruby do
 end
 
 platforms :ruby, :rbx do
-  gem 'mysql2', '~> 0.3.18'
+  gem 'mysql2', '~> 0.3.20'
   gem 'sqlite3', '~> 1.3.13'
 end
 

--- a/test/environments/rails40/Gemfile
+++ b/test/environments/rails40/Gemfile
@@ -2,7 +2,7 @@
 
 source 'https://rubygems.org'
 
-gem 'rake', '~> 12.3.3'
+gem 'rake', '10.0.4'
 gem 'rails', '~> 4.0.0'
 
 gem 'minitest', '4.7.5', require: false # Minitest ~> 4.2 required for Rails 3.2

--- a/test/environments/rails40/Gemfile
+++ b/test/environments/rails40/Gemfile
@@ -17,7 +17,7 @@ platforms :jruby do
 end
 
 platforms :ruby, :rbx do
-  gem 'mysql2', '~> 0.3.20'
+  gem 'mysql2'
   gem 'sqlite3', '~> 1.3.13'
 end
 

--- a/test/environments/rails41/Gemfile
+++ b/test/environments/rails41/Gemfile
@@ -2,7 +2,7 @@
 
 source 'https://rubygems.org'
 
-gem 'rake', '~> 12.3.3'
+gem 'rake', '10.0.4'
 gem 'rails', '~> 4.1.0'
 
 gem 'minitest', '5.2.3'

--- a/test/environments/rails41/Gemfile
+++ b/test/environments/rails41/Gemfile
@@ -17,7 +17,7 @@ platforms :jruby do
 end
 
 platforms :ruby do
-  gem 'mysql2', '~> 0.3.18'
+  gem 'mysql2', '~> 0.3.20'
   gem 'sqlite3', '~> 1.3.13'
 end
 

--- a/test/environments/rails41/Gemfile
+++ b/test/environments/rails41/Gemfile
@@ -17,7 +17,7 @@ platforms :jruby do
 end
 
 platforms :ruby do
-  gem 'mysql2'
+  gem 'mysql2', '~> 0.3.18'
   gem 'sqlite3', '~> 1.3.13'
 end
 

--- a/test/environments/rails41/Gemfile
+++ b/test/environments/rails41/Gemfile
@@ -17,7 +17,7 @@ platforms :jruby do
 end
 
 platforms :ruby do
-  gem 'mysql2', '~> 0.3.20'
+  gem 'mysql2'
   gem 'sqlite3', '~> 1.3.13'
 end
 


### PR DESCRIPTION
Rails40 and Rails41 failed the CI due to an installation error of the mysql2 gem. When moving to agent v9.0, some bundler configuration code was ripped out that looked like it was only needed for rubies 2.2. and 2.3, but was also being used for 2.4. This method has been added back. And older version of Rack was also needed to properly run. 