### PR TITLE
Active Record notifications: permit disabling

### DIFF
--- a/lib/new_relic/agent/instrumentation/active_record_notifications.rb
+++ b/lib/new_relic/agent/instrumentation/active_record_notifications.rb
@@ -90,7 +90,7 @@ DependencyDetection.defer do
   end
 
   depends_on do
-    !NewRelic::Agent.config[:disable_activerecord_instrumentation] &&
+    !NewRelic::Agent.config[:disable_active_record_instrumentation] &&
       !NewRelic::Agent::Instrumentation::ActiveRecordSubscriber.subscribed?
   end
 

--- a/test/new_relic/agent/instrumentation/rails/active_record_subscriber.rb
+++ b/test/new_relic/agent/instrumentation/rails/active_record_subscriber.rb
@@ -238,6 +238,21 @@ class NewRelic::Agent::Instrumentation::ActiveRecordSubscriberTest < Minitest::T
     end
   end
 
+  def test_instrumentation_can_be_disabled
+    parameter = :disable_active_record_instrumentation
+
+    item = DependencyDetection.instance_variable_get(:@items).detect { |i| i.name == :active_record_notifications }
+
+    assert item, 'Could not locate the dependency detection item for Active Record notifications'
+    dependency_check = item.dependencies.detect { |d| d.source.match?(/#{parameter}/) }
+
+    assert dependency_check, "Could not locate the dependency check related to the #{parameter} configuration parameter"
+
+    with_config(parameter => false) do
+      refute dependency_check.call
+    end
+  end
+
   private
 
   def simulate_query(duration = nil)


### PR DESCRIPTION
To prevent the agent from subscribing to Active Record notifications and otherwise instrumenting Active Record, the configuration parameter `:disable_active_record_instrumentation` should be set to a value of `true` in the `newrelic.yml` config file.

This change permits that parameter to function as expected by fixing a typo in which the code expected `:disable_activerecord_instrumentation` without an underscore. Note that prior to this change, putting `:disable_activerecord_instrumentation` in the config file would also not work, because the config parameter is spelled correctly in `default_source.rb`. This change is needed for the parameter to function at all.

resolves #2019