### PR TITLE
Pin redis version

### DIFF
--- a/test/multiverse/suites/sidekiq/sidekiq_with_redis_test.rb
+++ b/test/multiverse/suites/sidekiq/sidekiq_with_redis_test.rb
@@ -34,13 +34,12 @@ class SidekiqWithRedisTest < MiniTest::Test
   # NOTE: Because Sidekiq v7.0+ can use `redis-client` without `redis`, this
   #       test brings in the `redis` gem directly via `bundler/inline`
   def test_redis_client_pipelined_calls_work
-    skip 'The CI fails when trying to run this test because of a Bundler error' if RUBY_VERSION.match?(/^3\.1/)
     skip 'Testing conducted only using Sidekiq v7.0+ with redis not yet bundled' unless sidekiq_without_redis?
 
     gemfile do
       source 'https://rubygems.org'
 
-      gem 'redis'
+      gem 'redis', '5.0.5'
     end
 
     require 'newrelic_rpm'


### PR DESCRIPTION
Pinning redis version for a test that is bundling redis inline vs using Envfile. 

Previously, bundle inline was attempting to grab the latest version of redis to test with. This caused an error where bundler could not remove a previously installed version of the same redis version (used in Envfile), perhaps because different versions of bundler installed the same version of redis. Either way, using a different version of redis prevents this error.

Full CI run (since this is a ruby 3.1 error: https://github.com/newrelic/newrelic-ruby-agent/actions/runs/5028830638
Closes #1894