### PR TITLE
support aliases in YAML config

### DIFF
--- a/lib/new_relic/agent/configuration/yaml_source.rb
+++ b/lib/new_relic/agent/configuration/yaml_source.rb
@@ -41,6 +41,7 @@ module NewRelic
 
           substitute_transaction_threshold(config)
           booleanify_values(config, 'agent_enabled', 'enabled')
+          apply_aliases(config)
 
           super(config, true)
         end
@@ -164,6 +165,18 @@ module NewRelic
             end
           end
           result
+        end
+
+        def apply_aliases(config)
+          DEFAULTS.each do |config_setting, value|
+            next unless value[:aliases]
+
+            value[:aliases].each do |config_alias|
+              next unless config[config_setting].nil? && !config[config_alias.to_s].nil?
+
+              config[config_setting] = config[config_alias.to_s]
+            end
+          end
         end
       end
     end

--- a/test/new_relic/agent/configuration/yaml_source_test.rb
+++ b/test/new_relic/agent/configuration/yaml_source_test.rb
@@ -4,6 +4,7 @@
 
 require_relative '../../../test_helper'
 require 'new_relic/agent/configuration/yaml_source'
+require 'minitest/stub_const'
 
 module NewRelic::Agent::Configuration
   class YamlSourceTest < Minitest::Test
@@ -159,6 +160,68 @@ module NewRelic::Agent::Configuration
         refute_predicate source, :failed?
         assert_empty source.failures
       end
+    end
+
+    def test_applying_aliases_has_no_impact_when_aliases_are_absent
+      NewRelic::Agent::Configuration::DefaultSource.stub_const(:DEFAULTS, phony_defaults) do
+        config = phony_defaults.keys.each_with_object({}) { |k, h| h[k] = true }
+        original_config = config.dup.freeze
+        phony_source.send(:apply_aliases, config)
+
+        assert_equal original_config, config
+      end
+    end
+
+    def test_alias_values_will_not_overwrite_original_values
+      NewRelic::Agent::Configuration::DefaultSource.stub_const(:DEFAULTS, phony_defaults) do
+        config = phony_defaults.keys.each_with_object({}) { |k, h| h[k] = false }
+        config[:aluminum] = true
+        original_config = config.dup.freeze
+        phony_source.send(:apply_aliases, config)
+
+        assert_equal original_config, config
+      end
+    end
+
+    def test_alias_values_are_ignored_if_nil
+      NewRelic::Agent::Configuration::DefaultSource.stub_const(:DEFAULTS, phony_defaults) do
+        config = {aluminium: nil, leisure: true}
+        config[:aluminum] = nil
+        original_config = config.dup.freeze
+        phony_source.send(:apply_aliases, config)
+
+        assert_equal original_config, config
+      end
+    end
+
+    def test_applying_aliases_works_as_desired
+      NewRelic::Agent::Configuration::DefaultSource.stub_const(:DEFAULTS, phony_defaults) do
+        config = {aluminium: nil, leisure: true}
+        config[:aluminum] = false
+        phony_source.send(:apply_aliases, config)
+
+        refute config[:aluminium]
+      end
+    end
+
+    def phony_source
+      YamlSource.new(nil, nil)
+    end
+
+    def phony_defaults
+      {aluminium: {default: true,
+                   documentation_default: true,
+                   public: true,
+                   type: Boolean,
+                   allowed_from_server: false,
+                   description: 'Al',
+                   aliases: %i[aluminum]},
+       leisure: {default: false,
+                 documentation_default: false,
+                 public: true,
+                 type: Boolean,
+                 allowed_from_server: false,
+                 description: 'Pleasure'}}
     end
   end
 end


### PR DESCRIPTION
Config aliases were previously supported only for environment params and they are now supported for YAML params as well.

If a param is missing from config and its alias is present, the alias will now be respected. If both are present, the original wins.