### PR TITLE
CI: ignore Rails environment switches for db tasks

### DIFF
--- a/test/multiverse/suites/active_record_pg/before_suite.rb
+++ b/test/multiverse/suites/active_record_pg/before_suite.rb
@@ -8,6 +8,11 @@ def redefine_mysql_primary_key(const_str)
 end
 
 begin
+  # disable the environment check that would otherwise raise
+  # ActiveRecord::EnvironmentMismatchError when switching between the
+  # default_env and test environments
+  ENV['DISABLE_DATABASE_ENVIRONMENT_CHECK'] = 'true'
+
   load('Rakefile')
   Rake::Task['db:drop'].invoke
   Rake::Task['db:create'].invoke


### PR DESCRIPTION
When switching between the default_env and test Rails environments, the Rails database tasks will raise
`ActiveRecord::EnvironmentMismatchError`.

Rails can either be explicitly told that the environment being switched to is expected via a task that sets the target environment, or the check itself can be disabled via an environment variable.

For now we are opting for the latter with
`ENV['DISABLE_DATABASE_ENVIRONMENT_CHECK']`.