### PR TITLE
Don't test Puma with Ruby 3.3

### DIFF
--- a/test/multiverse/suites/rack/Envfile
+++ b/test/multiverse/suites/rack/Envfile
@@ -13,7 +13,7 @@ PUMA_VERSIONS = [
 ]
 
 # Puma 3.12.6's Regexp.new calls are incompatible with Ruby 3.3
-PUMA_VERSION.push('3.12.6') unless RUBY_VERSION >= '3.3.0'
+PUMA_VERSIONS.push('3.12.6') unless RUBY_VERSION >= '3.3.0'
 
 def gem_list(puma_version = nil)
   <<~RB

--- a/test/multiverse/suites/rack/Envfile
+++ b/test/multiverse/suites/rack/Envfile
@@ -9,9 +9,11 @@ instrumentation_methods :chain, :prepend
 PUMA_VERSIONS = [
   nil,
   '5.6.4',
-  '4.3.12',
-  '3.12.6'
+  '4.3.12'
 ]
+
+# Puma 3.12.6's Regexp.new calls are incompatible with Ruby 3.3
+PUMA_VERSION.push('3.12.6') unless RUBY_VERSION >= '3.3.0'
 
 def gem_list(puma_version = nil)
   <<~RB
@@ -27,19 +29,14 @@ create_gemfiles(PUMA_VERSIONS)
 gemfile <<~RB
   gem 'rack'
   gem 'rack-test'
-
 RB
 
 gemfile <<~RB if RUBY_VERSION < '3.3.0'
   gem 'rack', '2.2.4'
   gem 'rack-test'
-
 RB
 
-if RUBY_VERSION < '3.2.0'
-  gemfile <<~RB
-    gem 'rack', '1.6.13'
-    gem 'rack-test'
-
-  RB
-end
+gemfile <<~RB if RUBY_VERSION < '3.2.0'
+  gem 'rack', '1.6.13'
+  gem 'rack-test'
+RB

--- a/test/multiverse/suites/rack/Envfile
+++ b/test/multiverse/suites/rack/Envfile
@@ -30,7 +30,7 @@ gemfile <<~RB
 
 RB
 
-gemfile <<~RB
+gemfile <<~RB if RUBY_VERSION < '3.3.0'
   gem 'rack', '2.2.4'
   gem 'rack-test'
 

--- a/test/multiverse/suites/rack/Envfile
+++ b/test/multiverse/suites/rack/Envfile
@@ -9,7 +9,7 @@ instrumentation_methods :chain, :prepend
 #
 #       Remove this condition and allow Ruby 3.3 to be used with any updated
 #       Puma versions once they become available.
-suite_condition('Puma tests are temporarily skipped for Ruby v3.3') { !RUBY_VERSION == '3.3.0' }
+suite_condition('Puma tests are temporarily skipped for Ruby v3.3') { RUBY_VERSION != '3.3.0' }
 
 # The Rack suite also tests Puma::Rack::Builder
 # Which is why we also control Puma tested versions here

--- a/test/multiverse/suites/rack/Envfile
+++ b/test/multiverse/suites/rack/Envfile
@@ -4,16 +4,21 @@
 
 instrumentation_methods :chain, :prepend
 
+# TODO: Puma versions 3.12.6 through 6.2.2 all invoke Regexp.new with 3
+#       arguments, which worked for Ruby 3.2 but not for Ruby 3.3.
+#
+#       Remove this condition and allow Ruby 3.3 to be used with any updated
+#       Puma versions once they become available.
+suite_condition('Puma tests are temporarily skipped for Ruby v3.3') { !RUBY_VERSION == '3.3.0' }
+
 # The Rack suite also tests Puma::Rack::Builder
 # Which is why we also control Puma tested versions here
 PUMA_VERSIONS = [
   nil,
   '5.6.4',
-  '4.3.12'
+  '4.3.12',
+  '3.12.6'
 ]
-
-# Puma 3.12.6's Regexp.new calls are incompatible with Ruby 3.3
-PUMA_VERSIONS.push('3.12.6') unless RUBY_VERSION >= '3.3.0'
 
 def gem_list(puma_version = nil)
   <<~RB
@@ -31,7 +36,7 @@ gemfile <<~RB
   gem 'rack-test'
 RB
 
-gemfile <<~RB if RUBY_VERSION < '3.3.0'
+gemfile <<~RB
   gem 'rack', '2.2.4'
   gem 'rack-test'
 RB


### PR DESCRIPTION
For now, don't test Ruby v3.3 with any supported version of Puma, as it it currently thought to be incompatible.

resolves #2040
