### PR TITLE
Remove todo that doesn't apply anymore

### DIFF
--- a/test/new_relic/agent/method_tracer/instance_methods/trace_execution_scoped_test.rb
+++ b/test/new_relic/agent/method_tracer/instance_methods/trace_execution_scoped_test.rb
@@ -2,8 +2,6 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
-# TODO: Address intermittent failure where "after_fork" Supportability Metric appears
-
 require_relative '../../../../test_helper'
 
 class NewRelic::Agent::MethodTracer::TraceExecutionScopedTest < Minitest::Test


### PR DESCRIPTION
closes https://github.com/newrelic/newrelic-ruby-agent/issues/1435
we have a todo that references a test failure that doesn't happen anymore
```
# TODO: Address intermittent failure where "after_fork" Supportability Metric appears
```