### PR TITLE
Introduce log-level filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,19 @@
 
 ## dev
 
-Version <dev> of the agent expands instrumentation for Action Cable. 
+Version <dev> of the agent adds the ability to filter logs by level and expands instrumentation for Action Cable.
 
-**Feature: Instrument transmit_subscription_* Action Cable actions**
+- **Feature: Filter forwarded logs based on level**
+
+  Previously, all log events, regardless of their level, were forwarded to New Relic when log forwarding was enabled. Now, you may specify the lowest log level you'd like forwarded to New Relic.
+
+  | Configuration name          | Default | Behavior                                               | Valid values |
+  | --------------------------- | ------- | ------------------------------------------------------ | ------ |
+  | `application_logging.forwarding.log_level` | `debug` | Sets the minimum log level for events forwarded to New Relic | `debug`, `info`, `warn`, `error`, `fatal`, `unknown` |
+
+  This setting uses [Ruby's Logger::Severity constants integer values](https://github.com/ruby/ruby/blob/master/lib/logger/severity.rb#L6-L17) to determine precedence.
+
+- **Feature: Instrument transmit_subscription_* Action Cable actions**
 
   This change subscribes the agent to the Active Support notifications for:
     * `transmit_subscription_confirmation.action_cable`

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -749,6 +749,29 @@ module NewRelic
           :allowed_from_server => false,
           :description => 'If `true`, the agent captures log records emitted by your application.'
         },
+        :'application_logging.forwarding.log_level' => {
+          :default => 'debug',
+          :public => true,
+          :type => String,
+          :allowed_from_server => false,
+          :description => <<~DESCRIPTION
+            Sets the minimum level a log event must have to be forwarded to New Relic.
+
+            This is based on the integer values of Ruby's `Logger::Severity` constants: https://github.com/ruby/ruby/blob/master/lib/logger/severity.rb
+
+            The intention is to forward logs with the level given to the configuration, as well as any logs with a higher level of severity.
+
+            For example, setting this value to "debug" will forward all log events to New Relic. Setting this value to "error" will only forward log events with the levels "error", "fatal", and "unknown".
+
+            Valid values (ordered lowest to highest):
+              * "debug"
+              * "info"
+              * "warn"
+              * "error"
+              * "fatal"
+              * "unknown"
+          DESCRIPTION
+        },
         :'application_logging.forwarding.max_samples_stored' => {
           :default => 10000,
           :public => true,

--- a/lib/new_relic/agent/log_event_aggregator.rb
+++ b/lib/new_relic/agent/log_event_aggregator.rb
@@ -248,10 +248,6 @@ module NewRelic
         end
       end
 
-      def log_level
-        NewRelic::Agent.config[LOG_LEVEL_KEY]
-      end
-
       def configured_log_level_constant
         format_log_level_constant(NewRelic::Agent.config[LOG_LEVEL_KEY])
       end

--- a/lib/new_relic/agent/log_event_aggregator.rb
+++ b/lib/new_relic/agent/log_event_aggregator.rb
@@ -237,8 +237,19 @@ module NewRelic
         if Logger::Severity.constants.include?(configured_log_level_constant)
           configured_log_level_constant
         else
+          NewRelic::Agent.logger.log_once(
+            :error,
+            'Invalid application_logging.forwarding.log_level ' \
+            "'#{NewRelic::Agent.config[LOG_LEVEL_KEY]}' specified! " \
+            "Must be one of #{Logger::Severity.constants.join('|')}. " \
+            "Using default level of 'debug'"
+          )
           :DEBUG
         end
+      end
+
+      def log_level
+        NewRelic::Agent.config[LOG_LEVEL_KEY]
       end
 
       def configured_log_level_constant

--- a/lib/new_relic/agent/log_event_aggregator.rb
+++ b/lib/new_relic/agent/log_event_aggregator.rb
@@ -255,8 +255,6 @@ module NewRelic
         return false unless Logger::Severity.constants.include?(severity_constant)
 
         Logger::Severity.const_get(severity_constant) < Logger::Severity.const_get(minimum_log_level)
-      rescue NameError => e
-        NewRelic::Agent.logger.error('Log severity constant not found', e)
       end
     end
   end

--- a/newrelic.yml
+++ b/newrelic.yml
@@ -40,6 +40,19 @@ common: &default_settings
   # If `true`, the agent captures log records emitted by this application.
   # application_logging.forwarding.enabled: true
 
+  # Sets the minimum level a log event must have to be forwarded to New Relic.
+  # This is based on the integer values of Ruby's `Logger::Severity` constants: https://github.com/ruby/ruby/blob/master/lib/logger/severity.rb
+  # The intention is to forward logs with the level given to the configuration, as well as any logs with a higher level of severity.
+  # For example, setting this value to "debug" will forward all log events to New Relic. Setting this value to "error" will only forward log events with the levels "error", "fatal", and "unknown".
+  # Valid values (ordered lowest to highest):
+  #   * "debug"
+  #   * "info"
+  #   * "warn"
+  #   * "error"
+  #   * "fatal"
+  #   * "unknown"
+  # application_logging.forwarding.log_level: debug
+
   # Defines the maximum number of log records to buffer in memory at a time.
   # application_logging.forwarding.max_samples_stored: 10000
 

--- a/test/helpers/config_scanning.rb
+++ b/test/helpers/config_scanning.rb
@@ -7,13 +7,13 @@ module NewRelic
     module ConfigScanning
       # This is a bit loose (allows any config[] with the right key) so we can pass
       # NewRelic::Agent.config into classes as long as we call the variable config
-      AGENT_CONFIG_PATTERN = /config\[:['"]?([a-z\._]+)['"]?\s*\]/
-      DEFAULT_VALUE_OF_PATTERN = /:default\s*=>\s*value_of\(:['"]?([a-z\._]+)['"]?\)\s*/
-      DEFAULT_INST_VALUE_OF_PATTERN = /:default\s*=>\s*instrumentation_value_of\(:['"]?([a-z._]+)['"]?\)|\(:['"]?([a-z._]+)['"]?\s*,\s*:['"]?([a-z._]+)['"]?\)/
-      REGISTER_CALLBACK_PATTERN = /register_callback\(:['"]?([a-z\._]+)['"]?\)/
+      AGENT_CONFIG_PATTERN = /config\[:(['"])?([a-z\._]+)\1?\s*\]/
+      DEFAULT_VALUE_OF_PATTERN = /:default\s*=>\s*value_of\(:(['"])?([a-z\._]+)\1?\)\s*/
+      DEFAULT_INST_VALUE_OF_PATTERN = /:default\s*=>\s*instrumentation_value_of\(:(['"])?([a-z._]+)\1?\)|\(:(['"])?([a-z._]+)\3?\s*,\s*:(['"])?([a-z._]+)\5?\)/
+      REGISTER_CALLBACK_PATTERN = /register_callback\(:(['"])?([a-z\._]+)\1?\)/
       NAMED_DEPENDENCY_PATTERN = /^\s*named[ (]+\:?([a-z0-9\._]+).*$/
-      EVENT_BUFFER_MACRO_PATTERN = /(capacity_key|enabled_key)\s+:['"]?([a-z\._]+)['"]?/
-      ASSIGNED_CONSTANT_PATTERN = /[A-Z]+\s*=\s*:['"]?([a-z\._]+)['"]?\s*/
+      EVENT_BUFFER_MACRO_PATTERN = /(capacity_key|enabled_key)\s+:(['"])?([a-z\._]+)\2?/
+      ASSIGNED_CONSTANT_PATTERN = /[A-Z]+\s*=\s*:(['"])?([a-z\._]+)\1?\s*/
 
       def scan_and_remove_used_entries(default_keys, non_test_files)
         non_test_files.each do |file|

--- a/test/helpers/config_scanning.rb
+++ b/test/helpers/config_scanning.rb
@@ -13,6 +13,7 @@ module NewRelic
       REGISTER_CALLBACK_PATTERN = /register_callback\(:['"]?([a-z\._]+)['"]?\)/
       NAMED_DEPENDENCY_PATTERN = /^\s*named[ (]+\:?([a-z0-9\._]+).*$/
       EVENT_BUFFER_MACRO_PATTERN = /(capacity_key|enabled_key)\s+:['"]?([a-z\._]+)['"]?/
+      ASSIGNED_CONSTANT_PATTERN = /[A-Z]+\s*=\s*:['"]?([a-z\._]+)['"]?\s*/
 
       def scan_and_remove_used_entries(default_keys, non_test_files)
         non_test_files.each do |file|
@@ -23,6 +24,7 @@ module NewRelic
             captures << line.scan(DEFAULT_INST_VALUE_OF_PATTERN)
             captures << line.scan(REGISTER_CALLBACK_PATTERN)
             captures << line.scan(EVENT_BUFFER_MACRO_PATTERN)
+            captures << line.scan(ASSIGNED_CONSTANT_PATTERN)
             captures << line.scan(NAMED_DEPENDENCY_PATTERN).map(&method(:disable_name))
 
             captures.flatten.compact.each do |key|

--- a/test/new_relic/agent/log_event_aggregator_test.rb
+++ b/test/new_relic/agent/log_event_aggregator_test.rb
@@ -451,6 +451,18 @@ module NewRelic::Agent
       end
     end
 
+    def test_logs_error_when_log_level_not_within_default_severities
+      logger = MiniTest::Mock.new
+      logger.expect :log_once, nil, [:error, /Invalid application_logging.forwarding.log_level/]
+
+      with_config(LogEventAggregator::LOG_LEVEL_KEY => 'milkshake') do
+        NewRelic::Agent.stub :logger, logger do
+          @aggregator.send(:minimum_log_level)
+          logger.verify
+        end
+      end
+    end
+
     def test_sets_log_level_constant_to_symbolized_capitalized_level
       with_config(LogEventAggregator::LOG_LEVEL_KEY => 'info') do
         assert_equal :INFO, @aggregator.send(:configured_log_level_constant)


### PR DESCRIPTION
This creates a new configuration, `application_logging.forwarding.log_level`. This configuration defines the
minimum log level a log event should have to forward to New Relic.

Filtering is done in the `LogEventAggregator#record` method.

The default is "debug" which will forward all logs.

Setting the configuration to another built-in Ruby log level, such as "error", will forward only logs with the severity of error or above. This would mean logs with "error", "fatal" or "unknown" would be forwarded to New Relic.

This setting uses [Ruby's Logger::Severity constants integer values](https://github.com/ruby/ruby/blob/master/lib/logger/severity.rb#L6-L17) to determine precedence.

If an invalid log level is given to the configuration, the agent will default to forwarding all logs/having a "debug" level.

Log levels not defined as constants within Ruby's `Logger::Severity` class will always have their events forwarded.

This PR also: 
* replaces string references with constants in a few areas on the LogEventAggregator
* adds a pattern to ConfigScanning to permit config assignment to constants as a valid use case

Resolves #1831 