### PR TITLE
enable Rack and Puma tests with Ruby 3.3

### DIFF
--- a/test/multiverse/lib/multiverse/envfile.rb
+++ b/test/multiverse/lib/multiverse/envfile.rb
@@ -110,6 +110,7 @@ module Multiverse
 
     def add_version(version)
       return unless version
+      return ", #{version}" unless version[0].match?(/^[><=0-9]$/) # permit git, github, path, etc. pragmas
 
       # If the Envfile based version starts with '>', '<', '=', '>=', or '<=',
       # then preserve that prefix when creating a Gemfile. Otherwise, twiddle

--- a/test/multiverse/lib/multiverse/envfile.rb
+++ b/test/multiverse/lib/multiverse/envfile.rb
@@ -38,13 +38,7 @@ module Multiverse
           )
         end
 
-        version = if version&.start_with?('=')
-          add_version(version.sub('= ', ''), false) # don't twiddle wakka
-        else
-          add_version(version)
-        end
-
-        gemfile(gem_list(version))
+        gemfile(gem_list(add_version(version)))
       end
     end
 
@@ -114,8 +108,13 @@ module Multiverse
       @gemfiles.size
     end
 
-    def add_version(version, twiddle_wakka = true)
+    def add_version(version)
       return unless version
+
+      # If the Envfile based version starts with '>', '<', '=', '>=', or '<=',
+      # then preserve that prefix when creating a Gemfile. Otherwise, twiddle
+      # wakka the version (prefix the version with '~>')
+      twiddle_wakka = !version.start_with?('=', '>', '<')
 
       ", '#{'~> ' if twiddle_wakka}#{version}'"
     end

--- a/test/multiverse/suites/active_record/Envfile
+++ b/test/multiverse/suites/active_record/Envfile
@@ -40,9 +40,9 @@ end
 def minitest_activerecord_version(activerecord_version)
   return if activerecord_version.nil?
   if activerecord_version.delete('^0-9', '^.').start_with?('4.0')
-    add_version('4.2.0', false)
+    add_version('4.2.0')
   else
-    add_version('5.2.3', false)
+    add_version('5.2.3')
   end
 end
 

--- a/test/multiverse/suites/rack/Envfile
+++ b/test/multiverse/suites/rack/Envfile
@@ -8,7 +8,9 @@ instrumentation_methods :chain, :prepend
 # Which is why we also control Puma tested versions here
 # Puma <= v6.3.0's URLMap class won't work with Ruby v3.3+, see:
 #   https://github.com/puma/puma/pull/3165
-PUMA_VERSIONS = RUBY_VERSION >= '3.3.0' ? ['> 6.3.0'] : [
+# TODO: replace the GitHub ref with a version number greater than 6.3.0 once
+#       one has been published to RubyGems
+PUMA_VERSIONS = RUBY_VERSION >= '3.3.0' ? ["github: 'puma', ref: 'ffcc83e987e6a125b16bd6097ae72b611f268e76'"] : [
   'nil',
   '5.6.4',
   '4.3.12',

--- a/test/multiverse/suites/rack/Envfile
+++ b/test/multiverse/suites/rack/Envfile
@@ -4,17 +4,12 @@
 
 instrumentation_methods :chain, :prepend
 
-# TODO: Puma versions 3.12.6 through 6.2.2 all invoke Regexp.new with 3
-#       arguments, which worked for Ruby 3.2 but not for Ruby 3.3.
-#
-#       Remove this condition and allow Ruby 3.3 to be used with any updated
-#       Puma versions once they become available.
-suite_condition('Puma tests are temporarily skipped for Ruby v3.3') { RUBY_VERSION != '3.3.0' }
-
 # The Rack suite also tests Puma::Rack::Builder
 # Which is why we also control Puma tested versions here
-PUMA_VERSIONS = [
-  nil,
+# Puma <= v6.3.0's URLMap class won't work with Ruby v3.3+, see:
+#   https://github.com/puma/puma/pull/3165
+PUMA_VERSIONS = RUBY_VERSION >= '3.3.0' ? ['> 6.3.0'] : [
+  'nil',
   '5.6.4',
   '4.3.12',
   '3.12.6'


### PR DESCRIPTION
* test Ruby 3.3 with Puma (via the Rack suite) now that [puma/puma#3165](https://github.com/puma/puma/pull/3165) has been merged
* update `add_version` to respect _any_ prefix a human maintainer might want to specify for a version, and not just `=`
* update `add_version` to allow you do whatever Bundler lets you do. You can use `github`, `git`, `path`, etc.