### PR TITLE
Fix for incorrectly private method in DecoratingFormatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## dev
 
-Version <dev> of the agent adds the ability to filter logs by level, expands instrumentation for Action Cable, and provides a bugfix for Code-Level Metrics.
+Version <dev> of the agent adds the ability to filter logs by level, expands instrumentation for Action Cable,provides bugfix for Code-Level Metrics, and a bugfix for `NewRelic::Agent::Logging::DecoratingFormatter#clear_tags!` being incorrectly private.
 
 - **Feature: Filter forwarded logs based on level**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ Version <dev> of the agent adds the ability to filter logs by level, expands ins
 
   Controllers in Rails automatically render views with names that correspond to valid routes. This means that a controller method may not have a corresponding method in the controller class. Code-Level Metrics now report on these methods and don't log false warnings. Thanks to [@jcrisp](https://github.com/jcrisp) for reporting this issue. [PR#2061](https://github.com/newrelic/newrelic-ruby-agent/pull/2061)
 
+- **Bugfix: Private method `clear_tags!` for NewRelic::Agent::Logging::DecoratingFormatter**
+
+  As part of a refactor included in a previous release of the agent, the method `NewRelic::Agent::Logging::DecoratingFormatter#clear_tags!` was incorrectly made private. This method is now public again. Thanks to [@dark-panda](https://github.com/dark-panda) for reporting this issue. [PR#]()
+
 ## v9.2.2
 
   Version 9.2.2 of the agent fixes a bug with the `Transaction#finished?` method.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ Version <dev> of the agent adds the ability to filter logs by level, expands ins
 
 - **Bugfix: Private method `clear_tags!` for NewRelic::Agent::Logging::DecoratingFormatter**
 
-  As part of a refactor included in a previous release of the agent, the method `NewRelic::Agent::Logging::DecoratingFormatter#clear_tags!` was incorrectly made private. This method is now public again. Thanks to [@dark-panda](https://github.com/dark-panda) for reporting this issue. [PR#]()
+  As part of a refactor included in a previous release of the agent, the method `NewRelic::Agent::Logging::DecoratingFormatter#clear_tags!` was incorrectly made private. This method is now public again. Thanks to [@dark-panda](https://github.com/dark-panda) for reporting this issue. [PR#](https://github.com/newrelic/newrelic-ruby-agent/pull/2078)
 
 ## v9.2.2
 

--- a/lib/new_relic/agent/logging.rb
+++ b/lib/new_relic/agent/logging.rb
@@ -62,6 +62,10 @@ module NewRelic
           message << CLOSING_BRACE << NEWLINE
         end
 
+        def clear_tags!
+          # No-op; just avoiding issues with act-fluent-logger-rails
+        end
+
         private
 
         def add_app_name(message)
@@ -137,10 +141,6 @@ module NewRelic
             )
           end
           message.to_json
-        end
-
-        def clear_tags!
-          # No-op; just avoiding issues with act-fluent-logger-rails
         end
       end
 

--- a/test/new_relic/agent/logging_test.rb
+++ b/test/new_relic/agent/logging_test.rb
@@ -18,6 +18,11 @@ module NewRelic
           JSON.load(@output.string.split("\n")[-1])
         end
 
+        def test_clear_tags_is_called_without_error
+          logger = DecoratingLogger.new(@output)
+          logger.formatter.clear_tags!
+        end
+
         def test_log_to_json
           logger = DecoratingLogger.new(@output)
           logger.info('this is a test')


### PR DESCRIPTION
In a previous refactor, the method `NewRelic::Agent::Logging::DecoratingFormatter#clear_tags!` was included in the private section. This is a no op method that exists for rails compatibility, and should be public. This PR moves it back to public and adds a test to prevent this from happening in the future

closes #2077