### PR TITLE
Delete release notes branch on action fail

### DIFF
--- a/.github/workflows/release_notes.yml
+++ b/.github/workflows/release_notes.yml
@@ -37,7 +37,6 @@ jobs:
           # destination_repo: 'newrelic/docs-website'
           destination_repo: 'hannahramadan/docs-website'
           destination_folder: 'src/content/docs/release-notes/agent-release-notes/ruby-release-notes'
-          # user_email: '${{ secrets.EMAIL }}'
           user_email: 'hramadan@newrelic.com'
           # user_name: 'newrelic-ruby-agent-bot'
           user_name: 'hannahramadan'

--- a/.github/workflows/release_notes.yml
+++ b/.github/workflows/release_notes.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Make pull request
         uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5 # tag v2.12.1
         with:
-          github_token: ${{ secrets.HANNAH_RELEASE_NOTES_ERROR }}
+          github_token: ${{ secrets.HANNAH_RELEASE_NOTES }}
           source_branch: ${{env.branch_name}}
           destination_branch: "develop"
           pr_title: "Ruby Release Notes"

--- a/.github/workflows/release_notes.yml
+++ b/.github/workflows/release_notes.yml
@@ -41,7 +41,7 @@ jobs:
           # user_email: '${{ secrets.EMAIL }}'
           user_email: 'hramadan@newrelic.com'
           # user_name: 'newrelic-ruby-agent-bot'
-          user_name: 'hannahramadan'
+          user_name: 'hramadan'
           destination_branch: 'develop'
           destination_branch_create: ${{env.branch_name}}
           commit_message: 'chore(ruby agent): add release notes'

--- a/.github/workflows/release_notes.yml
+++ b/.github/workflows/release_notes.yml
@@ -31,15 +31,12 @@ jobs:
       - name: Create branch
         uses: dmnemec/copy_file_to_another_repo_action@c93037aa10fa8893de271f19978c980d0c1a9b37 # tag v1.1.1
         env:
-          API_TOKEN_GITHUB: ${{ secrets.HANNAH_RELEASE_NOTES }}
+          API_TOKEN_GITHUB: ${{ secrets.NEWRELIC_RUBY_AGENT_BOT_TOKEN }}
         with:
           source_file: "${{env.source_file}}"
-          # destination_repo: 'newrelic/docs-website'
-          destination_repo: 'hannahramadan/docs-website'
+          destination_repo: 'newrelic/docs-website'
           destination_folder: 'src/content/docs/release-notes/agent-release-notes/ruby-release-notes'
-          user_email: 'hannahr315@gmail.com'
-          # user_name: 'newrelic-ruby-agent-bot'
-          user_name: 'hannahramadan'
+          user_name: 'newrelic-ruby-agent-bot'
           destination_branch: 'develop'
           destination_branch_create: ${{env.branch_name}}
           commit_message: 'chore(ruby agent): add release notes'
@@ -47,13 +44,12 @@ jobs:
       - name: Make pull request
         uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5 # tag v2.12.1
         with:
-          github_token: ${{ secrets.HANNAH_RELEASE_NOTES }}
+          github_token: ${{ secrets.NEWRELIC_RUBY_AGENT_BOT_TOKEN }}
           source_branch: ${{env.branch_name}}
           destination_branch: "develop"
           pr_title: "Ruby Release Notes"
           pr_body: "This is an automated PR generated when the Ruby agent is released. Please merge as soon as possible."
-          # destination_repository: "newrelic/docs-website"
-          destination_repository: "hannahramadan/docs-website"
+          destination_repository: "newrelic/docs-website"
 
   delete_branch_on_fail:
     name: Delete branch on fail
@@ -61,17 +57,17 @@ jobs:
     runs-on: ubuntu-22.04
     if: failure()
     steps:
-      - name: Checkout code
+      - name: Checkout agent repository
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # tag v3.5.0
 
       - name: Get branch name
         run: echo "branch_name=$(ruby -r $PWD/.github/workflows/scripts/generate_release_notes.rb -e GenerateReleaseNotes.new.branch_name)" >> $GITHUB_ENV
 
-      - name: Checkout repository
+      - name: Checkout docs website repository
         uses: actions/checkout@v3
         with: 
-          repository: hannahramadan/docs-website # newrelic/docs-website
-          token: ${{ secrets.HANNAH_RELEASE_NOTES }} # Need new token from NR open bot!
+          repository: newrelic/docs-website
+          token: ${{ secrets.NEWRELIC_RUBY_AGENT_BOT_TOKEN }}
 
       - name: Build delete command
         run: echo "delete_file=git push origin --delete ${{env.branch_name}} --force" >> $GITHUB_ENV

--- a/.github/workflows/release_notes.yml
+++ b/.github/workflows/release_notes.yml
@@ -59,15 +59,13 @@ jobs:
     name: Delete branch on fail
     needs: [send-pull-requests]
     runs-on: ubuntu-22.04
-    if: always()
+    if: ${{ github.event.workflow_run.conclusion == 'failure' && github.event_name != 'workflow_dispatch' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # tag v3.5.0
 
       - name: Get branch name
-        run: |
-          ruby -r $PWD/.github/workflows/scripts/generate_release_notes.rb -e GenerateReleaseNotes.new.write_output_file
-          echo "branch_name=$(ruby -r $PWD/.github/workflows/scripts/generate_release_notes.rb -e GenerateReleaseNotes.new.branch_name)" >> $GITHUB_ENV
+        run: echo "branch_name=$(ruby -r $PWD/.github/workflows/scripts/generate_release_notes.rb -e GenerateReleaseNotes.new.branch_name)" >> $GITHUB_ENV
 
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -79,6 +77,4 @@ jobs:
         run: echo "delete_file=git push origin --delete ${{env.branch_name}} --force" >> $GITHUB_ENV
 
       - name: Delete branch
-        uses: technote-space/workflow-conclusion-action@v3
-      - run: ${{env.delete_file}}
-        if: ${{ env.WORKFLOW_CONCLUSION == 'failure' && github.event_name != 'workflow_dispatch' }}
+        run: ${{env.delete_file}}

--- a/.github/workflows/release_notes.yml
+++ b/.github/workflows/release_notes.yml
@@ -1,9 +1,10 @@
 name: Generate Release Notes
-
 on:
-  push:
-    branches:
-      - main
+  pull_request:
+# on:
+#   push:
+#     branches:
+#       - main
 
 jobs:
   send-pull-requests:
@@ -29,13 +30,17 @@ jobs:
       - name: Create branch
         uses: dmnemec/copy_file_to_another_repo_action@c93037aa10fa8893de271f19978c980d0c1a9b37 # tag v1.1.1
         env:
-          API_TOKEN_GITHUB: ${{ secrets.NEWRELIC_RUBY_AGENT_BOT_TOKEN }}
+          API_TOKEN_GITHUB: ${{ secrets.RELEASE_NOTES }}
+          # API_TOKEN_GITHUB: ${{ secrets.NEWRELIC_RUBY_AGENT_BOT_TOKEN }}
         with:
           source_file: "${{env.source_file}}"
-          destination_repo: 'newrelic/docs-website'
+          # destination_repo: 'newrelic/docs-website'
+          destination_repo: 'hannahramadan/docs-website'
           destination_folder: 'src/content/docs/release-notes/agent-release-notes/ruby-release-notes'
-          user_email: '${{ secrets.EMAIL }}'
-          user_name: 'newrelic-ruby-agent-bot'
+          # user_email: '${{ secrets.EMAIL }}'
+          user_email: 'hannahr315@gmail.com'
+          # user_name: 'newrelic-ruby-agent-bot'
+          user_name: 'hannahramadan'
           destination_branch: 'develop'
           destination_branch_create: ${{env.branch_name}}
           commit_message: 'chore(ruby agent): add release notes'
@@ -43,11 +48,14 @@ jobs:
       - name: Make pull request
         uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5 # tag v2.12.1
         with:
-          github_token: ${{ secrets.NEWRELIC_RUBY_AGENT_BOT_TOKEN }}
+          # github_token: ${{ secrets.NEWRELIC_RUBY_AGENT_BOT_TOKEN }}
+          github_token: ${{ secrets.RELEASE_NOTES }}
           source_branch: ${{env.branch_name}}
           destination_branch: "develop"
           pr_title: "Ruby Release Notes"
           pr_body: "This is an automated PR generated when the Ruby agent is released. Please merge as soon as possible."
-          destination_repository: "newrelic/docs-website"
+          # destination_repository: "newrelic/docs-website"
+          destination_repository: "hannahramadan/docs-website"
+
 
 # TODO: Add a job to delete branch on PR failure. 

--- a/.github/workflows/release_notes.yml
+++ b/.github/workflows/release_notes.yml
@@ -31,8 +31,7 @@ jobs:
       - name: Create branch
         uses: dmnemec/copy_file_to_another_repo_action@c93037aa10fa8893de271f19978c980d0c1a9b37 # tag v1.1.1
         env:
-          API_TOKEN_GITHUB: ${{ secrets.RELEASE_NOTES }}
-          # API_TOKEN_GITHUB: ${{ secrets.NEWRELIC_RUBY_AGENT_BOT_TOKEN }}
+          API_TOKEN_GITHUB: ${{ secrets.RUBY_RELEASE_NOTES }}
         with:
           source_file: "${{env.source_file}}"
           # destination_repo: 'newrelic/docs-website'
@@ -41,7 +40,7 @@ jobs:
           # user_email: '${{ secrets.EMAIL }}'
           user_email: 'hramadan@newrelic.com'
           # user_name: 'newrelic-ruby-agent-bot'
-          user_name: 'hramadan'
+          user_name: 'hannahramadan'
           destination_branch: 'develop'
           destination_branch_create: ${{env.branch_name}}
           commit_message: 'chore(ruby agent): add release notes'
@@ -49,8 +48,7 @@ jobs:
       - name: Make pull request
         uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5 # tag v2.12.1
         with:
-          # github_token: ${{ secrets.NEWRELIC_RUBY_AGENT_BOT_TOKEN }}
-          github_token: ${{ secrets.RELEASE_NOTES }}
+          github_token: ${{ secrets.RUBY_RELEASE_NOTES }}
           source_branch: ${{env.branch_name}}
           destination_branch: "develop"
           pr_title: "Ruby Release Notes"

--- a/.github/workflows/release_notes.yml
+++ b/.github/workflows/release_notes.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Make pull request
         uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5 # tag v2.12.1
         with:
-          github_token: ${{ secrets.HANNAH_RELEASE_NOTES }}
+          github_token: ${{ secrets.HANNAH_BROKEN_RELEASE_NOTES }}
           source_branch: ${{env.branch_name}}
           destination_branch: "develop"
           pr_title: "Ruby Release Notes"
@@ -56,4 +56,25 @@ jobs:
           destination_repository: "hannahramadan/docs-website"
 
 
-# TODO: Add a job to delete branch on PR failure.
+  delete_branch_on_fail:
+    name: Delete branch on fail
+    needs: [send-pull-requests]
+    runs-on: ubuntu-22.04
+    if: always()
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with: 
+          repository: hannahramadan/docs-website # newrelic/docs-website
+          token: ${{ secrets.HANNAH_RELEASE_NOTES }} # Need new token from NR open bot!
+
+      - name: Get file name
+        run: echo "file_name=$(ruby -r /home/runner/work/newrelic-ruby-agent/newrelic-ruby-agent/.github/workflows/scripts/generate_release_notes.rb -e GenerateReleaseNotes.new.file_name)" >> $GITHUB_ENV
+      
+      - name: Build delete command
+        run: echo "delete_file=git push origin --delete --force ${{env.file_name}}" >> $GITHUB_ENV
+
+      - name: Delete branch
+        uses: technote-space/workflow-conclusion-action@v3
+      - run: ${{env.delete_file}}
+        if: ${{ env.WORKFLOW_CONCLUSION == 'failure' && github.event_name != 'workflow_dispatch' }}

--- a/.github/workflows/release_notes.yml
+++ b/.github/workflows/release_notes.yml
@@ -59,7 +59,7 @@ jobs:
     name: Delete branch on fail
     needs: [send-pull-requests]
     runs-on: ubuntu-22.04
-    if: ${{ github.event.workflow_run.conclusion == 'failure' && github.event_name != 'workflow_dispatch' }}
+    if: always()
     steps:
       - uses: technote-space/workflow-conclusion-action@v3
         if: ${{ env.WORKFLOW_CONCLUSION == 'failure' && github.event_name != 'workflow_dispatch' }}

--- a/.github/workflows/release_notes.yml
+++ b/.github/workflows/release_notes.yml
@@ -10,9 +10,9 @@ on:
 jobs:
   send-pull-requests:
     runs-on: ubuntu-latest
-    # permissions:
-    #   contents: write
-    #   pull-requests: write
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: ruby/setup-ruby@7d546f4868fb108ed378764d873683f920672ae2 # tag v1.149.0
         with:
@@ -31,15 +31,16 @@ jobs:
       - name: Create branch
         uses: dmnemec/copy_file_to_another_repo_action@c93037aa10fa8893de271f19978c980d0c1a9b37 # tag v1.1.1
         env:
-          API_TOKEN_GITHUB: ${{ secrets.HANNAH_RELEASE_NOTES }}
+          API_TOKEN_GITHUB: ${{ secrets.NEWRELIC_RUBY_AGENT_BOT_TOKEN }}
         with:
           source_file: "${{env.source_file}}"
-          # destination_repo: 'newrelic/docs-website'
-          destination_repo: 'hannahramadan/docs-website'
+          destination_repo: 'newrelic/docs-website'
+          # destination_repo: 'hannahramadan/docs-website'
           destination_folder: 'src/content/docs/release-notes/agent-release-notes/ruby-release-notes'
-          user_email: 'hannahr315@gmail.com'
-          # user_name: 'newrelic-ruby-agent-bot'
-          user_name: 'hannahramadan'
+          user_email: '${{ secrets.EMAIL }}'
+          user_name: 'newrelic-ruby-agent-bot'
+          # user_email: 'hannahr315@gmail.com'
+          # user_name: 'hannahramadan'
           destination_branch: 'develop'
           destination_branch_create: ${{env.branch_name}}
           commit_message: 'chore(ruby agent): add release notes'
@@ -47,13 +48,13 @@ jobs:
       - name: Make pull request
         uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5 # tag v2.12.1
         with:
-          github_token: ${{ secrets.HANNAH_BROKEN_RELEASE_NOTES }}
+          github_token: ${{ secrets.NEWRELIC_RUBY_AGENT_BOT_TOKEN }}
           source_branch: ${{env.branch_name}}
           destination_branch: "develop"
           pr_title: "Ruby Release Notes"
           pr_body: "This is an automated PR generated when the Ruby agent is released. Please merge as soon as possible."
-          # destination_repository: "newrelic/docs-website"
-          destination_repository: "hannahramadan/docs-website"
+          destination_repository: "newrelic/docs-website"
+          # destination_repository: "hannahramadan/docs-website"
 
   delete_branch_on_fail:
     name: Delete branch on fail
@@ -61,24 +62,22 @@ jobs:
     runs-on: ubuntu-22.04
     if: always()
     steps:
-      - name: Checkout code
+      - name: Checkout agent code
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # tag v3.5.0
 
       - name: Get branch name
-        run: |
-          ruby -r $PWD/.github/workflows/scripts/generate_release_notes.rb -e GenerateReleaseNotes.new.write_output_file
-          echo "branch_name=$(ruby -r $PWD/.github/workflows/scripts/generate_release_notes.rb -e GenerateReleaseNotes.new.branch_name)" >> $GITHUB_ENV
+        run: echo "branch_name=$(ruby -r $PWD/.github/workflows/scripts/generate_release_notes.rb -e GenerateReleaseNotes.new.branch_name)" >> $GITHUB_ENV
 
-      - name: Checkout repository
+      - name: Checkout docs website repository
         uses: actions/checkout@v3
         with: 
-          repository: hannahramadan/docs-website # newrelic/docs-website
-          token: ${{ secrets.HANNAH_RELEASE_NOTES }} # Need new token from NR open bot!
+          repository: newrelic/docs-website
+          token: ${{ secrets.NEWRELIC_RUBY_AGENT_BOT_TOKEN }}
 
-      - name: Build delete command test2
+      - name: Build delete command
         run: echo "delete_file=git push origin --delete ${{env.branch_name}} --force" >> $GITHUB_ENV
 
-      - name: Delete branch
+      - name: Delete branch on fail
         uses: technote-space/workflow-conclusion-action@v3
       - run: ${{env.delete_file}}
         if: ${{ env.WORKFLOW_CONCLUSION == 'failure' && github.event_name != 'workflow_dispatch' }}

--- a/.github/workflows/release_notes.yml
+++ b/.github/workflows/release_notes.yml
@@ -34,6 +34,7 @@ jobs:
           source_file: "${{env.source_file}}"
           destination_repo: 'newrelic/docs-website'
           destination_folder: 'src/content/docs/release-notes/agent-release-notes/ruby-release-notes'
+          user_email: '${{ secrets.EMAIL }}'
           user_name: 'newrelic-ruby-agent-bot'
           destination_branch: 'develop'
           destination_branch_create: ${{env.branch_name}}

--- a/.github/workflows/release_notes.yml
+++ b/.github/workflows/release_notes.yml
@@ -1,11 +1,9 @@
 name: Generate Release Notes
+
 on:
-  pull_request:
-  workflow_dispatch:
-# on:
-#   push:
-#     branches:
-#       - main
+  push:
+    branches:
+      - main
 
 jobs:
   send-pull-requests:

--- a/.github/workflows/release_notes.yml
+++ b/.github/workflows/release_notes.yml
@@ -1,11 +1,9 @@
 name: Generate Release Notes
+
 on:
-  pull_request:
-  workflow_dispatch:
-# on:
-#   push:
-#     branches:
-#       - main
+  push:
+    branches:
+      - main
 
 jobs:
   send-pull-requests:
@@ -35,12 +33,9 @@ jobs:
         with:
           source_file: "${{env.source_file}}"
           destination_repo: 'newrelic/docs-website'
-          # destination_repo: 'hannahramadan/docs-website'
           destination_folder: 'src/content/docs/release-notes/agent-release-notes/ruby-release-notes'
           user_email: '${{ secrets.EMAIL }}'
           user_name: 'newrelic-ruby-agent-bot'
-          # user_email: 'hannahr315@gmail.com'
-          # user_name: 'hannahramadan'
           destination_branch: 'develop'
           destination_branch_create: ${{env.branch_name}}
           commit_message: 'chore(ruby agent): add release notes'
@@ -48,13 +43,12 @@ jobs:
       - name: Make pull request
         uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5 # tag v2.12.1
         with:
-          github_token: ${{ secrets.NEWRELIC_RUBY_AGENT_BOT_TOKEN_ERROR }}
+          github_token: ${{ secrets.NEWRELIC_RUBY_AGENT_BOT_TOKEN }}
           source_branch: ${{env.branch_name}}
           destination_branch: "develop"
           pr_title: "Ruby Release Notes"
           pr_body: "This is an automated PR generated when the Ruby agent is released. Please merge as soon as possible."
           destination_repository: "newrelic/docs-website"
-          # destination_repository: "hannahramadan/docs-website"
 
   delete_branch_on_fail:
     name: Delete branch on fail

--- a/.github/workflows/release_notes.yml
+++ b/.github/workflows/release_notes.yml
@@ -38,7 +38,7 @@ jobs:
           destination_repo: 'hannahramadan/docs-website'
           destination_folder: 'src/content/docs/release-notes/agent-release-notes/ruby-release-notes'
           # user_email: '${{ secrets.EMAIL }}'
-          user_email: 'hannahr315@gmail.com'
+          user_email: 'hramadan@newrelic.com'
           # user_name: 'newrelic-ruby-agent-bot'
           user_name: 'hannahramadan'
           destination_branch: 'develop'

--- a/.github/workflows/release_notes.yml
+++ b/.github/workflows/release_notes.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Make pull request
         uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5 # tag v2.12.1
         with:
-          github_token: ${{ secrets.NEWRELIC_RUBY_AGENT_BOT_TOKEN }}
+          github_token: ${{ secrets.NEWRELIC_RUBY_AGENT_BOT_TOKEN_ERROR }}
           source_branch: ${{env.branch_name}}
           destination_branch: "develop"
           pr_title: "Ruby Release Notes"

--- a/.github/workflows/release_notes.yml
+++ b/.github/workflows/release_notes.yml
@@ -1,6 +1,7 @@
 name: Generate Release Notes
 on:
   pull_request:
+  workflow_dispatch:
 # on:
 #   push:
 #     branches:

--- a/.github/workflows/release_notes.yml
+++ b/.github/workflows/release_notes.yml
@@ -34,8 +34,8 @@ jobs:
           API_TOKEN_GITHUB: ${{ secrets.HANNAH_RELEASE_NOTES }}
         with:
           source_file: "${{env.source_file}}"
-          destination_repo: 'newrelic/docs-website'
-          # destination_repo: 'hannahramadan/docs-website'
+          # destination_repo: 'newrelic/docs-website'
+          destination_repo: 'hannahramadan/docs-website'
           destination_folder: 'src/content/docs/release-notes/agent-release-notes/ruby-release-notes'
           user_email: 'hannahr315@gmail.com'
           # user_name: 'newrelic-ruby-agent-bot'

--- a/.github/workflows/release_notes.yml
+++ b/.github/workflows/release_notes.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Make pull request
         uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5 # tag v2.12.1
         with:
-          github_token: ${{ secrets.HANNAH_RELEASE_NOTES }}
+          github_token: ${{ secrets.HANNAH_RELEASE_NOTES_ERROR }}
           source_branch: ${{env.branch_name}}
           destination_branch: "develop"
           pr_title: "Ruby Release Notes"
@@ -59,11 +59,8 @@ jobs:
     name: Delete branch on fail
     needs: [send-pull-requests]
     runs-on: ubuntu-22.04
-    if: always()
+    if: failure()
     steps:
-      - uses: technote-space/workflow-conclusion-action@v3
-        if: ${{ env.WORKFLOW_CONCLUSION == 'failure' }}
-
       - name: Checkout code
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # tag v3.5.0
 

--- a/.github/workflows/release_notes.yml
+++ b/.github/workflows/release_notes.yml
@@ -58,4 +58,4 @@ jobs:
           destination_repository: "hannahramadan/docs-website"
 
 
-# TODO: Add a job to delete branch on PR failure. 
+# TODO: Add a job to delete branch on PR failure.

--- a/.github/workflows/release_notes.yml
+++ b/.github/workflows/release_notes.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Create branch
         uses: dmnemec/copy_file_to_another_repo_action@c93037aa10fa8893de271f19978c980d0c1a9b37 # tag v1.1.1
         env:
-          API_TOKEN_GITHUB: ${{ secrets.RUBY_RELEASE_NOTES }}
+          API_TOKEN_GITHUB: ${{ secrets.HANNAH_RELEASE_NOTES }}
         with:
           source_file: "${{env.source_file}}"
           # destination_repo: 'newrelic/docs-website'
@@ -47,7 +47,7 @@ jobs:
       - name: Make pull request
         uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5 # tag v2.12.1
         with:
-          github_token: ${{ secrets.RUBY_RELEASE_NOTES }}
+          github_token: ${{ secrets.HANNAH_RELEASE_NOTES }}
           source_branch: ${{env.branch_name}}
           destination_branch: "develop"
           pr_title: "Ruby Release Notes"

--- a/.github/workflows/release_notes.yml
+++ b/.github/workflows/release_notes.yml
@@ -1,9 +1,11 @@
 name: Generate Release Notes
-
 on:
-  push:
-    branches:
-      - main
+  pull_request:
+  workflow_dispatch:
+# on:
+#   push:
+#     branches:
+#       - main
 
 jobs:
   send-pull-requests:
@@ -29,13 +31,15 @@ jobs:
       - name: Create branch
         uses: dmnemec/copy_file_to_another_repo_action@c93037aa10fa8893de271f19978c980d0c1a9b37 # tag v1.1.1
         env:
-          API_TOKEN_GITHUB: ${{ secrets.NEWRELIC_RUBY_AGENT_BOT_TOKEN }}
+          API_TOKEN_GITHUB: ${{ secrets.HANNAH_RELEASE_NOTES }}
         with:
           source_file: "${{env.source_file}}"
           destination_repo: 'newrelic/docs-website'
+          # destination_repo: 'hannahramadan/docs-website'
           destination_folder: 'src/content/docs/release-notes/agent-release-notes/ruby-release-notes'
-          user_email: '${{ secrets.EMAIL }}'
-          user_name: 'newrelic-ruby-agent-bot'
+          user_email: 'hannahr315@gmail.com'
+          # user_name: 'newrelic-ruby-agent-bot'
+          user_name: 'hannahramadan'
           destination_branch: 'develop'
           destination_branch_create: ${{env.branch_name}}
           commit_message: 'chore(ruby agent): add release notes'
@@ -43,12 +47,13 @@ jobs:
       - name: Make pull request
         uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5 # tag v2.12.1
         with:
-          github_token: ${{ secrets.NEWRELIC_RUBY_AGENT_BOT_TOKEN }}
+          github_token: ${{ secrets.HANNAH_BROKEN_RELEASE_NOTES }}
           source_branch: ${{env.branch_name}}
           destination_branch: "develop"
           pr_title: "Ruby Release Notes"
           pr_body: "This is an automated PR generated when the Ruby agent is released. Please merge as soon as possible."
-          destination_repository: "newrelic/docs-website"
+          # destination_repository: "newrelic/docs-website"
+          destination_repository: "hannahramadan/docs-website"
 
   delete_branch_on_fail:
     name: Delete branch on fail
@@ -56,22 +61,24 @@ jobs:
     runs-on: ubuntu-22.04
     if: always()
     steps:
-      - name: Checkout agent code
+      - name: Checkout code
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # tag v3.5.0
 
       - name: Get branch name
-        run: echo "branch_name=$(ruby -r $PWD/.github/workflows/scripts/generate_release_notes.rb -e GenerateReleaseNotes.new.branch_name)" >> $GITHUB_ENV
+        run: |
+          ruby -r $PWD/.github/workflows/scripts/generate_release_notes.rb -e GenerateReleaseNotes.new.write_output_file
+          echo "branch_name=$(ruby -r $PWD/.github/workflows/scripts/generate_release_notes.rb -e GenerateReleaseNotes.new.branch_name)" >> $GITHUB_ENV
 
-      - name: Checkout docs website repository
+      - name: Checkout repository
         uses: actions/checkout@v3
         with: 
-          repository: newrelic/docs-website
-          token: ${{ secrets.NEWRELIC_RUBY_AGENT_BOT_TOKEN }}
+          repository: hannahramadan/docs-website # newrelic/docs-website
+          token: ${{ secrets.HANNAH_RELEASE_NOTES }} # Need new token from NR open bot!
 
       - name: Build delete command
         run: echo "delete_file=git push origin --delete ${{env.branch_name}} --force" >> $GITHUB_ENV
 
-      - name: Delete branch on fail
+      - name: Delete branch
         uses: technote-space/workflow-conclusion-action@v3
       - run: ${{env.delete_file}}
         if: ${{ env.WORKFLOW_CONCLUSION == 'failure' && github.event_name != 'workflow_dispatch' }}

--- a/.github/workflows/release_notes.yml
+++ b/.github/workflows/release_notes.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Make pull request
         uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5 # tag v2.12.1
         with:
-          github_token: ${{ secrets.HANNAH_BROKEN_RELEASE_NOTES }}
+          github_token: ${{ secrets.HANNAH_RELEASE_NOTES }}
           source_branch: ${{env.branch_name}}
           destination_branch: "develop"
           pr_title: "Ruby Release Notes"
@@ -62,7 +62,7 @@ jobs:
     if: always()
     steps:
       - uses: technote-space/workflow-conclusion-action@v3
-        if: ${{ env.WORKFLOW_CONCLUSION == 'failure' && github.event_name != 'workflow_dispatch' }}
+        if: ${{ env.WORKFLOW_CONCLUSION == 'failure' }}
 
       - name: Checkout code
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # tag v3.5.0

--- a/.github/workflows/release_notes.yml
+++ b/.github/workflows/release_notes.yml
@@ -55,24 +55,28 @@ jobs:
           # destination_repository: "newrelic/docs-website"
           destination_repository: "hannahramadan/docs-website"
 
-
   delete_branch_on_fail:
     name: Delete branch on fail
     needs: [send-pull-requests]
     runs-on: ubuntu-22.04
     if: always()
     steps:
+      - name: Checkout code
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # tag v3.5.0
+
+      - name: Get branch name
+        run: |
+          ruby -r $PWD/.github/workflows/scripts/generate_release_notes.rb -e GenerateReleaseNotes.new.write_output_file
+          echo "branch_name=$(ruby -r $PWD/.github/workflows/scripts/generate_release_notes.rb -e GenerateReleaseNotes.new.branch_name)" >> $GITHUB_ENV
+
       - name: Checkout repository
         uses: actions/checkout@v3
         with: 
           repository: hannahramadan/docs-website # newrelic/docs-website
           token: ${{ secrets.HANNAH_RELEASE_NOTES }} # Need new token from NR open bot!
 
-      - name: Get file name
-        run: echo "file_name=$(ruby -r /home/runner/work/newrelic-ruby-agent/newrelic-ruby-agent/.github/workflows/scripts/generate_release_notes.rb -e GenerateReleaseNotes.new.file_name)" >> $GITHUB_ENV
-      
       - name: Build delete command
-        run: echo "delete_file=git push origin --delete --force ${{env.file_name}}" >> $GITHUB_ENV
+        run: echo "delete_file=git push origin --delete ${{env.branch_name}} --force" >> $GITHUB_ENV
 
       - name: Delete branch
         uses: technote-space/workflow-conclusion-action@v3

--- a/.github/workflows/release_notes.yml
+++ b/.github/workflows/release_notes.yml
@@ -75,7 +75,7 @@ jobs:
           repository: hannahramadan/docs-website # newrelic/docs-website
           token: ${{ secrets.HANNAH_RELEASE_NOTES }} # Need new token from NR open bot!
 
-      - name: Build delete command
+      - name: Build delete command test2
         run: echo "delete_file=git push origin --delete ${{env.branch_name}} --force" >> $GITHUB_ENV
 
       - name: Delete branch

--- a/.github/workflows/release_notes.yml
+++ b/.github/workflows/release_notes.yml
@@ -10,9 +10,9 @@ on:
 jobs:
   send-pull-requests:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
+    # permissions:
+    #   contents: write
+    #   pull-requests: write
     steps:
       - uses: ruby/setup-ruby@7d546f4868fb108ed378764d873683f920672ae2 # tag v1.149.0
         with:

--- a/.github/workflows/release_notes.yml
+++ b/.github/workflows/release_notes.yml
@@ -61,6 +61,9 @@ jobs:
     runs-on: ubuntu-22.04
     if: ${{ github.event.workflow_run.conclusion == 'failure' && github.event_name != 'workflow_dispatch' }}
     steps:
+      - uses: technote-space/workflow-conclusion-action@v3
+        if: ${{ env.WORKFLOW_CONCLUSION == 'failure' && github.event_name != 'workflow_dispatch' }}
+
       - name: Checkout code
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # tag v3.5.0
 

--- a/.github/workflows/release_notes.yml
+++ b/.github/workflows/release_notes.yml
@@ -37,7 +37,7 @@ jobs:
           # destination_repo: 'newrelic/docs-website'
           destination_repo: 'hannahramadan/docs-website'
           destination_folder: 'src/content/docs/release-notes/agent-release-notes/ruby-release-notes'
-          user_email: 'hramadan@newrelic.com'
+          user_email: 'hannahr315@gmail.com'
           # user_name: 'newrelic-ruby-agent-bot'
           user_name: 'hannahramadan'
           destination_branch: 'develop'


### PR DESCRIPTION
This PR adds a new job to the `release_notes` action to delete a newly created branch upon job failure. Without this step, we couldn't re-run the action before manually deleting the branch.

A test run demonstrates a branch successfully created in the job `send-pull-request` that fails at the `make pull request step`. In the `Delete branch on fail job` we are successfully deleting the branch: https://github.com/newrelic/newrelic-ruby-agent/actions/runs/5294926446

Here is the job not running if successful: https://github.com/newrelic/newrelic-ruby-agent/actions/runs/5294997587

Resolves #1919