### PR TITLE
Bugfix for code level metrics on active record classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ Version <dev> of the agent adds log-level filtering, an API to add custom attrib
 
   Controllers in Rails automatically render views with names that correspond to valid routes. This means that a controller method may not have a corresponding method in the controller class. Code-Level Metrics now report on these methods and don't log false warnings. Thanks to [@jcrisp](https://github.com/jcrisp) for reporting this issue. [PR#2061](https://github.com/newrelic/newrelic-ruby-agent/pull/2061)
 
+- **Bugfix: Code-Level Metrics for ActiveRecord models**
+
+  Classes that inherit from ActiveRecord were not reporting Code-Level Metrics due to an error in the agent when identifying the class name. This has been fixed and Code-Level Metrics will now report for ActiveRecord models. Thanks to [@abigail-rolling](https://github.com/abigail-rolling) for reporting this issue. [PR#20]().
+
 - **Bugfix: Private method `clear_tags!` for NewRelic::Agent::Logging::DecoratingFormatter**
 
   As part of a refactor included in a previous release of the agent, the method `NewRelic::Agent::Logging::DecoratingFormatter#clear_tags!` was incorrectly made private. This method is now public again. Thanks to [@dark-panda](https://github.com/dark-panda) for reporting this issue. [PR#](https://github.com/newrelic/newrelic-ruby-agent/pull/2078)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ Version <dev> of the agent adds log-level filtering, an API to add custom attrib
 
 - **Bugfix: Code-Level Metrics for ActiveRecord models**
 
-  Classes that inherit from ActiveRecord were not reporting Code-Level Metrics due to an error in the agent when identifying the class name. This has been fixed and Code-Level Metrics will now report for ActiveRecord models. Thanks to [@abigail-rolling](https://github.com/abigail-rolling) for reporting this issue. [PR#20]().
+  Classes that inherit from ActiveRecord were not reporting Code-Level Metrics due to an error in the agent when identifying the class name. This has been fixed and Code-Level Metrics will now report for ActiveRecord models. Thanks to [@abigail-rolling](https://github.com/abigail-rolling) for reporting this issue. [PR#2092](https://github.com/newrelic/newrelic-ruby-agent/pull/2092).
 
 - **Bugfix: Private method `clear_tags!` for NewRelic::Agent::Logging::DecoratingFormatter**
 

--- a/lib/new_relic/agent/method_tracer_helpers.rb
+++ b/lib/new_relic/agent/method_tracer_helpers.rb
@@ -71,7 +71,7 @@ module NewRelic
       # '#<Class:MyModule::MyClass>', or '#<Class:MyModule::MyClass(id: integer, attrbiute: string)>'
       # Return the 'MyModule::MyClass' part of that string
       def klass_name(object)
-        name = Regexp.last_match(1) if object.to_s =~ /^#<Class:([\w|:{2}]*).*>$/
+        name = Regexp.last_match(1) if object.to_s =~ /^#<Class:([\w:]*).*>$/
         return name if name
 
         raise "Unable to glean a class name from string '#{object}'"

--- a/lib/new_relic/agent/method_tracer_helpers.rb
+++ b/lib/new_relic/agent/method_tracer_helpers.rb
@@ -71,7 +71,7 @@ module NewRelic
       # '#<Class:MyModule::MyClass>', or '#<Class:MyModule::MyClass(id: integer, attribute: string)>'
       # Return the 'MyModule::MyClass' part of that string
       def klass_name(object)
-        name = Regexp.last_match(1) if object.to_s =~ /^#<Class:([\w:]*).*>$/
+        name = Regexp.last_match(1) if object.to_s =~ /^#<Class:([\w:]+).*>$/
         return name if name
 
         raise "Unable to glean a class name from string '#{object}'"

--- a/lib/new_relic/agent/method_tracer_helpers.rb
+++ b/lib/new_relic/agent/method_tracer_helpers.rb
@@ -68,10 +68,10 @@ module NewRelic
       end
 
       # The string representation of a singleton class looks like
-      # '#<Class:MyModule::MyClass>'. Return the 'MyModule::MyClass' part of
-      # that string
+      # '#<Class:MyModule::MyClass>', or '#<Class:MyModule::MyClass(id: integer, attrbiute: string)>'
+      # Return the 'MyModule::MyClass' part of that string
       def klass_name(object)
-        name = Regexp.last_match(1) if object.to_s =~ /^#<Class:(.*)>$/
+        name = Regexp.last_match(1) if object.to_s =~ /^#<Class:([\w|:{2}]*).*>$/
         return name if name
 
         raise "Unable to glean a class name from string '#{object}'"

--- a/lib/new_relic/agent/method_tracer_helpers.rb
+++ b/lib/new_relic/agent/method_tracer_helpers.rb
@@ -68,7 +68,7 @@ module NewRelic
       end
 
       # The string representation of a singleton class looks like
-      # '#<Class:MyModule::MyClass>', or '#<Class:MyModule::MyClass(id: integer, attrbiute: string)>'
+      # '#<Class:MyModule::MyClass>', or '#<Class:MyModule::MyClass(id: integer, attribute: string)>'
       # Return the 'MyModule::MyClass' part of that string
       def klass_name(object)
         name = Regexp.last_match(1) if object.to_s =~ /^#<Class:([\w:]*).*>$/

--- a/test/new_relic/agent/method_tracer_helpers_test.rb
+++ b/test/new_relic/agent/method_tracer_helpers_test.rb
@@ -151,6 +151,23 @@ class NewRelic::Agent::MethodTracerHelpersTest < Minitest::Test
   if defined?(::Rails::VERSION::MAJOR) && ::Rails::VERSION::MAJOR >= 7
     require_relative '../../environments/rails70/app/controllers/no_method_controller'
 
+    module ::The
+      class ActiveRecordExample < ActiveRecord::Base
+        def self.class_method; end
+        def instance_method; end
+        private # rubocop:disable Layout/EmptyLinesAroundAccessModifier
+        def private_method; end
+      end
+    end
+
+    def test_provides_accurate_name_for_active_record_class
+      with_config(:'code_level_metrics.enabled' => true) do
+        klass = NewRelic::Agent::MethodTracerHelpers.send(:klassify_singleton, The::ActiveRecordExample.singleton_class)
+
+        assert_equal klass, The::ActiveRecordExample
+      end
+    end
+
     def test_provides_info_for_no_method_on_controller
       skip_unless_minitest5_or_above
 


### PR DESCRIPTION
The regex the agent was using didn't account for the possibility of active record adding attributes to inspect, which resulted in trying to call `Object.const_get` with a class name that was like `"Foo(id: integer, created_at: datetime, updated_at: datetime, name: string)"`, instead of just `"Foo"`. This would cause an error `NameError: wrong constant name` that prevent code level metrics from gathering the information and would log a warning.
Now, the regex will only grab word characters and :: for the name, preventing the `(....` from being included as the class name. 
A test was also added to confirm this works properly and prevent issues in the future. 

closes #2064