### PR TITLE
Pin rack version to <3 when using Puma 5

### DIFF
--- a/test/multiverse/suites/rack/Envfile
+++ b/test/multiverse/suites/rack/Envfile
@@ -23,7 +23,7 @@ PUMA_VERSIONS = [
 def gem_list(puma_version = nil)
   <<~RB
     gem 'puma'#{puma_version}
-    gem 'rack'
+    gem 'rack'#{puma_version&.include?('5.6.4') ? ', "~> 2.2.4"' : ''}
     gem 'rack-test'
 
   RB


### PR DESCRIPTION
Puma 5.6.6 was recently released, which will raise an error if the rack version being used is rack 3.
```
puma-5.6.6/lib/rack/version_restriction.rb:12:in `<top (required)>': Puma 5 is not compatible with Rack 3, please upgrade to Puma 6 or higher. (StandardError)
```
This was failing one of our multiverse suites, so now it is pinned to the correct version.