### PR TITLE
CI: permit `serialize!` in Envfile

### DIFF
--- a/test/multiverse/README.md
+++ b/test/multiverse/README.md
@@ -133,13 +133,15 @@ contain at least two files.
 The Envfile is a meta gem file.  It allows you to specify one or more gemset
 that the tests in this directory should be run against.  For example:
 
-    gemfile <<~GEMFILE
-      gem "rails", "~>6.1.0"
-    GEMFILE
+```ruby
+gemfile <<~GEMFILE
+  gem "rails", "~>6.1.0"
+GEMFILE
 
-    gemfile <<~GEMFILE
-      gem "rails", "~>6.0.0"
-    GEMFILE
+gemfile <<~GEMFILE
+  gem "rails", "~>6.0.0"
+GEMFILE
+```
 
 This will run these tests against 2 environments, one running rails 6.1, the
 other running rails 6.0.
@@ -150,11 +152,43 @@ using two environment variables.
 
 The default gemfile line is
 
-    gem 'newrelic_rpm', :path => '../../../ruby_agent'
+```ruby
+gem 'newrelic_rpm', path: '../../../ruby_agent'
+```
 
 `ENV['NEWRELIC_GEMFILE_LINE']` will specify the full line for the gemfile
 
 `ENV['NEWRELIC_GEM_PATH']` will override the `:path` option in the default line.
+
+To force a suite to serialize its tests instead of running them in parallel,
+place this line somewhere within `Envfile`:
+
+```ruby
+serialize!
+```
+
+Each `Minitest::Test` class defined by a suite in a `*_test.rb` file will
+perform prep work before each and every individual test if the class specifies
+a `setup` instance method. To perform a "before all" or "setup once" type of
+operation that is only executed once before all unit tests are invoked, there
+are 2 options:
+
+- Option 1 for smaller prep: In `Envfile`, declare a `before_suite` block:
+
+```ruby
+# Envfile
+before_suite do
+  complex_prep_operation_to_be_ran_once
+end
+```
+
+- Option 2 for larger prep: In the suite directory, create a `before_suite.rb`
+file:
+
+```ruby
+# before_suite.rb
+complex_prep_operation_to_be_ran_once
+```
 
 
 ### Test files

--- a/test/multiverse/lib/multiverse/envfile.rb
+++ b/test/multiverse/lib/multiverse/envfile.rb
@@ -120,6 +120,14 @@ module Multiverse
       ", '#{'~> ' if twiddle_wakka}#{version}'"
     end
 
+    def serialize!
+      @serialize = true
+    end
+
+    def serialize?
+      @serialize
+    end
+
     private
 
     def last_supported_ruby_version?(last_supported_ruby_version)

--- a/test/multiverse/lib/multiverse/suite.rb
+++ b/test/multiverse/lib/multiverse/suite.rb
@@ -413,10 +413,10 @@ module Multiverse
       puts yellow("Starting tests in child PID #{Process.pid} at #{Time.now}\n")
     end
 
-    # active_record_pg test suite runs in serial to prevent database conflicts
+    # to force a suite to run serialized, place `serialized!` somewhere in the
+    # suite's `Envfile` file
     def should_serialize?
-      # TODO: Devise a way for an individual suite to express that it doesn't support parallel
-      ENV['SERIALIZE'] || debug || self.directory.include?('active_record_pg')
+      ENV['SERIALIZE'] || debug || environments.serialize?
     end
 
     def check_environment_condition

--- a/test/multiverse/suites/active_record_pg/Envfile
+++ b/test/multiverse/suites/active_record_pg/Envfile
@@ -6,6 +6,11 @@ suite_condition('Skip AR for JRuby, initialization fails on GitHub Actions') do
   RUBY_PLATFORM != 'java'
 end
 
+# the after_teardown method defined in before_suite.rb performs database
+# cleanup that can be problematic when running in parallel, so force the
+# tests to be serialized
+serialize!
+
 ACTIVERECORD_VERSIONS = [
   [nil, 2.7],
   ['7.0.0', 2.7],


### PR DESCRIPTION
Satisfy the Multiverse CI testing TODO to permit individual suites to insist on running serialized.

For any suite that needs to be ran serialized (and we only have 1 currently), simply call `serialize!` somewhere within `Envfile`.

Updated the relevant `Envfile` documentation.

resolves #1154