### PR TITLE
CI: update multiverse usage documentation

### DIFF
--- a/test/multiverse/README.md
+++ b/test/multiverse/README.md
@@ -97,7 +97,7 @@ The first time you run this command on a new Ruby installation, it will take qui
 
 ## Running Specific Tests and Environments
 
-Multiverse tests live in the `test/multiverse` directory, with each subdirectory beneath that directory representing a suite. Generally speaking, a suite is a collection of tests that share a common 3rd-party dependency (or set of dependencies). You can run all tests belonging to a suite like so:
+Multiverse tests live in the `test/multiverse` directory, with each subdirectory beneath `test/multiverse/suites` representing a suite. Generally speaking, a suite is a collection of tests that share a common 3rd-party dependency (or set of dependencies). You can run all tests belonging to a suite like so:
 
 ```shell
 # agent_only = suite name

--- a/test/multiverse/README.md
+++ b/test/multiverse/README.md
@@ -97,11 +97,19 @@ The first time you run this command on a new Ruby installation, it will take qui
 
 ## Running Specific Tests and Environments
 
-Multiverse tests live in the test/multiverse directory and are organized into 'suites'. Generally speaking, a suite is a group of tests that share a common 3rd-party dependency (or set of dependencies). You can run one or more specific suites by providing a comma delimited list of suite names as parameters to the rake task:
+Multiverse tests live in the `test/multiverse` directory, with each subdirectory beneath that directory representing a suite. Generally speaking, a suite is a collection of tests that share a common 3rd-party dependency (or set of dependencies). You can run all tests belonging to a suite like so:
 
-    rake 'test:multiverse[agent_only]'
-    # or
-    rake 'test:multiverse[rails,net_http]'
+```shell
+# agent_only = suite name
+rake 'test:multiverse[agent_only]'
+```
+
+Multiverse groups collect multiple suites together within a shared broad topic. To run all tests for an entire group, use `group=<GROUP NAME>` as the first rake task argument in lieu of a suite name. For a complete list of group names, see the `GROUPS` constant defined in `test/multiverse/lib/multiverse/runner.rb`.
+
+```shell
+# database = group name
+rake 'test:multiverse[group=database]'
+``
 
 You can pass these additional parameters to the test:multiverse rake task to control how tests are run:
 


### PR DESCRIPTION
- Specifying multiple suite names hasn't worked in awhile, and can't be made to without refactoring the args parser and risking bugs. The current maintainers don't use multiple comma separated groups at once, so we've decided to update the docs.
- The maintainers do, however, use multiple suites at once by leveraging groups. So go ahead and document how to use groups.