### PR TITLE
CI: test config file loading with psych 5

### DIFF
--- a/test/multiverse/suites/config_file_loading/Envfile
+++ b/test/multiverse/suites/config_file_loading/Envfile
@@ -5,8 +5,7 @@
 omit_collector!
 
 PSYCH_VERSIONS = [
-  # TODO: re-enable 'nil' once Psych v5 testing (released 2022-12-05) is complete
-  # [nil],
+  [nil],
   ['4.0.0', 2.4],
   ['3.3.0', 2.4]
 ]


### PR DESCRIPTION
Now that psych v5 has seen some minor version updates since its release in December 2023, start testing it with our config file loading Multiverse suite.

resolves #1676