### PR TITLE
fix title for prerelease PR

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -40,7 +40,7 @@ jobs:
         gh pr create --label $LABEL --title "$TITLE" --body "$BODY"
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        TITLE: "Prerelease #{{env.prerelease_tag}}"
+        TITLE: "Prerelease ${{env.prerelease_tag}}"
         BODY: "Updates the version number, changelog, and newrelic.yml (if it needs updating). This is an automated PR."
         LABEL: prerelease
        


### PR DESCRIPTION
Accidentally used `#{{}}` instead of `${{}}` when making the title for the PR on the prerelease workflow