### PR TITLE
Add issue write permissions to repolinter

### DIFF
--- a/.github/workflows/repolinter.yml
+++ b/.github/workflows/repolinter.yml
@@ -8,6 +8,10 @@ name: Repolinter Action
 # filtered in the "Test Default Branch" step.
 on: [push, workflow_dispatch]
 
+permissions:
+  # Needed to create issues with the failed checks
+  issues: write
+
 jobs:
   repolint:
     name: Run Repolinter


### PR DESCRIPTION
Repolinter recently failed: https://github.com/newrelic/newrelic-ruby-agent/actions/runs/5359581716/jobs/9723356323?pr=2102 

Let's see if this fixes it.