### PR TITLE
Fix RDoc issues

### DIFF
--- a/lib/new_relic/agent.rb
+++ b/lib/new_relic/agent.rb
@@ -298,7 +298,7 @@ module NewRelic
 
     # Set a callback proc for determining an error's error group name
     #
-    # @param [Proc] the callback proc
+    # @param callback_proc [Proc] the callback proc
     #
     # Typically this method should be called only once to set a callback for
     # use with all noticed errors. If it is called multiple times, each new

--- a/lib/new_relic/agent/distributed_tracing.rb
+++ b/lib/new_relic/agent/distributed_tracing.rb
@@ -87,7 +87,7 @@ module NewRelic
       #                                   header-friendly string returned from
       #                                   {DistributedTracePayload#http_safe}
       #
-      # @param transport_Type  [String]   May be one of:  +HTTP+, +HTTPS+, +Kafka+, +JMS+,
+      # @param transport_type  [String]   May be one of:  +HTTP+, +HTTPS+, +Kafka+, +JMS+,
       #                                   +IronMQ+, +AMQP+, +Queue+, +Other+.  Values are
       #                                   case sensitive.  All other values result in +Unknown+
       #


### PR DESCRIPTION
The NewRelic::Agent module overview in RDoc was missing, showing the license information instead.
Also fixes capitalization within a param name.

More issues like this are likely hiding in our codebase.