### PR TITLE
Include `test/agent_helper.rb` in build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # New Relic Ruby Agent Release Notes
 
+## dev
+
+Version <dev> of the agent fixes `NewRelic::Agent.require_test_helper`.
+
+- **Bugfix: Fix NewRelic::Agent.require_test_helper**
+
+  Version 9.3.0 of the agent made a change to the files distributed with the gem. This change unintentionally broke the `NewRelic::Agent.require_test_helper` API by removing the `test/agent_helper.rb` file. The file has been added back to the gem. This change also removes the `lib/new_relic/build.rb` file from the list because it is no longer created with our current release process.
+
+  Our thanks go to [@ajesler](https://github.com/ajesler) for reporting this issue. [Issue#2113](https://github.com/newrelic/newrelic-ruby-agent/issues/2113), [PR#TBD](tbd)
+
 ## v9.3.0
 
 Version 9.3.0 of the agent adds log-level filtering, adds custom attributes for log events, and updates instrumentation for Action Cable. It also provides fixes for how `Fiber` args are treated, Code-Level Metrics, unnecessary files being included in the gem, and `NewRelic::Agent::Logging::DecoratingFormatter#clear_tags!` being incorrectly private.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Version <dev> of the agent fixes `NewRelic::Agent.require_test_helper`.
 
   Version 9.3.0 of the agent made a change to the files distributed with the gem. This change unintentionally broke the `NewRelic::Agent.require_test_helper` API by removing the `test/agent_helper.rb` file. The file has been added back to the gem. This change also removes the `lib/new_relic/build.rb` file from the list because it is no longer created with our current release process.
 
-  Our thanks go to [@ajesler](https://github.com/ajesler) for reporting this issue. [Issue#2113](https://github.com/newrelic/newrelic-ruby-agent/issues/2113), [PR#TBD](tbd)
+  Our thanks go to [@ajesler](https://github.com/ajesler) for reporting this issue and writing a test for the bug. [Issue#2113](https://github.com/newrelic/newrelic-ruby-agent/issues/2113), [PR#2115](https://github.com/newrelic/newrelic-ruby-agent/pull/2115), [Issue#2117](https://github.com/newrelic/newrelic-ruby-agent/issues/2117), [PR#2118](https://github.com/newrelic/newrelic-ruby-agent/pull/2118)
 
 ## v9.3.0
 

--- a/newrelic_rpm.gemspec
+++ b/newrelic_rpm.gemspec
@@ -40,8 +40,9 @@ Gem::Specification.new do |s|
 
   reject_list = File.read('./.build_ignore').split("\n")
   file_list = `git ls-files -z`.split("\x0").reject { |f| reject_list.any? { |rf| f.start_with?(rf) } }
-  build_file_path = 'lib/new_relic/build.rb'
-  file_list << build_file_path if File.exist?(build_file_path)
+  # test/agent_helper.rb is a requirement for the NewRelic::Agent.require_test_helper public API
+  test_helper_path = 'test/agent_helper.rb'
+  file_list << test_helper_path
   s.files = file_list
 
   s.homepage = 'https://github.com/newrelic/rpm'


### PR DESCRIPTION
The test/agent_helper.rb file was overlooked in our switch to the new file inclusion process introduced in
https://github.com/newrelic/newrelic-ruby-agent/pull/2089

This file is required for the public API
`NewRelic::Agent.require_test_helper`.

The file has been added back to the build. Furthermore, `build.rb` was still included. This file used to be generated with Jenkins during our release process and has not been created with a release since version 6.13.0.

Resolves #2113 
