### PR TITLE
Small gemspec fixes

### DIFF
--- a/.build_ignore
+++ b/.build_ignore
@@ -1,4 +1,4 @@
-.github
+.github/
 .gitignore
 .project
 .rubocop.yml

--- a/lib/new_relic/cli/command.rb
+++ b/lib/new_relic/cli/command.rb
@@ -60,6 +60,7 @@ module NewRelic
         extra = []
         options = ARGV.options do |opts|
           script_name = File.basename($0)
+          # TODO: MAJOR VERSION - remove newrelic_cmd, deprecated since version 2.13
           if /newrelic_cmd$/.match?(script_name)
             $stdout.puts "warning: the 'newrelic_cmd' script has been renamed 'newrelic'"
             script_name = 'newrelic'

--- a/newrelic_rpm.gemspec
+++ b/newrelic_rpm.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |s|
   file_list << build_file_path if File.exist?(build_file_path)
   s.files = file_list
 
-  s.homepage = 'https://github.com/newrelic/rpm'
+  s.homepage = 'https://github.com/newrelic/newrelic-ruby-agent'
   s.require_paths = ['lib']
   s.summary = 'New Relic Ruby Agent'
   s.add_development_dependency 'bundler'

--- a/newrelic_rpm.gemspec
+++ b/newrelic_rpm.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
     https://github.com/newrelic/newrelic-ruby-agent/
   EOS
   s.email = 'support@newrelic.com'
+  # TODO: MAJOR VERSION - remove newrelic_cmd, deprecated since version 2.13
   s.executables = %w[newrelic_cmd newrelic nrdebug]
   s.extra_rdoc_files = [
     'CHANGELOG.md',


### PR DESCRIPTION
While working on #2113, I found a few other things to clean up in our gemspec.

* Update `homepage` to current repo path
* Add `.github/`, as a directory to build ignore
* Create TODO to remove `newrelic_cmd`, deprecated since version 2.13