### PR TITLE
Specify grpc version for infinite tracing multiverse

### DIFF
--- a/test/multiverse/suites/infinite_tracing/Envfile
+++ b/test/multiverse/suites/infinite_tracing/Envfile
@@ -2,6 +2,11 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
+def grpc_version
+  RUBY_VERSION < '2.6.0' ? ", '1.49.1'" : ''
+end
+
 gemfile <<~RB
   gem 'newrelic-infinite_tracing', :path => '../../../../infinite_tracing'
+  gem 'grpc'#{grpc_version}
 RB


### PR DESCRIPTION
The grpc gem version reconciliation is having some issues. This change makes sure 1.49.1, the last version to officially support Ruby 2.5, will be installed for Rubies below 2.6.
