### PR TITLE
Link to github, not rubyforge [ci skip]

### DIFF
--- a/lib/new_relic/rack/browser_monitoring.rb
+++ b/lib/new_relic/rack/browser_monitoring.rb
@@ -143,7 +143,7 @@ module NewRelic
       end
 
       # Per "The Response > The Body" section of Rack spec, we should close
-      # if our response is able. http://rack.rubyforge.org/doc/SPEC.html
+      # if our response is able. https://github.com/rack/rack/blob/main/SPEC.rdoc
       def close_old_response(response)
         response.close if response.respond_to?(:close)
       end


### PR DESCRIPTION
# Overview

Updates a link to defunct website

Submitter Checklist:
- [ ] Include a link to the related GitHub issue, if applicable
- [ ] Include a security review link, if applicable

# Testing

Q: Would it be possible to add some "link checker" build step? Or have such a manual task, every year?

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
