### PR TITLE
CI: gemspec files test - bypass cache

### DIFF
--- a/newrelic_rpm.gemspec
+++ b/newrelic_rpm.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |s|
     'homepage_uri' => 'https://newrelic.com/ruby'
   }
 
-  reject_list = File.read('./.build_ignore').split("\n")
+  reject_list = File.read(File.expand_path('../.build_ignore', __FILE__)).split("\n")
   file_list = `git ls-files -z`.split("\x0").reject { |f| reject_list.any? { |rf| f.start_with?(rf) } }
   # test/agent_helper.rb is a requirement for the NewRelic::Agent.require_test_helper public API
   test_helper_path = 'test/agent_helper.rb'

--- a/test/new_relic/gemspec_files_test.rb
+++ b/test/new_relic/gemspec_files_test.rb
@@ -6,13 +6,16 @@ require 'minitest/autorun'
 
 class GemspecFilesTest < Minitest::Test
   def test_the_test_agent_helper_is_shipped_in_the_gem_files
-    skip if defined?(Rails::VERSION) || File.basename(Dir.pwd).match?('rails')
+    skip if defined?(Rails::VERSION)
 
     gem_spec_file_path = File.expand_path('../../../newrelic_rpm.gemspec', __FILE__)
-    gem_spec = eval(Gem.open_file(gem_spec_file_path, 'r:UTF-8:-', &:read))
 
-    assert gem_spec, "Failed to parse '#{gem_spec_file_path}'"
-    assert_equal('newrelic_rpm', gem_spec.name)
-    assert_includes(gem_spec.files, 'test/agent_helper.rb')
+    Dir.chdir(File.dirname(gem_spec_file_path)) do
+      gem_spec = eval(Gem.open_file(gem_spec_file_path, 'r:UTF-8:-', &:read))
+
+      assert gem_spec, "Failed to parse '#{gem_spec_file_path}'"
+      assert_equal('newrelic_rpm', gem_spec.name)
+      assert_includes(gem_spec.files, 'test/agent_helper.rb')
+    end
   end
 end

--- a/test/new_relic/gemspec_files_test.rb
+++ b/test/new_relic/gemspec_files_test.rb
@@ -6,7 +6,7 @@ require 'minitest/autorun'
 
 class GemspecFilesTest < Minitest::Test
   def test_the_test_agent_helper_is_shipped_in_the_gem_files
-    skip if defined?(Rails::VERSION)
+    skip if defined?(Rails::VERSION) || File.basename(Dir.pwd).match?('rails')
 
     gem_spec_file_path = File.expand_path('../../../newrelic_rpm.gemspec', __FILE__)
     gem_spec = eval(Gem.open_file(gem_spec_file_path, 'r:UTF-8:-', &:read))

--- a/test/new_relic/gemspec_files_test.rb
+++ b/test/new_relic/gemspec_files_test.rb
@@ -7,6 +7,7 @@ require 'minitest/autorun'
 class GemspecFilesTest < Minitest::Test
   def test_the_test_agent_helper_is_shipped_in_the_gem_files
     skip if defined?(Rails::VERSION)
+    skip 'Gemspec test requires a newer version of Rubygems' unless Gem.respond_to?(:open_file)
 
     gem_spec_file_path = File.expand_path('../../../newrelic_rpm.gemspec', __FILE__)
 

--- a/test/new_relic/gemspec_files_test.rb
+++ b/test/new_relic/gemspec_files_test.rb
@@ -8,13 +8,11 @@ class GemspecFilesTest < Minitest::Test
   def test_the_test_agent_helper_is_shipped_in_the_gem_files
     skip if defined?(Rails::VERSION)
 
-    agent_helper_file = 'test/agent_helper.rb'
-
     gem_spec_file_path = File.expand_path('../../../newrelic_rpm.gemspec', __FILE__)
+    gem_spec = eval(Gem.open_file(gem_spec_file_path, 'r:UTF-8:-', &:read))
 
-    gem_spec = Gem::Specification.load(gem_spec_file_path)
-
+    assert gem_spec, "Failed to parse '#{gem_spec_file_path}'"
     assert_equal('newrelic_rpm', gem_spec.name)
-    assert_includes(gem_spec.files, agent_helper_file)
+    assert_includes(gem_spec.files, 'test/agent_helper.rb')
   end
 end


### PR DESCRIPTION
Fixes to get the .gemspec test to work with our automated CI system:

- effectively fork `Gem::Specification.load` to bypass its internal caching mechanism
  - In so doing, the CI logs now report the actual underlying issue that caused a .gemspec eval to fail
- Assert that the parse succeeded before working with the result
- Update `newrelic_rpm.gemspec` to use an absolute path to the `.build_ignore` file
- `chdir` to the agent root for the evaluation of the .gemspec file