### PR TITLE
CI: URL checker - simplify hash value vivification

### DIFF
--- a/lib/new_relic/agent/instrumentation/memcache.rb
+++ b/lib/new_relic/agent/instrumentation/memcache.rb
@@ -5,7 +5,7 @@
 # NOTE: there are multiple implementations of the Memcached client in Ruby,
 # each with slightly different APIs and semantics.
 # See:
-#     http://www.deveiate.org/code/Ruby-MemCache/ (Gem: Ruby-MemCache)
+#     https://rubygems.org/gems/Ruby-MemCache (Gem: Ruby-MemCache)
 #     https://github.com/mperham/memcache-client (Gem: memcache-client)
 #     https://github.com/mperham/dalli (Gem: dalli)
 

--- a/test/new_relic/healthy_urls_test.rb
+++ b/test/new_relic/healthy_urls_test.rb
@@ -94,7 +94,7 @@ class HealthyUrlsTest < Minitest::Test
   end
 
   def gather_urls
-    Dir.glob(File.join(ROOT, '**', '*')).each_with_object({}) do |file, urls|
+    Dir.glob(File.join(ROOT, '**', '*')).each_with_object(Hash.new { |hash, key| hash[key] = [] }) do |file, urls|
       next unless File.file?(file) && File.basename(file).match?(FILE_PATTERN) && !file.match?(IGNORED_FILE_PATTERN)
 
       changelog_entries_seen = 0
@@ -104,10 +104,7 @@ class HealthyUrlsTest < Minitest::Test
         next unless line =~ URL_PATTERN
 
         url = Regexp.last_match(1).sub(%r{(?:/|\.)$}, '')
-        if real_url?(url)
-          urls[url] ||= []
-          urls[url] << file
-        end
+        urls[url] << file if real_url?(url)
       end
     end
   end


### PR DESCRIPTION
Implement the [suggested improvement](https://github.com/newrelic/newrelic-ruby-agent/pull/2127#pullrequestreview-1525607554) for the URLs hash to have an empty files array for the hash value by default.

Update an old library website to use RubyGems.org instead.