### PR TITLE
NoticedError: glean the txn id upon init

### DIFF
--- a/test/new_relic/noticed_error_test.rb
+++ b/test/new_relic/noticed_error_test.rb
@@ -325,6 +325,20 @@ class NewRelic::Agent::NoticedErrorTest < Minitest::Test
     assert_equal error_group, noticed_error.agent_attributes[::NewRelic::NoticedError::AGENT_ATTRIBUTE_ERROR_GROUP]
   end
 
+  def test_transaction_guid_is_present_when_in_a_transaction
+    in_transaction do |txn|
+      error = NewRelic::NoticedError.new(@path, StandardError.new)
+
+      assert_equal txn.guid, error.transaction_id, 'Expected the transaction_id reader to yield the transaction id'
+    end
+  end
+
+  def test_transaction_guid_is_absent_when_not_in_a_transaction
+    error = NewRelic::NoticedError.new(@path, StandardError.new)
+
+    assert_nil error.transaction_id, 'Expected the transaction_id reader to yield nil'
+  end
+
   def test_transaction_guid_present_in_json_array
     in_transaction do |txn|
       array = NewRelic::NoticedError.new(@path, StandardError.new).to_collector_array


### PR DESCRIPTION
NoticedError: grab the transaction id at initialization time, not harvest time