### PR TITLE
Remove old method

### DIFF
--- a/lib/new_relic/agent/instrumentation/controller_instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/controller_instrumentation.rb
@@ -41,8 +41,6 @@ module NewRelic
             clazz.extend(ClassMethodsShim)
           end
 
-          def new_relic_trace_controller_action(*args); yield; end
-
           def perform_action_with_newrelic_trace(*args); yield; end
         end
 

--- a/test/multiverse/suites/sinatra_agent_disabled/shim_test.rb
+++ b/test/multiverse/suites/sinatra_agent_disabled/shim_test.rb
@@ -23,7 +23,6 @@ class SinatraAgentDisabledTestCase < Minitest::Test
     assert_respond_to MiddlewareApp, :newrelic_ignore_enduser, 'Class method newrelic_ignore_enduser not defined'
 
     # instance method shims
-    assert_includes(MiddlewareApp.instance_methods, :new_relic_trace_controller_action, 'Instance method new_relic_trace_controller_action not defined')
     assert_includes(MiddlewareApp.instance_methods, :perform_action_with_newrelic_trace, 'Instance method perform_action_with_newrelic_trace not defined')
   end
 


### PR DESCRIPTION
`new_relic_trace_controller_action` is defined and added to customer Sinatra applications, but is never called.