### PR TITLE
upgrade RuboCop to v1.54

### DIFF
--- a/infinite_tracing/test/support/fixtures.rb
+++ b/infinite_tracing/test/support/fixtures.rb
@@ -15,6 +15,6 @@ def span_event_fixture(fixture_name)
   if YAML.respond_to?(:unsafe_load)
     YAML::unsafe_load(File.read(fixture_filename))
   else
-    YAML::load(File.read(fixture_filename))
+    YAML::load_file(fixture_filename)
   end
 end

--- a/lib/new_relic/agent/instrumentation/action_controller_other_subscriber.rb
+++ b/lib/new_relic/agent/instrumentation/action_controller_other_subscriber.rb
@@ -23,7 +23,7 @@ module NewRelic
 
         def metric_name(name, payload)
           controller_name = controller_name_for_metric(payload)
-          "Ruby/ActionController#{"/#{controller_name}" if controller_name}/#{name.gsub(/\.action_controller/, '')}"
+          "Ruby/ActionController#{"/#{controller_name}" if controller_name}/#{name.gsub('.action_controller', '')}"
         end
 
         def controller_name_for_metric(payload)

--- a/lib/new_relic/agent/tracer.rb
+++ b/lib/new_relic/agent/tracer.rb
@@ -66,9 +66,10 @@ module NewRelic
         #
         # @api public
         def transaction_sampled?
-          if txn = current_transaction
-            txn.sampled?
-          end
+          txn = current_transaction
+          return false unless txn
+
+          txn.sampled?
         end
         alias_method :sampled?, :transaction_sampled?
 

--- a/lib/new_relic/agent/transaction.rb
+++ b/lib/new_relic/agent/transaction.rb
@@ -289,7 +289,7 @@ module NewRelic
       end
 
       def sampled?
-        return unless Agent.config[:'distributed_tracing.enabled']
+        return false unless Agent.config[:'distributed_tracing.enabled']
 
         if @sampled.nil?
           @sampled = NewRelic::Agent.instance.adaptive_sampler.sampled?
@@ -545,8 +545,8 @@ module NewRelic
       end
 
       def user_defined_rules_ignore?
-        return unless request_path
-        return if (rules = NewRelic::Agent.config[:"rules.ignore_url_regexes"]).empty?
+        return false unless request_path
+        return false if (rules = NewRelic::Agent.config[:"rules.ignore_url_regexes"]).empty?
 
         rules.any? do |rule|
           request_path.match(rule)

--- a/lib/tasks/bump_version.rake
+++ b/lib/tasks/bump_version.rake
@@ -2,7 +2,7 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
-require_relative './helpers/version_bump'
+require_relative 'helpers/version_bump'
 
 namespace :newrelic do
   namespace :version do

--- a/lib/tasks/helpers/version_bump.rb
+++ b/lib/tasks/helpers/version_bump.rb
@@ -55,8 +55,8 @@ module VersionBump
   # Replace dev with version number in changelog
   def self.update_changelog(version)
     file = read_file('CHANGELOG.md')
-    file.gsub!(/## dev/, "## v#{version}")
-    file.gsub!(/Version <dev>/, "Version #{version}")
+    file.gsub!('## dev', "## v#{version}")
+    file.gsub!('Version <dev>', "Version #{version}")
     write_file('CHANGELOG.md', file)
   end
 end

--- a/lib/tasks/newrelicyml.rake
+++ b/lib/tasks/newrelicyml.rake
@@ -2,7 +2,7 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
-require_relative './helpers/newrelicyml'
+require_relative 'helpers/newrelicyml'
 
 namespace :newrelic do
   desc 'Update newrelic.yml with latest config options from default_source.rb'

--- a/newrelic_rpm.gemspec
+++ b/newrelic_rpm.gemspec
@@ -58,7 +58,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pry' unless ENV['CI']
   s.add_development_dependency 'rake', '12.3.3'
 
-  s.add_development_dependency 'rubocop', '1.51' unless ENV['CI'] && RUBY_VERSION < '3.0.0'
+  s.add_development_dependency 'rubocop', '1.54' unless ENV['CI'] && RUBY_VERSION < '3.0.0'
   s.add_development_dependency 'rubocop-ast', '1.28.1' unless ENV['CI'] && RUBY_VERSION < '3.0.0'
   s.add_development_dependency 'rubocop-minitest', '0.27.0' unless ENV['CI'] && RUBY_VERSION < '3.0.0'
   s.add_development_dependency 'rubocop-performance', '1.16.0' unless ENV['CI'] && RUBY_VERSION < '3.0.0'

--- a/test/new_relic/agent/tracer_test.rb
+++ b/test/new_relic/agent/tracer_test.rb
@@ -52,7 +52,7 @@ module NewRelic
       def test_sampled?
         with_config(:'distributed_tracing.enabled' => true) do
           in_transaction do |txn|
-            refute_nil Tracer.sampled?
+            assert_predicate Tracer, :sampled?
           end
           # with sampled explicity set true, assert that it's true
           in_transaction do |txn|
@@ -70,7 +70,7 @@ module NewRelic
 
         with_config(:'distributed_tracing.enabled' => false) do
           in_transaction do |txn|
-            assert_nil Tracer.sampled?
+            refute Tracer.sampled?
           end
         end
       end

--- a/test/new_relic/agent/tracer_test.rb
+++ b/test/new_relic/agent/tracer_test.rb
@@ -50,17 +50,19 @@ module NewRelic
       end
 
       def test_sampled?
+        # If DT is enabled, the Tracer yields the #sampled? result for the
+        # underlying current transaction
         with_config(:'distributed_tracing.enabled' => true) do
           in_transaction do |txn|
-            assert_predicate Tracer, :sampled?
+            assert_equal txn.sampled?,
+              Tracer.sampled?,
+              'Tracer.sampled should match the #sampled? result for the current transaction'
           end
-          # with sampled explicity set true, assert that it's true
           in_transaction do |txn|
             txn.sampled = true
 
             assert_predicate Tracer, :sampled?
           end
-          # with sampled explicity set false, assert that it's false
           in_transaction do |txn|
             txn.sampled = false
 
@@ -68,6 +70,7 @@ module NewRelic
           end
         end
 
+        # If DT is disabled, Tracer.sampled? is always false
         with_config(:'distributed_tracing.enabled' => false) do
           in_transaction do |txn|
             refute_predicate Tracer, :sampled?
@@ -76,7 +79,7 @@ module NewRelic
       end
 
       def test_sampled_not_in_transaction
-        assert_nil Tracer.sampled?
+        refute_predicate Tracer, :sampled?
       end
 
       def test_tracing_enabled

--- a/test/new_relic/agent/tracer_test.rb
+++ b/test/new_relic/agent/tracer_test.rb
@@ -70,7 +70,7 @@ module NewRelic
 
         with_config(:'distributed_tracing.enabled' => false) do
           in_transaction do |txn|
-            refute Tracer.sampled?
+            refute_predicate Tracer, :sampled?
           end
         end
       end

--- a/test/warning_test_helper.rb
+++ b/test/warning_test_helper.rb
@@ -9,4 +9,4 @@ end
 
 # this is to ignore warnings that happen on the CI only
 # the site_ruby part of the path needs to be removed if it exists otherwise the CI keeps doing the warnings
-Warning.ignore(//, Gem::RUBYGEMS_DIR.gsub(/site_ruby\//, ''))
+Warning.ignore(//, Gem::RUBYGEMS_DIR.gsub('site_ruby/', ''))


### PR DESCRIPTION
- upgrade RuboCop to v1.54
- apply newly recommended linting changes