### PR TITLE
CI: multiverse - unpin webrick

### DIFF
--- a/test/multiverse/lib/multiverse/suite.rb
+++ b/test/multiverse/lib/multiverse/suite.rb
@@ -283,9 +283,7 @@ module Multiverse
 
         f.puts "gem 'mocha', '~> 1.9.0', require: false"
         f.puts "gem 'minitest-stub-const', '~> 0.6', require: false"
-
         f.puts "gem 'webrick'"
-
         f.puts "gem 'warning'"
 
         if debug

--- a/test/multiverse/lib/multiverse/suite.rb
+++ b/test/multiverse/lib/multiverse/suite.rb
@@ -284,9 +284,7 @@ module Multiverse
         f.puts "gem 'mocha', '~> 1.9.0', require: false"
         f.puts "gem 'minitest-stub-const', '~> 0.6', require: false"
 
-        # pin webrick until we investigate why 1.8.1 breaks things
-        f.puts "gem 'webrick', '< 1.8.0'"
-        # f.puts ruby3_gem_webrick
+        f.puts "gem 'webrick'"
 
         f.puts "gem 'warning'"
 

--- a/test/new_relic/fake_collector.rb
+++ b/test/new_relic/fake_collector.rb
@@ -132,7 +132,7 @@ module NewRelic
         res.write('Method not found')
       end
       run_id = uri.query =~ /run_id=(\d+)/ ? $1 : nil
-      req.body.rewind
+      req.body.rewind if req.body.respond_to?(:rewind) # no #rewind for an instance of Rackup::Handler::WEBrick::Input
 
       begin
         raw_body = req.body.read

--- a/test/new_relic/fake_server.rb
+++ b/test/new_relic/fake_server.rb
@@ -14,10 +14,13 @@ module NewRelic
     # Use ephemeral ports by default
     DEFAULT_PORT = 0
 
+    # Ignore all WEBrick output by default. Set ENV['DEBUG'] to enable it
+    WEBRICK_OUTPUT_DEVICE = ENV['DEBUG'] ? STDOUT : '/dev/null'
+
     # Default server options
     DEFAULT_OPTIONS = {
-      :Logger => ::WEBrick::Log.new((+'/dev/null')),
-      :AccessLog => [[+'/dev/null', '']]
+      :Logger => ::WEBrick::Log.new((WEBRICK_OUTPUT_DEVICE)),
+      :AccessLog => [[WEBRICK_OUTPUT_DEVICE, '']]
     }
 
     CONFIG_PATH = String.new(File.join(File.dirname(__FILE__), '..', 'config'))


### PR DESCRIPTION
- Update the fake server based classes used for unit tests to run on the latest version of WEBrick (previously we were not compatible with v1.8.0+ and locked to v1.7.0)
- Update the fake server class to respect `ENV['DEBUG']`. Going forward if there are any errors happening that are fake server related, we need only to set the `DEBUG` environment variable to see what is going on.
- Update the fake collector class to stop attempting to call `#rewind` on objects that don't support it (for improved WEBrick compatibility)