### PR TITLE
NewRelic::Control - drop competing `camelize`

### DIFF
--- a/lib/new_relic/control/class_methods.rb
+++ b/lib/new_relic/control/class_methods.rb
@@ -49,18 +49,12 @@ module NewRelic
           # maybe it is already loaded by some external system
           # i.e. rpm_contrib or user extensions?
         end
-        NewRelic::Control::Frameworks.const_get(camelize(framework.to_s))
+        NewRelic::Control::Frameworks.const_get(NewRelic::LanguageSupport.camelize(framework.to_s))
       end
 
       # The root directory for the plugin or gem
       def newrelic_root
         File.expand_path(File.join('..', '..', '..', '..'), __FILE__)
-      end
-
-      def camelize(snake_case_name)
-        snake_case_name.gsub(/(\_|^)[a-z]/) do |substring|
-          substring[-1].capitalize!
-        end
       end
     end
     extend ClassMethods

--- a/test/new_relic/control/class_methods_test.rb
+++ b/test/new_relic/control/class_methods_test.rb
@@ -50,8 +50,4 @@ class NewRelic::Control::ClassMethodsTest < Minitest::Test
       @base.load_framework_class('missing')
     end
   end
-
-  def test_camelize
-    assert_equal 'TestConstantize', @base.camelize('test_constantize')
-  end
 end


### PR DESCRIPTION
The LanguageSupport's `camelize` method appears to be faster, so let's just standardize on using that whenever we need to convert from snake to camel.

```shell
newrelic-ruby-agent 17:03:40 $ ruby test.rb
Rehearsal ---------------------------------------------------
LanguageSupport  20.492525   0.126348  20.618873 ( 20.645389)
Control          29.277619   0.177723  29.455342 ( 29.524243)
----------------------------------------- total: 50.074215sec

                      user     system      total        real
LanguageSupport  21.267743   0.145529  21.413272 ( 21.493573)
Control          30.793050   0.221045  31.014095 ( 31.085878)
```

resolves #2151 