### PR TITLE
CI: require Rack 3 for Ruby 3.3+

### DIFF
--- a/test/multiverse/suites/rack/Envfile
+++ b/test/multiverse/suites/rack/Envfile
@@ -33,12 +33,12 @@ gemfile <<~RB
   gem 'rack-test'
 RB
 
-gemfile <<~RB
+gemfile <<~RB if RUBY_VERSION < '3.3.0' # require Rack v3+ for Ruby 3.3+
   gem 'rack', '2.2.4'
   gem 'rack-test'
 RB
 
-gemfile <<~RB if RUBY_VERSION < '3.2.0'
+gemfile <<~RB if RUBY_VERSION < '3.2.0' # require Rack v2+ for Ruby 3.2+
   gem 'rack', '1.6.13'
   gem 'rack-test'
 RB


### PR DESCRIPTION
Stop testing Rack 2 with Ruby 3.3+ (we previously stopped testing Rack 1 with Ruby 3.2+)