### PR TITLE
CI allow_all_headers requires Rack v2+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ Version <dev> of the agent adds [Roda](https://roda.jeremyevans.net/) instrument
 
   A new `allow_all_headers` configuration parameter brings parity with the Node.js agent (see the [v2.7.0 changelog](https://docs.newrelic.com/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-270/)). This configuration parameter defaults to a value of `false`. When set to `true`, and as long as the agent is not operating in high-security mode, all HTTP headers gleaned from a request will be captured and relayed to New Relic instead of the default core set of headers. All existing behavior for `.*attributes.include` and `.*attributes.exclude` configuration parameters will be respected for any desired filtration of the headers when `allow_all_headers` is enabled. This work was done in response to a feature request submitted by community member [@jamesarosen](https://github.com/jamesarosen). Thank you very much, @jamesarosen! [Issue#1029](https://github.com/newrelic/newrelic-ruby-agent/issues/1029)
 
+  NOTE: The extra headers collected by having `allow_all_headers` enabled requires Rack version 2 or higher.
+  NOTE: The extra headers will appear as attributes prefixed with `request.headers.`
+
 - **Feature: Improved error tracking transaction linking**
 
   Errors tracked and sent to the New Relic errors inbox will now be associated with a transaction id to enable improved UI/UX associations between transactions and errors. [PR#2035](https://github.com/newrelic/newrelic-ruby-agent/pull/2035) 

--- a/test/helpers/misc.rb
+++ b/test/helpers/misc.rb
@@ -125,13 +125,6 @@ def skip_unless_minitest5_or_above
   skip 'This test requires MiniTest v5+'
 end
 
-def skip_unless_no_rails_or_rails_version_at_or_above(min_version)
-  return unless defined?(Rails) && Rails.respond_to?(:version)
-  return if Gem::Version.new(Rails.version) >= Gem::Version.new(min_version)
-
-  skip "This test requires no Rails or Rails >= v#{min_version}"
-end
-
 def skip_unless_ci_cron
   return if ENV['CI_CRON']
 

--- a/test/new_relic/agent/transaction/request_attributes_test.rb
+++ b/test/new_relic/agent/transaction/request_attributes_test.rb
@@ -178,7 +178,7 @@ module NewRelic
         end
 
         def test_if_allow_all_headers_is_specified_then_allow_them_all
-          skip 'Test requires Rack v2+' if Rack.respond_to?(:release) && Rack.release.start_with?('1.')
+          skip 'Test requires Rack v2+' unless Rack.respond_to?(:release) && !Rack.release.start_with?('1.')
           skip_unless_minitest5_or_above
 
           with_config(allow_all_headers: true) do
@@ -236,7 +236,7 @@ module NewRelic
         end
 
         def test_the_use_of_attributes_exclude_as_a_blocklist
-          skip 'Test requires Rack v2+' if Rack.respond_to?(:release) && Rack.release.start_with?('1.')
+          skip 'Test requires Rack v2+' unless Rack.respond_to?(:release) && !Rack.release.start_with?('1.')
           skip_unless_minitest5_or_above
 
           excluded_header = :'request.headers.customHeader'

--- a/test/new_relic/agent/transaction/request_attributes_test.rb
+++ b/test/new_relic/agent/transaction/request_attributes_test.rb
@@ -178,7 +178,7 @@ module NewRelic
         end
 
         def test_if_allow_all_headers_is_specified_then_allow_them_all
-          skip_unless_no_rails_or_rails_version_at_or_above(5.2)
+          skip 'Test requires Rack v2+' if Rack.respond_to?(:release) && Rack.release.start_with?('1.')
           skip_unless_minitest5_or_above
 
           with_config(allow_all_headers: true) do
@@ -236,7 +236,7 @@ module NewRelic
         end
 
         def test_the_use_of_attributes_exclude_as_a_blocklist
-          skip_unless_no_rails_or_rails_version_at_or_above(5.2)
+          skip 'Test requires Rack v2+' if Rack.respond_to?(:release) && Rack.release.start_with?('1.')
           skip_unless_minitest5_or_above
 
           excluded_header = :'request.headers.customHeader'


### PR DESCRIPTION
Technically allow_all_headers doesn't require Rails v5.2+ but rather Rack v2+