### PR TITLE
LogEventAttributes: instance var check

### DIFF
--- a/lib/new_relic/agent/log_event_attributes.rb
+++ b/lib/new_relic/agent/log_event_attributes.rb
@@ -10,7 +10,7 @@ module NewRelic
       ATTRIBUTE_VALUE_CHARACTER_LIMIT = 4094
 
       def add_custom_attributes(attributes)
-        return if @custom_attribute_limit_reached
+        return if defined?(@custom_attribute_limit_reached) && @custom_attribute_limit_reached
 
         attributes.each do |key, value|
           next if absent?(key) || absent?(value)


### PR DESCRIPTION
Don't attempt to read `@custom_attribute_limit_reached` until it has been defined

Addresses the following Ruby warning:

```shell
/Users/jbond007/git/public/newrelic-ruby-agent/lib/new_relic/agent/log_event_attributes.rb:17: warning: instance variable @custom_attribute_limit_reached not initialized
```