### PR TITLE
Fix docker compose when running it on m1 mac

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
     mem_limit: 1g
   mysql:
     image: mysql:5.7
+    platform: linux/x86_64
     restart: always
     environment:
       MYSQL_ROOT_PASSWORD: mysql_root_password


### PR DESCRIPTION
the mysql container won't run on the new m1 macs, and fails with the error
```
no matching manifest for linux/arm64/v8 in the manifest list entries
```

I found this fix for it, and now it's running on my new laptop. 