### PR TITLE
Remove duplicate to_json

### DIFF
--- a/.github/workflows/scripts/slack_notifications/cve_notifier.rb
+++ b/.github/workflows/scripts/slack_notifications/cve_notifier.rb
@@ -29,7 +29,7 @@ class CveNotifier < SlackNotifier
   end
 
   def self.cve_message(title, url)
-    ":rotating_light: #{title}\n<#{url}|More info here>".to_json
+    ":rotating_light: #{title}\n<#{url}|More info here>"
   end
 end
 


### PR DESCRIPTION
We're already turning our CVE message into JSON through a `slack_notifier` file. The additional to_json call is causing quotes and newlines to be posted literally. 