### PR TITLE
Describe Rails subscriber implementation

### DIFF
--- a/lib/new_relic/agent/instrumentation/notifications_subscriber.rb
+++ b/lib/new_relic/agent/instrumentation/notifications_subscriber.rb
@@ -50,7 +50,7 @@ module NewRelic
         # The agent doesn't use the traditional ActiveSupport::Notifications.subscribe
         # pattern due to threading issues discovered on initial instrumentation.
         # Instead we define a #start and #finish method, which Rails responds to.
-        # See: rails/rails#12069
+        # See: https://github.com/rails/rails/issues/12069
         def start(name, id, payload)
           return unless state.is_execution_traced?
 

--- a/lib/new_relic/agent/instrumentation/notifications_subscriber.rb
+++ b/lib/new_relic/agent/instrumentation/notifications_subscriber.rb
@@ -47,6 +47,9 @@ module NewRelic
           end
         end
 
+        # The agent doesn't use the traditional ActiveSupport::Notifications.subscribe
+        # pattern due to threading issues discovered on initial instrumentation.
+        # Instead we define a #start and #finish method, which Rails responds to.
         def start(name, id, payload)
           return unless state.is_execution_traced?
 

--- a/lib/new_relic/agent/instrumentation/notifications_subscriber.rb
+++ b/lib/new_relic/agent/instrumentation/notifications_subscriber.rb
@@ -50,6 +50,7 @@ module NewRelic
         # The agent doesn't use the traditional ActiveSupport::Notifications.subscribe
         # pattern due to threading issues discovered on initial instrumentation.
         # Instead we define a #start and #finish method, which Rails responds to.
+        # See: rails/rails#12069
         def start(name, id, payload)
           return unless state.is_execution_traced?
 


### PR DESCRIPTION
Adds a code comment for future readers. The agent uses a non-traditional way to subscribe to Rails events. Instead of passing a block to `ActiveSupport::Notifications.subscribe`, the agent defines a `#start` and `#finish` method, which Rails responds to. This is due to a threading issue discovered on initial instrumentation.
- [Original Issue](https://github.com/rails/rails/issues/12069 )
- [Rails Code](https://github.com/rails/rails/blob/ed5af004598fa7645fec2210453cca00f4b59168/activesupport/lib/active_support/notifications/fanout.rb#L320)