### PR TITLE
Update Elasticsearch port_path_or_id value

### DIFF
--- a/lib/new_relic/agent/instrumentation/elasticsearch/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/elasticsearch/instrumentation.rb
@@ -16,7 +16,7 @@ module NewRelic::Agent::Instrumentation
         product: PRODUCT_NAME,
         operation: nr_operation || OPERATION,
         host: nr_hosts[:host],
-        port_path_or_id: path,
+        port_path_or_id: nr_hosts[:port],
         database_name: nr_cluster_name
       )
       begin

--- a/test/multiverse/suites/elasticsearch/elasticsearch_instrumentation_test.rb
+++ b/test/multiverse/suites/elasticsearch/elasticsearch_instrumentation_test.rb
@@ -74,10 +74,10 @@ class ElasticsearchInstrumentationTest < Minitest::Test
     assert_equal Socket.gethostname, @segment.host
   end
 
-  def test_segment_port_path_or_id_uses_path_if_present
+  def test_segment_port_path_or_id_uses_port
     search
 
-    assert_equal 'my-index/_search', @segment.port_path_or_id
+    assert_equal port.to_s, @segment.port_path_or_id
   end
 
   def test_segment_database_name


### PR DESCRIPTION
Previously, the `port_path_or_id` value for Elasticsearch segments was set to the path given to the `request_with_tracing` method. This caused a metrics grouping issue for a customer because a new instance metric (ex. "Datastore/instance/Elasticsearch/<host>/<port>") was created for every Elasticsearch document ID.

The source of the host value is a hash that also contains a port key. This updates the value of `port_path_or_id` to use the port from the `nr_hosts` hash.