### PR TITLE
CI: Sidekiq multiverse - remove old dependencies

### DIFF
--- a/test/multiverse/suites/sidekiq/Envfile
+++ b/test/multiverse/suites/sidekiq/Envfile
@@ -14,9 +14,6 @@ SIDEKIQ_VERSIONS = [
 
 def gem_list(sidekiq_version = nil)
   <<-RB
-    gem 'rack', "~> 2.2.4"
-    gem 'json'
-    #{ruby3_gem_sorted_set}
     gem 'sidekiq'#{sidekiq_version}
     gem 'newrelic_rpm', :require => false, :path => File.expand_path('../../../../')
   RB

--- a/test/multiverse/suites/sidekiq/sidekiq_test_helpers.rb
+++ b/test/multiverse/suites/sidekiq/sidekiq_test_helpers.rb
@@ -66,10 +66,11 @@ module SidekiqTestHelpers
   end
 
   def cli
-    @cli ||= begin
+    @@cli ||= begin
       cli = Sidekiq::CLI.instance
       cli.parse(['--require', File.absolute_path(__FILE__), '--queue', 'default,1'])
       cli.logger.instance_variable_get(:@logdev).instance_variable_set(:@dev, File.new('/dev/null', 'w'))
+      cli.instance_variable_set(:@config, Sidekiq::Config.new) unless cli.config
       cli
     end
   end

--- a/test/multiverse/suites/sidekiq/sidekiq_test_helpers.rb
+++ b/test/multiverse/suites/sidekiq/sidekiq_test_helpers.rb
@@ -70,9 +70,18 @@ module SidekiqTestHelpers
       cli = Sidekiq::CLI.instance
       cli.parse(['--require', File.absolute_path(__FILE__), '--queue', 'default,1'])
       cli.logger.instance_variable_get(:@logdev).instance_variable_set(:@dev, File.new('/dev/null', 'w'))
-      cli.instance_variable_set(:@config, Sidekiq::Config.new) unless cli.respond_to?(:config) && cli.config
+      ensure_sidekiq_config(cli)
       cli
     end
+  end
+
+  def ensure_sidekiq_config(cli)
+    return unless Sidekiq::VERSION.split('.').first.to_i >= 7
+    return unless cli.respond_to?(:config)
+    return unless cli.config.nil?
+
+    require 'sidekiq/config'
+    cli.instance_variable_set(:@config, ::Sidekiq::Config.new)
   end
 
   def flatten(object)

--- a/test/multiverse/suites/sidekiq/sidekiq_test_helpers.rb
+++ b/test/multiverse/suites/sidekiq/sidekiq_test_helpers.rb
@@ -70,7 +70,7 @@ module SidekiqTestHelpers
       cli = Sidekiq::CLI.instance
       cli.parse(['--require', File.absolute_path(__FILE__), '--queue', 'default,1'])
       cli.logger.instance_variable_get(:@logdev).instance_variable_set(:@dev, File.new('/dev/null', 'w'))
-      cli.instance_variable_set(:@config, Sidekiq::Config.new) unless cli.config
+      cli.instance_variable_set(:@config, Sidekiq::Config.new) unless cli.respond_to?(:config) && cli.config
       cli
     end
   end


### PR DESCRIPTION
Our CI system has recently errored out when running the Sidekiq multiverse suite for 2 reasons:

- `json` gem dependency issues: The `json` version specified by `Gemfile.n` conflicts with the one already activated. Given the recent reworking of the Sidekiq suite, we should no longer need anything but Sidekiq and the agent.
- CLI instance issues. For some reason, we occasionally end up with a nil `config` object for `Sidekiq::CLI.instance`. Set a config if this happens. Also fix memoization in the test helper.