### PR TITLE
Sidekiq: update deprecation warning, CI testing

### DIFF
--- a/lib/new_relic/agent/instrumentation/sidekiq.rb
+++ b/lib/new_relic/agent/instrumentation/sidekiq.rb
@@ -43,8 +43,8 @@ DependencyDetection.defer do
   executes do
     next unless Gem::Version.new(Sidekiq::VERSION) < Gem::Version.new('5.0.0')
 
-    deprecation_msg = 'Instrumentation for Sidekiq versions below 5.0.0 is deprecated.' \
-      'They will stop being monitored in version 9.0.0. ' \
+    deprecation_msg = 'Instrumentation for Sidekiq versions below 5.0.0 is deprecated ' \
+      'and will be dropped entirely in a future major New Relic Ruby agent release.' \
       'Please upgrade your Sidekiq version to continue receiving full support. '
 
     NewRelic::Agent.logger.log_once(

--- a/test/multiverse/suites/sidekiq/Envfile
+++ b/test/multiverse/suites/sidekiq/Envfile
@@ -9,7 +9,7 @@ end
 SIDEKIQ_VERSIONS = [
   [nil, 2.7],
   ['6.4.0', 2.5],
-  ['5.0.3', 2.4]
+  ['5.0.3', 2.4, 2.5]
 ]
 
 def gem_list(sidekiq_version = nil)


### PR DESCRIPTION
- Update the deprecation warning text for Sidekiq v5
- Update the CI testing of Sidekiq v5 to stop testing it with Rubies newer than 2.5
