### PR TITLE
supportability metrics for gem method invocation

### DIFF
--- a/lib/new_relic/agent.rb
+++ b/lib/new_relic/agent.rb
@@ -214,6 +214,17 @@ module NewRelic
       record_metric(metric_name, value)
     end
 
+    def record_instrumentation_invocation(library)
+      record_metric_once("Supportability/#{library}/Invoked")
+    end
+
+    # see ActiveSupport::Inflector.demodulize
+    def base_name(klass_name)
+      return klass_name unless ridx = klass_name.rindex('::')
+
+      klass_name[(ridx + 2), klass_name.length]
+    end
+
     SUPPORTABILITY_INCREMENT_METRIC = 'Supportability/API/increment_metric'.freeze
 
     # Increment a simple counter metric.

--- a/lib/new_relic/agent/instrumentation/active_support_logger/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/active_support_logger/instrumentation.rb
@@ -6,8 +6,12 @@ module NewRelic
   module Agent
     module Instrumentation
       module ActiveSupportLogger
+        INSTRUMENTATION_NAME = NewRelic::Agent.base_name(name)
+
         # Mark @skip_instrumenting on any broadcasted loggers to instrument Rails.logger only
         def broadcast_with_tracing(logger)
+          NewRelic::Agent.record_instrumentation_invocation(INSTRUMENTATION_NAME)
+
           NewRelic::Agent::Instrumentation::Logger.mark_skip_instrumenting(logger)
           yield
         rescue => error

--- a/lib/new_relic/agent/instrumentation/bunny/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/bunny/instrumentation.rb
@@ -12,6 +12,7 @@ module NewRelic
         DEFAULT_NAME = 'Default'
         DEFAULT_TYPE = :direct
         SLASH = '/'
+        INSTRUMENTATION_NAME = NewRelic::Agent.base_name(name)
 
         def exchange_name(name)
           name.empty? ? DEFAULT_NAME : name
@@ -28,6 +29,8 @@ module NewRelic
           include Bunny
 
           def publish_with_tracing(payload, opts = {})
+            NewRelic::Agent.record_instrumentation_invocation(INSTRUMENTATION_NAME)
+
             begin
               destination = exchange_name(name)
 
@@ -62,6 +65,8 @@ module NewRelic
           include Bunny
 
           def pop_with_tracing
+            NewRelic::Agent.record_instrumentation_invocation(INSTRUMENTATION_NAME)
+
             bunny_error, delivery_info, message_properties, _payload = nil, nil, nil, nil
             begin
               t0 = Process.clock_gettime(Process::CLOCK_REALTIME)
@@ -104,6 +109,8 @@ module NewRelic
           end
 
           def purge_with_tracing
+            NewRelic::Agent.record_instrumentation_invocation(INSTRUMENTATION_NAME)
+
             begin
               type = server_named? ? :temporary_queue : :queue
               segment = NewRelic::Agent::Tracer.start_message_broker_segment(
@@ -129,6 +136,8 @@ module NewRelic
           include Bunny
 
           def call_with_tracing(*args)
+            NewRelic::Agent.record_instrumentation_invocation(INSTRUMENTATION_NAME)
+
             delivery_info, message_properties, _ = args
             queue_name = queue.respond_to?(:name) ? queue.name : queue
 

--- a/lib/new_relic/agent/instrumentation/concurrent_ruby/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/concurrent_ruby/instrumentation.rb
@@ -5,10 +5,10 @@
 module NewRelic::Agent::Instrumentation
   module ConcurrentRuby
     SEGMENT_NAME = 'Concurrent/Task'
-    SUPPORTABILITY_METRIC = 'Supportability/ConcurrentRuby/Invoked'
+    INSTRUMENTATION_NAME = NewRelic::Agent.base_name(name)
 
     def add_task_tracing(&task)
-      NewRelic::Agent.record_metric_once(SUPPORTABILITY_METRIC)
+      NewRelic::Agent.record_instrumentation_invocation(INSTRUMENTATION_NAME)
 
       NewRelic::Agent::Tracer.thread_block_with_current_transaction(
         segment_name: SEGMENT_NAME,

--- a/lib/new_relic/agent/instrumentation/curb/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/curb/instrumentation.rb
@@ -15,8 +15,6 @@ module NewRelic
             :_nr_original_on_failure,
             :_nr_serial
 
-          INSTRUMENTATION_NAME = 'Curb'
-
           # We have to hook these three methods separately, as they don't use
           # Curl::Easy#http
           def http_head_with_tracing
@@ -69,6 +67,8 @@ module NewRelic
 
         module Multi
           include NewRelic::Agent::MethodTracer
+
+          INSTRUMENTATION_NAME = 'Curb'
 
           # Add CAT with callbacks if the request is serial
           def add_with_tracing(curl)

--- a/lib/new_relic/agent/instrumentation/curb/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/curb/instrumentation.rb
@@ -15,6 +15,8 @@ module NewRelic
             :_nr_original_on_failure,
             :_nr_serial
 
+          INSTRUMENTATION_NAME = 'Curb'
+
           # We have to hook these three methods separately, as they don't use
           # Curl::Easy#http
           def http_head_with_tracing
@@ -80,6 +82,8 @@ module NewRelic
           # Trace as an External/Multiple call if the first request isn't serial.
           def perform_with_tracing
             return yield if first_request_is_serial?
+
+            NewRelic::Agent.record_instrumentation_invocation(INSTRUMENTATION_NAME)
 
             trace_execution_scoped('External/Multiple/Curb::Multi/perform') do
               yield

--- a/lib/new_relic/agent/instrumentation/delayed_job/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/delayed_job/instrumentation.rb
@@ -6,6 +6,8 @@ module NewRelic
   module Agent
     module Instrumentation
       module DelayedJob
+        INSTRUMENTATION_NAME = NewRelic::Agent.base_name(name)
+
         def initialize_with_tracing
           yield
           worker_name = case
@@ -33,6 +35,8 @@ module NewRelic
         NR_TRANSACTION_CATEGORY = 'OtherTransaction/DelayedJob'.freeze
 
         def invoke_job_with_tracing
+          NewRelic::Agent.record_instrumentation_invocation(INSTRUMENTATION_NAME)
+
           options = {
             :category => NR_TRANSACTION_CATEGORY,
             :path => ::NewRelic::Agent::Instrumentation::DelayedJob::Naming.name_from_payload(payload_object)

--- a/lib/new_relic/agent/instrumentation/delayed_job/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/delayed_job/instrumentation.rb
@@ -6,8 +6,6 @@ module NewRelic
   module Agent
     module Instrumentation
       module DelayedJob
-        INSTRUMENTATION_NAME = NewRelic::Agent.base_name(name)
-
         def initialize_with_tracing
           yield
           worker_name = case
@@ -33,6 +31,7 @@ module NewRelic
         include NewRelic::Agent::Instrumentation::ControllerInstrumentation
 
         NR_TRANSACTION_CATEGORY = 'OtherTransaction/DelayedJob'.freeze
+        INSTRUMENTATION_NAME = 'DelayedJob'
 
         def invoke_job_with_tracing
           NewRelic::Agent.record_instrumentation_invocation(INSTRUMENTATION_NAME)

--- a/lib/new_relic/agent/instrumentation/elasticsearch/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/elasticsearch/instrumentation.rb
@@ -8,9 +8,12 @@ module NewRelic::Agent::Instrumentation
   module Elasticsearch
     PRODUCT_NAME = 'Elasticsearch'
     OPERATION = 'perform_request'
+    INSTRUMENTATION_NAME = NewRelic::Agent.base_name(name)
 
     def perform_request_with_tracing(method, path, params = {}, body = nil, headers = nil)
       return yield unless NewRelic::Agent::Tracer.tracing_enabled?
+
+      NewRelic::Agent.record_instrumentation_invocation(INSTRUMENTATION_NAME)
 
       segment = NewRelic::Agent::Tracer.start_datastore_segment(
         product: PRODUCT_NAME,

--- a/lib/new_relic/agent/instrumentation/excon/middleware.rb
+++ b/lib/new_relic/agent/instrumentation/excon/middleware.rb
@@ -6,6 +6,7 @@ module ::Excon
   module Middleware
     class NewRelicCrossAppTracing
       TRACE_DATA_IVAR = :@newrelic_trace_data
+      INSTRUMENTATION_NAME = 'Excon'
 
       def initialize(stack)
         @stack = stack
@@ -18,6 +19,8 @@ module ::Excon
           # :idempotent in the options, but there will be only a single
           # accompanying response_call/error_call.
           if datum[:connection] && !datum[:connection].instance_variable_get(TRACE_DATA_IVAR)
+            NewRelic::Agent.record_instrumentation_invocation(INSTRUMENTATION_NAME)
+
             wrapped_request = ::NewRelic::Agent::HTTPClients::ExconHTTPRequest.new(datum)
             segment = NewRelic::Agent::Tracer.start_external_request_segment(
               library: wrapped_request.type,

--- a/lib/new_relic/agent/instrumentation/grape/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/grape/instrumentation.rb
@@ -9,6 +9,8 @@ module NewRelic::Agent::Instrumentation
     module Instrumentation
       extend self
 
+      INSTRUMENTATION_NAME = NewRelic::Agent.base_name(name)
+
       # Since 1.2.0, the class `Grape::API` no longer refers to an API instance, rather, what used to be `Grape::API` is `Grape::API::Instance`
       # https://github.com/ruby-grape/grape/blob/c20a73ac1e3f3ba1082005ed61bf69452373ba87/UPGRADING.md#upgrading-to--120
       def instrumented_class
@@ -45,6 +47,8 @@ module NewRelic::Agent::Instrumentation
 
       def handle_transaction(endpoint, class_name, version)
         return unless endpoint && route = endpoint.route
+
+        NewRelic::Agent.record_instrumentation_invocation(INSTRUMENTATION_NAME)
 
         name_transaction(route, class_name, version)
         capture_params(endpoint)

--- a/lib/new_relic/agent/instrumentation/grpc/client/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/grpc/client/instrumentation.rb
@@ -12,7 +12,7 @@ module NewRelic
         module Client
           include NewRelic::Agent::Instrumentation::GRPC::Helper
 
-          INSTRUMENTATION_NAME = 'GRPCClient'
+          INSTRUMENTATION_NAME = 'gRPC_Client'
 
           def issue_request_with_tracing(grpc_type, method, requests, marshal, unmarshal,
             deadline:, return_op:, parent:, credentials:, metadata:)

--- a/lib/new_relic/agent/instrumentation/grpc/client/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/grpc/client/instrumentation.rb
@@ -12,9 +12,13 @@ module NewRelic
         module Client
           include NewRelic::Agent::Instrumentation::GRPC::Helper
 
+          INSTRUMENTATION_NAME = 'GRPCClient'
+
           def issue_request_with_tracing(grpc_type, method, requests, marshal, unmarshal,
             deadline:, return_op:, parent:, credentials:, metadata:)
             return yield unless trace_with_newrelic?
+
+            NewRelic::Agent.record_instrumentation_invocation(INSTRUMENTATION_NAME)
 
             segment = request_segment(method)
             request_wrapper = NewRelic::Agent::Instrumentation::GRPC::Client::RequestWrapper.new(@host)

--- a/lib/new_relic/agent/instrumentation/grpc/server/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/grpc/server/instrumentation.rb
@@ -11,7 +11,7 @@ module NewRelic
         module Server
           include NewRelic::Agent::Instrumentation::GRPC::Helper
 
-          INSTRUMENTATION_NAME = 'GRPCServer'
+          INSTRUMENTATION_NAME = 'gRPC_Server'
 
           DT_KEYS = [NewRelic::NEWRELIC_KEY, NewRelic::TRACEPARENT_KEY, NewRelic::TRACESTATE_KEY].freeze
           INSTANCE_VAR_HOST = :@host_nr

--- a/lib/new_relic/agent/instrumentation/grpc/server/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/grpc/server/instrumentation.rb
@@ -11,6 +11,8 @@ module NewRelic
         module Server
           include NewRelic::Agent::Instrumentation::GRPC::Helper
 
+          INSTRUMENTATION_NAME = 'GRPCServer'
+
           DT_KEYS = [NewRelic::NEWRELIC_KEY, NewRelic::TRACEPARENT_KEY, NewRelic::TRACESTATE_KEY].freeze
           INSTANCE_VAR_HOST = :@host_nr
           INSTANCE_VAR_PORT = :@port_nr
@@ -22,6 +24,8 @@ module NewRelic
 
           def handle_with_tracing(streamer_type, active_call, mth, _inter_ctx)
             return yield unless trace_with_newrelic?
+
+            NewRelic::Agent.record_instrumentation_invocation(INSTRUMENTATION_NAME)
 
             metadata = metadata_for_call(active_call)
             txn = NewRelic::Agent::Transaction.start_new_transaction(NewRelic::Agent::Tracer.state,

--- a/lib/new_relic/agent/instrumentation/grpc_client.rb
+++ b/lib/new_relic/agent/instrumentation/grpc_client.rb
@@ -13,7 +13,7 @@ DependencyDetection.defer do
   end
 
   executes do
-    supportability_name = 'gRPC_Client'
+    supportability_name = NewRelic::Agent::Instrumentation::GRPC::Client::INSTRUMENTATION_NAME
     if use_prepend?
       prepend_instrument GRPC::ClientStub, NewRelic::Agent::Instrumentation::GRPC::Client::Prepend, supportability_name
     else

--- a/lib/new_relic/agent/instrumentation/grpc_server.rb
+++ b/lib/new_relic/agent/instrumentation/grpc_server.rb
@@ -14,7 +14,7 @@ DependencyDetection.defer do
   end
 
   executes do
-    supportability_name = 'gRPC_Server'
+    supportability_name = NewRelic::Agent::Instrumentation::GRPC::Client::INSTRUMENTATION_NAME
     if use_prepend?
       prepend_instrument GRPC::RpcServer, NewRelic::Agent::Instrumentation::GRPC::Server::RpcServerPrepend, supportability_name
       prepend_instrument GRPC::RpcDesc, NewRelic::Agent::Instrumentation::GRPC::Server::RpcDescPrepend, supportability_name

--- a/lib/new_relic/agent/instrumentation/httpclient/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/httpclient/instrumentation.rb
@@ -5,7 +5,11 @@
 module NewRelic::Agent::Instrumentation
   module HTTPClient
     module Instrumentation
+      INSTRUMENTATION_NAME = 'HTTPClient'
+
       def with_tracing(request, connection)
+        NewRelic::Agent.record_instrumentation_invocation(INSTRUMENTATION_NAME)
+
         wrapped_request = NewRelic::Agent::HTTPClients::HTTPClientRequest.new(request)
         segment = NewRelic::Agent::Tracer.start_external_request_segment(
           library: wrapped_request.type,

--- a/lib/new_relic/agent/instrumentation/httprb/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/httprb/instrumentation.rb
@@ -4,7 +4,11 @@
 
 module NewRelic::Agent::Instrumentation
   module HTTPrb
+    INSTRUMENTATION_NAME = NewRelic::Agent.base_name(name)
+
     def with_tracing(request)
+      NewRelic::Agent.record_instrumentation_invocation(INSTRUMENTATION_NAME)
+
       wrapped_request = ::NewRelic::Agent::HTTPClients::HTTPRequest.new(request)
 
       begin

--- a/lib/new_relic/agent/instrumentation/logger/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/logger/instrumentation.rb
@@ -6,6 +6,8 @@ module NewRelic
   module Agent
     module Instrumentation
       module Logger
+        INSTRUMENTATION_NAME = NewRelic::Agent.base_name(name)
+
         def skip_instrumenting?
           defined?(@skip_instrumenting) && @skip_instrumenting
         end
@@ -51,6 +53,7 @@ module NewRelic
             mark_skip_instrumenting
 
             unless ::NewRelic::Agent.agent.nil?
+              ::NewRelic::Agent.record_instrumentation_invocation(INSTRUMENTATION_NAME)
               ::NewRelic::Agent.agent.log_event_aggregator.record(formatted_message, severity)
               formatted_message = LocalLogDecorator.decorate(formatted_message)
             end

--- a/lib/new_relic/agent/instrumentation/logger/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/logger/instrumentation.rb
@@ -6,7 +6,7 @@ module NewRelic
   module Agent
     module Instrumentation
       module Logger
-        INSTRUMENTATION_NAME = NewRelic::Agent.base_name(name)
+        INSTRUMENTATION_NAME = 'Logger'
 
         def skip_instrumenting?
           defined?(@skip_instrumenting) && @skip_instrumenting

--- a/lib/new_relic/agent/instrumentation/memcache/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/memcache/instrumentation.rb
@@ -10,8 +10,11 @@ module NewRelic::Agent::Instrumentation
       LOCALHOST = 'localhost'
       MULTIGET_METRIC_NAME = 'get_multi_request'
       MEMCACHED = 'Memcached'
+      INSTRUMENTATION_NAME = 'Dalli'
 
       def with_newrelic_tracing(operation, *args)
+        NewRelic::Agent.record_instrumentation_invocation(INSTRUMENTATION_NAME)
+
         segment = NewRelic::Agent::Tracer.start_datastore_segment(
           product: MEMCACHED,
           operation: operation
@@ -28,6 +31,8 @@ module NewRelic::Agent::Instrumentation
       end
 
       def server_for_key_with_newrelic_tracing
+        NewRelic::Agent.record_instrumentation_invocation(INSTRUMENTATION_NAME)
+
         yield.tap do |server|
           begin
             if txn = ::NewRelic::Agent::Tracer.current_transaction
@@ -43,6 +48,8 @@ module NewRelic::Agent::Instrumentation
       end
 
       def get_multi_with_newrelic_tracing(method_name)
+        NewRelic::Agent.record_instrumentation_invocation(INSTRUMENTATION_NAME)
+
         segment = NewRelic::Agent::Tracer.start_segment(
           name: "Ruby/Memcached/Dalli/#{method_name}"
         )
@@ -55,6 +62,8 @@ module NewRelic::Agent::Instrumentation
       end
 
       def send_multiget_with_newrelic_tracing(keys)
+        NewRelic::Agent.record_instrumentation_invocation(INSTRUMENTATION_NAME)
+
         segment = ::NewRelic::Agent::Tracer.start_datastore_segment(
           product: MEMCACHED,
           operation: MULTIGET_METRIC_NAME

--- a/lib/new_relic/agent/instrumentation/net_http/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/net_http/instrumentation.rb
@@ -6,7 +6,11 @@ module NewRelic
   module Agent
     module Instrumentation
       module NetHTTP
+        INSTRUMENTATION_NAME = NewRelic::Agent.base_name(name)
+
         def request_with_tracing(request)
+          NewRelic::Agent.record_instrumentation_invocation(INSTRUMENTATION_NAME)
+
           wrapped_request = NewRelic::Agent::HTTPClients::NetHTTPRequest.new(self, request)
 
           segment = NewRelic::Agent::Tracer.start_external_request_segment(

--- a/lib/new_relic/agent/instrumentation/padrino/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/padrino/instrumentation.rb
@@ -4,7 +4,11 @@
 
 module NewRelic::Agent::Instrumentation
   module Padrino
+    INSTRUMENTATION_NAME = NewRelic::Agent.base_name(name)
+
     def invoke_route_with_tracing(*args)
+      NewRelic::Agent.record_instrumentation_invocation(INSTRUMENTATION_NAME)
+
       begin
         env['newrelic.last_route'] = args[0].original_path
       rescue => e

--- a/lib/new_relic/agent/instrumentation/rack/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/rack/instrumentation.rb
@@ -6,6 +6,8 @@ module NewRelic
   module Agent
     module Instrumentation
       module RackBuilder
+        INSTRUMENTATION_NAME = 'Rack'
+
         def self.track_deferred_detection(builder_class)
           class << builder_class
             attr_accessor :_nr_deferred_detection_ran
@@ -51,12 +53,16 @@ module NewRelic
         def run_with_tracing(app)
           return yield(app) unless middleware_instrumentation_enabled?
 
+          NewRelic::Agent.record_instrumentation_invocation(INSTRUMENTATION_NAME)
+
           yield(::NewRelic::Agent::Instrumentation::MiddlewareProxy.wrap(app, true))
         end
 
         def use_with_tracing(middleware_class)
           return if middleware_class.nil?
           return yield(middleware_class) unless middleware_instrumentation_enabled?
+
+          NewRelic::Agent.record_instrumentation_invocation(INSTRUMENTATION_NAME)
 
           yield(::NewRelic::Agent::Instrumentation::MiddlewareProxy.for_class(middleware_class))
         end

--- a/lib/new_relic/agent/instrumentation/rails3/action_controller.rb
+++ b/lib/new_relic/agent/instrumentation/rails3/action_controller.rb
@@ -9,6 +9,8 @@ module NewRelic
     module Instrumentation
       module Rails3
         module ActionController
+          INSTRUMENTATION_NAME = NewRelic::Agent.base_name(name)
+
           # determine the path that is used in the metric name for
           # the called controller action
           def newrelic_metric_path(action_name_override = nil)
@@ -21,6 +23,8 @@ module NewRelic
           end
 
           def process_action(*args) # THREAD_LOCAL_ACCESS
+            NewRelic::Agent.record_instrumentation_invocation(INSTRUMENTATION_NAME)
+
             munged_params = NewRelic::Agent::ParameterFiltering.filter_rails_request_parameters(request.filtered_parameters)
             perform_action_with_newrelic_trace(:category => :controller,
               :name => self.action_name,

--- a/lib/new_relic/agent/instrumentation/rake/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/rake/instrumentation.rb
@@ -7,10 +7,14 @@ module NewRelic
     module Instrumentation
       module Rake
         module Tracer
+          INSTRUMENTATION_NAME = 'Rake'
+
           def invoke_with_newrelic_tracing(*args)
             unless NewRelic::Agent::Instrumentation::Rake.should_trace?(name)
               return yield
             end
+
+            NewRelic::Agent.record_instrumentation_invocation(INSTRUMENTATION_NAME)
 
             begin
               timeout = NewRelic::Agent.config[:'rake.connect_timeout']

--- a/lib/new_relic/agent/instrumentation/redis/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/redis/instrumentation.rb
@@ -6,6 +6,8 @@ require_relative 'constants'
 
 module NewRelic::Agent::Instrumentation
   module Redis
+    INSTRUMENTATION_NAME = NewRelic::Agent.base_name(name)
+
     def connect_with_tracing
       with_tracing(Constants::CONNECT, database: db) { yield }
     end
@@ -43,6 +45,8 @@ module NewRelic::Agent::Instrumentation
     private
 
     def with_tracing(operation, statement: nil, database: nil)
+      NewRelic::Agent.record_instrumentation_invocation(INSTRUMENTATION_NAME)
+
       segment = NewRelic::Agent::Tracer.start_datastore_segment(
         product: Constants::PRODUCT_NAME,
         operation: operation,

--- a/lib/new_relic/agent/instrumentation/resque/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/resque/instrumentation.rb
@@ -6,7 +6,11 @@ module NewRelic::Agent::Instrumentation
   module Resque
     include NewRelic::Agent::Instrumentation::ControllerInstrumentation
 
+    INSTRUMENTATION_NAME = NewRelic::Agent.base_name(name)
+
     def with_tracing
+      NewRelic::Agent.record_instrumentation_invocation(INSTRUMENTATION_NAME)
+
       begin
         perform_action_with_newrelic_trace(
           :name => 'perform',

--- a/lib/new_relic/agent/instrumentation/roda/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/roda/instrumentation.rb
@@ -7,6 +7,8 @@ module NewRelic::Agent::Instrumentation
     module Tracer
       include ::NewRelic::Agent::Instrumentation::ControllerInstrumentation
 
+      INSTRUMENTATION_NAME = 'Roda'
+
       def self.included(clazz)
         clazz.extend(self)
       end
@@ -39,6 +41,8 @@ module NewRelic::Agent::Instrumentation
       end
 
       def _roda_handle_main_route_with_tracing(*args)
+        NewRelic::Agent.record_instrumentation_invocation(INSTRUMENTATION_NAME)
+
         perform_action_with_newrelic_trace(
           category: :roda,
           name: ::NewRelic::Agent::Instrumentation::Roda::TransactionNamer.transaction_name(request),

--- a/lib/new_relic/agent/instrumentation/sidekiq/client.rb
+++ b/lib/new_relic/agent/instrumentation/sidekiq/client.rb
@@ -6,7 +6,11 @@ module NewRelic::Agent::Instrumentation::Sidekiq
   class Client
     include Sidekiq::ClientMiddleware if defined?(Sidekiq::ClientMiddleware)
 
+    INSTRUMENTATION_NAME = 'SidekiqClient'
+
     def call(_worker_class, job, *_)
+      NewRelic::Agent.record_instrumentation_invocation(INSTRUMENTATION_NAME)
+
       job[NewRelic::NEWRELIC_KEY] ||= distributed_tracing_headers if ::NewRelic::Agent.config[:'distributed_tracing.enabled']
       yield
     end

--- a/lib/new_relic/agent/instrumentation/sidekiq/server.rb
+++ b/lib/new_relic/agent/instrumentation/sidekiq/server.rb
@@ -10,10 +10,13 @@ module NewRelic::Agent::Instrumentation::Sidekiq
     ATTRIBUTE_BASE_NAMESPACE = 'sidekiq.args'
     ATTRIBUTE_FILTER_TYPES = %i[include exclude].freeze
     ATTRIBUTE_JOB_NAMESPACE = :"job.#{ATTRIBUTE_BASE_NAMESPACE}"
+    INSTRUMENTATION_NAME = 'SidekiqServer'
 
     # Client middleware has additional parameters, and our tests use the
     # middleware client-side to work inline.
     def call(worker, msg, queue, *_)
+      NewRelic::Agent.record_instrumentation_invocation(INSTRUMENTATION_NAME)
+
       trace_args = if worker.respond_to?(:newrelic_trace_args)
         worker.newrelic_trace_args(msg, queue)
       else

--- a/lib/new_relic/agent/instrumentation/sinatra/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/sinatra/instrumentation.rb
@@ -13,6 +13,8 @@ module NewRelic::Agent::Instrumentation
     module Tracer
       include ::NewRelic::Agent::Instrumentation::ControllerInstrumentation
 
+      INSTRUMENTATION_NAME = 'Sinatra'
+
       def self.included(clazz)
         clazz.extend(self)
       end
@@ -90,6 +92,8 @@ module NewRelic::Agent::Instrumentation
       end
 
       def dispatch_with_tracing
+        NewRelic::Agent.record_instrumentation_invocation(INSTRUMENTATION_NAME)
+
         request_params = get_request_params
         filtered_params = ::NewRelic::Agent::ParameterFiltering::apply_filters(request.env, request_params || {})
 

--- a/lib/new_relic/agent/instrumentation/tilt/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/tilt/instrumentation.rb
@@ -6,6 +6,8 @@ module NewRelic
   module Agent
     module Instrumentation
       module Tilt
+        INSTRUMENTATION_NAME = NewRelic::Agent.base_name(name)
+
         def metric_name(klass, file)
           "View/#{klass}/#{file}/Rendering"
         end
@@ -21,6 +23,8 @@ module NewRelic
         end
 
         def render_with_tracing(*args, &block)
+          NewRelic::Agent.record_instrumentation_invocation(INSTRUMENTATION_NAME)
+
           begin
             finishable = Tracer.start_segment(
               name: metric_name(self.class, create_filename_for_metric(self.file))

--- a/lib/new_relic/agent/instrumentation/typhoeus/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/typhoeus/instrumentation.rb
@@ -8,8 +8,8 @@ module NewRelic
       module Typhoeus
         HYDRA_SEGMENT_NAME = 'External/Multiple/Typhoeus::Hydra/run'
         NOTICEABLE_ERROR_CLASS = 'Typhoeus::Errors::TyphoeusError'
-
         EARLIEST_VERSION = Gem::Version.new('0.5.3')
+        INSTRUMENTATION_NAME = NewRelic::Agent.base_name(name)
 
         def self.is_supported_version?
           Gem::Version.new(::Typhoeus::VERSION) >= EARLIEST_VERSION
@@ -31,6 +31,8 @@ module NewRelic
         end
 
         def with_tracing
+          NewRelic::Agent.record_instrumentation_invocation(INSTRUMENTATION_NAME)
+
           segment = NewRelic::Agent::Tracer.start_segment(name: HYDRA_SEGMENT_NAME)
           instance_variable_set(:@__newrelic_hydra_segment, segment)
           begin
@@ -41,6 +43,8 @@ module NewRelic
         end
 
         def self.trace(request)
+          NewRelic::Agent.record_instrumentation_invocation(INSTRUMENTATION_NAME)
+
           state = NewRelic::Agent::Tracer.state
           return unless state.is_execution_traced?
 

--- a/test/multiverse/suites/concurrent_ruby/concurrent_ruby_instrumentation_test.rb
+++ b/test/multiverse/suites/concurrent_ruby/concurrent_ruby_instrumentation_test.rb
@@ -123,6 +123,6 @@ class ConcurrentRubyInstrumentationTest < Minitest::Test
       Concurrent::Promises.future { 'two-banana' }
     end
 
-    assert_metrics_recorded(NewRelic::Agent::Instrumentation::ConcurrentRuby::SUPPORTABILITY_METRIC)
+    assert_metrics_recorded('Supportability/ConcurrentRuby/Invoked')
   end
 end

--- a/test/multiverse/suites/logger/logger_instrumentation_test.rb
+++ b/test/multiverse/suites/logger/logger_instrumentation_test.rb
@@ -209,6 +209,6 @@ class LoggerInstrumentationTest < Minitest::Test
       'Supportability/Logging/Forwarding/Seen' => {},
       'Supportability/Logging/Forwarding/Sent' => {}
     },
-      :ignore_filter => %r{^Supportability/API/})
+      :ignore_filter => %r{^Supportability/(?:API/|Logger/Invoked)})
   end
 end

--- a/test/new_relic/agent_test.rb
+++ b/test/new_relic/agent_test.rb
@@ -622,6 +622,28 @@ module NewRelic
       end
     end
 
+    def test_record_instrumentation_invocation
+      library = 'NewRelicFly'
+      dummy_engine = NewRelic::Agent.agent.stats_engine
+      dummy_engine.expects(:tl_record_unscoped_metrics).with('Supportability/API/record_metric')
+      dummy_engine.expects(:tl_record_unscoped_metrics).with("Supportability/#{library}/Invoked", 0.0).once
+      NewRelic::Agent.record_instrumentation_invocation(library)
+      NewRelic::Agent.record_instrumentation_invocation(library)
+      NewRelic::Agent.record_instrumentation_invocation(library)
+    end
+
+    def test_base_name
+      name = 'Ladies::Gentlemen::May::I::Welcome::You'
+
+      assert_equal 'You', NewRelic::Agent.base_name(name)
+    end
+
+    def test_base_name_without_module_namespace
+      name = 'Poirot'
+
+      assert_equal name, NewRelic::Agent.base_name(name)
+    end
+
     private
 
     def with_unstarted_agent


### PR DESCRIPTION
Following a pattern established by the concurrent-ruby instrumentation, establish a way for all instrumentation to differentiate between the simple presence of an instrumented gem and its invocation.

resolves #1923