### PR TITLE
Stripe: exclude list works on user data values

### DIFF
--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -1630,9 +1630,10 @@ module NewRelic
           allowed_from_server: false,
           :transform => DefaultSource.method(:convert_to_list),
           :description => <<~DESCRIPTION
-            An array of strings to specify which keys inside a Stripe event's `user_data` hash should not be reported
-            to New Relic. Each string in this array will be turned into a regular expression via `Regexp.new` to
-            permit advanced matching. By default, no `user_data` is reported, so this option should only be used if 
+            An array of strings to specify which keys and/or values inside a Stripe event's `user_data` hash should
+            not be reported to New Relic. Each string in this array will be turned into a regular expression via
+            `Regexp.new` to permit advanced matching. For each hash pair, if either the key or value is matched the
+            pair will not be reported. By default, no `user_data` is reported, so this option should only be used if 
             the `stripe.user_data.include` option is being used.
           DESCRIPTION
         },


### PR DESCRIPTION
While the Stripe include list is only concerned with user data hash keys, the exclude list looks at both the keys and their corresponding values in case there's anything sensitive or otherwise unwanted in the value.

- Added a new test to demonstrate hash value filtration
- Updated existing exclusion test which was yielding a false positive by not setting an include list (excludes won't work without an include list)
- Updated the exclude list config option description