### PR TITLE
CI: perf tests - bundler, git ignore logs

### DIFF
--- a/.github/workflows/performance_tests.yml
+++ b/.github/workflows/performance_tests.yml
@@ -37,10 +37,10 @@ jobs:
         with:
           ruby-version: '3.2'
       - run: bundle
-      - run: script/runner -B
+      - run: bundle exec script/runner -B
       - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # tag v3.5.0
       - run: bundle
-      - run: script/runner -C -M > performance_results.md
+      - run: bundle exec script/runner -C -M > performance_results.md
       - name: Save performance results
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # tag v3.1.2
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ lib/new_relic/build.rb
 artifacts/
 test/performance/log/
 test/performance/script/log/
+test/performance/rails_app/log/
 infinite_tracing/log/
 test/fixtures/cross_agent_tests/*/README.md
 node_modules/


### PR DESCRIPTION
* invoke the script with `bundle exec` to focus on the right `Gemfile`
* ignore perf test Rails app logs