### PR TITLE
perf tests: fix arg passing

### DIFF
--- a/test/performance/script/runner
+++ b/test/performance/script/runner
@@ -9,4 +9,4 @@ require_relative '../rails_app/config/boot'
 require 'rails/command'
 require_relative '../lib/performance'
 
-Rails::Command.invoke(:runner, %w[Performance::Runner.new.run_and_report])
+Rails::Command.invoke(:runner, %w[Performance::Runner.new.run_and_report] + ARGV)

--- a/test/performance/suites/agent_module.rb
+++ b/test/performance/suites/agent_module.rb
@@ -9,7 +9,7 @@ class AgentModuleTest < Performance::TestCase
   ITERATIONS = 50_000
 
   def test_increment_metric_by_1
-    measure do
+    measure(ITERATIONS) do
       NewRelic::Agent.increment_metric(METRIC)
     end
   end


### PR DESCRIPTION
- now that we wrap the perf tests in a Rails wrapper, the outer `ARGV` needs to be passed to the inner one
- fix straggler that wasn't previously converted to use an iteration count

resolves #2212 