### PR TITLE
Support cgroups v1 and v2 for Docker containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # New Relic Ruby Agent Release Notes
 
+## dev
+
+Version <dev> brings support for gleaning a Docker container id from cgroups v2 based containers.
+
+- **Feature: Enhance Docker container id reporting**
+
+  Previously the agent was only capable of determining a host Docker container's id if the container was based on cgroups v1. Now containers based on cgroups v2 will also have their container ids reported to New Relic. [PR#2026](https://github.com/newrelic/newrelic-ruby-agent/issues/2026).
+
 ## v9.5.0
 
 Version 9.5.0 introduces Stripe instrumentation, allows the agent to record additional response information on a transaction when middleware instrumentation is disabled, introduces new `:'sidekiq.args.include'` and `:'sidekiq.args.exclude:` configuration options to permit capturing only certain Sidekiq job arguments, updates Elasticsearch datastore instance metrics, and fixes a bug in `NewRelic::Rack::AgentHooks.needed?`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Version <dev> brings support for gleaning a Docker container id from cgroups v2 
 
 - **Feature: Enhance Docker container id reporting**
 
-  Previously the agent was only capable of determining a host Docker container's id if the container was based on cgroups v1. Now containers based on cgroups v2 will also have their container ids reported to New Relic. [PR#2026](https://github.com/newrelic/newrelic-ruby-agent/issues/2026).
+  Previously the agent was only capable of determining a host Docker container's id if the container was based on cgroups v1. Now containers based on cgroups v2 will also have their container ids reported to New Relic. [PR#2229](https://github.com/newrelic/newrelic-ruby-agent/issues/2229).
 
 ## v9.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Version <dev> brings support for gleaning a Docker container id from cgroups v2 
 
 - **Feature: Enhance Docker container id reporting**
 
-  Previously the agent was only capable of determining a host Docker container's id if the container was based on cgroups v1. Now containers based on cgroups v2 will also have their container ids reported to New Relic. [PR#2229](https://github.com/newrelic/newrelic-ruby-agent/issues/2229).
+  Previously, the agent was only capable of determining a host Docker container's ID if the container was based on cgroups v1. Now, containers based on cgroups v2 will also have their container IDs reported to New Relic. [PR#2229](https://github.com/newrelic/newrelic-ruby-agent/issues/2229).
 
 ## v9.5.0
 


### PR DESCRIPTION
Previously the agent was only capable of gleaning a Docker container id by leveraging a cgroups v1 approach. Now, it will first attempt to leverage a cgroups v2 approach and fall back to the v1 approach if that doesn't work. All other Docker related behavior such as that seen with containers that don't have cgroups functionality enabled is not impacted.

resolves #2026 