### PR TITLE
CI: Ruby v3.3.0+ requires Puma v6.4.0+

### DIFF
--- a/test/multiverse/suites/rack/Envfile
+++ b/test/multiverse/suites/rack/Envfile
@@ -6,19 +6,14 @@ instrumentation_methods :chain, :prepend
 
 # The Rack suite also tests Puma::Rack::Builder
 # Which is why we also control Puma tested versions here
-PUMA_VERSIONS = [
-  'nil',
-  '5.6.4',
-  '4.3.12',
-  '3.12.6'
-]
-
 # Ruby v3.3.0+ requires Puma v6.4.0+
 # https://github.com/puma/puma/commit/188f5da1920ff99a8689b3e9b46f2f26b7c62d66
-if RUBY_VERSION >= Gem::Version.new('3.3.0')
-  puma_min = Gem::Version.new('6.4.0')
-  PUMA_VERSIONS.reject! { |v| !v.eql?('nil') && Gem::Version.new(v) < puma_min }
-end
+PUMA_VERSIONS = [
+  [nil, 2.4],
+  ['5.6.4', 2.4, 3.2],
+  ['4.3.12', 2.4, 3.2],
+  ['3.12.6', 2.4, 3.2]
+]
 
 def gem_list(puma_version = nil)
   <<~RB

--- a/test/multiverse/suites/rack/Envfile
+++ b/test/multiverse/suites/rack/Envfile
@@ -13,6 +13,13 @@ PUMA_VERSIONS = [
   '3.12.6'
 ]
 
+# Ruby v3.3.0+ requires Puma v6.4.0+
+# https://github.com/puma/puma/commit/188f5da1920ff99a8689b3e9b46f2f26b7c62d66
+if RUBY_VERSION >= Gem::Version.new('3.3.0')
+  puma_min = Gem::Version.new('6.4.0')
+  PUMA_VERSIONS.reject! { |v| !v.eql?('nil') && Gem::Version.new(v) < puma_min }
+end
+
 def gem_list(puma_version = nil)
   <<~RB
     gem 'puma'#{puma_version}


### PR DESCRIPTION
Now that Puma v6.4.0 is out, we can resume testing with "nil" (latest) on Ruby v3.3.0, but we need to prevent Ruby v3.3.0 and future rubies from ever testing Pumas older than v6.4.0.