### PR TITLE
CI: fix flapping Sidekiq test

### DIFF
--- a/test/multiverse/suites/sidekiq/sidekiq_instrumentation_test.rb
+++ b/test/multiverse/suites/sidekiq/sidekiq_instrumentation_test.rb
@@ -47,7 +47,7 @@ class SidekiqInstrumentationTest < Minitest::Test
     exception = StandardError.new('bonk')
     noticed = []
     NewRelic::Agent.stub :notice_error, proc { |e| noticed.push(e) } do
-      Sidekiq::CLI.instance.handle_exception(exception)
+      cli.handle_exception(exception)
     end
 
     assert_equal 1, noticed.size


### PR DESCRIPTION
The singleton instance of `Sidekiq::CLI` needs to have a Sidekiq configuration set on it for certain operations to work.

Previously we had been lucking out by having the `cli` test helper method be called prior to the `test_captures_sidekiq_internal_errors` test (which does not make use of the helper) being ran.

To prevent flapping, have the test make use of the `cli` helper (which preps a CLI instance with a config) to make it always pass regardless of the run order.

resolves #2227 