### PR TITLE
#2247, removes unused variable warnings in tests suite

### DIFF
--- a/test/new_relic/agent/configuration/manager_test.rb
+++ b/test/new_relic/agent/configuration/manager_test.rb
@@ -494,7 +494,7 @@ module NewRelic::Agent::Configuration
     def test_auto_determined_values_stay_cached
       name = :knockbreck_manse
 
-      dd = DependencyDetection.defer do
+      DependencyDetection.defer do
         named(name)
         executes { use_prepend? }
       end
@@ -512,7 +512,7 @@ module NewRelic::Agent::Configuration
     def test_unsatisfied_values_stay_cached
       name = :tears_of_the_kingdom
 
-      dd = DependencyDetection.defer do
+      DependencyDetection.defer do
         named(name)
 
         # guarantee the instrumentation's dependencies are unsatisfied

--- a/test/new_relic/agent/monitors/synthetics_monitor_test.rb
+++ b/test/new_relic/agent/monitors/synthetics_monitor_test.rb
@@ -79,7 +79,6 @@ module NewRelic::Agent
     end
 
     def test_records_synthetics_info_header_if_available
-      key = SyntheticsMonitor::SYNTHETICS_HEADER_KEY
       synthetics_payload = [VERSION_ID] + STANDARD_DATA
       info_payload = <<~PAYLOAD
         {

--- a/test/new_relic/agent/tracer_test.rb
+++ b/test/new_relic/agent/tracer_test.rb
@@ -308,7 +308,7 @@ module NewRelic
         txn = Tracer.start_transaction(name: 'Controller/blogs/index', category: :controller)
         threads = []
         threads << Thread.new do
-          segment = Tracer.start_segment(name: 'Custom/MyClass/myoperation')
+          Tracer.start_segment(name: 'Custom/MyClass/myoperation')
           sleep(0.01) until txn.finished?
 
           threads << Thread.new do

--- a/test/new_relic/dependency_detection_test.rb
+++ b/test/new_relic/dependency_detection_test.rb
@@ -211,11 +211,9 @@ class DependencyDetectionTest < Minitest::Test
   end
 
   def test_config_enabling_with_auto
-    executed = false
-
     dd = DependencyDetection.defer do
       named(:testing)
-      executes { executed = true }
+      executes { true }
     end
 
     with_config(:'instrumentation.testing' => 'auto') do
@@ -228,11 +226,9 @@ class DependencyDetectionTest < Minitest::Test
   end
 
   def test_config_enabling_with_prepend
-    executed = false
-
     dd = DependencyDetection.defer do
       named(:testing)
-      executes { executed = true }
+      executes { true }
     end
 
     with_config(:'instrumentation.testing' => 'prepend') do
@@ -245,11 +241,9 @@ class DependencyDetectionTest < Minitest::Test
   end
 
   def test_config_enabling_with_chain
-    executed = false
-
     dd = DependencyDetection.defer do
       named(:testing)
-      executes { executed = true }
+      executes { true }
     end
 
     with_config(:'instrumentation.testing' => 'chain') do


### PR DESCRIPTION
# Overview
- This PR removes all the unused variable warnings during the execution of test suites. 
- Resolves #2247 

Submitter Checklist:
- [x] Include a link to the related GitHub issue, if applicable
- [ ] Include a security review link, if applicable

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
