### PR TITLE
Add and Replace SLASH and ROOT constants

### DIFF
--- a/lib/new_relic/agent/instrumentation/active_record_helper.rb
+++ b/lib/new_relic/agent/instrumentation/active_record_helper.rb
@@ -232,7 +232,6 @@ module NewRelic
 
           DEFAULT = 'default'.freeze
           UNKNOWN = 'unknown'.freeze
-          SLASH = '/'.freeze
           LOCALHOST = 'localhost'.freeze
 
           def adapter_from_config(config)
@@ -288,7 +287,7 @@ module NewRelic
           private
 
           def postgres_unix_domain_socket_case?(host, adapter)
-            adapter == :postgres && host && host.start_with?(SLASH)
+            adapter == :postgres && host && host.start_with?(NewRelic::SLASH)
           end
 
           def mysql_default_case?(config, adapter)

--- a/lib/new_relic/agent/instrumentation/mongodb_command_subscriber.rb
+++ b/lib/new_relic/agent/instrumentation/mongodb_command_subscriber.rb
@@ -131,10 +131,8 @@ module NewRelic
           UNKNOWN
         end
 
-        SLASH = '/'.freeze
-
         def unix_domain_socket?(host)
-          host.start_with?(SLASH)
+          host.start_with?(NewRelic::SLASH)
         end
       end
     end

--- a/lib/new_relic/agent/instrumentation/roda/roda_transaction_namer.rb
+++ b/lib/new_relic/agent/instrumentation/roda/roda_transaction_namer.rb
@@ -9,13 +9,12 @@ module NewRelic
         module TransactionNamer
           extend self
 
-          ROOT = '/'.freeze
           REGEX_MULTIPLE_SLASHES = %r{^[/^]*(.*?)[/$?]*$}.freeze
 
           def transaction_name(request)
             path = request.path || ::NewRelic::Agent::UNKNOWN_METRIC
             name = path.gsub(REGEX_MULTIPLE_SLASHES, '\1') # remove any rogue slashes
-            name = ROOT if name.empty?
+            name = NewRelic::ROOT if name.empty?
             name = "#{request.request_method} #{name}" if request.respond_to?(:request_method)
 
             name

--- a/lib/new_relic/agent/instrumentation/sinatra/transaction_namer.rb
+++ b/lib/new_relic/agent/instrumentation/sinatra/transaction_namer.rb
@@ -25,14 +25,12 @@ module NewRelic
             transaction_name(::NewRelic::Agent::UNKNOWN_METRIC, request)
           end
 
-          ROOT = '/'.freeze
-
           def transaction_name(route_text, request)
             verb = http_verb(request)
 
             route_text = route_text.source if route_text.is_a?(Regexp)
             name = route_text.gsub(%r{^[/^\\A]*(.*?)[/\$\?\\z]*$}, '\1')
-            name = ROOT if name.empty?
+            name = NewRelic::ROOT if name.empty?
             name = "#{verb} #{name}" unless verb.nil?
             name
           rescue => e

--- a/lib/new_relic/agent/messaging.rb
+++ b/lib/new_relic/agent/messaging.rb
@@ -329,9 +329,9 @@ module NewRelic
 
       def transaction_name(library, destination_type, destination_name)
         transaction_name = Transaction::MESSAGE_PREFIX + library
-        transaction_name << Transaction::MessageBrokerSegment::SLASH
+        transaction_name << NewRelic::SLASH
         transaction_name << Transaction::MessageBrokerSegment::TYPES[destination_type]
-        transaction_name << Transaction::MessageBrokerSegment::SLASH
+        transaction_name << NewRelic::SLASH
 
         case destination_type
         when :queue

--- a/lib/new_relic/agent/rules_engine.rb
+++ b/lib/new_relic/agent/rules_engine.rb
@@ -9,7 +9,7 @@ require 'new_relic/language_support'
 module NewRelic
   module Agent
     class RulesEngine
-      SEGMENT_SEPARATOR = '/'.freeze
+      SEGMENT_SEPARATOR = NewRelic::SLASH
       LEADING_SLASH_REGEX = %r{^/}.freeze
 
       include Enumerable

--- a/lib/new_relic/agent/transaction/message_broker_segment.rb
+++ b/lib/new_relic/agent/transaction/message_broker_segment.rb
@@ -15,7 +15,6 @@ module NewRelic
         PRODUCE = 'Produce'.freeze
         QUEUE = 'Queue'.freeze
         PURGE = 'Purge'.freeze
-        SLASH = '/'.freeze
         TEMP = 'Temp'.freeze
         TOPIC = 'Topic'.freeze
         UNKNOWN = 'Unknown'.freeze
@@ -73,7 +72,7 @@ module NewRelic
           return @name if @name
 
           @name = METRIC_PREFIX + library
-          @name << SLASH << TYPES[destination_type] << SLASH << ACTIONS[action] << SLASH
+          @name << NewRelic::SLASH << TYPES[destination_type] << NewRelic::SLASH << ACTIONS[action] << NewRelic::SLASH
 
           if destination_type == :temporary_queue || destination_type == :temporary_topic
             @name << TEMP

--- a/lib/new_relic/agent/transaction/request_attributes.rb
+++ b/lib/new_relic/agent/transaction/request_attributes.rb
@@ -103,12 +103,10 @@ module NewRelic
         # rails construct the PATH_INFO enviroment variable improperly and we're generally
         # being defensive.
 
-        ROOT_PATH = '/'.freeze
-
         def path_from_request(request)
           path = attribute_from_request(request, :path) || ''
           path = HTTPClients::URIUtil.strip_query_string(path)
-          path.empty? ? ROOT_PATH : path
+          path.empty? ? NewRelic::ROOT : path
         end
 
         def content_length_from_request(request)

--- a/lib/new_relic/agent/utilization/gcp.rb
+++ b/lib/new_relic/agent/utilization/gcp.rb
@@ -24,10 +24,8 @@ module NewRelic
           body
         end
 
-        SLASH = '/'.freeze
-
         def trim_leading(value)
-          value.split(SLASH).last
+          value.split(NewRelic::SLASH).last
         end
       end
     end

--- a/lib/new_relic/constants.rb
+++ b/lib/new_relic/constants.rb
@@ -35,4 +35,7 @@ module NewRelic
 
   CONNECT_RETRY_PERIODS = [15, 15, 30, 60, 120, 300]
   MAX_RETRY_PERIOD = 300
+
+  SLASH = '/'
+  ROOT = SLASH
 end


### PR DESCRIPTION
# Overview

- This PR adds the SLASH and ROOT constants and replaces them throughout the agent.
- I created the ROOT (`/`) constant because I felt that we are using it in the path's context in many places as well
- I thought it would be handy to separate it out into a new constant.

Submitter Checklist:
- [x] Include a link to the related GitHub issue, if applicable
- [ ] Include a security review link, if applicable

Resolves #2153 