### PR TITLE
Fix deprecation warning from sidekiq error handler

### DIFF
--- a/lib/new_relic/agent/instrumentation/sidekiq.rb
+++ b/lib/new_relic/agent/instrumentation/sidekiq.rb
@@ -33,7 +33,9 @@ DependencyDetection.defer do
       end
 
       if config.respond_to?(:error_handlers)
-        config.error_handlers << proc do |error, *_|
+        # Sidekiq 3.0.0 - 7.1.4 expect error_handlers to have 2 arguments
+        # Sidekiq 7.1.5+ expect error_handlers to have 3 arguments
+        config.error_handlers << proc do |error, _ctx, *_|
           NewRelic::Agent.notice_error(error)
         end
       end


### PR DESCRIPTION
- [x] _Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview

Fix deprecation warning: `DEPRECATION: Sidekiq exception handlers now take three arguments...`

> DEPRECATION: Sidekiq exception handlers now take three arguments, see #<Proc:0x00007f9015db7ef8 /home/me/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/newrelic_rpm-9.5.0/lib/new_relic/agent/instrumentation/sidekiq.rb:36>

NOTE: This warning is shown when using sidekiq main branch.

- https://github.com/sidekiq/sidekiq/pull/6051
- https://github.com/sidekiq/sidekiq/pull/6073
- https://github.com/bugsnag/bugsnag-ruby/pull/796

Submitter Checklist:
- [x] Include a link to the related GitHub issue, if applicable
- ~~[ ] Include a security review link, if applicable~~

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
GitHub Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
