### PR TITLE
send_stream subscriber

### DIFF
--- a/lib/new_relic/agent/instrumentation/rails_notifications/action_controller.rb
+++ b/lib/new_relic/agent/instrumentation/rails_notifications/action_controller.rb
@@ -34,6 +34,7 @@ DependencyDetection.defer do
 
     subs = %w[send_file
       send_data
+      send_stream
       redirect_to
       halted_callback
       unpermitted_parameters]

--- a/test/multiverse/suites/rails/action_controller_other_test.rb
+++ b/test/multiverse/suites/rails/action_controller_other_test.rb
@@ -17,6 +17,11 @@ if defined?(ActionController::Live)
       send_data('wow its a adata')
     end
 
+    # send_stream
+    def send_test_stream
+      send_stream(filename: 'dinosaurs.html')
+    end
+
     # halted_callback
     before_action :do_a_redirect, only: :halt_my_callback
     def halt_my_callback; end
@@ -49,6 +54,13 @@ if defined?(ActionController::Live)
       get('/data/send_test_data')
 
       assert_metrics_recorded(['Controller/data/send_test_data', 'Ruby/ActionController/send_data'])
+    end
+
+    def test_send_stream
+      skip if Gem::Version.new(Rails::VERSION::STRING) < Gem::Version.new('7.2.0')
+      get('/data/send_test_stream')
+
+      assert_metrics_recorded(['Controller/data/send_test_stream', 'Ruby/ActionController/send_stream'])
     end
 
     def test_halted_callback


### PR DESCRIPTION
A [PR to add ](https://github.com/rails/rails/pull/49297)`send_stream` notifications is sitting with the Rails team and has been labeled to go out in Rails 7.2. Rather than hold this PR, let's just skip the send_stream subscriber test until Rails 7.2. is released. 

Closes #1588