### PR TITLE
Ethon: focus on return_code for errors

### DIFF
--- a/lib/new_relic/agent/instrumentation/ethon/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/ethon/instrumentation.rb
@@ -24,8 +24,9 @@ module NewRelic::Agent::Instrumentation
           wrapped_response = NewRelic::Agent::HTTPClients::EthonHTTPResponse.new(easy)
           segment.process_response_headers(wrapped_response)
 
-          if easy.response_code == 0
-            e = NewRelic::Agent::NoticeableError.new(NOTICEABLE_ERROR_CLASS, "return_code: >>#{easy.return_code}<<")
+          if easy.return_code != :ok
+            e = NewRelic::Agent::NoticeableError.new(NOTICEABLE_ERROR_CLASS,
+              "return_code: >>#{easy.return_code}<<, response_code: >>#{easy.response_code}<<")
             segment.notice_error(e)
           end
 


### PR DESCRIPTION
For an instance of `Ethon::Easy`, consider a `#return_code` result not equal to `:ok` to be the indicator of an error instead of the `#response_code` being equal to `0`. With direct Ethon usage, these equality checks seem interchangeable but with Typhoeus the underyling easy object is left with a 0 for its response code on success.