### PR TITLE
Update grape Envfile to handle activesupport 7.1

### DIFF
--- a/test/multiverse/suites/grape/Envfile
+++ b/test/multiverse/suites/grape/Envfile
@@ -10,13 +10,22 @@ GRAPE_VERSIONS = [
   ['1.5.3', 2.4, 3.0]
 ]
 
+# Active Support 7.1 introduced a change to the deprecator
+# that is incompatible with version 1.5.x of grape.
+# Since version 7.1 is compatible with Ruby 2.7 and 3.0,
+# this will cause the tests to fail unless we specify
+# a lower activesupport version.
+def activesupport_version(grape_version)
+  ", '< 7.1'" if grape_version&.include?('1.5')
+end
+
 def gem_list(grape_version = nil)
   <<~RB
     gem 'rack'
     gem 'rack-test', '>= 0.8.0'
     gem 'grape'#{grape_version}
 
-    gem 'activesupport'
+    gem 'activesupport'#{activesupport_version(grape_version)}
   RB
 end
 


### PR DESCRIPTION
Active Support 7.1 introduced a change to the deprecator that is incompatible with version 1.5.x of grape.
Since version 7.1 is compatible with Ruby 2.7 and 3.0, this will cause the tests to fail unless we specify a lower `activesupport` version to run on those Ruby versions.

Full scheduled CI run: https://github.com/newrelic/newrelic-ruby-agent/actions/runs/6593602933 
(The failing suite on that CI run is unrelated to this change)
