### PR TITLE
docker container id: ensure sha256 format

### DIFF
--- a/lib/new_relic/agent/system_info.rb
+++ b/lib/new_relic/agent/system_info.rb
@@ -13,6 +13,8 @@ require 'socket'
 module NewRelic
   module Agent
     module SystemInfo
+      DOCKER_CGROUPS_V2_PATTERN = %r{.*/docker/containers/([0-9a-f]{64})/.*}.freeze
+
       def self.ruby_os_identifier
         RbConfig::CONFIG['target_os']
       end
@@ -202,7 +204,7 @@ module NewRelic
         mountinfo = proc_try_read('/proc/self/mountinfo')
         return unless mountinfo
 
-        Regexp.last_match(1) if mountinfo =~ %r{/docker/containers/([^/]+)/}
+        Regexp.last_match(1) if mountinfo =~ DOCKER_CGROUPS_V2_PATTERN
       end
 
       def self.parse_docker_container_id(cgroup_info)


### PR DESCRIPTION
update the Docker cgroups v2 container id regex to insist on a sha256 formatted id string