### PR TITLE
Cleanup of duplicated constants from individual HTTP wrapper classes to abstract class

### DIFF
--- a/lib/new_relic/agent/http_clients/abstract.rb
+++ b/lib/new_relic/agent/http_clients/abstract.rb
@@ -14,6 +14,10 @@ module NewRelic
       #
       # @api public
       class AbstractRequest
+        LHOST = 'host'
+        UHOST = 'Host'
+        COLON = ':'
+
         %i[[] []= type host_from_header host method headers uri].each do |name|
           define_method(name) do
             not_implemented(name)

--- a/lib/new_relic/agent/http_clients/async_http_wrappers.rb
+++ b/lib/new_relic/agent/http_clients/async_http_wrappers.rb
@@ -31,9 +31,6 @@ module NewRelic
         end
 
         ASYNC_HTTP = 'Async::HTTP'
-        LHOST = 'host'
-        UHOST = 'Host'
-        COLON = ':'
 
         def type
           ASYNC_HTTP

--- a/lib/new_relic/agent/http_clients/curb_wrappers.rb
+++ b/lib/new_relic/agent/http_clients/curb_wrappers.rb
@@ -7,10 +7,8 @@ require_relative 'abstract'
 module NewRelic
   module Agent
     module HTTPClients
-      class CurbRequest
+      class CurbRequest < AbstractRequest
         CURB = 'Curb'
-        LHOST = 'host'
-        UHOST = 'Host'
 
         def initialize(curlobj)
           @curlobj = curlobj

--- a/lib/new_relic/agent/http_clients/ethon_wrappers.rb
+++ b/lib/new_relic/agent/http_clients/ethon_wrappers.rb
@@ -42,8 +42,6 @@ module NewRelic
         DEFAULT_ACTION = 'GET'
         DEFAULT_HOST = 'UNKNOWN_HOST'
         ETHON = 'Ethon'
-        LHOST = 'host'.freeze
-        UHOST = 'Host'.freeze
 
         def initialize(easy)
           @easy = easy

--- a/lib/new_relic/agent/http_clients/excon_wrappers.rb
+++ b/lib/new_relic/agent/http_clients/excon_wrappers.rb
@@ -47,9 +47,6 @@ module NewRelic
         attr_reader :method
 
         EXCON = 'Excon'
-        LHOST = 'host'
-        UHOST = 'Host'
-        COLON = ':'
 
         def initialize(datum)
           @datum = datum

--- a/lib/new_relic/agent/http_clients/http_rb_wrappers.rb
+++ b/lib/new_relic/agent/http_clients/http_rb_wrappers.rb
@@ -20,8 +20,6 @@ module NewRelic
 
       class HTTPRequest < AbstractRequest
         HTTP_RB = 'http.rb'
-        HOST = 'host'
-        COLON = ':'
 
         def initialize(wrapped_request)
           @wrapped_request = wrapped_request

--- a/lib/new_relic/agent/http_clients/http_rb_wrappers.rb
+++ b/lib/new_relic/agent/http_clients/http_rb_wrappers.rb
@@ -34,7 +34,7 @@ module NewRelic
         end
 
         def host_from_header
-          if hostname = self[HOST]
+          if hostname = self[LHOST]
             hostname.split(COLON).first
           end
         end

--- a/lib/new_relic/agent/http_clients/httpclient_wrappers.rb
+++ b/lib/new_relic/agent/http_clients/httpclient_wrappers.rb
@@ -26,9 +26,6 @@ module NewRelic
         attr_reader :request
 
         HTTP_CLIENT = 'HTTPClient'.freeze
-        LHOST = 'host'.freeze
-        UHOST = 'Host'.freeze
-        COLON = ':'.freeze
 
         def initialize(request)
           @request = request

--- a/lib/new_relic/agent/http_clients/httpx_wrappers.rb
+++ b/lib/new_relic/agent/http_clients/httpx_wrappers.rb
@@ -52,8 +52,6 @@ module NewRelic
 
         DEFAULT_HOST = 'UNKNOWN_HOST'
         TYPE = 'HTTPX'
-        LHOST = 'host'.freeze
-        UHOST = 'Host'.freeze
 
         def initialize(request)
           @request = request

--- a/lib/new_relic/agent/http_clients/net_http_wrappers.rb
+++ b/lib/new_relic/agent/http_clients/net_http_wrappers.rb
@@ -30,9 +30,6 @@ module NewRelic
           NET_HTTP
         end
 
-        HOST = 'host'
-        COLON = ':'
-
         def host_from_header
           if hostname = self[HOST]
             hostname.split(COLON).first

--- a/lib/new_relic/agent/http_clients/net_http_wrappers.rb
+++ b/lib/new_relic/agent/http_clients/net_http_wrappers.rb
@@ -31,7 +31,7 @@ module NewRelic
         end
 
         def host_from_header
-          if hostname = self[HOST]
+          if hostname = self[LHOST]
             hostname.split(COLON).first
           end
         end

--- a/lib/new_relic/agent/http_clients/typhoeus_wrappers.rb
+++ b/lib/new_relic/agent/http_clients/typhoeus_wrappers.rb
@@ -48,9 +48,6 @@ module NewRelic
           TYPHOEUS
         end
 
-        LHOST = 'host'.freeze
-        UHOST = 'Host'.freeze
-
         def host_from_header
           self[LHOST] || self[UHOST]
         end


### PR DESCRIPTION
# Overview

Cleans up some duplication of constants that are the same across the HTTP wrapper classes, and moves them to the abstract class.

I've modified the Curb wrapper to also extend from the abstract class as well, it was the only one I saw that didn't, and couldn't see anything that jumped out on why that would be. I can adjust if that was done for a reason.

Pull request is related to https://github.com/newrelic/newrelic-ruby-agent/issues/2279

I didn't see any existing unit tests or anything for these wrapper classes, and I couldn't see a good way to test/review these changes manually, so wanted to put the PR up incase y'all have something internal that's separate to run regression tests.

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
