### PR TITLE
Update newrelic_rpm.gemspec

### DIFF
--- a/lib/new_relic/supportability_helper.rb
+++ b/lib/new_relic/supportability_helper.rb
@@ -80,7 +80,7 @@ module NewRelic
         "Expected #{klass} for `#{name}` but got #{arg.class}"
 
       NewRelic::Agent.logger.warn(message)
-      nil
+      false
     end
   end
 end

--- a/newrelic_rpm.gemspec
+++ b/newrelic_rpm.gemspec
@@ -62,7 +62,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rack'
   s.add_development_dependency 'rake', '12.3.3'
 
-  s.add_development_dependency 'rubocop', '1.54' unless ENV['CI'] && RUBY_VERSION < '3.0.0'
+  s.add_development_dependency 'rubocop', '1.57.2' unless ENV['CI'] && RUBY_VERSION < '3.0.0'
   s.add_development_dependency 'rubocop-ast', '1.28.1' unless ENV['CI'] && RUBY_VERSION < '3.0.0'
   s.add_development_dependency 'rubocop-minitest', '0.27.0' unless ENV['CI'] && RUBY_VERSION < '3.0.0'
   s.add_development_dependency 'rubocop-performance', '1.16.0' unless ENV['CI'] && RUBY_VERSION < '3.0.0'

--- a/test/multiverse/suites/sinatra/ignoring_test.rb
+++ b/test/multiverse/suites/sinatra/ignoring_test.rb
@@ -3,31 +3,53 @@
 # frozen_string_literal: true
 
 class SinatraIgnoreTestApp < Sinatra::Base
-  get '/record' do request.path_info end
+  get '/record' do
+    request.path_info
+  end
 
   newrelic_ignore '/ignore'
-  get '/ignore' do request.path_info end
+  get '/ignore' do
+    request.path_info
+  end
 
   newrelic_ignore '/splat*'
-  get '/splattered' do request.path_info end
+  get '/splattered' do
+    request.path_info
+  end
 
   newrelic_ignore '/named/:id'
-  get '/named/:id' do request.path_info end
+  get '/named/:id' do
+    request.path_info
+  end
 
   newrelic_ignore '/v1', '/v2'
-  get '/v1' do request.path_info end
-  get '/v2' do request.path_info end
-  get '/v3' do request.path_info end
+  get '/v1' do
+    request.path_info
+  end
+  get '/v2' do
+    request.path_info
+  end
+  get '/v3' do
+    request.path_info
+  end
 
   newrelic_ignore(/\/.+regex.*/)
-  get '/skip_regex' do request.path_info end
-  get '/regex_seen' do request.path_info end
+  get '/skip_regex' do
+    request.path_info
+  end
+  get '/regex_seen' do
+    request.path_info
+  end
 
   newrelic_ignore '/ignored_erroring'
-  get '/ignored_erroring' do raise 'boom'; end
+  get '/ignored_erroring' do
+    raise 'boom';
+  end
 
   newrelic_ignore_apdex '/no_apdex'
-  get '/no_apdex' do request.path_info end
+  get '/no_apdex' do
+    request.path_info
+  end
 
   newrelic_ignore_enduser '/no_enduser'
 
@@ -202,7 +224,9 @@ end
 class SinatraIgnoreItAllApp < Sinatra::Base
   newrelic_ignore
 
-  get '/' do request.path_info end
+  get '/' do
+    request.path_info
+  end
 end
 
 class SinatraIgnoreItAllTest < SinatraTestCase
@@ -227,7 +251,9 @@ class SinatraIgnoreApdexAndEndUserApp < Sinatra::Base
   newrelic_ignore_apdex
   newrelic_ignore_enduser
 
-  get '/' do request.path_info end
+  get '/' do
+    request.path_info
+  end
 end
 
 class SinatraIgnoreApdexAndEndUserTest < SinatraTestCase

--- a/test/new_relic/agent/agent_logger_test.rb
+++ b/test/new_relic/agent/agent_logger_test.rb
@@ -204,7 +204,7 @@ class AgentLoggerTest < Minitest::Test
 
       logger.info('The nice thing about standards is that you have so many to choose from. -- ast')
 
-      assert_logged(/#{Date.today.strftime("%Y-%m-%d")}/)
+      assert_logged(/#{Date.today.strftime('%Y-%m-%d')}/)
     end
   end
 


### PR DESCRIPTION
Change rubocop to 1.57.2, as 1.54 breaks an installation using bundler 1.17, fix was posted to robucop and a new release was created.

_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
This change updates the rubocop version, to one that works in bundler 1 and bundler 2 environments.
1.54 will fail under bundler 1, with conflicting version of base64. the fix in rubocop release corrects this issue

Submitter Checklist:
- [Rubocup fix](https://github.com/rubocop/rubocop/issues/12310)

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
GitHub Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
