### PR TITLE
CONTRIBUTING.md - remove Slack workspace mention

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -178,13 +178,6 @@ opensource@newrelic.com.
 For more information about CLAs, please check out Alex Russell’s excellent post,
 [“Why Do I Need to Sign This?”](https://infrequently.org/2008/06/why-do-i-need-to-sign-this/).
 
-## Slack
-
-We host a public Slack with a dedicated channel for contributors and maintainers
-of open source projects hosted by New Relic.  If you are contributing to this
-project, you're welcome to request access to the #oss-contributors channel in
-the newrelicusers.slack.com workspace.  To request access, please use this [link](https://join.slack.com/t/newrelicusers/shared_invite/zt-1ayj69rzm-~go~Eo1whIQGYnu3qi15ng).
-
 ## Explorer's Hub
 
 New Relic hosts and moderates an online forum where customers can interact with


### PR DESCRIPTION
Update `CONTIBUTING.md` to remove the reference to the Slack workspace