### PR TITLE
stop testing 8T with Ruby < 2.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,7 +286,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: [2.5.9, 3.2.2]
+        ruby-version: [2.7.8, 3.2.2]
     steps:
       - name: Configure git
         run: 'git config --global init.defaultBranch main'

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -278,7 +278,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: [2.5.9, 2.6.10, 2.7.8, 3.0.6, 3.1.4, 3.2.2, 3.3.0-preview2]
+        ruby-version: [2.7.8, 3.0.6, 3.1.4, 3.2.2, 3.3.0-preview2]
     steps:
       - name: Configure git
         run: 'git config --global init.defaultBranch main'

--- a/infinite_tracing/newrelic-infinite_tracing.gemspec
+++ b/infinite_tracing/newrelic-infinite_tracing.gemspec
@@ -72,7 +72,7 @@ Gem::Specification.new do |s|
   s.summary = 'New Relic Infinite Tracing for the Ruby agent'
 
   s.add_dependency 'newrelic_rpm', NewRelic::VERSION::STRING
-  s.add_dependency 'grpc', '~> 1.59'
+  s.add_dependency 'grpc', '~> 1.34'
 
   s.add_development_dependency 'rake', '12.3.3'
   s.add_development_dependency 'rb-inotify'

--- a/infinite_tracing/newrelic-infinite_tracing.gemspec
+++ b/infinite_tracing/newrelic-infinite_tracing.gemspec
@@ -72,7 +72,7 @@ Gem::Specification.new do |s|
   s.summary = 'New Relic Infinite Tracing for the Ruby agent'
 
   s.add_dependency 'newrelic_rpm', NewRelic::VERSION::STRING
-  s.add_dependency 'grpc', '~> 1.34'
+  s.add_dependency 'grpc', '~> 1.59'
 
   s.add_development_dependency 'rake', '12.3.3'
   s.add_development_dependency 'rb-inotify'

--- a/test/multiverse/suites/infinite_tracing/Envfile
+++ b/test/multiverse/suites/infinite_tracing/Envfile
@@ -2,8 +2,13 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
+# gRPC's Ruby mainainers have broken the 'grpc' gem's compatibility with
+# Ruby 2.5 by updating (grpc dependency) 'google-protobuf' with a Ruby 2.7+
+# requirement. So for Ruby 2.5 and 2.6, use a known-to-work older 'grpc' gem
+# version. For Rubies >= 2.7, use '' (no version constraint - permit Bundler to
+# grab the latest stable version).
 def grpc_version
-  RUBY_VERSION < '2.6.0' ? ", '1.49.1'" : ''
+  RUBY_VERSION < '2.7.0' ? ", '1.49.1'" : ''
 end
 
 gemfile <<~RB


### PR DESCRIPTION
Infinite Tracing depends on the `grpc` gem, which requires Ruby 2.5+.

Frequently, the gRPC Ruby gem maintainers inadvertently break compatibility with Ruby 2.5 and 2.6 by publishing a new version of `google-protobuf` (which `grpc` depends on) that itself requires Ruby 2.7+.

We do not wish to pin our `grpc` dependency to an exact version that is known to be compatible with Ruby 2.5 and Ruby 2.6 so that we leave users free to use whatever 1.x version of `grpc` that they wish, especially if they are themselves using `grpc` in their application.

Whether the gRPC maintainers' frequent breaking of Ruby 2.5 and 2.6 compatibility is accidental or deliberate, supporting these Rubies with our CI system has simply caused too many issues.

We are not actively introducing any new Ruby code to Infinite Tracing that could break Ruby 2.5 and 2.6 compatibility, so we will switch to manual testing of these Rubies as appropriate moving forward.