### PR TITLE
Rename bin/newrelic -> bin/newrelic_rpm and remove older bin/newrelic_cmd references and binstub

### DIFF
--- a/bin/newrelic
+++ b/bin/newrelic
@@ -1,15 +1,8 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+# This command has been renamed "newrelic_rpm"
 # executes one of the commands in the new_relic/commands directory
 # pass the name of the command as an argument
 
-$LOAD_PATH << File.expand_path(File.join(File.dirname(__FILE__), '..', 'lib'))
-require 'new_relic/cli/command'
-begin
-  NewRelic::Cli::Command.run
-rescue NewRelic::Cli::Command::CommandFailure => failure
-  STDERR.puts failure.message
-  STDERR.puts failure.options if failure.options
-  exit(1)
-end
+load File.dirname(__FILE__) + '/newrelic_rpm'

--- a/bin/newrelic_cmd
+++ b/bin/newrelic_cmd
@@ -1,7 +1,0 @@
-#!/usr/bin/env ruby
-# frozen_string_literal: true
-
-# This command has been renamed "newrelic"
-# executes one of the commands in the new_relic/commands directory
-# pass the name of the command as an argument
-load File.dirname(__FILE__) + '/newrelic'

--- a/bin/newrelic_rpm
+++ b/bin/newrelic_rpm
@@ -1,0 +1,15 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# executes one of the commands in the new_relic/commands directory
+# pass the name of the command as an argument
+
+$LOAD_PATH << File.expand_path(File.join(File.dirname(__FILE__), '..', 'lib'))
+require 'new_relic/cli/command'
+begin
+  NewRelic::Cli::Command.run
+rescue NewRelic::Cli::Command::CommandFailure => failure
+  STDERR.puts failure.message
+  STDERR.puts failure.options if failure.options
+  exit(1)
+end

--- a/lib/new_relic/cli/command.rb
+++ b/lib/new_relic/cli/command.rb
@@ -60,11 +60,13 @@ module NewRelic
         extra = []
         options = ARGV.options do |opts|
           script_name = File.basename($0)
-          # TODO: MAJOR VERSION - remove newrelic_cmd, deprecated since version 2.13
-          if /newrelic_cmd$/.match?(script_name)
-            $stdout.puts "warning: the 'newrelic_cmd' script has been renamed 'newrelic'"
-            script_name = 'newrelic'
+
+          # TODO: MAJOR VERSION - remove newrelic, deprecated since version x.xx
+          if /newrelic$/.match?(script_name)
+            $stdout.puts "warning: the 'newrelic' script has been renamed 'newrelic_rpm'"
+            script_name = 'newrelic_rpm'
           end
+
           opts.banner = "Usage: #{script_name} [ #{@command_names.join(' | ')} ] [options]"
           opts.separator("use '#{script_name} <command> -h' to see detailed command options")
           opts

--- a/newrelic_rpm.gemspec
+++ b/newrelic_rpm.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |s|
     https://github.com/newrelic/newrelic-ruby-agent/
   EOS
   s.email = 'support@newrelic.com'
-  # TODO: MAJOR VERSION - remove newrelic_cmd, deprecated since version 2.13
-  s.executables = %w[newrelic_cmd newrelic nrdebug]
+  # TODO: MAJOR VERSION - remove newrelic, deprecated since version xxx.
+  s.executables = %w[newrelic_rpm newrelic nrdebug]
   s.extra_rdoc_files = [
     'CHANGELOG.md',
     'LICENSE',

--- a/test/new_relic/healthy_urls_test.rb
+++ b/test/new_relic/healthy_urls_test.rb
@@ -36,7 +36,7 @@ class HealthyUrlsTest < Minitest::Test
     LICENSE
     mega-runner
     newrelic
-    newrelic_cmd
+    newrelic_rpm
     nrdebug
     Rakefile
     run_tests


### PR DESCRIPTION
# Overview

This addresses the issue opened [here](https://github.com/newrelic/newrelic-ruby-agent/issues/2240) where there's currently a naming conflict with `newrelic-cli` and the Ruby agent if both are installed.

It will require the `newrelic` binstub to be removed in a future major release before the actual name collision issue is solved.

It also removes the older binstub for `newrelic_cmd` when a previous rename was done, as such this has the potential to be a breaking change for anyone not moved over to the new name.

I've left the version number just a `xxx` as I'm unsure what version this will be merged into. Happy to update it to whatever, or leave that to y'all when it gets merged!

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
