### PR TITLE
latest async-http: require Ruby 2.7+ for now

### DIFF
--- a/test/multiverse/suites/async_http/Envfile
+++ b/test/multiverse/suites/async_http/Envfile
@@ -4,8 +4,11 @@
 
 instrumentation_methods :chain, :prepend
 
+# TODO: pending the outcome of async-io#74, the latest version of async-io
+#       may again support Ruby 2.5.
+#       https://github.com/socketry/async-io/issues/74
 ASYNC_HTTP_VERSIONS = [
-  [nil, 2.5],
+  [nil, 2.7],
   ['0.59.0', 2.5]
 ]
 


### PR DESCRIPTION
when testing the latest stable async-http gem, require Ruby 2.7+

depending on the outcome of async-io#74, a new version of async-io may be released in future that restores Ruby 2.5 and 2.6 compatibility