### PR TITLE
Pin async-io to < 1.37.0 on ruby < 2.7

### DIFF
--- a/test/multiverse/suites/async_http/Envfile
+++ b/test/multiverse/suites/async_http/Envfile
@@ -15,6 +15,7 @@ ASYNC_HTTP_VERSIONS = [
 def gem_list(async_http_version = nil)
   <<~GEM_LIST
     gem 'async-http'#{async_http_version}
+    #{"gem 'async-io', '< 1.37.0'" if RUBY_VERSION < '2.7'}
     gem 'rack'
   GEM_LIST
 end


### PR DESCRIPTION
Add a line to pin specifically async-io due to the ruby version support issue

ci cron: https://github.com/newrelic/newrelic-ruby-agent/actions/runs/6871235976