### PR TITLE
Simplify CRuby GC.stat info fetching

### DIFF
--- a/lib/new_relic/agent/vm/mri_vm.rb
+++ b/lib/new_relic/agent/vm/mri_vm.rb
@@ -24,7 +24,7 @@ module NewRelic
 
         def gather_gc_stats(snap)
           gather_gc_runs(snap) if supports?(:gc_runs)
-          gather_derived_stats(snap) if GC.respond_to?(:stat)
+          gather_derived_stats(snap)
         end
 
         def gather_gc_runs(snap)
@@ -33,19 +33,11 @@ module NewRelic
 
         def gather_derived_stats(snap)
           stat = GC.stat
-          snap.total_allocated_object = derive_from_gc_stats(%i[total_allocated_objects total_allocated_object], stat)
-          snap.major_gc_count = derive_from_gc_stats(:major_gc_count, stat)
-          snap.minor_gc_count = derive_from_gc_stats(:minor_gc_count, stat)
-          snap.heap_live = derive_from_gc_stats(%i[heap_live_slots heap_live_slot heap_live_num], stat)
-          snap.heap_free = derive_from_gc_stats(%i[heap_free_slots heap_free_slot heap_free_num], stat)
-        end
-
-        def derive_from_gc_stats(keys, stat)
-          Array(keys).each do |key|
-            value = stat[key]
-            return value if value
-          end
-          nil
+          snap.total_allocated_object = stat.fetch(:total_allocated_objects, nil)
+          snap.major_gc_count = stat.fetch(:major_gc_count, nil)
+          snap.minor_gc_count = stat.fetch(:minor_gc_count, nil)
+          snap.heap_live = stat.fetch(:heap_live_slots, nil)
+          snap.heap_free = stat.fetch(:heap_free_slots, nil)
         end
 
         def gather_gc_time(snap)


### PR DESCRIPTION
Now that this gem requires Ruby 2.4+, we no longer have to worry about `GC` not responding to `:stat` or the `GC.stat` hash having different key names for the same stat between different Ruby versions.