### PR TITLE
re-enable testing async-http with Ruby 2.5 & 2.6

### DIFF
--- a/test/multiverse/suites/async_http/Envfile
+++ b/test/multiverse/suites/async_http/Envfile
@@ -4,18 +4,14 @@
 
 instrumentation_methods :chain, :prepend
 
-# TODO: pending the outcome of async-io#74, the latest version of async-io
-#       may again support Ruby 2.5.
-#       https://github.com/socketry/async-io/issues/74
 ASYNC_HTTP_VERSIONS = [
-  [nil, 2.7],
+  [nil, 2.5],
   ['0.59.0', 2.5]
 ]
 
 def gem_list(async_http_version = nil)
   <<~GEM_LIST
     gem 'async-http'#{async_http_version}
-    #{"gem 'async-io', '< 1.37.0'" if RUBY_VERSION < '2.7'}
     gem 'rack'
   GEM_LIST
 end


### PR DESCRIPTION
async-io PR 75 fixed async-io Issue 74 and that gem can again be used with Ruby 2.5 and 2.6