### PR TITLE
Exclude the js_agent_loader JS from logs/connect

### DIFF
--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2228,7 +2228,8 @@ module NewRelic
           :public => false,
           :type => String,
           :allowed_from_server => true,
-          :description => 'JavaScript agent loader content.'
+          :description => 'JavaScript agent loader content.',
+          :exclude_from_reported_settings => true
         },
         :keep_alive_timeout => {
           :default => 60,


### PR DESCRIPTION
Don't bother relaying the JS blob for JS agent to either the log file or to the server on connect.