### PR TITLE
Create :'elasticsearch.perform_health_check' config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # New Relic Ruby Agent Release Notes
 
+## v9.7.0
+
+Version 9.7.0 adds a configuration value that toggles whether the agent will perform health check requests on Elasticsearch clusters.
+
+- **Feature: Add elasticsearch.perform_health_check configuration**
+
+  In [#2360](https://github.com/newrelic/newrelic-ruby-agent/pull/2360), it was brought to our attention that large clusters starting the agent can be overwhelmed by requests to `_cluster/health` performed by the agent to acquire the cluster name. The cluster name, once acquired, is assigned to the `database_name` attribute on Elasticsearch datastore segments. Now, users can disable these requests using a new configuration value. When set to `false`, the `database_name` will be `nil`. Thank you [@erikkessler1](https://github.com/erikkessler1) for bringing this to our attention.
+
+  | Configuration name          | Default | Behavior                                               |
+  | --------------------------- | ------- | ------------------------------------------------------ |
+  | `elasticsearch.perform_health_check` | `true` | If true, the agent will query the cluster's `_cluster/health` endpoint to determine information about the cluster, including its name. When false, the database_name attribute will be `nil``. |
+
 ## v9.6.0
 
 Version 9.6.0 adds instrumentation for Async::HTTP, Ethon, and HTTPX, adds the ability to ignore specific routes with Roda, gleans Docker container IDs from cgroups v2-based containers, records additional synthetics attributes, fixes an issue with Rails 7.1 that could cause duplicate log records to be sent to New Relic, fixes a deprecation warning for the Sidekiq error handler, adds additional attributes for OpenTelemetry compatibility, and resolves some technical debt, thanks to the community.

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -313,6 +313,7 @@ module NewRelic
         'webpacker:compile'
       ].join(',').freeze
 
+      # rubocop:disable Metrics/CollectionLiteralLength
       DEFAULTS = {
         # Critical
         :agent_enabled => {
@@ -1324,6 +1325,13 @@ module NewRelic
           :type => Boolean,
           :allowed_from_server => true,
           :description => 'If `true`, the agent obfuscates Elasticsearch queries in transaction traces.'
+        },
+        :'elasticsearch.perform_health_check' => {
+          :default => true,
+          :public => true,
+          :type => Boolean,
+          :allowed_from_server => false,
+          :description => "If true, the agent will query the cluster's `_cluster/health` endpoint to determine information about the cluster, including its name. When false, the database_name attribute for Elasticsearch datastore segements will be nil."
         },
         # Heroku
         :'heroku.use_dyno_names' => {
@@ -2405,6 +2413,7 @@ module NewRelic
           :description => 'This value represents the total amount of memory available to the host (not the process), in mebibytes (1024 squared or 1,048,576 bytes).'
         }
       }.freeze
+      # rubocop:enable Metrics/CollectionLiteralLength
     end
   end
 end

--- a/lib/new_relic/agent/instrumentation/elasticsearch/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/elasticsearch/instrumentation.rb
@@ -52,11 +52,13 @@ module NewRelic::Agent::Instrumentation
     end
 
     def nr_cluster_name
-      return @nr_cluster_name if @nr_cluster_name
+      return @nr_cluster_name if defined?(@nr_cluster_name)
       return if nr_hosts.empty?
 
       NewRelic::Agent.disable_all_tracing do
-        @nr_cluster_name ||= perform_request('GET', '_cluster/health').body['cluster_name']
+        @nr_cluster_name ||= if NewRelic::Agent.config[:'elasticsearch.perform_health_check']
+          perform_request('GET', '_cluster/health').body['cluster_name']
+        end
       end
     rescue StandardError => e
       NewRelic::Agent.logger.error('Failed to get cluster name for elasticsearch', e)


### PR DESCRIPTION
To access the cluster name to assign to the `database_name` attribute on the Elasticsearch datastore segment, we currently make a request to the `'_cluster/health'` endpoint. This can cause CPU and network spikes when large clusters start. 

To avoid this performance issue, we're introducing the `:'elasticsearch.perform_health_check'` config value. This value can be set to false to stop the agent from making requests to requests to `'_cluster/health'`. 

When this config is false, the `database_name` attribute on all Elasticsearch datastore segments will be 'Unknown'.

Relates to: #2360