### PR TITLE
Use _cluster/stats to access cluster name

### DIFF
--- a/lib/new_relic/agent/instrumentation/elasticsearch/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/elasticsearch/instrumentation.rb
@@ -56,7 +56,7 @@ module NewRelic::Agent::Instrumentation
       return if nr_hosts.empty?
 
       NewRelic::Agent.disable_all_tracing do
-        @nr_cluster_name ||= perform_request('GET', '_cluster/health').body['cluster_name']
+        @nr_cluster_name ||= perform_request('GET', '/_cluster/stats/nodes/_all,master:false').body['cluster_name']
       end
     rescue StandardError => e
       NewRelic::Agent.logger.error('Failed to get cluster name for elasticsearch', e)


### PR DESCRIPTION
Unlike `_cluster/health`, this request does not call `wait_for_status`. With the addition of `master:false`, stats will not be generated for the master node.

See: https://github.com/newrelic/newrelic-ruby-agent/pull/2369#issuecomment-1860909721 

Relates to #2360