### PR TITLE
Remove runtime dependency on base64

### DIFF
--- a/lib/new_relic/agent/distributed_tracing/distributed_trace_payload.rb
+++ b/lib/new_relic/agent/distributed_tracing/distributed_trace_payload.rb
@@ -3,7 +3,7 @@
 # frozen_string_literal: true
 
 require 'json'
-require 'base64'
+require 'new_relic/base64'
 
 module NewRelic
   module Agent
@@ -78,7 +78,7 @@ module NewRelic
         end
 
         def from_http_safe(http_safe_payload)
-          decoded_payload = Base64.strict_decode64(http_safe_payload)
+          decoded_payload = NewRelic::Base64.strict_decode64(http_safe_payload)
           from_json(decoded_payload)
         end
 
@@ -156,7 +156,7 @@ module NewRelic
       #
       # @api public
       def http_safe
-        Base64.strict_encode64(text)
+        NewRelic::Base64.strict_encode64(text)
       end
     end
   end

--- a/lib/new_relic/agent/javascript_instrumentor.rb
+++ b/lib/new_relic/agent/javascript_instrumentor.rb
@@ -2,7 +2,6 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
-require 'base64'
 require 'json'
 require 'new_relic/agent/obfuscator'
 

--- a/lib/new_relic/agent/new_relic_service/encoders.rb
+++ b/lib/new_relic/agent/new_relic_service/encoders.rb
@@ -2,10 +2,10 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
-require 'base64'
 require 'json'
 require 'stringio'
 require 'zlib'
+require 'new_relic/base64'
 
 module NewRelic
   module Agent
@@ -45,7 +45,7 @@ module NewRelic
               data = NewRelic::Agent::EncodingNormalizer.normalize_object(data)
             end
             json = ::JSON.dump(data)
-            Base64.encode64(Compressed::Deflate.encode(json))
+            NewRelic::Base64.encode64(Compressed::Deflate.encode(json))
           end
         end
       end

--- a/lib/new_relic/agent/obfuscator.rb
+++ b/lib/new_relic/agent/obfuscator.rb
@@ -2,8 +2,6 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
-# require 'base64'
-
 module NewRelic
   module Agent
     class Obfuscator

--- a/lib/new_relic/agent/pipe_channel_manager.rb
+++ b/lib/new_relic/agent/pipe_channel_manager.rb
@@ -2,7 +2,7 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
-require 'base64'
+require 'new_relic/base64'
 
 module NewRelic
   module Agent
@@ -257,7 +257,7 @@ module NewRelic
           Marshal.load(data)
         rescue StandardError => e
           ::NewRelic::Agent.logger.error('Failure unmarshalling message from Resque child process', e)
-          ::NewRelic::Agent.logger.debug(Base64.encode64(data))
+          ::NewRelic::Agent.logger.debug(NewRelic::Base64.encode64(data))
           nil
         end
 

--- a/lib/new_relic/agent/sql_sampler.rb
+++ b/lib/new_relic/agent/sql_sampler.rb
@@ -3,7 +3,6 @@
 # frozen_string_literal: true
 
 require 'zlib'
-require 'base64'
 require 'digest/md5'
 
 module NewRelic

--- a/lib/new_relic/base64.rb
+++ b/lib/new_relic/base64.rb
@@ -1,0 +1,25 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+module NewRelic
+  module Base64
+    extend self
+
+    def encode64(bin)
+      [bin].pack('m')
+    end
+
+    def decode64(str)
+      str.unpack1('m')
+    end
+
+    def strict_encode64(bin)
+      [bin].pack('m0')
+    end
+
+    def strict_decode64(str)
+      str.unpack1('m0')
+    end
+  end
+end

--- a/newrelic_rpm.gemspec
+++ b/newrelic_rpm.gemspec
@@ -50,8 +50,6 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
   s.summary = 'New Relic Ruby Agent'
 
-  s.add_dependency 'base64'
-
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'feedjira', '3.2.1' unless ENV['CI'] || RUBY_VERSION < '2.5' # for Gabby
   s.add_development_dependency 'httparty' unless ENV['CI'] # for perf tests and Gabby

--- a/test/agent_helper.rb
+++ b/test/agent_helper.rb
@@ -845,7 +845,7 @@ ensure
 end
 
 def json_dump_and_encode(object)
-  Base64.encode64(JSON.dump(object))
+  NewRelic::Base64.encode64(JSON.dump(object))
 end
 
 def get_last_analytics_event

--- a/test/multiverse/lib/multiverse/suite.rb
+++ b/test/multiverse/lib/multiverse/suite.rb
@@ -9,9 +9,9 @@
 
 require_relative '../../../warning_test_helper'
 require_relative '../../../simplecov_test_helper'
+require_relative '../../../../lib/new_relic/base64'
 
 require 'rubygems'
-require 'base64'
 require 'fileutils'
 require 'digest'
 require_relative 'bundler_patch'
@@ -33,11 +33,11 @@ module Multiverse
     end
 
     def self.encode_options(decoded_opts)
-      Base64.encode64(Marshal.dump(decoded_opts)).delete("\n")
+      NewRelic::Base64.encode64(Marshal.dump(decoded_opts)).delete("\n")
     end
 
     def self.decode_options(encoded_opts)
-      Marshal.load(Base64.decode64(encoded_opts))
+      Marshal.load(NewRelic::Base64.decode64(encoded_opts))
     end
 
     def suite

--- a/test/multiverse/suites/agent_only/cross_application_tracing_test.rb
+++ b/test/multiverse/suites/agent_only/cross_application_tracing_test.rb
@@ -35,27 +35,27 @@ class CrossApplicationTracingTest < Minitest::Test
   end
 
   def test_cross_app_doesnt_modify_with_invalid_header
-    get('/', nil, {'HTTP_X_NEWRELIC_ID' => Base64.encode64('otherjunk')})
+    get('/', nil, {'HTTP_X_NEWRELIC_ID' => NewRelic::Base64.encode64('otherjunk')})
 
     refute last_response.headers['X-NewRelic-App-Data']
   end
 
   def test_cross_app_writes_out_information
-    get('/', nil, {'HTTP_X_NEWRELIC_ID' => Base64.encode64('1#234')})
+    get('/', nil, {'HTTP_X_NEWRELIC_ID' => NewRelic::Base64.encode64('1#234')})
 
     refute_nil last_response.headers['X-NewRelic-App-Data']
     assert_metrics_recorded(['ClientApplication/1#234/all'])
   end
 
   def test_cross_app_doesnt_modify_if_txn_is_ignored
-    get('/', {'transaction_name' => 'ignored_transaction'}, {'HTTP_X_NEWRELIC_ID' => Base64.encode64('1#234')})
+    get('/', {'transaction_name' => 'ignored_transaction'}, {'HTTP_X_NEWRELIC_ID' => NewRelic::Base64.encode64('1#234')})
 
     refute last_response.headers['X-NewRelic-App-Data']
   end
 
   def test_cross_app_error_attaches_process_id_to_intrinsics
     assert_raises(RuntimeError) do
-      get('/', {'fail' => 'true'}, {'HTTP_X_NEWRELIC_ID' => Base64.encode64('1#234')})
+      get('/', {'fail' => 'true'}, {'HTTP_X_NEWRELIC_ID' => NewRelic::Base64.encode64('1#234')})
     end
 
     assert_includes attributes_for(last_traced_error, :intrinsic), :client_cross_process_id
@@ -66,7 +66,7 @@ class CrossApplicationTracingTest < Minitest::Test
     if !test_case['outboundRequests']
       if test_case['inboundPayload']
         request_headers = {
-          'HTTP_X_NEWRELIC_ID' => Base64.encode64('1#234'),
+          'HTTP_X_NEWRELIC_ID' => NewRelic::Base64.encode64('1#234'),
           'HTTP_X_NEWRELIC_TRANSACTION' => json_dump_and_encode(test_case['inboundPayload'])
         }
       else

--- a/test/multiverse/suites/rails/ignore_test.rb
+++ b/test/multiverse/suites/rails/ignore_test.rb
@@ -73,7 +73,7 @@ class IgnoredActionsTest < ActionDispatch::IntegrationTest
 
   def test_should_not_write_cat_response_headers_for_ignored_transactions
     get('/ignored/action_to_ignore',
-      headers: {'X-NewRelic-ID' => Base64.encode64('1#234')})
+      headers: {'X-NewRelic-ID' => NewRelic::Base64.encode64('1#234')})
 
     refute @response.headers['X-NewRelic-App-Data']
   end

--- a/test/multiverse/suites/rails/request_statistics_test.rb
+++ b/test/multiverse/suites/rails/request_statistics_test.rb
@@ -102,8 +102,8 @@ class RequestStatsTest < ActionDispatch::IntegrationTest
       :'encoding_key' => "\0",
       :'trusted_account_ids' => [1]) do
       rack_env = {
-        'HTTP_X_NEWRELIC_ID' => Base64.encode64('1#234'),
-        'HTTP_X_NEWRELIC_TRANSACTION' => Base64.encode64('["8badf00d",1]')
+        'HTTP_X_NEWRELIC_ID' => NewRelic::Base64.encode64('1#234'),
+        'HTTP_X_NEWRELIC_TRANSACTION' => NewRelic::Base64.encode64('["8badf00d",1]')
       }
 
       get('/request_stats/cross_app_action', headers: rack_env)

--- a/test/new_relic/agent/commands/thread_profiler_session_test.rb
+++ b/test/new_relic/agent/commands/thread_profiler_session_test.rb
@@ -3,13 +3,13 @@
 # frozen_string_literal: true
 
 require_relative '../../../test_helper'
-require 'base64'
 require 'thread'
 require 'timeout'
 require 'zlib'
 require 'new_relic/agent/threading/backtrace_service'
 require 'new_relic/agent/threading/threaded_test_case'
 require 'new_relic/agent/commands/thread_profiler_session'
+require 'new_relic/base64'
 
 module ThreadProfilerSessionTestHelpers
   START = {

--- a/test/new_relic/agent/javascript_instrumentor_test.rb
+++ b/test/new_relic/agent/javascript_instrumentor_test.rb
@@ -4,7 +4,6 @@
 
 require_relative '../../test_helper'
 require 'new_relic/agent/javascript_instrumentor'
-require 'base64'
 
 class NewRelic::Agent::JavaScriptInstrumentorTest < Minitest::Test
   attr_reader :instrumentor

--- a/test/new_relic/agent/monitors/cross_app_monitor_test.rb
+++ b/test/new_relic/agent/monitors/cross_app_monitor_test.rb
@@ -239,7 +239,7 @@ module NewRelic::Agent
     end
 
     def for_id(id)
-      encoded_id = id == '' ? '' : Base64.encode64(id)
+      encoded_id = id == '' ? '' : NewRelic::Base64.encode64(id)
       encoded_txn_info = json_dump_and_encode([REF_TRANSACTION_GUID, false])
 
       return {
@@ -255,7 +255,7 @@ module NewRelic::Agent
     def unpacked_response
       return nil unless response_app_data
 
-      ::JSON.load(Base64.decode64(response_app_data))
+      ::JSON.load(NewRelic::Base64.decode64(response_app_data))
     end
   end
 end

--- a/test/new_relic/agent/new_relic_service_test.rb
+++ b/test/new_relic/agent/new_relic_service_test.rb
@@ -751,7 +751,7 @@ class NewRelicServiceTest < Minitest::Test
     assert_equal(expected_string, result[0])
 
     base64_encoded_compressed_json_field = result[1]
-    compressed_json_field = Base64.decode64(base64_encoded_compressed_json_field)
+    compressed_json_field = NewRelic::Base64.decode64(base64_encoded_compressed_json_field)
     json_field = Zlib::Inflate.inflate(compressed_json_field)
     field = JSON.parse(json_field)
 

--- a/test/new_relic/agent/obfuscator_test.rb
+++ b/test/new_relic/agent/obfuscator_test.rb
@@ -74,8 +74,8 @@ class NewRelic::Agent::ObfuscatorTest < Minitest::Test
 
     assert_equal(expected, output)
 
-    unoutput = obfuscator.obfuscate(Base64.decode64(output))
+    unoutput = obfuscator.obfuscate(NewRelic::Base64.decode64(output))
 
-    assert_equal Base64.encode64(text).delete("\n"), unoutput
+    assert_equal NewRelic::Base64.encode64(text).delete("\n"), unoutput
   end
 end

--- a/test/new_relic/fake_collector.rb
+++ b/test/new_relic/fake_collector.rb
@@ -227,7 +227,7 @@ module NewRelic
       def self.unblob(blob)
         return unless blob
 
-        JSON.load(Zlib::Inflate.inflate(Base64.decode64(blob)))
+        JSON.load(Zlib::Inflate.inflate(NewRelic::Base64.decode64(blob)))
       end
     end
 


### PR DESCRIPTION
The used portions of the base64 gem are just wrappers around unpack/pack, dependency added in #2238 for ruby 3.3 compat.
RuboCop as an example has taken a similar approach by simply inlining this on their one callsite.

# Overview
Describe the changes present in the pull request

Submitter Checklist:
- [ ] Include a link to the related GitHub issue, if applicable
- [ ] Include a security review link, if applicable

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
GitHub Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
