### PR TITLE
Remove Ruby/Thread and Ruby/Fiber spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v9.7.0
 
-Version 9.7.0 changes the endpoint used to access the cluster name for Elasticsearch instrumentation and adds support for Falcon.
+Version 9.7.0 changes the endpoint used to access the cluster name for Elasticsearch instrumentation, adds support for Falcon, and removes the creation of the Ruby/Thread and Ruby/Fiber spans.
 
 - **Feature: Use root path to access Elasticsearch cluster name**
 
@@ -21,6 +21,10 @@ Version 9.7.0 changes the endpoint used to access the cluster name for Elasticse
 - **Feature: Add Falcon support**
 
   The agent now supports the web server [Falcon](https://socketry.github.io/falcon/). [PR#2383](https://github.com/newrelic/newrelic-ruby-agent/pull/2383)
+
+- **Feature: Remove spans with name Ruby/Thread and Ruby/Fiber**
+
+  Due to the lack of helpful information and the confusion commonly caused by the spans named Ruby/Thread and Ruby/Fiber, these spans have been removed. However, the agents ability to monitor instrumented code running in a thread or fiber will remain unchanged. [PR#2389](https://github.com/newrelic/newrelic-ruby-agent/pull/2389)
 
 ## v9.6.0
 

--- a/lib/new_relic/agent/instrumentation/fiber/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/fiber/instrumentation.rb
@@ -14,10 +14,7 @@ module NewRelic::Agent::Instrumentation
     def add_thread_tracing(&block)
       return block if !NewRelic::Agent::Tracer.thread_tracing_enabled?
 
-      NewRelic::Agent::Tracer.thread_block_with_current_transaction(
-        segment_name: 'Ruby/Fiber',
-        &block
-      )
+      NewRelic::Agent::Tracer.thread_block_with_current_transaction(&block)
     end
   end
 end

--- a/lib/new_relic/agent/instrumentation/thread/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/thread/instrumentation.rb
@@ -16,10 +16,7 @@ module NewRelic
         def add_thread_tracing(*args, &block)
           return block if !NewRelic::Agent::Tracer.thread_tracing_enabled?
 
-          NewRelic::Agent::Tracer.thread_block_with_current_transaction(
-            segment_name: 'Ruby/Thread',
-            &block
-          )
+          NewRelic::Agent::Tracer.thread_block_with_current_transaction(&block)
         end
       end
     end

--- a/lib/new_relic/agent/tracer.rb
+++ b/lib/new_relic/agent/tracer.rb
@@ -418,16 +418,17 @@ module NewRelic
           NewRelic::Agent.config[:'instrumentation.thread.tracing']
         end
 
-        def thread_block_with_current_transaction(segment_name:, parent: nil, &block)
+        def thread_block_with_current_transaction(segment_name: nil, parent: nil, &block)
           parent ||= current_segment
           current_txn = ::Thread.current[:newrelic_tracer_state]&.current_transaction if ::Thread.current[:newrelic_tracer_state]&.is_execution_traced?
           proc do |*args|
             begin
               if current_txn && !current_txn.finished?
                 NewRelic::Agent::Tracer.state.current_transaction = current_txn
+                ::Thread.current[:newrelic_thread_span_parent] = parent
                 current_txn.async = true
-                segment_name += "/Thread#{::Thread.current.object_id}/Fiber#{::Fiber.current.object_id}" if NewRelic::Agent.config[:'thread_ids_enabled']
-                segment = NewRelic::Agent::Tracer.start_segment(name: segment_name, parent: parent)
+                segment_name = segment_name.to_s + "/Thread#{::Thread.current.object_id}/Fiber#{::Fiber.current.object_id}" if NewRelic::Agent.config[:'thread_ids_enabled']
+                segment = NewRelic::Agent::Tracer.start_segment(name: segment_name, parent: parent) if segment_name
               end
               NewRelic::Agent::Tracer.capture_segment_error(segment) do
                 yield(*args)

--- a/lib/new_relic/agent/tracer.rb
+++ b/lib/new_relic/agent/tracer.rb
@@ -427,7 +427,7 @@ module NewRelic
                 NewRelic::Agent::Tracer.state.current_transaction = current_txn
                 ::Thread.current[:newrelic_thread_span_parent] = parent
                 current_txn.async = true
-                segment_name = segment_name.to_s + "/Thread#{::Thread.current.object_id}/Fiber#{::Fiber.current.object_id}" if NewRelic::Agent.config[:'thread_ids_enabled']
+                segment_name = "#{segment_name}/Thread#{::Thread.current.object_id}/Fiber#{::Fiber.current.object_id}" if NewRelic::Agent.config[:'thread_ids_enabled']
                 segment = NewRelic::Agent::Tracer.start_segment(name: segment_name, parent: parent) if segment_name
               end
               NewRelic::Agent::Tracer.capture_segment_error(segment) do

--- a/test/new_relic/agent/tracer_test.rb
+++ b/test/new_relic/agent/tracer_test.rb
@@ -383,7 +383,6 @@ module NewRelic
           threads.each(&:join)
           txn.finish
 
-          assert_equal 2, txn.segments.count { |s| s.name == 'Ruby/Thread' }
           assert_nil Tracer.current_segment
         end
       end
@@ -419,11 +418,11 @@ module NewRelic
             Thread.new { 'woof' }.join
           end
 
-          assert_match %r{Ruby/Thread/Thread\d+/Fiber\d+}, txn.segments.last.name
+          assert_match %r{/Thread\d+/Fiber\d+}, txn.segments.last.name
         end
       end
 
-      def test_thread_ids_absent_when_disabled
+      def test_thread_spans_absent_when_ids_disabled
         with_config(
           :'instrumentation.thread.tracing' => true,
           :'thread_ids_enabled' => false
@@ -432,7 +431,7 @@ module NewRelic
             Thread.new { 'woof' }.join
           end
 
-          assert_match %r{Ruby/Thread$}, txn.segments.last.name
+          assert_equal 1, txn.segments.count
         end
       end
 


### PR DESCRIPTION

To reduce confusing information being reported, the agent no longer creates the new spans for `Ruby/Thread` and `Ruby/Fiber`. The agent will still record anything happening inside of these threads/fibers correctly. The parents will still also be created correctly. We did have to make some adjustment to segment parent logic to accommodate the removal of these spans while maintaining consistently correct parent nesting. 

I decided to leave the concurrent ruby spans as is, since those are more likely to be useful information for customers compared to the ruby/thread spans.

resolves https://github.com/newrelic/newrelic-ruby-agent/issues/2371