### PR TITLE
Refactor local_environment methods

### DIFF
--- a/lib/new_relic/local_environment.rb
+++ b/lib/new_relic/local_environment.rb
@@ -127,22 +127,24 @@ module NewRelic
     end
 
     def check_for_unicorn
-      if (defined?(::Unicorn) && defined?(::Unicorn::HttpServer)) && NewRelic::LanguageSupport.object_space_usable?
-        v = find_class_in_object_space(::Unicorn::HttpServer)
-        @discovered_dispatcher = :unicorn if v
-      end
+      return unless (defined?(::Unicorn) && defined?(::Unicorn::HttpServer)) &&
+        NewRelic::LanguageSupport.object_space_usable?
+
+      v = find_class_in_object_space(::Unicorn::HttpServer)
+      @discovered_dispatcher = :unicorn if v
     end
 
     def check_for_puma
-      if defined?(::Puma) && File.basename($0) == 'puma'
-        @discovered_dispatcher = :puma
-      end
+      return unless defined?(::Puma) && File.basename($0) == 'puma'
+
+      @discovered_dispatcher = :puma
     end
 
     def check_for_falcon
-      if defined?(::Falcon::Server) && NewRelic::LanguageSupport.object_space_usable?
-        @discovered_dispatcher = :falcon if find_class_in_object_space(::Falcon::Server)
-      end
+      return unless defined?(::Falcon::Server) &&
+        NewRelic::LanguageSupport.object_space_usable?
+
+      @discovered_dispatcher = :falcon if find_class_in_object_space(::Falcon::Server)
     end
 
     def check_for_delayed_job
@@ -185,15 +187,15 @@ module NewRelic
     end
 
     def check_for_litespeed
-      if caller.pop.include?('fcgi-bin/RailsRunner.rb')
-        @discovered_dispatcher = :litespeed
-      end
+      return unless caller.pop.include?('fcgi-bin/RailsRunner.rb')
+
+      @discovered_dispatcher = :litespeed
     end
 
     def check_for_passenger
-      if defined?(::PhusionPassenger)
-        @discovered_dispatcher = :passenger
-      end
+      return unless defined?(::PhusionPassenger)
+
+      @discovered_dispatcher = :passenger
     end
 
     public


### PR DESCRIPTION
# Overview
Cleaned up methods to replace single if statements with early returns.

Ran `bundle exec rake` and there were 0 failures and 0 errors 🌈  (just 5 skips, which I had when I ran the command before refactoring).

Resolves #2388

_I wasn't sure if the `check_for_thin` method (line 173 old, 175 new) could be refactored as it seemed that the `NewRelic::LanguageSupport.object_space_usable?` if-else returned `@discovered_dispatcher = :thin` either way. But I'm a beginner so I am sure the if-else is needed as is! Wanted to flag though, just in case._

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
