### PR TITLE
Skip Async-http instrumentation installation when Traces::Backend::NewRelic is defined

### DIFF
--- a/lib/new_relic/agent/instrumentation/async_http.rb
+++ b/lib/new_relic/agent/instrumentation/async_http.rb
@@ -10,7 +10,9 @@ DependencyDetection.defer do
   named :async_http
 
   depends_on do
-    defined?(Async::HTTP) && Gem::Version.new(Async::HTTP::VERSION) >= Gem::Version.new('0.59.0')
+    defined?(Async::HTTP) &&
+      Gem::Version.new(Async::HTTP::VERSION) >= Gem::Version.new('0.59.0') &&
+      !defined?(Traces::Backend::NewRelic)
   end
 
   executes do

--- a/lib/new_relic/agent/instrumentation/async_http.rb
+++ b/lib/new_relic/agent/instrumentation/async_http.rb
@@ -12,7 +12,7 @@ DependencyDetection.defer do
   depends_on do
     defined?(Async::HTTP) &&
       Gem::Version.new(Async::HTTP::VERSION) >= Gem::Version.new('0.59.0') &&
-      !defined?(Traces::Backend::NewRelic)
+      !defined?(Traces::Backend::NewRelic) # defined in the traces-backend-newrelic gem
   end
 
   executes do


### PR DESCRIPTION


If the traces-backend-newrelic instrumentation is being used, then skip async-http instrumentation installation since this gem provides instrumentation. 
https://github.com/newrelic/traces-backend-newrelic