### PR TITLE
Use GRPC::Server instrumentation name

### DIFF
--- a/lib/new_relic/agent/instrumentation/grpc_server.rb
+++ b/lib/new_relic/agent/instrumentation/grpc_server.rb
@@ -14,7 +14,7 @@ DependencyDetection.defer do
   end
 
   executes do
-    supportability_name = NewRelic::Agent::Instrumentation::GRPC::Client::INSTRUMENTATION_NAME
+    supportability_name = NewRelic::Agent::Instrumentation::GRPC::Server::INSTRUMENTATION_NAME
     if use_prepend?
       prepend_instrument GRPC::RpcServer, NewRelic::Agent::Instrumentation::GRPC::Server::RpcServerPrepend, supportability_name
       prepend_instrument GRPC::RpcDesc, NewRelic::Agent::Instrumentation::GRPC::Server::RpcDescPrepend, supportability_name


### PR DESCRIPTION
Previously, the name for GRPC::Client was being applied.