### PR TITLE
Fix for failing CI

### DIFF
--- a/test/multiverse/suites/deferred_instrumentation/Envfile
+++ b/test/multiverse/suites/deferred_instrumentation/Envfile
@@ -15,7 +15,7 @@ def gem_list(sinatra_version = nil)
   <<~RB
     gem 'sinatra'#{sinatra_version}, :require => false
     gem 'rack-test', '>= 0.8.0', :require => 'rack/test'
-    #{"gem 'rackup'" if sinatra_version.nil? || sinatra_version > '2.1.0'}
+    #{"gem 'rackup'" if sinatra_version.nil? || sinatra_version > '3.2.0'}
     
   RB
 end

--- a/test/multiverse/suites/deferred_instrumentation/Envfile
+++ b/test/multiverse/suites/deferred_instrumentation/Envfile
@@ -6,7 +6,7 @@ instrumentation_methods :chain, :prepend
 
 SINATRA_VERSIONS = [
   [nil, 2.7],
-  ['3.2.0', 2.4],
+  ['3.2.0', 2.6],
   ['2.1.0', 2.4],
   ['1.4.8']
 ]

--- a/test/multiverse/suites/deferred_instrumentation/Envfile
+++ b/test/multiverse/suites/deferred_instrumentation/Envfile
@@ -5,7 +5,7 @@
 instrumentation_methods :chain, :prepend
 
 SINATRA_VERSIONS = [
-  [nil, 2.4],
+  [nil, 2.7],
   ['3.2.0', 2.4],
   ['2.1.0', 2.4],
   ['1.4.8']
@@ -15,7 +15,7 @@ def gem_list(sinatra_version = nil)
   <<~RB
     gem 'sinatra'#{sinatra_version}, :require => false
     gem 'rack-test', '>= 0.8.0', :require => 'rack/test'
-    #{"gem 'rackup'" if sinatra_version.nil? || sinatra_version > '3.2.0'}
+    gem 'rack'#{", '~> 2.2'" if !sinatra_version.nil? && sinatra_version < '4.0.0'}
     
   RB
 end

--- a/test/multiverse/suites/deferred_instrumentation/Envfile
+++ b/test/multiverse/suites/deferred_instrumentation/Envfile
@@ -15,7 +15,7 @@ def gem_list(sinatra_version = nil)
   <<~RB
     gem 'sinatra'#{sinatra_version}, :require => false
     gem 'rack-test', '>= 0.8.0', :require => 'rack/test'
-    gem 'rack'#{", '~> 2.2'" if !sinatra_version.nil? && sinatra_version < '4.0.0'}
+    #{"gem 'rackup'" if sinatra_version.nil? || sinatra_version > '3.2.0'}
     
   RB
 end

--- a/test/multiverse/suites/deferred_instrumentation/Envfile
+++ b/test/multiverse/suites/deferred_instrumentation/Envfile
@@ -6,6 +6,7 @@ instrumentation_methods :chain, :prepend
 
 SINATRA_VERSIONS = [
   [nil, 2.4],
+  ['3.2.0', 2.4],
   ['2.1.0', 2.4],
   ['1.4.8']
 ]
@@ -14,9 +15,11 @@ def gem_list(sinatra_version = nil)
   <<~RB
     gem 'sinatra'#{sinatra_version}, :require => false
     gem 'rack-test', '>= 0.8.0', :require => 'rack/test'
+    #{"gem 'rackup'" if sinatra_version.nil? || sinatra_version > '2.1.0'}
     
   RB
 end
+
 
 create_gemfiles(SINATRA_VERSIONS)
 

--- a/test/multiverse/suites/padrino/Envfile
+++ b/test/multiverse/suites/padrino/Envfile
@@ -9,7 +9,7 @@ gemfile <<~RB
   gem 'activesupport'
   gem 'padrino'
   gem 'rack-test'
-  gem 'sinatra'
+  gem 'sinatra', '< 4'
 RB
 
 # Sinatra <3

--- a/test/multiverse/suites/resque/Envfile
+++ b/test/multiverse/suites/resque/Envfile
@@ -11,6 +11,8 @@ RESQUE_VERSIONS = [
 def gem_list(resque_version = nil)
   <<~RB
   gem 'resque'#{resque_version}
+  #{"gem 'rackup'" if RUBY_VERSION >= '3.0.0'}
+
   
   RB
 end

--- a/test/multiverse/suites/resque/Envfile
+++ b/test/multiverse/suites/resque/Envfile
@@ -10,8 +10,8 @@ RESQUE_VERSIONS = [
 
 def gem_list(resque_version = nil)
   <<~RB
-  gem 'resque'#{resque_version}
-  #{"gem 'rackup'" if RUBY_VERSION >= '3.0.0'}
+    gem 'resque'#{resque_version}
+    #{"gem 'rackup'" if RUBY_VERSION >= '2.7.8'}
 
   
   RB

--- a/test/multiverse/suites/sinatra/Envfile
+++ b/test/multiverse/suites/sinatra/Envfile
@@ -6,7 +6,7 @@ instrumentation_methods :chain, :prepend
 
 SINATRA_VERSIONS = [
   [nil, 2.7],
-  ['3.2.0', 2.4],
+  ['3.2.0', 2.6],
   ['2.0.0', 2.4]
 ]
 

--- a/test/multiverse/suites/sinatra/Envfile
+++ b/test/multiverse/suites/sinatra/Envfile
@@ -13,7 +13,7 @@ SINATRA_VERSIONS = [
 def gem_list(sinatra_version = nil)
   <<~RB
     gem 'sinatra'#{sinatra_version}
-    gem 'rack', '~> 2.2'
+    gem 'rack'#{", '~> 2.2'" if !sinatra_version.nil? && sinatra_version < '4.0.0'}
     gem 'rack-test', '>= 0.8.0', :require => 'rack/test'
     
   RB

--- a/test/multiverse/suites/sinatra/Envfile
+++ b/test/multiverse/suites/sinatra/Envfile
@@ -6,6 +6,7 @@ instrumentation_methods :chain, :prepend
 
 SINATRA_VERSIONS = [
   [nil, 2.4],
+  ['3.2.0', 2.4],
   ['2.0.0', 2.4]
 ]
 

--- a/test/multiverse/suites/sinatra/Envfile
+++ b/test/multiverse/suites/sinatra/Envfile
@@ -5,7 +5,7 @@
 instrumentation_methods :chain, :prepend
 
 SINATRA_VERSIONS = [
-  [nil, 2.4],
+  [nil, 2.7],
   ['3.2.0', 2.4],
   ['2.0.0', 2.4]
 ]


### PR DESCRIPTION
Sinatra 4.0 came out today, which is what caused the failures. Older sinatra versions had pinned its rack dependency, but now with this new version, rack 3 can be installed causing the rackup file failures. 