### PR TITLE
Don't suppress view component rendering errors

### DIFF
--- a/lib/new_relic/agent/instrumentation/view_component/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/view_component/instrumentation.rb
@@ -15,7 +15,8 @@ module NewRelic::Agent::Instrumentation
         )
         yield
       rescue => e
-        ::NewRelic::Agent.logger.debug('Error capturing ViewComponent segment', e)
+        NewRelic::Agent.notice_error(e)
+        raise
       ensure
         segment&.finish
       end


### PR DESCRIPTION


_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview

Fixes a bug introduced in https://github.com/newrelic/newrelic-ruby-agent/pull/2367, where the render_in behavior was changed, suppressing errors.

We should be able to se error pages, specially in when Rails.env is development. The piece of code that was removed here prevented from happening. Instead, it would have the `render_in` method return `nil` when an error happened, resulting in either a blank page, or an incomplete page.

I believe we also want to raise errors in production. We should not make a decision here, whether the error should be suppressed. Otherwise we are making the assumption "incomplete pages are better than error pages", which may be the correct assumption under some circumstances, but not under other circumstances.

Fixes https://github.com/ViewComponent/view_component/issues/1981

Submitter Checklist:
- [x] Include a link to the related GitHub issue, if applicable
- [ ] Include a security review link, if applicable

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
GitHub Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
