### PR TITLE
Add ViewComponent regression test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Version 9.7.1 fixes a ViewComponent instrumentation bug and enforces maximum siz
 
 - **Bugfix: Stop suppressing ViewComponent errors**
 
-  Previously, the agent suppressed ViewComponent render errors. The agent now reports these errors and allows them to raise. Thank you @mjacobus for reporting this bug and providing a fix! [PR#2410](https://github.com/newrelic/newrelic-ruby-agent/pull/2410)
+  Previously, the agent suppressed ViewComponent render errors. The agent now reports these errors and allows them to raise. Thank you [@mjacobus](https://github.com/mjacobus) for reporting this bug and providing a fix! [PR#2410](https://github.com/newrelic/newrelic-ruby-agent/pull/2410)
 
 - **Bugfix: Enforce maximum size limits for custom event attributes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,23 +1,25 @@
 # New Relic Ruby Agent Release Notes
 
 
-## dev 
+## v9.7.1
 
-Version <dev> adds maximum size limits to custom event attributes.
+Version 9.7.1 fixes a ViewComponent instrumentation bug and enforces maximum size limits for custom event attributes.
+
+- **Bugfix: Stop suppressing ViewComponent errors**
+
+  Previously, the agent suppressed ViewComponent render errors. The agent now reports these errors and allows them to raise. Thank you @mjacobus for reporting this bug and providing a fix! [PR#2410](https://github.com/newrelic/newrelic-ruby-agent/pull/2410)
 
 - **Bugfix: Enforce maximum size limits for custom event attributes**
 
   Previously, the agent would allow custom event attributes to be any size. This would lead to the New Relic backend dropping attributes larger than the maximum size. Now, the agent will truncate custom event attribute values to 4095 characters, attribute names to 255 characters, and the total count of attributes to 64. [PR#2401](https://github.com/newrelic/newrelic-ruby-agent/pull/2401)
 
-
 ## v9.7.0
-
 
 Version 9.7.0 introduces ViewComponent instrumentation, changes the endpoint used to access the cluster name for Elasticsearch instrumentation, removes the creation of the Ruby/Thread and Ruby/Fiber spans, and adds support for Falcon.
 
 - **Feature: ViewComponent instrumentation**
 
-  [ViewComponent](https://viewcomponent.org/) is a now an instrumented framework. The agent currently supports Roda versions 2.0.0+. [PR#2367](https://github.com/newrelic/newrelic-ruby-agent/pull/2367) 
+  [ViewComponent](https://viewcomponent.org/) is a now an instrumented library. [PR#2367](https://github.com/newrelic/newrelic-ruby-agent/pull/2367) 
 
 - **Feature: Use root path to access Elasticsearch cluster name**
 

--- a/test/multiverse/suites/view_component/view_component_instrumentation_test.rb
+++ b/test/multiverse/suites/view_component/view_component_instrumentation_test.rb
@@ -52,7 +52,7 @@ class ViewComponentInstrumentationTest < ActionDispatch::IntegrationTest
     assert(FAKE_CLASS.metric_path('nothing_to_see_here'), 'unknown')
   end
 
-    def test_error_raised
+  def test_error_raised
     NewRelic::Agent::Tracer.stub(:start_segment, proc { |_args| raise 'kaboom' }) do
       assert_equal(500, get('/view_components'))
     end

--- a/test/multiverse/suites/view_component/view_component_instrumentation_test.rb
+++ b/test/multiverse/suites/view_component/view_component_instrumentation_test.rb
@@ -51,4 +51,10 @@ class ViewComponentInstrumentationTest < ActionDispatch::IntegrationTest
   def test_metric_path_unknown_file_pattern
     assert(FAKE_CLASS.metric_path('nothing_to_see_here'), 'unknown')
   end
+
+    def test_error_raised
+    NewRelic::Agent::Tracer.stub(:start_segment, proc { |_args| raise 'kaboom' }) do
+      assert_equal(500, get('/view_components'))
+    end
+  end
 end


### PR DESCRIPTION
ViewComponent errors are being suppressed, as  #2410 reported. Once the fix from that PR is merged, our new test should pass.

Update: fix merged and new test passing!