### PR TITLE
Update thor scaffold command

### DIFF
--- a/lib/tasks/instrumentation_generator/instrumentation.thor
+++ b/lib/tasks/instrumentation_generator/instrumentation.thor
@@ -82,7 +82,7 @@ class Instrumentation < Thor
     insert_into_file(
       DEFAULT_SOURCE_LOCATION,
       config_block(name.downcase),
-      after: ":description => 'Controls auto-instrumentation of bunny at start-up.  May be one of [auto|prepend|chain|disabled].'
+      after: ":description => 'Controls auto-instrumentation of bunny at start-up. May be one of: `auto`, `prepend`, `chain`, `disabled`.'
         },\n"
     )
   end

--- a/lib/tasks/instrumentation_generator/templates/chain.tt
+++ b/lib/tasks/instrumentation_generator/templates/chain.tt
@@ -9,7 +9,6 @@ module NewRelic::Agent::Instrumentation
         include NewRelic::Agent::Instrumentation::<%= @class_name %>
 
         alias_method(:<%= @method.downcase %>_without_new_relic, :<%= @method.downcase %>)
-        alias_method(:<%= @method.downcase %>, :<%= @method.downcase %>_with_new_relic)
 
         def <%= @method.downcase %><%= "(#{@args})" unless @args.empty? %>
           <%= @method.downcase %>_with_new_relic<%= "(#{@args})" unless @args.empty? %> do

--- a/lib/tasks/instrumentation_generator/templates/chain_method.tt
+++ b/lib/tasks/instrumentation_generator/templates/chain_method.tt
@@ -1,5 +1,4 @@
 alias_method(:<%= @method.downcase %>_without_new_relic, :<%= @method.downcase %>)
-alias_method(:<%= @method.downcase %>, :<%= @method.downcase %>_with_new_relic)
 
 def <%= @method.downcase %><%= "(#{@args})" unless @args.empty? %>
   <%= @method.downcase %>_with_new_relic<%= "(#{@args})" unless @args.empty? %> do


### PR DESCRIPTION
Fixes the insert point for the default_source.rb, since it was no longer working after updates we made to default_source.rm
Also, I fixed the extra line that we've had in the chain instrumentation. I always remove it, and I know we've discussed how that line is redundant in other PRs that used the scaffold, so I updated it. (The method gets redefined immediately after that line.)