### PR TITLE
[WIP] Create LLM Events

### DIFF
--- a/lib/new_relic/agent.rb
+++ b/lib/new_relic/agent.rb
@@ -62,6 +62,7 @@ module NewRelic
     require 'new_relic/agent/attribute_processing'
     require 'new_relic/agent/linking_metadata'
     require 'new_relic/agent/local_log_decorator'
+    require 'new_relic/agent/llm_event'
 
     require 'new_relic/agent/instrumentation/controller_instrumentation'
 

--- a/lib/new_relic/agent/llm_event.rb
+++ b/lib/new_relic/agent/llm_event.rb
@@ -29,7 +29,7 @@ module NewRelic
 
       def llm_event_attributes
         {id: @id, app_name: @app_name, request_id: @request_id, span_id: @span_id, transaction_id: @transaction_id,
-        trace_id: @trace_id, response_model: @response_model, vendor: @vendor }
+         trace_id: @trace_id, response_model: @response_model, vendor: @vendor}
       end
 
       # Method for subclasses to override

--- a/lib/new_relic/agent/llm_event.rb
+++ b/lib/new_relic/agent/llm_event.rb
@@ -3,18 +3,21 @@
 # frozen_string_literal: true
 
 require_relative 'llm_event/chat_completion'
+# require_relative 'llm_event/embedding'
+# require_relative 'llm_event/feedback'
+require_relative 'llm_event/chat_completion/message'
+# require_relative 'llm_event/chat_completion/summary'
 
 module NewRelic
   module Agent
     class LlmEvent
-
       # response_model looks like repsonse.model
       attr_accessor :id, :app_name, :request_id, :span_id, :transaction_id, :trace_id, :response_model, :vendor
       INGEST_SOURCE = 'Ruby'
 
-      def initialize(id:, app_name:, request_id:, span_id:, transaction_id:, trace_id:, response_model:, vendor:, **args)
+      def initialize(id: nil, request_id: nil, span_id: nil, transaction_id: nil, trace_id: nil, response_model: nil, vendor: nil, **args)
         @id = id
-        @app_name = app_name
+        @app_name = NewRelic::Agent.config[:app_name]
         @request_id = request_id
         @span_id = span_id
         @transaction_id = transaction_id
@@ -23,8 +26,13 @@ module NewRelic
         @vendor = vendor
       end
 
+      def llm_event_attributes
+        {id: @id, app_name: @app_name}
+      end
+
       # Method for subclasses to override
-      def record; end
+      def record
+      end
     end
   end
 end

--- a/lib/new_relic/agent/llm_event.rb
+++ b/lib/new_relic/agent/llm_event.rb
@@ -14,7 +14,7 @@ module NewRelic
       # response_model looks like repsonse.model
       attr_accessor :id, :app_name, :request_id, :span_id, :transaction_id, :trace_id, :response_model, :vendor
       INGEST_SOURCE = 'Ruby'
-
+ 
       def initialize(id: nil, request_id: nil, span_id: nil, transaction_id: nil, trace_id: nil, response_model: nil, vendor: nil, **args)
         @id = id
         @app_name = NewRelic::Agent.config[:app_name]
@@ -27,7 +27,8 @@ module NewRelic
       end
 
       def llm_event_attributes
-        {id: @id, app_name: @app_name}
+        {id: @id, app_name: @app_name, request_id: @request_id, span_id: @span_id, transaction_id: @transaction_id,
+        trace_id: @trace_id, response_model: @response_model, vendor: @vendor }
       end
 
       # Method for subclasses to override

--- a/lib/new_relic/agent/llm_event.rb
+++ b/lib/new_relic/agent/llm_event.rb
@@ -1,0 +1,30 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+require_relative 'llm_event/chat_completion'
+
+module NewRelic
+  module Agent
+    class LlmEvent
+
+      # response_model looks like repsonse.model
+      attr_accessor :id, :app_name, :request_id, :span_id, :transaction_id, :trace_id, :response_model, :vendor
+      INGEST_SOURCE = 'Ruby'
+
+      def initialize(id:, app_name:, request_id:, span_id:, transaction_id:, trace_id:, response_model:, vendor:, **args)
+        @id = id
+        @app_name = app_name
+        @request_id = request_id
+        @span_id = span_id
+        @transaction_id = transaction_id
+        @trace_id = trace_id
+        @response_model = response_model
+        @vendor = vendor
+      end
+
+      # Method for subclasses to override
+      def record; end
+    end
+  end
+end

--- a/lib/new_relic/agent/llm_event.rb
+++ b/lib/new_relic/agent/llm_event.rb
@@ -3,10 +3,11 @@
 # frozen_string_literal: true
 
 require_relative 'llm_event/chat_completion'
-# require_relative 'llm_event/embedding'
-# require_relative 'llm_event/feedback'
 require_relative 'llm_event/chat_completion/message'
-# require_relative 'llm_event/chat_completion/summary'
+require_relative 'llm_event/chat_completion/summary'
+require_relative 'llm_event/embedding'
+require_relative 'llm_event/feedback'
+require_relative 'llm_event/response_headers'
 
 module NewRelic
   module Agent
@@ -14,7 +15,7 @@ module NewRelic
       # response_model looks like repsonse.model
       attr_accessor :id, :app_name, :request_id, :span_id, :transaction_id, :trace_id, :response_model, :vendor
       INGEST_SOURCE = 'Ruby'
- 
+
       def initialize(id: nil, request_id: nil, span_id: nil, transaction_id: nil, trace_id: nil, response_model: nil, vendor: nil, **args)
         @id = id
         @app_name = NewRelic::Agent.config[:app_name]

--- a/lib/new_relic/agent/llm_event.rb
+++ b/lib/new_relic/agent/llm_event.rb
@@ -13,12 +13,10 @@ module NewRelic
   module Agent
     class LlmEvent
       # response_model looks like repsonse.model
-      attr_accessor :id, :app_name, :request_id, :span_id, :transaction_id, :trace_id, :response_model, :vendor
       INGEST_SOURCE = 'Ruby'
 
       def initialize(id: nil, request_id: nil, span_id: nil, transaction_id: nil, trace_id: nil, response_model: nil, vendor: nil, **args)
         @id = id
-        @app_name = NewRelic::Agent.config[:app_name]
         @request_id = request_id
         @span_id = span_id
         @transaction_id = transaction_id
@@ -27,8 +25,9 @@ module NewRelic
         @vendor = vendor
       end
 
+      # TODO: make sure attribute keys match the spec, or are okay to be snake_case
       def llm_event_attributes
-        {id: @id, app_name: @app_name, request_id: @request_id, span_id: @span_id, transaction_id: @transaction_id,
+        {id: @id, request_id: @request_id, span_id: @span_id, transaction_id: @transaction_id,
          trace_id: @trace_id, response_model: @response_model, vendor: @vendor}
       end
 

--- a/lib/new_relic/agent/llm_event/chat_completion.rb
+++ b/lib/new_relic/agent/llm_event/chat_completion.rb
@@ -6,10 +6,8 @@ module NewRelic
   module Agent
     class LlmEvent
       class ChatCompletion < LlmEvent
-        # Real metrics are written: request.max_tokens, response.number_of_messages
-        attr_accessor :api_key_last_four_digits, :conversation_id, :request_max_tokens, :response_number_of_messages
-
-        def initialize(api_key_last_four_digits:, conversation_id:, request_max_tokens:, response_number_of_messages:, **args)
+        # TODO: should any of the attrs be required on initialization?
+        def initialize(api_key_last_four_digits: nil, conversation_id: nil, request_max_tokens: nil, response_number_of_messages: nil, **args)
           @api_key_last_four_digits = api_key_last_four_digits
           @conversation_id = conversation_id
           @request_max_tokens = request_max_tokens

--- a/lib/new_relic/agent/llm_event/chat_completion.rb
+++ b/lib/new_relic/agent/llm_event/chat_completion.rb
@@ -17,7 +17,7 @@ module NewRelic
 
         def chat_completion_attributes
           {api_key_last_four_digits: @api_key_last_four_digits, conversation_id: @conversation_id,
-          request_max_tokens: @request_max_tokens, response_number_of_messages: @response_number_of_messages}
+           request_max_tokens: @request_max_tokens, response_number_of_messages: @response_number_of_messages}
         end
 
         # Method for subclasses to override

--- a/lib/new_relic/agent/llm_event/chat_completion.rb
+++ b/lib/new_relic/agent/llm_event/chat_completion.rb
@@ -18,12 +18,12 @@ module NewRelic
         end
 
         def chat_completion_attributes
-          {api_key_last_four_digits: @api_key_last_four_digits, conversation_id: @conversation_id}
+          {api_key_last_four_digits: @api_key_last_four_digits, conversation_id: @conversation_id,
+          request_max_tokens: @request_max_tokens, response_number_of_messages: @response_number_of_messages}
         end
 
         # Method for subclasses to override
-        def record
-        end
+        def record; end
       end
     end
   end

--- a/lib/new_relic/agent/llm_event/chat_completion.rb
+++ b/lib/new_relic/agent/llm_event/chat_completion.rb
@@ -1,0 +1,28 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+
+module NewRelic
+  module Agent
+    class LlmEvent
+      class ChatCompletion < NewRelic::Agent::LlmEvent
+
+        # Real metrics are written: request.max_tokens, response.number_of_messages
+        attr_accessor :api_key_last_four_digits, :conversation_id, :request_max_tokens, :response_number_of_messages
+
+        def initialize(api_key_last_four_digits:, conversation_id:, request_max_tokens:, response_number_of_messages:)
+          @api_key_last_four_digits = api_key_last_four_digits
+          @conversation_id = conversation_id
+          @request_max_tokens = request_max_tokens
+          @response_number_of_messages = response_number_of_messages
+          super
+        end
+
+      # Method for subclasses to override
+      def record; end
+      end
+    end
+  end
+end
+

--- a/lib/new_relic/agent/llm_event/chat_completion.rb
+++ b/lib/new_relic/agent/llm_event/chat_completion.rb
@@ -2,16 +2,14 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
-
 module NewRelic
   module Agent
     class LlmEvent
-      class ChatCompletion < NewRelic::Agent::LlmEvent
-
+      class ChatCompletion < LlmEvent
         # Real metrics are written: request.max_tokens, response.number_of_messages
         attr_accessor :api_key_last_four_digits, :conversation_id, :request_max_tokens, :response_number_of_messages
 
-        def initialize(api_key_last_four_digits:, conversation_id:, request_max_tokens:, response_number_of_messages:)
+        def initialize(api_key_last_four_digits:, conversation_id:, request_max_tokens:, response_number_of_messages:, **args)
           @api_key_last_four_digits = api_key_last_four_digits
           @conversation_id = conversation_id
           @request_max_tokens = request_max_tokens
@@ -19,10 +17,14 @@ module NewRelic
           super
         end
 
-      # Method for subclasses to override
-      def record; end
+        def chat_completion_attributes
+          {api_key_last_four_digits: @api_key_last_four_digits, conversation_id: @conversation_id}
+        end
+
+        # Method for subclasses to override
+        def record
+        end
       end
     end
   end
 end
-

--- a/lib/new_relic/agent/llm_event/chat_completion/message.rb
+++ b/lib/new_relic/agent/llm_event/chat_completion/message.rb
@@ -7,7 +7,6 @@ module NewRelic
     class LlmEvent
       class ChatCompletion
         class Message < ChatCompletion
-          attr_accessor :content, :role, :sequence, :completion_id, :is_response
           EVENT_NAME = 'LlmChatCompletionMessage'
 
           def initialize(content: nil, role: nil, sequence: nil, completion_id: nil, is_response: nil, **args)

--- a/lib/new_relic/agent/llm_event/chat_completion/message.rb
+++ b/lib/new_relic/agent/llm_event/chat_completion/message.rb
@@ -20,7 +20,7 @@ module NewRelic
           end
 
           def message_attributes
-            {content: @content, role: @role}.merge(chat_completion_attributes, llm_event_attributes)
+            {content: @content, role: @role, sequence: @sequence, completion_id: @completion_id, is_response: @is_response}.merge(chat_completion_attributes, llm_event_attributes)
           end
 
           def record

--- a/lib/new_relic/agent/llm_event/chat_completion/message.rb
+++ b/lib/new_relic/agent/llm_event/chat_completion/message.rb
@@ -1,0 +1,24 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+class NewRelic
+  class Agent
+    class LlmEvent
+      class ChatCompletion
+        class Message < NewRelic::Agent::LlmEvent::ChatCompletion
+
+          attr_accessor :content, :role, :sequence, :completion_id, :is_response
+
+          def initialize
+            
+          end
+    
+          def record
+    
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/new_relic/agent/llm_event/chat_completion/message.rb
+++ b/lib/new_relic/agent/llm_event/chat_completion/message.rb
@@ -2,20 +2,29 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
-class NewRelic
-  class Agent
+module NewRelic
+  module Agent
     class LlmEvent
       class ChatCompletion
-        class Message < NewRelic::Agent::LlmEvent::ChatCompletion
-
+        class Message < ChatCompletion
           attr_accessor :content, :role, :sequence, :completion_id, :is_response
+          EVENT_NAME = 'LlmChatCompletionMessage'
 
-          def initialize
-            
+          def initialize(content: nil, role: nil, sequence: nil, completion_id: nil, is_response: nil, **args)
+            @content = content
+            @role = role
+            @sequence = sequence
+            @completion_id = completion_id
+            @is_response = is_response
+            super
           end
-    
+
+          def message_attributes
+            {content: @content, role: @role}.merge(chat_completion_attributes, llm_event_attributes)
+          end
+
           def record
-    
+            NewRelic::Agent.record_custom_event(EVENT_NAME, message_attributes)
           end
         end
       end

--- a/lib/new_relic/agent/llm_event/chat_completion/summary.rb
+++ b/lib/new_relic/agent/llm_event/chat_completion/summary.rb
@@ -6,35 +6,73 @@ class NewRelic
   class Agent
     class LlmEvent
       class ChatCompletion
-
-        attr_accessor 
-          :'request.model', 
-          :'response.organization', 
-          :'response.usage.total_tokens', 
-          :'response.usage.prompt_tokens', 
-          :'response.usage.completion_tokens',
-          :'response.choices.finish_reason',
-          :'response.headers.llmVersion',
-          :'response.headers.ratelimitLimitRequests',
-          :'response.headers.ratelimitLimitTokens',
-          :'response.headers.ratelimitResetTokens',
-          :'response.headers.ratelimitResetRequests',
-          :'response.headers.ratelimitRemainingTokens',
-          :'response.headers.ratelimitRemainingRequests',
+        attr_accessor
+          :request_model,
+          :response_organization,
+          :response_usage_total_tokens,
+          :response_usage_prompt_tokens,
+          :response_usage_completion_tokens,
+          :response_choices_finish_reason,
+          :response_headers_llmVersion,
+          :response_headers_ratelimitLimitRequests,
+          :response_headers_ratelimitLimitTokens,
+          :response_headers_ratelimitResetTokens,
+          :response_headers_ratelimitResetRequests,
+          :response_headers_ratelimitRemainingTokens,
+          :response_headers_ratelimitRemainingRequests,
           :duration,
-          :'request.temperature',
+          :request_temperature,
           :error
 
-
+        EVENT_NAME = 'LlmChatCompletionSummary'
 
         class Summary < NewRelic::Agent::LlmEvent::ChatCompletion
-          
-          def initialize
-            
+          def initialize (request_model:, response_organization:, response_usage_total_tokens:, response_usage_prompt_tokens:, response_usage_completion_tokens:,
+            response_choices_finish_reason:, response_headers_llmVersion:, response_headers_ratelimitLimitRequests:, response_headers_ratelimitLimitTokens:,
+            response_headers_ratelimitResetTokens:, response_headers_ratelimitResetRequests:, response_headers_ratelimitRemainingTokens:,
+            response_headers_ratelimitRemainingRequests:, duration:, request_temperature:, error:, **args)
+            @request_model = request_model
+            @response_organization = response_organization
+            @response_usage_total_tokens = response_usage_total_tokens
+            @response_usage_prompt_tokens = response_usage_prompt_tokens
+            @response_usage_completion_tokens = response_usage_completion_tokens
+            @response_choices_finish_reason = response_choices_finish_reason
+            @response_headers_llmVersion = response_headers_llmVersion
+            @response_headers_ratelimitLimitRequests = response_headers_ratelimitLimitRequests
+            @response_headers_ratelimitLimitTokens = response_headers_ratelimitLimitTokens
+            @response_headers_ratelimitResetTokens = response_headers_ratelimitResetTokens
+            @response_headers_ratelimitResetRequests = response_headers_ratelimitResetRequests
+            @response_headers_ratelimitRemainingTokens = response_headers_ratelimitRemainingTokens
+            @response_headers_ratelimitRemainingRequests = response_headers_ratelimitRemainingRequests
+            @duration = duration
+            @request_temperature = request_temperature
+            @error = error
+            super
           end
-    
+
+          def summary_attributes
+            {
+              request_model: @request_model,
+              response_organization: @response_organization,
+              response_usage_total_tokens: @response_usage_total_tokens,
+              response_usage_prompt_tokens: @response_usage_prompt_tokens,
+              response_usage_completion_tokens: @response_usage_completion_tokens,
+              response_choices_finish_reason: @response_choices_finish_reason,
+              response_headers_llmVersion: @response_headers_llmVersion,
+              response_headers_ratelimitLimitRequests: @response_headers_ratelimitLimitRequests,
+              response_headers_ratelimitLimitTokens: @response_headers_ratelimitLimitTokens,
+              response_headers_ratelimitResetTokens: @response_headers_ratelimitResetTokens,
+              response_headers_ratelimitResetRequests: @response_headers_ratelimitResetRequests,
+              response_headers_ratelimitRemainingTokens: @response_headers_ratelimitRemainingTokens,
+              response_headers_ratelimitRemainingRequests: @response_headers_ratelimitRemainingRequests,
+              duration: @duration,
+              request_temperature: @request_temperature,
+              error: @error
+            }.merge(chat_completion_attributes, llm_event_attributes)
+          end
+
           def record
-    
+            NewRelic::Agent.record_custom_event(EVENT_NAME, summary_attributes)
           end
         end
       end

--- a/lib/new_relic/agent/llm_event/chat_completion/summary.rb
+++ b/lib/new_relic/agent/llm_event/chat_completion/summary.rb
@@ -2,48 +2,22 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
-class NewRelic
-  class Agent
+module NewRelic
+  module Agent
     class LlmEvent
       class ChatCompletion
-        attr_accessor
-          :request_model,
-          :response_organization,
-          :response_usage_total_tokens,
-          :response_usage_prompt_tokens,
-          :response_usage_completion_tokens,
-          :response_choices_finish_reason,
-          :response_headers_llmVersion,
-          :response_headers_ratelimitLimitRequests,
-          :response_headers_ratelimitLimitTokens,
-          :response_headers_ratelimitResetTokens,
-          :response_headers_ratelimitResetRequests,
-          :response_headers_ratelimitRemainingTokens,
-          :response_headers_ratelimitRemainingRequests,
-          :duration,
-          :request_temperature,
-          :error
-
         EVENT_NAME = 'LlmChatCompletionSummary'
 
         class Summary < NewRelic::Agent::LlmEvent::ChatCompletion
-          def initialize (request_model:, response_organization:, response_usage_total_tokens:, response_usage_prompt_tokens:, response_usage_completion_tokens:,
-            response_choices_finish_reason:, response_headers_llmVersion:, response_headers_ratelimitLimitRequests:, response_headers_ratelimitLimitTokens:,
-            response_headers_ratelimitResetTokens:, response_headers_ratelimitResetRequests:, response_headers_ratelimitRemainingTokens:,
-            response_headers_ratelimitRemainingRequests:, duration:, request_temperature:, error:, **args)
+          def initialize (request_model: nil, response_organization: nil, response_usage_total_tokens: nil, response_usage_prompt_tokens: nil, response_usage_completion_tokens: nil,
+            response_choices_finish_reason: nil, duration: nil, request_temperature: nil, error: nil, **args)
             @request_model = request_model
             @response_organization = response_organization
             @response_usage_total_tokens = response_usage_total_tokens
             @response_usage_prompt_tokens = response_usage_prompt_tokens
             @response_usage_completion_tokens = response_usage_completion_tokens
             @response_choices_finish_reason = response_choices_finish_reason
-            @response_headers_llmVersion = response_headers_llmVersion
-            @response_headers_ratelimitLimitRequests = response_headers_ratelimitLimitRequests
-            @response_headers_ratelimitLimitTokens = response_headers_ratelimitLimitTokens
-            @response_headers_ratelimitResetTokens = response_headers_ratelimitResetTokens
-            @response_headers_ratelimitResetRequests = response_headers_ratelimitResetRequests
-            @response_headers_ratelimitRemainingTokens = response_headers_ratelimitRemainingTokens
-            @response_headers_ratelimitRemainingRequests = response_headers_ratelimitRemainingRequests
+            @response_headers = LlmEvent::ResponseHeaders.new
             @duration = duration
             @request_temperature = request_temperature
             @error = error
@@ -58,13 +32,7 @@ class NewRelic
               response_usage_prompt_tokens: @response_usage_prompt_tokens,
               response_usage_completion_tokens: @response_usage_completion_tokens,
               response_choices_finish_reason: @response_choices_finish_reason,
-              response_headers_llmVersion: @response_headers_llmVersion,
-              response_headers_ratelimitLimitRequests: @response_headers_ratelimitLimitRequests,
-              response_headers_ratelimitLimitTokens: @response_headers_ratelimitLimitTokens,
-              response_headers_ratelimitResetTokens: @response_headers_ratelimitResetTokens,
-              response_headers_ratelimitResetRequests: @response_headers_ratelimitResetRequests,
-              response_headers_ratelimitRemainingTokens: @response_headers_ratelimitRemainingTokens,
-              response_headers_ratelimitRemainingRequests: @response_headers_ratelimitRemainingRequests,
+              response_headers: @response_headers, # need to do something to break this down further... or just treat like another thing to merge
               duration: @duration,
               request_temperature: @request_temperature,
               error: @error

--- a/lib/new_relic/agent/llm_event/chat_completion/summary.rb
+++ b/lib/new_relic/agent/llm_event/chat_completion/summary.rb
@@ -1,0 +1,43 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+class NewRelic
+  class Agent
+    class LlmEvent
+      class ChatCompletion
+
+        attr_accessor 
+          :'request.model', 
+          :'response.organization', 
+          :'response.usage.total_tokens', 
+          :'response.usage.prompt_tokens', 
+          :'response.usage.completion_tokens',
+          :'response.choices.finish_reason',
+          :'response.headers.llmVersion',
+          :'response.headers.ratelimitLimitRequests',
+          :'response.headers.ratelimitLimitTokens',
+          :'response.headers.ratelimitResetTokens',
+          :'response.headers.ratelimitResetRequests',
+          :'response.headers.ratelimitRemainingTokens',
+          :'response.headers.ratelimitRemainingRequests',
+          :duration,
+          :'request.temperature',
+          :error
+
+
+
+        class Summary < NewRelic::Agent::LlmEvent::ChatCompletion
+          
+          def initialize
+            
+          end
+    
+          def record
+    
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/new_relic/agent/llm_event/chat_completion/summary.rb
+++ b/lib/new_relic/agent/llm_event/chat_completion/summary.rb
@@ -9,7 +9,7 @@ module NewRelic
         EVENT_NAME = 'LlmChatCompletionSummary'
 
         class Summary < NewRelic::Agent::LlmEvent::ChatCompletion
-          def initialize (request_model: nil, response_organization: nil, response_usage_total_tokens: nil, response_usage_prompt_tokens: nil, response_usage_completion_tokens: nil,
+          def initialize(request_model: nil, response_organization: nil, response_usage_total_tokens: nil, response_usage_prompt_tokens: nil, response_usage_completion_tokens: nil,
             response_choices_finish_reason: nil, duration: nil, request_temperature: nil, error: nil, **args)
             @request_model = request_model
             @response_organization = response_organization

--- a/lib/new_relic/agent/llm_event/chat_completion/summary.rb
+++ b/lib/new_relic/agent/llm_event/chat_completion/summary.rb
@@ -32,11 +32,10 @@ module NewRelic
               response_usage_prompt_tokens: @response_usage_prompt_tokens,
               response_usage_completion_tokens: @response_usage_completion_tokens,
               response_choices_finish_reason: @response_choices_finish_reason,
-              response_headers: @response_headers, # need to do something to break this down further... or just treat like another thing to merge
               duration: @duration,
               request_temperature: @request_temperature,
               error: @error
-            }.merge(chat_completion_attributes, llm_event_attributes)
+            }.merge(chat_completion_attributes, llm_event_attributes, @response_headers.attributes)
           end
 
           def record

--- a/lib/new_relic/agent/llm_event/embedding.rb
+++ b/lib/new_relic/agent/llm_event/embedding.rb
@@ -2,45 +2,19 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
-class NewRelic
-  class Agent
+module NewRelic
+  module Agent
     class LlmEvent
       class Embedding < NewRelic::Agent::LlmEvent
+        EVENT_NAME = 'LlmEmbedding'
 
-        # The real object for all response_ actially is response.x.
-        attr_accessor
-          :input,
-          :request_model,
-          :response_organization,
-          :response_usage_total_tokens,
-          :response_usage_prompt_tokens,
-          :response_headers_llmVersion,
-          :response_headers_ratelimitLimitRequests
-          :response_headers_ratelimitLimitTokens,
-          :response_headers_ratelimitResetTokens,
-          :response_headers_ratelimitResetRequests,
-          :response_headers_ratelimitRemainingTokens,
-          :response_headers_ratelimitRemainingRequests,
-          :duration,
-          :error
-
-          EVENT_NAME = 'LlmEmbedding'
-
-        def initialize (input:, request_model:, response_organization:, response_usage_total_tokens:, response_usage_prompt_tokens:, response_headers_llmVersion:,
-          response_headers_ratelimitLimitRequests:, response_headers_ratelimitLimitTokens:, response_headers_ratelimitResetTokens:, response_headers_ratelimitResetRequests:,
-          response_headers_ratelimitRemainingTokens:, response_headers_ratelimitRemainingRequests:, duration:, error:, **args)
+        def initialize (input: nil, request_model: nil, response_organization: nil, response_usage_total_tokens: nil, response_usage_prompt_tokens: nil, response_headers: nil, duration: nil, error: nil, **args)
           @input = input
           @request_model = request_model
           @response_organization = response_organization
           @response_usage_total_tokens = response_usage_total_tokens
           @response_usage_prompt_tokens = response_usage_prompt_tokens
-          @response_headers_llmVersion = response_headers_llmVersion
-          @response_headers_ratelimitLimitRequests = response_headers_ratelimitLimitRequests
-          @response_headers_ratelimitLimitTokens = response_headers_ratelimitLimitTokens
-          @response_headers_ratelimitResetTokens = response_headers_ratelimitResetTokens
-          @response_headers_ratelimitResetRequests = response_headers_ratelimitResetRequests
-          @response_headers_ratelimitRemainingTokens = response_headers_ratelimitRemainingTokens
-          @response_headers_ratelimitRemainingRequests = response_headers_ratelimitRemainingRequests
+          @response_headers = LlmEvent::ResponseHeaders.new
           @duration = duration
           @error = error
           super
@@ -53,13 +27,7 @@ class NewRelic
             response_organization: @response_organization,
             response_usage_total_tokens: @response_usage_total_tokens,
             response_usage_prompt_tokens: @response_usage_prompt_tokens,
-            response_headers_llmVersion: @response_headers_llmVersion,
-            response_headers_ratelimitLimitRequests: @response_headers_ratelimitLimitRequests,
-            response_headers_ratelimitLimitTokens: @response_headers_ratelimitLimitTokens,
-            response_headers_ratelimitResetTokens: @response_headers_ratelimitResetTokens,
-            response_headers_ratelimitResetRequests: @response_headers_ratelimitResetRequests,
-            response_headers_ratelimitRemainingTokens: @response_headers_ratelimitRemainingTokens,
-            response_headers_ratelimitRemainingRequests: @response_headers_ratelimitRemainingRequests,
+            response_headers: @response_headers, # may need to break down further
             duration: @duration,
             error: @error
           }.merge(llm_event_attributes)

--- a/lib/new_relic/agent/llm_event/embedding.rb
+++ b/lib/new_relic/agent/llm_event/embedding.rb
@@ -27,10 +27,9 @@ module NewRelic
             response_organization: @response_organization,
             response_usage_total_tokens: @response_usage_total_tokens,
             response_usage_prompt_tokens: @response_usage_prompt_tokens,
-            response_headers: @response_headers, # may need to break down further
             duration: @duration,
             error: @error
-          }.merge(llm_event_attributes)
+          }.merge(llm_event_attributes, @response_headers.attributes)
         end
 
         def record

--- a/lib/new_relic/agent/llm_event/embedding.rb
+++ b/lib/new_relic/agent/llm_event/embedding.rb
@@ -1,0 +1,36 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+class NewRelic
+  class Agent
+    class LlmEvent
+      class Embedding < NewRelic::Agent::LlmEvent
+
+        attr_accessor 
+          :input, 
+          :'request.model', 
+          :'response.organization', 
+          :'response.usage.total_tokens', 
+          :'response.usage.prompt_tokens',
+          :'response.headers.llmVersion',
+          :'response.headers.ratelimitLimitRequests'
+          :'response.headers.ratelimitLimitTokens',
+          :'response.headers.ratelimitResetTokens',
+          :'response.headers.ratelimitResetRequests',
+          :'response.headers.ratelimitRemainingTokens',
+          :'response.headers.ratelimitRemainingRequests',
+          :duration,
+          :error
+
+        def initialize
+
+        end
+
+        def record
+
+        end
+      end
+    end
+  end
+end

--- a/lib/new_relic/agent/llm_event/embedding.rb
+++ b/lib/new_relic/agent/llm_event/embedding.rb
@@ -8,7 +8,7 @@ module NewRelic
       class Embedding < NewRelic::Agent::LlmEvent
         EVENT_NAME = 'LlmEmbedding'
 
-        def initialize (input: nil, request_model: nil, response_organization: nil, response_usage_total_tokens: nil, response_usage_prompt_tokens: nil, response_headers: nil, duration: nil, error: nil, **args)
+        def initialize(input: nil, request_model: nil, response_organization: nil, response_usage_total_tokens: nil, response_usage_prompt_tokens: nil, response_headers: nil, duration: nil, error: nil, **args)
           @input = input
           @request_model = request_model
           @response_organization = response_organization

--- a/lib/new_relic/agent/llm_event/embedding.rb
+++ b/lib/new_relic/agent/llm_event/embedding.rb
@@ -7,28 +7,66 @@ class NewRelic
     class LlmEvent
       class Embedding < NewRelic::Agent::LlmEvent
 
-        attr_accessor 
-          :input, 
-          :'request.model', 
-          :'response.organization', 
-          :'response.usage.total_tokens', 
-          :'response.usage.prompt_tokens',
-          :'response.headers.llmVersion',
-          :'response.headers.ratelimitLimitRequests'
-          :'response.headers.ratelimitLimitTokens',
-          :'response.headers.ratelimitResetTokens',
-          :'response.headers.ratelimitResetRequests',
-          :'response.headers.ratelimitRemainingTokens',
-          :'response.headers.ratelimitRemainingRequests',
+        # The real object for all response_ actially is response.x.
+        attr_accessor
+          :input,
+          :request_model,
+          :response_organization,
+          :response_usage_total_tokens,
+          :response_usage_prompt_tokens,
+          :response_headers_llmVersion,
+          :response_headers_ratelimitLimitRequests
+          :response_headers_ratelimitLimitTokens,
+          :response_headers_ratelimitResetTokens,
+          :response_headers_ratelimitResetRequests,
+          :response_headers_ratelimitRemainingTokens,
+          :response_headers_ratelimitRemainingRequests,
           :duration,
           :error
 
-        def initialize
+          EVENT_NAME = 'LlmEmbedding'
 
+        def initialize (input:, request_model:, response_organization:, response_usage_total_tokens:, response_usage_prompt_tokens:, response_headers_llmVersion:,
+          response_headers_ratelimitLimitRequests:, response_headers_ratelimitLimitTokens:, response_headers_ratelimitResetTokens:, response_headers_ratelimitResetRequests:,
+          response_headers_ratelimitRemainingTokens:, response_headers_ratelimitRemainingRequests:, duration:, error:, **args)
+          @input = input
+          @request_model = request_model
+          @response_organization = response_organization
+          @response_usage_total_tokens = response_usage_total_tokens
+          @response_usage_prompt_tokens = response_usage_prompt_tokens
+          @response_headers_llmVersion = response_headers_llmVersion
+          @response_headers_ratelimitLimitRequests = response_headers_ratelimitLimitRequests
+          @response_headers_ratelimitLimitTokens = response_headers_ratelimitLimitTokens
+          @response_headers_ratelimitResetTokens = response_headers_ratelimitResetTokens
+          @response_headers_ratelimitResetRequests = response_headers_ratelimitResetRequests
+          @response_headers_ratelimitRemainingTokens = response_headers_ratelimitRemainingTokens
+          @response_headers_ratelimitRemainingRequests = response_headers_ratelimitRemainingRequests
+          @duration = duration
+          @error = error
+          super
+        end
+
+        def embedding_attributes
+          {
+            input: @input,
+            request_model: @request_model,
+            response_organization: @response_organization,
+            response_usage_total_tokens: @response_usage_total_tokens,
+            response_usage_prompt_tokens: @response_usage_prompt_tokens,
+            response_headers_llmVersion: @response_headers_llmVersion,
+            response_headers_ratelimitLimitRequests: @response_headers_ratelimitLimitRequests,
+            response_headers_ratelimitLimitTokens: @response_headers_ratelimitLimitTokens,
+            response_headers_ratelimitResetTokens: @response_headers_ratelimitResetTokens,
+            response_headers_ratelimitResetRequests: @response_headers_ratelimitResetRequests,
+            response_headers_ratelimitRemainingTokens: @response_headers_ratelimitRemainingTokens,
+            response_headers_ratelimitRemainingRequests: @response_headers_ratelimitRemainingRequests,
+            duration: @duration,
+            error: @error
+          }.merge(llm_event_attributes)
         end
 
         def record
-
+          NewRelic::Agent.record_custom_event(EVENT_NAME, embedding_attributes)
         end
       end
     end

--- a/lib/new_relic/agent/llm_event/feedback.rb
+++ b/lib/new_relic/agent/llm_event/feedback.rb
@@ -2,7 +2,6 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
-
 module NewRelic
   module Agent
     class LlmEvent

--- a/lib/new_relic/agent/llm_event/feedback.rb
+++ b/lib/new_relic/agent/llm_event/feedback.rb
@@ -1,0 +1,13 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+
+class NewRelic
+  class Agent
+    class LlmEvent
+      class Feedback < NewRelic::Agent::LlmEvent
+      end
+    end
+  end
+end

--- a/lib/new_relic/agent/llm_event/feedback.rb
+++ b/lib/new_relic/agent/llm_event/feedback.rb
@@ -3,8 +3,8 @@
 # frozen_string_literal: true
 
 
-class NewRelic
-  class Agent
+module NewRelic
+  module Agent
     class LlmEvent
       class Feedback < NewRelic::Agent::LlmEvent
       end

--- a/lib/new_relic/agent/llm_event/response_headers.rb
+++ b/lib/new_relic/agent/llm_event/response_headers.rb
@@ -6,7 +6,6 @@ module NewRelic
   module Agent
     class LlmEvent
       class ResponseHeaders < NewRelic::Agent::LlmEvent
-        # may need to update the attribute keys to use camel casing
         def initialize(llm_version: nil, rate_limit_requests: nil, rate_limit_tokens: nil,
           rate_limit_reset_requests: nil, rate_limit_reset_tokens: nil,
           rate_limit_remaining_requests: nil, rate_limit_remaining_tokens: nil)
@@ -28,6 +27,22 @@ module NewRelic
           @rate_limit_reset_tokens = headers['x-ratelimit-reset-tokens'][0]
           @rate_limit_remaining_requests = headers['x-ratelimit-remaining-requests'][0]
           @rate_limit_remaining_tokens = headers['x-ratelimit-remaining-tokens'][0]
+        end
+
+        # this reflects the string casing in the spec
+        # we may or may not need to do it this way
+        # if we need to do it like this, we should update the
+        # attribute methods in the other classes
+        def attributes
+          {
+            :'response.headers.llmVersion' => @llm_version,
+            :'response.headers.rateLimitRequests' => @rate_limit_requests,
+            :'response.headers.rateLimitTokens' => @rate_limit_tokens,
+            :'response.headers.rateLimitResetRequests' => @rate_limit_reset_requests,
+            :'response.headers.rateLimitResetTokens' => @rate_limit_reset_tokens,
+            :'response.headers.rateLimitRemainingRequests' => @rate_limit_remaining_requests,
+            :'response.headers.rateLimitRemainingTokens' => @rate_limit_remaining_tokens
+          }
         end
       end
     end

--- a/lib/new_relic/agent/llm_event/response_headers.rb
+++ b/lib/new_relic/agent/llm_event/response_headers.rb
@@ -9,8 +9,7 @@ module NewRelic
         # may need to update the attribute keys to use camel casing
         def initialize(llm_version: nil, rate_limit_requests: nil, rate_limit_tokens: nil,
           rate_limit_reset_requests: nil, rate_limit_reset_tokens: nil,
-          rate_limit_remaining_requests: nil, rate_limit_remaining_tokens: nil
-        )
+          rate_limit_remaining_requests: nil, rate_limit_remaining_tokens: nil)
           @llm_version = llm_version
           @rate_limit_requests = rate_limit_requests
           @rate_limit_tokens = rate_limit_tokens
@@ -18,9 +17,9 @@ module NewRelic
           @rate_limit_reset_tokens = rate_limit_reset_tokens
           @rate_limit_remaining_requests = rate_limit_remaining_requests
           @rate_limit_remaining_tokens = rate_limit_remaining_tokens
-       end
+        end
 
-       # Headers is a hash of Net::HTTP response headers 
+        # Headers is a hash of Net::HTTP response headers
         def populate_openai_response_headers(headers)
           @llm_version = headers['openai-version'][0]
           @rate_limit_requests = headers['x-ratelimit-limit-requests'][0]

--- a/lib/new_relic/agent/llm_event/response_headers.rb
+++ b/lib/new_relic/agent/llm_event/response_headers.rb
@@ -1,0 +1,36 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+module NewRelic
+  module Agent
+    class LlmEvent
+      class ResponseHeaders < NewRelic::Agent::LlmEvent
+        # may need to update the attribute keys to use camel casing
+        def initialize(llm_version: nil, rate_limit_requests: nil, rate_limit_tokens: nil,
+          rate_limit_reset_requests: nil, rate_limit_reset_tokens: nil,
+          rate_limit_remaining_requests: nil, rate_limit_remaining_tokens: nil
+        )
+          @llm_version = llm_version
+          @rate_limit_requests = rate_limit_requests
+          @rate_limit_tokens = rate_limit_tokens
+          @rate_limit_reset_requests = rate_limit_reset_requests
+          @rate_limit_reset_tokens = rate_limit_reset_tokens
+          @rate_limit_remaining_requests = rate_limit_remaining_requests
+          @rate_limit_remaining_tokens = rate_limit_remaining_tokens
+       end
+
+       # Headers is a hash of Net::HTTP response headers 
+        def populate_openai_response_headers(headers)
+          @llm_version = headers['openai-version'][0]
+          @rate_limit_requests = headers['x-ratelimit-limit-requests'][0]
+          @rate_limit_tokens = headers['x-ratelimit-limit-tokens'][0]
+          @rate_limit_reset_requests = headers['x-ratelimit-reset-requests'][0]
+          @rate_limit_reset_tokens = headers['x-ratelimit-reset-tokens'][0]
+          @rate_limit_remaining_requests = headers['x-ratelimit-remaining-requests'][0]
+          @rate_limit_remaining_tokens = headers['x-ratelimit-remaining-tokens'][0]
+        end
+      end
+    end
+  end
+end

--- a/test/new_relic/agent/llm_event_test.rb
+++ b/test/new_relic/agent/llm_event_test.rb
@@ -24,10 +24,7 @@ module NewRelic::Agent
          'conversation_id' => 123,
          'request_max_tokens' => 10,
          'response_number_of_messages' => 5,
-         'id' => 345,
-         'app_name.0' => 'a',
-         'app_name.1' => 'b',
-         'app_name.2' => 'c'}
+         'id' => 345}
       ]], events)
     end
 
@@ -37,7 +34,6 @@ module NewRelic::Agent
         role: 'speaker',
         api_key_last_four_digits: 'sk-0',
         conversation_id: 123, id: 345,
-        app_name: NewRelic::Agent.config[:app_name],
         request_max_tokens: 10,
         response_number_of_messages: 5
       )

--- a/test/new_relic/agent/llm_event_test.rb
+++ b/test/new_relic/agent/llm_event_test.rb
@@ -15,21 +15,20 @@ module NewRelic::Agent
       priority = events[0][0]['priority']
 
       assert_equal([[
-        {"type"=>"LlmChatCompletionMessage",
-        "timestamp"=>timestamp,
-        "priority"=>priority
-        },
-        {"content"=>"hi",
-        "role"=>"speaker",
-        "api_key_last_four_digits"=>"sk-0",
-        "conversation_id"=>123,
-        "request_max_tokens"=>10,
-        "response_number_of_messages"=>5,
-        "id"=>345,
-        "app_name.0"=>"a",
-        "app_name.1"=>"b",
-        "app_name.2"=>"c"
-        }]], events)
+        {'type' => 'LlmChatCompletionMessage',
+         'timestamp' => timestamp,
+         'priority' => priority},
+        {'content' => 'hi',
+         'role' => 'speaker',
+         'api_key_last_four_digits' => 'sk-0',
+         'conversation_id' => 123,
+         'request_max_tokens' => 10,
+         'response_number_of_messages' => 5,
+         'id' => 345,
+         'app_name.0' => 'a',
+         'app_name.1' => 'b',
+         'app_name.2' => 'c'}
+      ]], events)
     end
 
     def chat_message
@@ -39,8 +38,8 @@ module NewRelic::Agent
         api_key_last_four_digits: 'sk-0',
         conversation_id: 123, id: 345,
         app_name: NewRelic::Agent.config[:app_name],
-        request_max_tokens:10,
-        response_number_of_messages:5
+        request_max_tokens: 10,
+        response_number_of_messages: 5
       )
     end
   end

--- a/test/new_relic/agent/llm_event_test.rb
+++ b/test/new_relic/agent/llm_event_test.rb
@@ -1,0 +1,19 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+require_relative '../../test_helper'
+
+
+module NewRelic::Agent
+  class LlmEventTest < Minitest::Test
+    # def test_attributes
+    #   NewRelic::Agent::LlmEvent.new
+
+    # end
+
+    def test_attributes_chat
+      NewRelic::Agent::LlmEvent::ChatCompletion.new
+    end
+  end
+end

--- a/test/new_relic/agent/llm_event_test.rb
+++ b/test/new_relic/agent/llm_event_test.rb
@@ -3,17 +3,35 @@
 # frozen_string_literal: true
 
 require_relative '../../test_helper'
-
+require_relative '../../agent_helper'
 
 module NewRelic::Agent
   class LlmEventTest < Minitest::Test
     # def test_attributes
     #   NewRelic::Agent::LlmEvent.new
-
-    # end
+    def setup
+      events = NewRelic::Agent.instance.events
+      @aggregator = NewRelic::Agent::CustomEventAggregator.new(events)
+    end
 
     def test_attributes_chat
-      NewRelic::Agent::LlmEvent::ChatCompletion.new
+      NewRelic::Agent::LlmEvent::ChatCompletion::Message.new(id: 123)
+    end
+
+    def test_attribute_merge
+      message = NewRelic::Agent::LlmEvent::ChatCompletion::Message.new(content: 'hi', role: 'speaker', api_key_last_four_digits: 'sk-0', conversation_id: 123, id: 345, app_name: NewRelic::Agent.config[:app_name])
+      message.record
+      binding.irb
+      _, events = @aggregator.harvest!
+      # NewRelic::Agent.agent.send(:harvest_and_send_custom_event_data)
+      # returned = first_call_for('custom_event_data').events
+      # events.first[0].delete('priority')
+      # event = events.first
+
+      expected_event = [{'type' => 'DummyType', 'timestamp' => 'bhjbjh'},
+        {'foo' => 'bar', 'baz' => 'qux'}]
+
+      assert_equal(expected_event, events)
     end
   end
 end


### PR DESCRIPTION
We need to create events with specific attributes regardless of what library is instrumented.

These classes are one strategy to solve this problem. There might be a better way to do this.

To reduce duplication, some attributes are passed down from parents/grandparents to child classes, ex. LlmEvents::ChatCompletion::Message has some of its attributes defined in LlmEvents, ChatCompletion and Messages. They all get merged in an attributes method in the child class, which in this example would be messages. 

The child classes have their own record methods. These methods are intended to create the custom events. The record method is defined in parent/grandparent classes, but it is empty. Following patterns elsewhere in the agent, we don't raise an error if a child class hasn't defined the record method.

One way to use these classes: 
```
event = NewRelic::Agent::LlmEvents::ChatCompletion::Summary.new(...pass attributes)
event.instance_variable_set(:@attribute, value_not_available_at_creation)
event.record
```

Closes #2408 

co-authored-by: @hannahramadan 