### PR TITLE
Update SQL obfuscation tests to include cases for Active Record Query Logs

### DIFF
--- a/test/fixtures/cross_agent_tests/sql_obfuscation/sql_obfuscation.json
+++ b/test/fixtures/cross_agent_tests/sql_obfuscation/sql_obfuscation.json
@@ -674,5 +674,35 @@
       "cassandra",
       "mssql"
     ]
+  },
+  {
+    "name": "prepended_comments_with_quotes.postgres",
+    "sql": "/*application:Demo,controller:posts,action:update*/ UPDATE \"posts\" SET \"updated_at\" = '2023-11-01 19:02:34.795909' WHERE \"posts\".\"id\" = 3",
+    "obfuscated": [
+      "? UPDATE \"posts\" SET \"updated_at\" = ? WHERE \"posts\".\"id\" = ?"
+    ],
+    "dialects": [
+      "postgres"
+    ]
+  },
+  {
+    "name": "prepended_comments_with_quotes.mysql",
+    "sql": "/*action='show',application='TrilogyTest',controller='users'*/ SELECT `users`.* FROM `users` WHERE `users`.`id` = 1 LIMIT 1",
+    "obfuscated": [
+      "? SELECT `users`.* FROM `users` WHERE `users`.`id` = ? LIMIT ?"
+    ],
+    "dialects": [
+      "mysql"
+    ]
+  },
+  {
+    "name": "prepended_multiline_comments_with_quotes.mysql",
+    "sql": "/*action='show',\napplication='TrilogyTest',controller='users'*/\nSELECT `users`.*\nFROM `users`\nWHERE `users`.`id` = 1 LIMIT 1",
+    "obfuscated": [
+      "?\nSELECT `users`.*\nFROM `users`\nWHERE `users`.`id` = ? LIMIT ?"
+    ],
+    "dialects": [
+      "mysql"
+    ]
   }
 ]

--- a/test/fixtures/cross_agent_tests/sql_parsing.json
+++ b/test/fixtures/cross_agent_tests/sql_parsing.json
@@ -57,7 +57,8 @@
   {"input":"SELECT * /* a */ FROM alpha",                            "operation":"select", "table":"alpha"},
   {"input":"SELECT * FROM /* a */ alpha",                            "operation":"select", "table":"alpha"},
   {"input":"/* X */ SELECT /* Y */ foo/**/ FROM /**/alpha/**/",      "operation":"select", "table":"alpha"},
-  
+  {"input":"/* insert */ SELECT * FROM alpha",                       "operation":"select", "table":"alpha"},
+
   {"input":"mystoredprocedure'123'",                                 "operation":"other", "table":null},
   {"input":"mystoredprocedure\t'123'",                               "operation":"other", "table":null},
   {"input":"mystoredprocedure\r'123'",                               "operation":"other", "table":null},


### PR DESCRIPTION
# Overview
SQL Obfuscation work in https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/529 revealed we may have a gap in testing for queries prepended by comments in the style of [Marginalia](https://github.com/basecamp/marginalia) (pre-Rails 7) and [Active Record Query Logs](https://api.rubyonrails.org/classes/ActiveRecord/QueryLogs.html) (Rails 7+). 


This PR adds tests for those cases. If we choose to merge this PR, we'll need to follow-up with an update to the cross-agent tests, since these fixtures are synced with that repository. If we don't want to go that route, I'll move these tests so they're separate from the cross-agent tests.

This type of test may have cross-agent value because Google's [sqlcommenter](https://google.github.io/sqlcommenter/) tool supports many different languages and databases and uses a similar syntax. 