### PR TITLE
Add concurrency to PR Continuous Integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}  # Ensure that only one instance of this workflow is running per Pull Request
+  cancel-in-progress: true  # Cancel any previous runs of this workflow
+
 jobs:
   run_rubocop:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
This will stop previous runs if we've pushed up changes to our PR.

Documentation on concurrency in GHA: https://docs.github.com/en/actions/using-jobs/using-concurrency