### PR TITLE
Skip flaky scoped metric reporting test

### DIFF
--- a/test/new_relic/agent/transaction/segment_test.rb
+++ b/test/new_relic/agent/transaction/segment_test.rb
@@ -154,6 +154,9 @@ module NewRelic
         end
 
         def test_segment_can_disable_scoped_metric_recording
+          # TODO: Fix this test via Issue #2429
+          skip 'This test fails intermittently on multiple Ruby versions'
+
           in_transaction('test') do |txn|
             segment = Segment.new('Custom/simple/segment', 'Segment/all')
             segment.record_scoped_metric = false


### PR DESCRIPTION
This test has failed on Ruby versions ranging from 2.5 to 3.2 (perhaps more, but I didn't look too deeply into this). Skip the test until we can figure out why it's broken.

#2429 is an issue to fix this test when we can get around to it.