### PR TITLE
Add `ai_monitoring.enabled` configuration

### DIFF
--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -365,7 +365,7 @@ module NewRelic
           :public => true,
           :type => Boolean,
           :allowed_from_server => false,
-          :description => 'If `false`, all LLM (OpenAI, Bedrock) instrumentation will be disabled and no metrics, events, or spans will be sent. AI Monitoring is automatically disabled if `high_security` mode is enabled.'
+          :description => 'If `false`, all LLM (OpenAI) instrumentation will be disabled and no metrics, events, or spans will be sent. AI Monitoring is automatically disabled if `high_security` mode is enabled.'
         },
         # this is only set via server side config
         :apdex_t => {

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -364,7 +364,7 @@ module NewRelic
           :default => true,
           :public => true,
           :type => Boolean,
-          :allowed_from_server => true,
+          :allowed_from_server => false,
           :description => 'If `false`, all LLM (OpenAI, Bedrock) instrumentation will be disabled and no metrics, events, or spans will be sent. If `high_security` mode is enabled, no LLM events will be sent.'
         },
         # this is only set via server side config

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -360,6 +360,13 @@ module NewRelic
               - a.third.event
           DESCRIPTION
         },
+        :'ai_monitoring.enabled' => {
+          :default => true,
+          :public => true,
+          :type => Boolean,
+          :allowed_from_server => true,
+          :description => 'If `false`, all LLM (OpenAI, Bedrock) instrumentation will be disabled and no metrics, events, or spans will be sent. If `high_security` mode is enabled, no LLM events will be sent.'
+        },
         # this is only set via server side config
         :apdex_t => {
           :default => 0.5,

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -365,7 +365,7 @@ module NewRelic
           :public => true,
           :type => Boolean,
           :allowed_from_server => false,
-          :description => 'If `false`, all LLM (OpenAI, Bedrock) instrumentation will be disabled and no metrics, events, or spans will be sent. If `high_security` mode is enabled, no LLM events will be sent.'
+          :description => 'If `false`, all LLM (OpenAI, Bedrock) instrumentation will be disabled and no metrics, events, or spans will be sent. AI Monitoring is automatically disabled if `high_security` mode is enabled.'
         },
         # this is only set via server side config
         :apdex_t => {

--- a/lib/new_relic/agent/configuration/high_security_source.rb
+++ b/lib/new_relic/agent/configuration/high_security_source.rb
@@ -21,7 +21,7 @@ module NewRelic
 
             :'ai_monitoring.enabled' => false,
             :'custom_insights_events.enabled' => false,
-            :'strip_exception_messages.enabled' => true,
+            :'strip_exception_messages.enabled' => true
           })
         end
 

--- a/lib/new_relic/agent/configuration/high_security_source.rb
+++ b/lib/new_relic/agent/configuration/high_security_source.rb
@@ -19,8 +19,9 @@ module NewRelic
             :'elasticsearch.obfuscate_queries' => true,
             :'transaction_tracer.record_redis_arguments' => false,
 
+            :'ai_monitoring.enabled' => false,
             :'custom_insights_events.enabled' => false,
-            :'strip_exception_messages.enabled' => true
+            :'strip_exception_messages.enabled' => true,
           })
         end
 

--- a/lib/new_relic/agent/configuration/security_policy_source.rb
+++ b/lib/new_relic/agent/configuration/security_policy_source.rb
@@ -7,6 +7,8 @@ require 'new_relic/agent/configuration/dotted_hash'
 module NewRelic
   module Agent
     module Configuration
+      # The Language Security Policy Source gives customers the ability to
+      # configure high security mode settings.
       class SecurityPolicySource < DottedHash
         class << self
           def enabled?(option)
@@ -35,8 +37,6 @@ module NewRelic
           end
         end
 
-        # The Language Security Policy Source gives customers the ability to
-        # configure high security mode settings.
         # The keys of the security settings map are the names of security
         # policies received from the server. They map to multiple configuration
         # options in the local config. There is a hash of metadata that

--- a/lib/new_relic/agent/configuration/security_policy_source.rb
+++ b/lib/new_relic/agent/configuration/security_policy_source.rb
@@ -211,7 +211,6 @@ module NewRelic
         COLON_COLON = '::'.freeze
 
         def build_overrides(security_policies)
-          binding.irb
           security_policies.inject({}) do |settings, (policy_name, policy_settings)|
             SECURITY_SETTINGS_MAP[policy_name].each do |policy|
               next unless policy[:supported]

--- a/lib/new_relic/agent/configuration/security_policy_source.rb
+++ b/lib/new_relic/agent/configuration/security_policy_source.rb
@@ -147,6 +147,15 @@ module NewRelic
               permitted_fn: nil
             }
           ],
+          'ai_monitoring' => [
+            {
+              option: :'ai_monitoring.enabled',
+              supported: true,
+              enabled_fn: method(:enabled?),
+              disabled_value: false,
+              permitted_fn: nil
+            }
+          ],
           'allow_raw_exception_messages' => [
             {
               option: :'strip_exception_messages.enabled',
@@ -202,6 +211,7 @@ module NewRelic
         COLON_COLON = '::'.freeze
 
         def build_overrides(security_policies)
+          binding.irb
           security_policies.inject({}) do |settings, (policy_name, policy_settings)|
             SECURITY_SETTINGS_MAP[policy_name].each do |policy|
               next unless policy[:supported]

--- a/lib/new_relic/agent/configuration/security_policy_source.rb
+++ b/lib/new_relic/agent/configuration/security_policy_source.rb
@@ -35,6 +35,8 @@ module NewRelic
           end
         end
 
+        # The Language Security Policy Source gives customers the ability to
+        # configure high security mode settings.
         # The keys of the security settings map are the names of security
         # policies received from the server. They map to multiple configuration
         # options in the local config. There is a hash of metadata that

--- a/lib/new_relic/agent/instrumentation/ruby_openai.rb
+++ b/lib/new_relic/agent/instrumentation/ruby_openai.rb
@@ -13,7 +13,8 @@ DependencyDetection.defer do
 
   depends_on do
     NewRelic::Agent.config[:'ai_monitoring.enabled'] != false &&
-    # maybe add DT check here eventually?
+      NewRelic::Agent.config[:'instrumentation.ruby_openai'] != 'disabled' &&
+      # maybe add DT check here eventually?
       defined?(OpenAI) && defined?(OpenAI::Client) &&
       OPENAI_VERSION >= Gem::Version.new('3.4.0')
   end

--- a/lib/new_relic/agent/instrumentation/ruby_openai.rb
+++ b/lib/new_relic/agent/instrumentation/ruby_openai.rb
@@ -13,8 +13,6 @@ DependencyDetection.defer do
 
   depends_on do
     NewRelic::Agent.config[:'ai_monitoring.enabled'] != false &&
-      NewRelic::Agent.config[:'instrumentation.ruby_openai'] != 'disabled' &&
-      # maybe add DT check here eventually?
       defined?(OpenAI) && defined?(OpenAI::Client) &&
       OPENAI_VERSION >= Gem::Version.new('3.4.0')
   end

--- a/lib/new_relic/agent/instrumentation/ruby_openai.rb
+++ b/lib/new_relic/agent/instrumentation/ruby_openai.rb
@@ -12,9 +12,9 @@ DependencyDetection.defer do
   OPENAI_VERSION = Gem::Version.new(OpenAI::VERSION) if defined?(OpenAI)
 
   depends_on do
-    # add a config check for ai_monitoring.enabled
+    NewRelic::Agent.config[:'ai_monitoring.enabled'] != false &&
     # maybe add DT check here eventually?
-    defined?(OpenAI) && defined?(OpenAI::Client) &&
+      defined?(OpenAI) && defined?(OpenAI::Client) &&
       OPENAI_VERSION >= Gem::Version.new('3.4.0')
   end
 


### PR DESCRIPTION
Add new configuration `ai_monitoring.enabled`. This configuration will automatically be set to `false` if high-security mode is on and has been added to the Security Policy Source, which allows customers to customize high-security settings. 

closes #2439