### PR TITLE
Replace OPENAI_VERSION constant with direct calls

### DIFF
--- a/lib/new_relic/agent/instrumentation/ruby_openai.rb
+++ b/lib/new_relic/agent/instrumentation/ruby_openai.rb
@@ -9,18 +9,16 @@ require_relative 'ruby_openai/prepend'
 DependencyDetection.defer do
   named :'ruby_openai'
 
-  OPENAI_VERSION = Gem::Version.new(OpenAI::VERSION) if defined?(OpenAI)
-
   depends_on do
     # add a config check for ai_monitoring.enabled
     # maybe add DT check here eventually?
     defined?(OpenAI) && defined?(OpenAI::Client) &&
-      OPENAI_VERSION >= Gem::Version.new('3.4.0')
+      Gem::Version.new(OpenAI::VERSION) >= Gem::Version.new('3.4.0')
   end
 
   executes do
     if use_prepend?
-      if OPENAI_VERSION >= Gem::Version.new('5.0.0')
+      if Gem::Version.new(OpenAI::VERSION) >= Gem::Version.new('5.0.0')
         prepend_instrument OpenAI::Client,
           NewRelic::Agent::Instrumentation::OpenAI::Prepend,
           NewRelic::Agent::Instrumentation::OpenAI::VENDOR


### PR DESCRIPTION
This file may be loaded before OpenAI is loaded, so the constant may be incorrectly assigned to nil.