### PR TITLE
OpenAI: Error tracing

### DIFF
--- a/lib/new_relic/agent/error_collector.rb
+++ b/lib/new_relic/agent/error_collector.rb
@@ -216,6 +216,10 @@ module NewRelic
       def notice_segment_error(segment, exception, options = {})
         return if skip_notice_error?(exception)
 
+        if segment.llm_event
+          options.merge!(segment.llm_event.error_attributes(exception))
+        end
+
         segment.set_noticed_error(create_noticed_error(exception, options))
         exception
       rescue => e

--- a/lib/new_relic/agent/error_collector.rb
+++ b/lib/new_relic/agent/error_collector.rb
@@ -216,9 +216,7 @@ module NewRelic
       def notice_segment_error(segment, exception, options = {})
         return if skip_notice_error?(exception)
 
-        if segment.llm_event
-          options.merge!(segment.llm_event.error_attributes(exception))
-        end
+        options.merge!(segment.llm_event.error_attributes(exception)) if segment.llm_event
 
         segment.set_noticed_error(create_noticed_error(exception, options))
         exception

--- a/lib/new_relic/agent/instrumentation/ruby_openai/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/ruby_openai/instrumentation.rb
@@ -33,7 +33,7 @@ module NewRelic::Agent::Instrumentation
       segment.llm_event = event
       begin
         response = NewRelic::Agent::Tracer.capture_segment_error(segment) { yield }
-        # TODO: Remove !response.include?('error) when we drop support for versions below 4.0.0
+        # TODO: Remove !response.include?('error') when we drop support for versions below 4.0.0
         add_embeddings_response_params(response, event) if response && !response.include?('error')
 
         response
@@ -51,7 +51,7 @@ module NewRelic::Agent::Instrumentation
 
       begin
         response = NewRelic::Agent::Tracer.capture_segment_error(segment) { yield }
-        # TODO: Remove !response.include?('error) when we drop support for versions below 4.0.0
+        # TODO: Remove !response.include?('error') when we drop support for versions below 4.0.0
         if response && !response.include?('error')
           add_chat_completion_response_params(parameters, response, event)
           messages = update_chat_completion_messages(messages, response, event)

--- a/lib/new_relic/agent/llm/chat_completion_summary.rb
+++ b/lib/new_relic/agent/llm/chat_completion_summary.rb
@@ -23,7 +23,7 @@ module NewRelic
           response_choices_finish_reason: 'response.choices.finish_reason',
           temperature: 'request.temperature'
         }
-
+        ERROR_COMPLETION_ID = 'completion_id'
         EVENT_NAME = 'LlmChatCompletionSummary'
 
         attr_accessor(*ATTRIBUTES)
@@ -45,6 +45,29 @@ module NewRelic
 
         def event_name
           EVENT_NAME
+        end
+
+        def error_attributes(exception)
+          attrs = {}
+
+          if exception.respond_to?(:response)
+            attrs[ERROR_ATTRIBUTE_STATUS_CODE] = exception.response.dig(:status)
+
+            attrs[ERROR_ATTRIBUTE_CODE] = exception.response.dig(
+              :body,
+              LlmEvent::ERROR_STRING,
+              LlmEvent::CODE_STRING
+            )
+            attrs[ERROR_ATTRIBUTE_PARAM] = exception.response.dig(
+              :body,
+              LlmEvent::ERROR_STRING,
+              LlmEvent::PARAM_STRING
+            )
+          end
+
+          attrs[ERROR_COMPLETION_ID] = id
+
+          attrs
         end
       end
     end

--- a/lib/new_relic/agent/llm/chat_completion_summary.rb
+++ b/lib/new_relic/agent/llm/chat_completion_summary.rb
@@ -49,23 +49,19 @@ module NewRelic
 
         def error_attributes(exception)
           attrs = {}
-
-          if exception.respond_to?(:response)
-            attrs[ERROR_ATTRIBUTE_STATUS_CODE] = exception.response.dig(:status)
-
-            attrs[ERROR_ATTRIBUTE_CODE] = exception.response.dig(
-              :body,
-              LlmEvent::ERROR_STRING,
-              LlmEvent::CODE_STRING
-            )
-            attrs[ERROR_ATTRIBUTE_PARAM] = exception.response.dig(
-              :body,
-              LlmEvent::ERROR_STRING,
-              LlmEvent::PARAM_STRING
-            )
-          end
-
           attrs[ERROR_COMPLETION_ID] = id
+
+          error_attributes_from_response(exception, attrs)
+        end
+
+        private
+
+        def error_attributes_from_response(exception, attrs)
+          return attrs unless exception.respond_to?(:response)
+
+          attrs[ERROR_ATTRIBUTE_STATUS_CODE] = exception.response.dig(:status)
+          attrs[ERROR_ATTRIBUTE_CODE] = exception.response.dig(:body, ERROR_STRING, CODE_STRING)
+          attrs[ERROR_ATTRIBUTE_PARAM] = exception.response.dig(:body, ERROR_STRING, PARAM_STRING)
 
           attrs
         end

--- a/lib/new_relic/agent/llm/embedding.rb
+++ b/lib/new_relic/agent/llm/embedding.rb
@@ -42,23 +42,19 @@ module NewRelic
 
         def error_attributes(exception)
           attrs = {}
-
-          if exception.respond_to?(:response)
-            attrs[ERROR_ATTRIBUTE_STATUS_CODE] = exception.response.dig(:status)
-
-            attrs[ERROR_ATTRIBUTE_CODE] = exception.response.dig(
-              :body,
-              LlmEvent::ERROR_STRING,
-              LlmEvent::CODE_STRING
-            )
-            attrs[ERROR_ATTRIBUTE_PARAM] = exception.response.dig(
-              :body,
-              LlmEvent::ERROR_STRING,
-              LlmEvent::PARAM_STRING
-            )
-          end
-
           attrs[ERROR_EMBEDDING_ID] = id
+
+          error_attributes_from_response(exception, attrs)
+        end
+
+        private
+
+        def error_attributes_from_response(exception, attrs)
+          return attrs unless exception.respond_to?(:response)
+
+          attrs[ERROR_ATTRIBUTE_STATUS_CODE] = exception.response.dig(:status)
+          attrs[ERROR_ATTRIBUTE_CODE] = exception.response.dig(:body, ERROR_STRING, CODE_STRING)
+          attrs[ERROR_ATTRIBUTE_PARAM] = exception.response.dig(:body, ERROR_STRING, PARAM_STRING)
 
           attrs
         end

--- a/lib/new_relic/agent/llm/embedding.rb
+++ b/lib/new_relic/agent/llm/embedding.rb
@@ -16,6 +16,7 @@ module NewRelic
           response_usage_total_tokens: 'response.usage.total_tokens',
           response_usage_prompt_tokens: 'response.usage.prompt_tokens'
         }
+        ERROR_EMBEDDING_ID = 'embedding_id'
         EVENT_NAME = 'LlmEmbedding'
 
         attr_accessor(*ATTRIBUTES)
@@ -37,6 +38,29 @@ module NewRelic
 
         def event_name
           EVENT_NAME
+        end
+
+        def error_attributes(exception)
+          attrs = {}
+
+          if exception.respond_to?(:response)
+            attrs[ERROR_ATTRIBUTE_STATUS_CODE] = exception.response.dig(:status)
+
+            attrs[ERROR_ATTRIBUTE_CODE] = exception.response.dig(
+              :body,
+              LlmEvent::ERROR_STRING,
+              LlmEvent::CODE_STRING
+            )
+            attrs[ERROR_ATTRIBUTE_PARAM] = exception.response.dig(
+              :body,
+              LlmEvent::ERROR_STRING,
+              LlmEvent::PARAM_STRING
+            )
+          end
+
+          attrs[ERROR_EMBEDDING_ID] = id
+
+          attrs
         end
       end
     end

--- a/lib/new_relic/agent/llm/llm_event.rb
+++ b/lib/new_relic/agent/llm/llm_event.rb
@@ -81,7 +81,7 @@ module NewRelic
 
         # Subclasses that add attributes to noticed errors will override this method
         def error_attributes(exception)
-          {}
+          NewRelic::EMPTY_HASH
         end
 
         private

--- a/lib/new_relic/agent/llm/llm_event.rb
+++ b/lib/new_relic/agent/llm/llm_event.rb
@@ -19,6 +19,12 @@ module NewRelic
         INGEST_SOURCE = 'Ruby'
         LLM = :llm
         CUSTOM_ATTRIBUTE_CONVERSATION_ID = 'llm.conversation_id'
+        ERROR_ATTRIBUTE_STATUS_CODE = 'http.statusCode'
+        ERROR_ATTRIBUTE_CODE = 'error.code'
+        ERROR_ATTRIBUTE_PARAM = 'error.param'
+        ERROR_STRING = 'error'
+        CODE_STRING = 'code'
+        PARAM_STRING = 'param'
 
         attr_accessor(*ATTRIBUTES)
 
@@ -71,6 +77,11 @@ module NewRelic
 
         def record
           NewRelic::Agent.record_custom_event(event_name, event_attributes)
+        end
+
+        # Subclasses that add attributes to noticed errors will override this method
+        def error_attributes(exception)
+          {}
         end
 
         private

--- a/test/new_relic/agent/error_collector_test.rb
+++ b/test/new_relic/agent/error_collector_test.rb
@@ -615,6 +615,25 @@ module NewRelic::Agent
         assert_nothing_harvested_for_segment_errors
       end
 
+      def test_segment_error_with_llm_event_adds_attributes
+        expected_error_attributes = {'embedding_id' => 123}
+        with_segment do |segment|
+          segment.llm_event = NewRelic::Agent::Llm::Embedding.new(id: 123)
+          @error_collector.notice_segment_error(segment, StandardError.new)
+
+          assert_equal expected_error_attributes, segment.noticed_error.attributes_from_notice_error
+        end
+      end
+
+      def test_segment_error_without_llm_event
+        with_segment do |segment|
+          @error_collector.notice_segment_error(segment, StandardError.new)
+
+          assert_nil segment.llm_event
+          assert_equal NewRelic::EMPTY_HASH, segment.noticed_error.attributes_from_notice_error
+        end
+      end
+
       def test_build_customer_callback_hash
         custom_attributes = {billie_eilish: :bored}
         agent_attributes = {'http.statusCode': :bleachers__dont_take_the_money}

--- a/test/new_relic/agent/llm/llm_event_test.rb
+++ b/test/new_relic/agent/llm/llm_event_test.rb
@@ -89,5 +89,9 @@ module NewRelic::Agent::Llm
       assert_truthy harvest_transaction_events![1][0][2][:llm]
       assert_equal NewRelic::TestHelpers::Exceptions::TestError, exceptions.keys[0].class
     end
+
+    def test_error_attributes
+      assert_equal NewRelic::EMPTY_HASH, NewRelic::Agent::Llm::LlmEvent.new.error_attributes(StandardError.new)
+    end
   end
 end


### PR DESCRIPTION
When an error is raised by a segment that has an associated LLM event, the agent will add the following to the NoticedError's `attributes_from_notice_error` instance variable:
* `http.statusCode` => status code of the response with the error
* `error.code` => Value of `code` attribute returned from exception body
* `error.param` => Value of `param` attribute returned from exception body
* `completion_id` => `id`  of the related Llm::ChatCompletionSummary if the LlmEvent was of that type
* `embedding_id` => `id` of the related Llm::Embedding if the LlmEvent was of that type

This currently is formatted specifically for OpenAI responses, and may need to change when Bedrock is supported.

Closes #2405 