### PR TITLE
Update LLM event attributes 

### DIFF
--- a/lib/new_relic/agent/instrumentation/ruby_openai/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/ruby_openai/instrumentation.rb
@@ -69,7 +69,6 @@ module NewRelic::Agent::Instrumentation
         # TODO: POST-GA: Add metadata from add_custom_attributes if prefixed with 'llm.', except conversation_id
         vendor: VENDOR,
         conversation_id: conversation_id,
-        api_key_last_four_digits: parse_api_key,
         request_max_tokens: parameters[:max_tokens] || parameters['max_tokens'],
         request_model: parameters[:model] || parameters['model'],
         temperature: parameters[:temperature] || parameters['temperature']
@@ -81,7 +80,6 @@ module NewRelic::Agent::Instrumentation
         # TODO: POST-GA: Add metadata from add_custom_attributes if prefixed with 'llm.', except conversation_id
         vendor: VENDOR,
         input: parameters[:input] || parameters['input'],
-        api_key_last_four_digits: parse_api_key,
         request_model: parameters[:model] || parameters['model']
       )
     end
@@ -100,10 +98,6 @@ module NewRelic::Agent::Instrumentation
       event.response_model = response['model']
       event.response_usage_total_tokens = response['usage']['total_tokens']
       event.response_usage_prompt_tokens = response['usage']['prompt_tokens']
-    end
-
-    def parse_api_key
-      'sk-' + headers['Authorization'][-4..-1]
     end
 
     # The customer must call add_custom_attributes with llm.conversation_id

--- a/lib/new_relic/agent/llm/chat_completion_summary.rb
+++ b/lib/new_relic/agent/llm/chat_completion_summary.rb
@@ -11,8 +11,9 @@ module NewRelic
         include ChatCompletion
         include ResponseHeaders
 
-        ATTRIBUTES = %i[api_key_last_four_digits request_max_tokens
-          response_number_of_messages request_model response_usage_total_tokens response_usage_prompt_tokens response_usage_completion_tokens response_choices_finish_reason
+        ATTRIBUTES = %i[request_max_tokens response_number_of_messages
+          request_model response_usage_total_tokens response_usage_prompt_tokens
+          response_usage_completion_tokens response_choices_finish_reason
           request_temperature duration error]
         ATTRIBUTE_NAME_EXCEPTIONS = {
           response_number_of_messages: 'response.number_of_messages',
@@ -21,7 +22,7 @@ module NewRelic
           response_usage_prompt_tokens: 'response.usage.prompt_tokens',
           response_usage_completion_tokens: 'response.usage.completion_tokens',
           response_choices_finish_reason: 'response.choices.finish_reason',
-          temperature: 'request.temperature'
+          request_temperature: 'request.temperature'
         }
         ERROR_COMPLETION_ID = 'completion_id'
         EVENT_NAME = 'LlmChatCompletionSummary'

--- a/lib/new_relic/agent/llm/embedding.rb
+++ b/lib/new_relic/agent/llm/embedding.rb
@@ -8,9 +8,8 @@ module NewRelic
       class Embedding < LlmEvent
         include ResponseHeaders
 
-        ATTRIBUTES = %i[input api_key_last_four_digits request_model
-          response_usage_total_tokens response_usage_prompt_tokens duration
-          error]
+        ATTRIBUTES = %i[input request_model response_usage_total_tokens
+          response_usage_prompt_tokens duration error]
         ATTRIBUTE_NAME_EXCEPTIONS = {
           request_model: 'request.model',
           response_usage_total_tokens: 'response.usage.total_tokens',

--- a/lib/new_relic/agent/llm/llm_event.rb
+++ b/lib/new_relic/agent/llm/llm_event.rb
@@ -8,10 +8,10 @@ module NewRelic
       class LlmEvent
         # Every subclass must define its own ATTRIBUTES constant, an array of symbols representing
         # that class's unique attributes
-        ATTRIBUTES = %i[id request_id span_id transaction_id trace_id
-          response_model vendor ingest_source]
+        ATTRIBUTES = %i[id request_id span_id trace_id response_model vendor
+          ingest_source]
         # These attributes should not be passed as arguments to initialize and will be set by the agent
-        AGENT_DEFINED_ATTRIBUTES = %i[span_id transaction_id trace_id ingest_source]
+        AGENT_DEFINED_ATTRIBUTES = %i[span_id trace_id ingest_source]
         # Some attributes have names that can't be written as symbols used for metaprogramming.
         # The ATTRIBUTE_NAME_EXCEPTIONS hash should use the symbolized version of the name as the key
         # and the string version expected by the UI as the value.
@@ -44,7 +44,6 @@ module NewRelic
 
           @id = id || NewRelic::Agent::GuidGenerator.generate_guid
           @span_id = NewRelic::Agent::Tracer.current_span_id
-          @transaction_id = NewRelic::Agent::Tracer.current_transaction&.guid
           @trace_id = NewRelic::Agent::Tracer.current_trace_id
           @ingest_source = INGEST_SOURCE
         end

--- a/test/new_relic/agent/llm/chat_completion_message_test.rb
+++ b/test/new_relic/agent/llm/chat_completion_message_test.rb
@@ -12,12 +12,12 @@ module NewRelic::Agent::Llm
 
     def test_attributes_assigned_by_parent_present
       assert_includes NewRelic::Agent::Llm::ChatCompletionMessage.ancestors, NewRelic::Agent::Llm::LlmEvent
-      assert_includes NewRelic::Agent::Llm::LlmEvent::AGENT_DEFINED_ATTRIBUTES, :transaction_id
+      assert_includes NewRelic::Agent::Llm::LlmEvent::AGENT_DEFINED_ATTRIBUTES, :trace_id
 
       in_transaction do |txn|
         event = NewRelic::Agent::Llm::ChatCompletionMessage.new
 
-        assert_equal txn.guid, event.transaction_id
+        assert_equal txn.trace_id, event.trace_id
       end
     end
 
@@ -75,10 +75,9 @@ module NewRelic::Agent::Llm
         assert_equal 'LlmChatCompletionMessage', type['type']
 
         assert_equal 7, attributes['id']
-        assert_equal 25, attributes['conversation_id']
         assert_equal '789', attributes['request_id']
+        assert_equal 25, attributes['conversation_id'] # needs to be removed, see #2437
         assert_equal txn.current_segment.guid, attributes['span_id']
-        assert_equal txn.guid, attributes['transaction_id']
         assert_equal txn.trace_id, attributes['trace_id']
         assert_equal 'gpt-4', attributes['response.model']
         assert_equal 'OpenAI', attributes['vendor']

--- a/test/new_relic/agent/llm/embedding_test.rb
+++ b/test/new_relic/agent/llm/embedding_test.rb
@@ -12,12 +12,12 @@ module NewRelic::Agent::Llm
 
     def test_attributes_assigned_by_parent_present
       assert_includes NewRelic::Agent::Llm::Embedding.ancestors, NewRelic::Agent::Llm::LlmEvent
-      assert_includes NewRelic::Agent::Llm::LlmEvent::AGENT_DEFINED_ATTRIBUTES, :transaction_id
+      assert_includes NewRelic::Agent::Llm::LlmEvent::AGENT_DEFINED_ATTRIBUTES, :trace_id
 
       in_transaction do |txn|
         event = NewRelic::Agent::Llm::Embedding.new
 
-        assert_equal txn.guid, event.transaction_id
+        assert_equal txn.trace_id, event.trace_id
       end
     end
 
@@ -48,7 +48,6 @@ module NewRelic::Agent::Llm
       in_transaction do |txn|
         embedding = NewRelic::Agent::Llm::Embedding.new(input: 'Bonjour', request_model: 'text-embedding-ada-002', id: 123)
         embedding.request_id = '789'
-        embedding.api_key_last_four_digits = 'sk-0126'
         embedding.response_model = 'text-embedding-3-large'
         embedding.response_organization = 'newrelic-org-abc123'
         embedding.response_usage_total_tokens = '20'
@@ -73,10 +72,8 @@ module NewRelic::Agent::Llm
         assert_equal 123, attributes['id']
         assert_equal '789', attributes['request_id']
         assert_equal txn.current_segment.guid, attributes['span_id']
-        assert_equal txn.guid, attributes['transaction_id']
         assert_equal txn.trace_id, attributes['trace_id']
         assert_equal 'Bonjour', attributes['input']
-        assert_equal 'sk-0126', attributes['api_key_last_four_digits']
         assert_equal 'text-embedding-ada-002', attributes['request.model']
         assert_equal 'text-embedding-3-large', attributes['response.model']
         assert_equal 'newrelic-org-abc123', attributes['response.organization']

--- a/test/new_relic/agent/llm/llm_event_test.rb
+++ b/test/new_relic/agent/llm/llm_event_test.rb
@@ -11,13 +11,13 @@ module NewRelic::Agent::Llm
     end
 
     def test_agent_defined_attributes_set
-      assert_includes NewRelic::Agent::Llm::LlmEvent::AGENT_DEFINED_ATTRIBUTES, :transaction_id
+      assert_includes NewRelic::Agent::Llm::LlmEvent::AGENT_DEFINED_ATTRIBUTES, :trace_id
 
       in_transaction do |txn|
-        event = NewRelic::Agent::Llm::LlmEvent.new(transaction_id: 'fake')
+        event = NewRelic::Agent::Llm::LlmEvent.new(trace_id: 'fake')
 
-        refute_equal 'fake', event.transaction_id
-        assert_equal txn.guid, event.transaction_id
+        refute_equal 'fake', event.trace_id
+        assert_equal txn.trace_id, event.trace_id
       end
     end
 


### PR DESCRIPTION
The specification has changed since we initially created LLM events.
This PR updates the attributes to reflect the current spec.

Removes:
api_key_last_four_digits
transaction_id

Adds:
assertion for request.temperature

Closes #2459 