### PR TITLE
concurrent-ruby: verify a version string exists

### DIFF
--- a/lib/new_relic/agent/instrumentation/concurrent_ruby.rb
+++ b/lib/new_relic/agent/instrumentation/concurrent_ruby.rb
@@ -10,8 +10,9 @@ DependencyDetection.defer do
   named :'concurrent_ruby'
 
   depends_on do
-    defined?(Concurrent) &&
-      Gem::Version.new(Concurrent::VERSION) >= Gem::Version.new('1.1.5')
+    defined?(::Concurrent) &&
+      defined?(::Concurrent::VERSION) &&
+      Gem::Version.new(::Concurrent::VERSION) >= Gem::Version.new('1.1.5')
   end
 
   executes do

--- a/lib/new_relic/agent/instrumentation/concurrent_ruby.rb
+++ b/lib/new_relic/agent/instrumentation/concurrent_ruby.rb
@@ -10,9 +10,9 @@ DependencyDetection.defer do
   named :'concurrent_ruby'
 
   depends_on do
-    defined?(::Concurrent) &&
-      defined?(::Concurrent::VERSION) &&
-      Gem::Version.new(::Concurrent::VERSION) >= Gem::Version.new('1.1.5')
+    defined?(Concurrent) &&
+      defined?(Concurrent::VERSION) &&
+      Gem::Version.new(Concurrent::VERSION) >= Gem::Version.new('1.1.5')
   end
 
   executes do


### PR DESCRIPTION
Verify that `Concurrent::VERSION` is defined prior to attempting to use it.

Closes #2464