### PR TITLE
Add support for `llm.` custom attributes

### DIFF
--- a/lib/new_relic/agent/instrumentation/ruby_openai/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/ruby_openai/instrumentation.rb
@@ -151,7 +151,7 @@ module NewRelic::Agent::Instrumentation
     end
 
     def llm_custom_attributes
-      NewRelic::Agent::Tracer.current_transaction.attributes.custom_attributes.select { |k, v| k.to_s.match(/llm.*/) }
+      NewRelic::Agent::Tracer.current_transaction.attributes.custom_attributes.select { |k| k.to_s.match(/llm.*/) }
     end
 
     def record_openai_metric

--- a/lib/new_relic/agent/instrumentation/ruby_openai/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/ruby_openai/instrumentation.rb
@@ -150,7 +150,7 @@ module NewRelic::Agent::Instrumentation
     end
 
     def llm_custom_attributes
-      NewRelic::Agent::Tracer.current_transaction.attributes.custom_attributes.select { |k,v| k.to_s.match(/llm.*/)}
+      NewRelic::Agent::Tracer.current_transaction.attributes.custom_attributes.select { |k, v| k.to_s.match(/llm.*/) }
     end
 
     def record_openai_metric

--- a/lib/new_relic/agent/instrumentation/ruby_openai/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/ruby_openai/instrumentation.rb
@@ -146,6 +146,7 @@ module NewRelic::Agent::Instrumentation
         message.conversation_id = conversation_id
         message.request_id = summary.request_id
         message.response_model = response['model']
+        message.metadata = llm_custom_attributes
       end
     end
 

--- a/lib/new_relic/agent/instrumentation/ruby_openai/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/ruby_openai/instrumentation.rb
@@ -153,7 +153,7 @@ module NewRelic::Agent::Instrumentation
     def llm_custom_attributes
       attributes = NewRelic::Agent::Tracer.current_transaction&.attributes&.custom_attributes&.select { |k| k.to_s.match(/llm.*/) }
 
-      attributes.transform_keys! { |key| key[4..-1] } if !attributes.nil?
+      attributes&.transform_keys! { |key| key[4..-1] }
     end
 
     def record_openai_metric

--- a/lib/new_relic/agent/llm/llm_event.rb
+++ b/lib/new_relic/agent/llm/llm_event.rb
@@ -55,7 +55,7 @@ module NewRelic
           attributes_hash = attributes.each_with_object({}) do |attr, hash|
             hash[replace_attr_with_string(attr)] = instance_variable_get(:"@#{attr}")
           end
-          attributes_hash.merge!(metadata)
+          attributes_hash.merge!(metadata) if !metadata.empty?
         end
 
         # Subclasses define an attributes method to concatenate attributes
@@ -77,7 +77,6 @@ module NewRelic
         end
 
         def record
-          binding.irb
           NewRelic::Agent.record_custom_event(event_name, event_attributes)
         end
 

--- a/lib/new_relic/agent/llm/llm_event.rb
+++ b/lib/new_relic/agent/llm/llm_event.rb
@@ -54,7 +54,7 @@ module NewRelic
           attributes_hash = attributes.each_with_object({}) do |attr, hash|
             hash[replace_attr_with_string(attr)] = instance_variable_get(:"@#{attr}")
           end
-          attributes_hash.merge!(metadata) && attributes_hash.delete(:metadata)
+          attributes_hash.merge!(metadata) && attributes_hash.delete(:metadata) if !metadata.nil?
 
           attributes_hash
         end

--- a/lib/new_relic/agent/llm/llm_event.rb
+++ b/lib/new_relic/agent/llm/llm_event.rb
@@ -55,7 +55,9 @@ module NewRelic
           attributes_hash = attributes.each_with_object({}) do |attr, hash|
             hash[replace_attr_with_string(attr)] = instance_variable_get(:"@#{attr}")
           end
-          attributes_hash.merge!(metadata) if !metadata.empty?
+          attributes_hash.merge!(metadata) if !metadata.nil?
+
+          attributes_hash
         end
 
         # Subclasses define an attributes method to concatenate attributes

--- a/lib/new_relic/agent/llm/llm_event.rb
+++ b/lib/new_relic/agent/llm/llm_event.rb
@@ -27,6 +27,7 @@ module NewRelic
         PARAM_STRING = 'param'
 
         attr_accessor(*ATTRIBUTES)
+        attr_accessor :metadata
 
         def self.set_llm_agent_attribute_on_transaction
           NewRelic::Agent::Transaction.add_agent_attribute(LLM, true, NewRelic::Agent::AttributeFilter::DST_TRANSACTION_EVENTS)
@@ -51,9 +52,10 @@ module NewRelic
         # All subclasses use event_attributes to get a full hash of all
         # attributes and their values
         def event_attributes
-          attributes.each_with_object({}) do |attr, hash|
+          attributes_hash = attributes.each_with_object({}) do |attr, hash|
             hash[replace_attr_with_string(attr)] = instance_variable_get(:"@#{attr}")
           end
+          attributes_hash.merge!(metadata)
         end
 
         # Subclasses define an attributes method to concatenate attributes
@@ -75,6 +77,7 @@ module NewRelic
         end
 
         def record
+          binding.irb
           NewRelic::Agent.record_custom_event(event_name, event_attributes)
         end
 

--- a/lib/new_relic/agent/llm/llm_event.rb
+++ b/lib/new_relic/agent/llm/llm_event.rb
@@ -9,7 +9,7 @@ module NewRelic
         # Every subclass must define its own ATTRIBUTES constant, an array of symbols representing
         # that class's unique attributes
         ATTRIBUTES = %i[id request_id span_id trace_id response_model vendor
-          ingest_source]
+          ingest_source metadata]
         # These attributes should not be passed as arguments to initialize and will be set by the agent
         AGENT_DEFINED_ATTRIBUTES = %i[span_id trace_id ingest_source]
         # Some attributes have names that can't be written as symbols used for metaprogramming.
@@ -27,7 +27,6 @@ module NewRelic
         PARAM_STRING = 'param'
 
         attr_accessor(*ATTRIBUTES)
-        attr_accessor :metadata
 
         def self.set_llm_agent_attribute_on_transaction
           NewRelic::Agent::Transaction.add_agent_attribute(LLM, true, NewRelic::Agent::AttributeFilter::DST_TRANSACTION_EVENTS)
@@ -55,7 +54,7 @@ module NewRelic
           attributes_hash = attributes.each_with_object({}) do |attr, hash|
             hash[replace_attr_with_string(attr)] = instance_variable_get(:"@#{attr}")
           end
-          attributes_hash.merge!(metadata) if !metadata.nil?
+          attributes_hash.merge!(metadata) && attributes_hash.delete(:metadata)
 
           attributes_hash
         end

--- a/test/multiverse/suites/ruby_openai/ruby_openai_instrumentation_test.rb
+++ b/test/multiverse/suites/ruby_openai/ruby_openai_instrumentation_test.rb
@@ -135,7 +135,8 @@ class RubyOpenAIInstrumentationTest < Minitest::Test
       NewRelic::Agent.add_custom_attributes({
         'llm.conversation_id' => '1993',
         'llm.JurassicPark' => 'Steven Spielberg',
-        'trex' => 'carnivore' })
+        'trex' => 'carnivore'
+      })
       stub_post_request do
         client.chat(parameters: chat_params)
       end
@@ -154,7 +155,8 @@ class RubyOpenAIInstrumentationTest < Minitest::Test
       NewRelic::Agent.add_custom_attributes({
         'llm.conversation_id' => '1997',
         'llm.TheLostWorld' => 'Steven Spielberg',
-        'triceratops' => 'herbivore' })
+        'triceratops' => 'herbivore'
+      })
       stub_post_request do
         client.embeddings(parameters: chat_params)
       end
@@ -172,7 +174,8 @@ class RubyOpenAIInstrumentationTest < Minitest::Test
       NewRelic::Agent.add_custom_attributes({
         'llm.conversation_id' => '2001',
         'llm.JurassicParkIII' => 'Joe Johnston',
-        'Pterosaur' => 'Can fly — scary!' })
+        'Pterosaur' => 'Can fly — scary!'
+      })
       stub_post_request do
         client.chat(parameters: chat_params)
       end

--- a/test/multiverse/suites/ruby_openai/ruby_openai_instrumentation_test.rb
+++ b/test/multiverse/suites/ruby_openai/ruby_openai_instrumentation_test.rb
@@ -145,8 +145,8 @@ class RubyOpenAIInstrumentationTest < Minitest::Test
     _, events = @aggregator.harvest!
     summary_event = events.find { |event| event[0]['type'] == NewRelic::Agent::Llm::ChatCompletionSummary::EVENT_NAME }
 
-    assert_equal '1993', summary_event[1]['llm.conversation_id']
-    assert_equal 'Steven Spielberg', summary_event[1]['llm.JurassicPark']
+    assert_equal '1993', summary_event[1]['conversation_id']
+    assert_equal 'Steven Spielberg', summary_event[1]['JurassicPark']
     refute summary_event[1]['trex']
   end
 
@@ -164,8 +164,8 @@ class RubyOpenAIInstrumentationTest < Minitest::Test
     _, events = @aggregator.harvest!
     embedding_event = events.find { |event| event[0]['type'] == NewRelic::Agent::Llm::Embedding::EVENT_NAME }
 
-    assert_equal '1997', embedding_event[1]['llm.conversation_id']
-    assert_equal 'Steven Spielberg', embedding_event[1]['llm.TheLostWorld']
+    assert_equal '1997', embedding_event[1]['conversation_id']
+    assert_equal 'Steven Spielberg', embedding_event[1]['TheLostWorld']
     refute embedding_event[1]['fruit']
   end
 
@@ -184,8 +184,8 @@ class RubyOpenAIInstrumentationTest < Minitest::Test
     message_events = events.filter { |event| event[0]['type'] == NewRelic::Agent::Llm::ChatCompletionMessage::EVENT_NAME }
 
     message_events.each do |event|
-      assert_equal '2001', event[1]['llm.conversation_id']
-      assert_equal 'Joe Johnston', event[1]['llm.JurassicParkIII']
+      assert_equal '2001', event[1]['conversation_id']
+      assert_equal 'Joe Johnston', event[1]['JurassicParkIII']
       refute event[1]['Pterosaur']
     end
   end

--- a/test/new_relic/agent/llm/llm_event_test.rb
+++ b/test/new_relic/agent/llm/llm_event_test.rb
@@ -55,6 +55,7 @@ module NewRelic::Agent::Llm
 
       assert_equal('26.2', result['Marathon'])
       assert_equal('Ouch', result['Ultra Marathon'])
+      assert_equal('OpenAI', result[:vendor])
     end
 
     def test_record_does_not_create_an_event

--- a/test/new_relic/agent/llm/llm_event_test.rb
+++ b/test/new_relic/agent/llm/llm_event_test.rb
@@ -46,6 +46,17 @@ module NewRelic::Agent::Llm
       assert_equal('gpt-4', result['response.model'])
     end
 
+    def test_event_attributes_adds_custom_attributes
+      event = NewRelic::Agent::Llm::LlmEvent.new(id: 123)
+      event.vendor = 'OpenAI'
+      event.response_model = 'gpt-4'
+      event.metadata = {'Marathon' => 26.2, 'Ultra Marathon' => 'Ouch'}
+      result = event.event_attributes
+
+      assert_equal(26.2, result['Marathon'])
+      assert_equal('Ouch', result['Ultra Marathon'])
+    end
+
     def test_record_does_not_create_an_event
       event = NewRelic::Agent::Llm::LlmEvent.new
       event.record

--- a/test/new_relic/agent/llm/llm_event_test.rb
+++ b/test/new_relic/agent/llm/llm_event_test.rb
@@ -50,10 +50,10 @@ module NewRelic::Agent::Llm
       event = NewRelic::Agent::Llm::LlmEvent.new(id: 123)
       event.vendor = 'OpenAI'
       event.response_model = 'gpt-4'
-      event.metadata = {'Marathon' => 26.2, 'Ultra Marathon' => 'Ouch'}
+      event.metadata = {'Marathon' => '26.2', 'Ultra Marathon' => 'Ouch'}
       result = event.event_attributes
 
-      assert_equal(26.2, result['Marathon'])
+      assert_equal('26.2', result['Marathon'])
       assert_equal('Ouch', result['Ultra Marathon'])
     end
 


### PR DESCRIPTION
Adds custom attributes to LLM events when prefixed with `llm.`. 

Closes #2437 

