### PR TITLE
Thread-local storage for Tracer.state

### DIFF
--- a/lib/new_relic/agent.rb
+++ b/lib/new_relic/agent.rb
@@ -31,6 +31,7 @@ module NewRelic
     require 'new_relic/noticed_error'
     require 'new_relic/agent/noticeable_error'
     require 'new_relic/supportability_helper'
+    require 'new_relic/thread_local_storage'
 
     require 'new_relic/agent/encoding_normalizer'
     require 'new_relic/agent/stats'

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -554,6 +554,13 @@ module NewRelic
           :allowed_from_server => false,
           :description => 'When set to `true`, forces a synchronous connection to the New Relic [collector](/docs/using-new-relic/welcome-new-relic/get-started/glossary/#collector) during application startup. For very short-lived processes, this helps ensure the New Relic agent has time to report.'
         },
+        :thread_local_tracer_state => {
+          :default => false,
+          :public => true,
+          :type => Boolean,
+          :allowed_from_server => false,
+          :description => 'If `true`, tracer state storage is thread-local, otherwise, fiber-local'
+        },
         :timeout => {
           :default => 2 * 60, # 2 minutes
           :public => true,

--- a/lib/new_relic/agent/threading/agent_thread.rb
+++ b/lib/new_relic/agent/threading/agent_thread.rb
@@ -9,8 +9,7 @@ module NewRelic
         def self.create(label, &blk)
           ::NewRelic::Agent.logger.debug("Creating AgentThread: #{label}")
           wrapped_blk = proc do
-            if ::Thread.current[:newrelic_tracer_state] && Thread.current[:newrelic_tracer_state].current_transaction
-              txn = ::Thread.current[:newrelic_tracer_state].current_transaction
+            if (txn = ::NewRelic::ThreadLocalStorage[:newrelic_tracer_state]&.current_transaction)
               ::NewRelic::Agent.logger.warn("AgentThread created with current transaction #{txn.best_name}")
             end
             begin

--- a/lib/new_relic/agent/transaction/tracing.rb
+++ b/lib/new_relic/agent/transaction/tracing.rb
@@ -41,11 +41,11 @@ module NewRelic
 
         def thread_starting_span
           # if the previous current segment was in another thread, use the thread local parent
-          if ::Thread.current[:newrelic_thread_span_parent] &&
+          if ThreadLocalStorage[:newrelic_thread_span_parent] &&
               current_segment &&
               current_segment.starting_segment_key != NewRelic::Agent::Tracer.current_segment_key
 
-            ::Thread.current[:newrelic_thread_span_parent]
+            ThreadLocalStorage[:newrelic_thread_span_parent]
           end
         end
 

--- a/lib/new_relic/thread_local_storage.rb
+++ b/lib/new_relic/thread_local_storage.rb
@@ -1,0 +1,23 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+module NewRelic
+  module ThreadLocalStorage
+    def self.get(thread, key)
+      thread[key]
+    end
+
+    def self.set(thread, key, value)
+      thread[key] = value
+    end
+
+    def self.[](key)
+      get(::Thread.current, key)
+    end
+
+    def self.[]=(key, value)
+      set(::Thread.current, key, value)
+    end
+  end
+end

--- a/lib/new_relic/thread_local_storage.rb
+++ b/lib/new_relic/thread_local_storage.rb
@@ -5,11 +5,19 @@
 module NewRelic
   module ThreadLocalStorage
     def self.get(thread, key)
-      thread[key]
+      if Agent.config[:thread_local_tracer_state]
+        thread.thread_variable_get(key)
+      else
+        thread[key]
+      end
     end
 
     def self.set(thread, key, value)
-      thread[key] = value
+      if Agent.config[:thread_local_tracer_state]
+        thread.thread_variable_set(key, value)
+      else
+        thread[key] = value
+      end
     end
 
     def self.[](key)

--- a/newrelic.yml
+++ b/newrelic.yml
@@ -704,6 +704,9 @@ common: &default_settings
   # the New Relic agent has time to report.
   # sync_startup: false
 
+  # If true, tracer state storage is thread-local, otherwise, fiber-local
+  # thread_local_tracer_state: false
+
   # If true, enables use of the thread profiler.
   # thread_profiler.enabled: false
 

--- a/test/multiverse/suites/rake/instrumentation_test.rb
+++ b/test/multiverse/suites/rake/instrumentation_test.rb
@@ -57,7 +57,7 @@ class RakeInstrumentationTest < Minitest::Test
     NewRelic::Agent::Instrumentation::Rake.stub :should_trace?, true, [instance.name] do
       error = RuntimeError.new('expected')
       # produce the exception we want to have the method rescue
-      NewRelic::Agent.stub :config, -> { raise error } do
+      NewRelic::Agent.stub :instance, -> { raise error } do
         logger = MiniTest::Mock.new
         NewRelic::Agent.stub :logger, logger do
           logger.expect :error, nil, [/^Exception/, error]

--- a/test/new_relic/agent/tracer_test.rb
+++ b/test/new_relic/agent/tracer_test.rb
@@ -17,6 +17,16 @@ module NewRelic
         refute_nil state
       end
 
+      def test_tracer_state_in_fiber_with_thread_local_tracer_state
+        with_config(:thread_local_tracer_state => true) do
+          state = Tracer.state
+          fiber = Fiber.new do
+            assert_equal Tracer.state, state
+          end
+          fiber.resume
+        end
+      end
+
       def test_current_transaction_with_transaction
         in_transaction do |txn|
           assert_equal txn, Tracer.current_transaction

--- a/test/new_relic/thread_local_storage_test.rb
+++ b/test/new_relic/thread_local_storage_test.rb
@@ -1,0 +1,42 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require 'new_relic/thread_local_storage'
+
+class NewRelic::ThreadLocalStorageTest < Minitest::Test
+  def test_basic_ops
+    assert_nil NewRelic::ThreadLocalStorage.get(Thread.current, :basic)
+    NewRelic::ThreadLocalStorage.set(Thread.current, :basic, 'foobar')
+
+    assert_equal('foobar', NewRelic::ThreadLocalStorage.get(Thread.current, :basic))
+    NewRelic::ThreadLocalStorage.set(Thread.current, :basic, 12345)
+
+    assert_equal(12345, NewRelic::ThreadLocalStorage.get(Thread.current, :basic))
+  end
+
+  def test_shortcut_ops
+    assert_nil NewRelic::ThreadLocalStorage[:shortcut]
+    NewRelic::ThreadLocalStorage[:shortcut] = 'baz'
+
+    assert_equal('baz', NewRelic::ThreadLocalStorage[:shortcut])
+    NewRelic::ThreadLocalStorage[:shortcut] = 98765
+
+    assert_equal(98765, NewRelic::ThreadLocalStorage[:shortcut])
+  end
+
+  def test_new_thread
+    NewRelic::ThreadLocalStorage[:new_thread] = :parent
+    thread = Thread.new do
+      assert_nil NewRelic::ThreadLocalStorage[:new_thread]
+      NewRelic::ThreadLocalStorage[:new_thread] = :child
+      sleep
+    end
+    sleep 0.2
+
+    assert_equal(:parent, NewRelic::ThreadLocalStorage[:new_thread])
+    assert_equal(:child, NewRelic::ThreadLocalStorage.get(thread, :new_thread))
+    thread.exit
+  end
+end


### PR DESCRIPTION
# Overview

## Background

We were working on a certain sidekiq job that was generating a large (300+mb) CSV file, and to deal with the growing memory usage, we've implemented streaming. That implementation included using custom Ruby Enumerators.

When we launched it in production, we've noticed that NewRelic no longer traces database calls within the sidekiq job transaction. After some debugging, it turned out that the reason for that was that NewRelic holds its tracer state in the `Thread#[...]` storage. However, `Thread#[...]` is actually a fiber-local storage, and our implementation specifically used `Enumerator#next`, which spawns a new `Fiber`. As a result, NewRelic lost track of the current tracer state and attributed everything within that enumerator to CPU burn.

Support case where this issue originated is at https://support.newrelic.com/s/case-details?caseId=500Ph000007YRJX

## Proposed Solution

This PR includes a small new abstraction `NewRelic::ThreadLocalStorage` that is used instead of the `Thread#[...]` where applicable. Its behavior is controlled by the new configuration option: `thread_local_tracer_state` (default: false) — when `false`, keeps the original behavior, when `true`, uses `Thread#thread_variable_get` and `Thread#thread_variable_set` in place of `Thread#[]` and `Thread#[]=` respectively. I'm not 100% sure how safe it would be to use the new behavior across the board, because there could be fiber-based server implementations that also use NewRelic and rely on that storage being fiber-local, hence the configuration option.

There is also one spot where I wasn't entirely sure whether a change from `Thread.current[]` to `ThreadLocalStorage[]` makes sense (`NewRelic::Agent::Instrumentation::NotificationsSubscriber#segment_stack`), so I haven't touched that. 

# Submitter Checklist:
- [x] Include a link to the related GitHub issue, if applicable
- [x] Include a security review link, if applicable

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
