### PR TITLE
Remove outdated token-related attributes

### DIFF
--- a/lib/new_relic/agent/instrumentation/ruby_openai/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/ruby_openai/instrumentation.rb
@@ -88,16 +88,11 @@ module NewRelic::Agent::Instrumentation
       event.response_number_of_messages = (parameters[:messages] || parameters['messages']).size + response['choices'].size
       # The response hash always returns keys as strings, so we don't need to run an || check here
       event.response_model = response['model']
-      event.response_usage_total_tokens = response['usage']['total_tokens']
-      event.response_usage_prompt_tokens = response['usage']['prompt_tokens']
-      event.response_usage_completion_tokens = response['usage']['completion_tokens']
       event.response_choices_finish_reason = response['choices'][0]['finish_reason']
     end
 
     def add_embeddings_response_params(response, event)
       event.response_model = response['model']
-      event.response_usage_total_tokens = response['usage']['total_tokens']
-      event.response_usage_prompt_tokens = response['usage']['prompt_tokens']
     end
 
     # The customer must call add_custom_attributes with llm.conversation_id

--- a/lib/new_relic/agent/llm/chat_completion_summary.rb
+++ b/lib/new_relic/agent/llm/chat_completion_summary.rb
@@ -12,15 +12,11 @@ module NewRelic
         include ResponseHeaders
 
         ATTRIBUTES = %i[request_max_tokens response_number_of_messages
-          request_model response_usage_total_tokens response_usage_prompt_tokens
-          response_usage_completion_tokens response_choices_finish_reason
-          request_temperature duration error]
+          request_model response_choices_finish_reason request_temperature
+          duration error]
         ATTRIBUTE_NAME_EXCEPTIONS = {
           response_number_of_messages: 'response.number_of_messages',
           request_model: 'request.model',
-          response_usage_total_tokens: 'response.usage.total_tokens',
-          response_usage_prompt_tokens: 'response.usage.prompt_tokens',
-          response_usage_completion_tokens: 'response.usage.completion_tokens',
           response_choices_finish_reason: 'response.choices.finish_reason',
           request_temperature: 'request.temperature'
         }

--- a/lib/new_relic/agent/llm/embedding.rb
+++ b/lib/new_relic/agent/llm/embedding.rb
@@ -8,12 +8,9 @@ module NewRelic
       class Embedding < LlmEvent
         include ResponseHeaders
 
-        ATTRIBUTES = %i[input request_model response_usage_total_tokens
-          response_usage_prompt_tokens duration error]
+        ATTRIBUTES = %i[input request_model duration error]
         ATTRIBUTE_NAME_EXCEPTIONS = {
           request_model: 'request.model',
-          response_usage_total_tokens: 'response.usage.total_tokens',
-          response_usage_prompt_tokens: 'response.usage.prompt_tokens'
         }
         ERROR_EMBEDDING_ID = 'embedding_id'
         EVENT_NAME = 'LlmEmbedding'

--- a/lib/new_relic/agent/llm/embedding.rb
+++ b/lib/new_relic/agent/llm/embedding.rb
@@ -10,7 +10,7 @@ module NewRelic
 
         ATTRIBUTES = %i[input request_model duration error]
         ATTRIBUTE_NAME_EXCEPTIONS = {
-          request_model: 'request.model',
+          request_model: 'request.model'
         }
         ERROR_EMBEDDING_ID = 'embedding_id'
         EVENT_NAME = 'LlmEmbedding'

--- a/test/new_relic/agent/llm/chat_completion_summary_test.rb
+++ b/test/new_relic/agent/llm/chat_completion_summary_test.rb
@@ -62,16 +62,12 @@ module NewRelic::Agent::Llm
         )
         summary.request_id = '789'
         summary.conversation_id = 456
-        summary.response_usage_total_tokens = 20
         summary.request_temperature = 0.7
         summary.request_max_tokens = 500
         summary.request_model = 'gpt-4-turbo-preview'
         summary.response_model = 'gpt-4'
         summary.response_organization = 'newrelic-org-abc123'
         summary.response_number_of_messages = 5
-        summary.response_usage_total_tokens = 20
-        summary.response_usage_prompt_tokens = '24'
-        summary.response_usage_completion_tokens = '26'
         summary.response_choices_finish_reason = 'stop'
         summary.vendor = 'OpenAI'
         summary.duration = '500'
@@ -101,9 +97,6 @@ module NewRelic::Agent::Llm
         assert_equal 'gpt-4-turbo-preview', attributes['request.model']
         assert_equal 'gpt-4', attributes['response.model']
         assert_equal 'newrelic-org-abc123', attributes['response.organization']
-        assert_equal 20, attributes['response.usage.total_tokens']
-        assert_equal '24', attributes['response.usage.prompt_tokens']
-        assert_equal '26', attributes['response.usage.completion_tokens']
         assert_equal 'stop', attributes['response.choices.finish_reason']
         assert_equal 'OpenAI', attributes['vendor']
         assert_equal 'Ruby', attributes['ingest_source']

--- a/test/new_relic/agent/llm/embedding_test.rb
+++ b/test/new_relic/agent/llm/embedding_test.rb
@@ -50,8 +50,6 @@ module NewRelic::Agent::Llm
         embedding.request_id = '789'
         embedding.response_model = 'text-embedding-3-large'
         embedding.response_organization = 'newrelic-org-abc123'
-        embedding.response_usage_total_tokens = '20'
-        embedding.response_usage_prompt_tokens = '24'
         embedding.vendor = 'OpenAI'
         embedding.duration = '500'
         embedding.error = 'true'
@@ -77,8 +75,6 @@ module NewRelic::Agent::Llm
         assert_equal 'text-embedding-ada-002', attributes['request.model']
         assert_equal 'text-embedding-3-large', attributes['response.model']
         assert_equal 'newrelic-org-abc123', attributes['response.organization']
-        assert_equal '20', attributes['response.usage.total_tokens']
-        assert_equal '24', attributes['response.usage.prompt_tokens']
         assert_equal 'OpenAI', attributes['vendor']
         assert_equal 'Ruby', attributes['ingest_source']
         assert_equal '500', attributes['duration']


### PR DESCRIPTION
The following attributes are no longer in ChatCompletionSummary events:
* response_usage.total_tokens
* response_usage.prompt_tokens
* response_usage.completion_tokens

The following attributes are no longer in Embedding events:
* response_usage.total_tokens
* response_usage.prompt_tokens

Closes: #2449