### PR TITLE
Create `set_llm_token_count_callback` API

### DIFF
--- a/lib/new_relic/agent.rb
+++ b/lib/new_relic/agent.rb
@@ -445,7 +445,7 @@ module NewRelic
     #
     # @param callback_proc [Proc] the callback proc
     #
-    # Typically this method should be called only once to set a callback for
+    # This method should be called only once to set a callback for
     # use with all LLM token calculations. If it is called multiple times, each
     # new callback will replace the old one.
     #

--- a/lib/new_relic/supportability_helper.rb
+++ b/lib/new_relic/supportability_helper.rb
@@ -46,6 +46,7 @@ module NewRelic
       :recording_web_transaction?,
       :require_test_helper,
       :set_error_group_callback,
+      :set_llm_token_count_callback,
       :set_segment_callback,
       :set_sql_obfuscator,
       :set_transaction_name,

--- a/test/new_relic/agent_test.rb
+++ b/test/new_relic/agent_test.rb
@@ -587,6 +587,60 @@ module NewRelic
       assert called
     end
 
+    def test_set_llm_token_count_callback
+      lambda = -> { 'Hello, World!' }
+      NewRelic::Agent.set_llm_token_count_callback(lambda)
+
+      assert_equal lambda,
+        NewRelic::Agent.instance_variable_get(:@llm_token_count_callback),
+        'Supplied llm token callback proc was not found to be set.'
+    end
+
+    def test_set_llm_token_count_callback_can_be_called_multiple_times
+      procs = [proc { 'one' }, proc { 'two' }, proc { 'three' }]
+      procs.each { |proc| NewRelic::Agent.set_llm_token_count_callback(proc) }
+
+      assert_equal procs.last,
+        NewRelic::Agent.instance_variable_get(:@llm_token_count_callback),
+        'Supplied llm token callback proc was not found to be set.'
+    end
+
+    def test_set_llm_token_count_callback_rejects_non_proc
+      skip_unless_minitest5_or_above
+
+      NewRelic::Agent.instance_variable_set(:@llm_token_count_callback, nil)
+
+      mock_logger = MiniTest::Mock.new
+      mock_logger.expect :error, nil, [/expected an argument of type Proc/]
+
+      NewRelic::Agent.stub(:logger, mock_logger) do
+        NewRelic::Agent.set_llm_token_count_callback([])
+      end
+
+      mock_logger.verify
+
+      assert_nil NewRelic::Agent.instance_variable_get(:@llm_token_count_callback)
+    end
+
+    def test_llm_token_count_callback_is_exposed
+      callback = 'shhhhhh'
+      NewRelic::Agent.instance_variable_set(:@llm_token_count_callback, callback)
+
+      assert_equal callback, NewRelic::Agent.llm_token_count_callback
+    ensure
+      NewRelic::Agent.remove_instance_variable(:@llm_token_count_callback)
+    end
+
+    def test_successful_set_llm_token_count_callback_api_invocation_produces_supportability_metrics
+      called = false
+      verification_proc = proc { |name| called = true if name == :set_llm_token_count_callback }
+      NewRelic::Agent.stub :record_api_supportability_metric, verification_proc do
+        NewRelic::Agent.set_llm_token_count_callback(proc {})
+      end
+
+      assert called
+    end
+
     def test_set_user_id_attribute
       test_user = 'test_user_id'
 


### PR DESCRIPTION
The API accepts one argument, a proc, that should contain the callback the agent will invoke if it cannot glean the token count from instrumentation.

A supportability metric is recorded when the API is called.

Closes: #2451