### PR TITLE
OpenAI: Update response headers

### DIFF
--- a/lib/new_relic/agent/llm/response_headers.rb
+++ b/lib/new_relic/agent/llm/response_headers.rb
@@ -50,8 +50,8 @@ module NewRelic
           self.request_id = headers[X_REQUEST_ID]&.first
           self.response_organization = headers[OPENAI_ORGANIZATION]&.first
           self.llm_version = headers[OPENAI_VERSION]&.first
-          self.rate_limit_requests = headers[X_RATELIMIT_LIMIT_REQUESTS]&.first
-          self.rate_limit_tokens = headers[X_RATELIMIT_LIMIT_TOKENS]&.first
+          self.rate_limit_requests = headers[X_RATELIMIT_LIMIT_REQUESTS]&.first&.to_i
+          self.rate_limit_tokens = headers[X_RATELIMIT_LIMIT_TOKENS]&.first&.to_i
           remaining_headers(headers)
           reset_headers(headers)
           tokens_usage_based_headers(headers)
@@ -60,8 +60,8 @@ module NewRelic
         private
 
         def remaining_headers(headers)
-          self.rate_limit_remaining_requests = headers[X_RATELIMIT_REMAINING_REQUESTS]&.first
-          self.rate_limit_remaining_tokens = headers[X_RATELIMIT_REMAINING_TOKENS]&.first
+          self.rate_limit_remaining_requests = headers[X_RATELIMIT_REMAINING_REQUESTS]&.first&.to_i
+          self.rate_limit_remaining_tokens = headers[X_RATELIMIT_REMAINING_TOKENS]&.first&.to_i
         end
 
         def reset_headers(headers)
@@ -71,8 +71,8 @@ module NewRelic
 
         def tokens_usage_based_headers(headers)
           self.rate_limit_limit_tokens_usage_based = headers[X_RATELIMIT_LIMIT_TOKENS_USAGE_BASED]&.first
-          self.rate_limit_reset_tokens_usage_based = headers[X_RATELIMIT_RESET_TOKENS_USAGE_BASED]&.first
-          self.rate_limit_remaining_tokens_usage_based = headers[X_RATELIMIT_REMAINING_TOKENS_USAGE_BASED]&.first
+          self.rate_limit_reset_tokens_usage_based = headers[X_RATELIMIT_RESET_TOKENS_USAGE_BASED]&.first&.to_i
+          self.rate_limit_remaining_tokens_usage_based = headers[X_RATELIMIT_REMAINING_TOKENS_USAGE_BASED]&.first&.to_i
         end
       end
     end

--- a/lib/new_relic/agent/llm/response_headers.rb
+++ b/lib/new_relic/agent/llm/response_headers.rb
@@ -70,8 +70,8 @@ module NewRelic
         end
 
         def tokens_usage_based_headers(headers)
-          self.ratelimit_limit_tokens_usage_based = headers[X_RATELIMIT_LIMIT_TOKENS_USAGE_BASED]&.first
-          self.ratelimit_reset_tokens_usage_based = headers[X_RATELIMIT_RESET_TOKENS_USAGE_BASED]&.first&.to_i
+          self.ratelimit_limit_tokens_usage_based = headers[X_RATELIMIT_LIMIT_TOKENS_USAGE_BASED]&.first&.to_i
+          self.ratelimit_reset_tokens_usage_based = headers[X_RATELIMIT_RESET_TOKENS_USAGE_BASED]&.first
           self.ratelimit_remaining_tokens_usage_based = headers[X_RATELIMIT_REMAINING_TOKENS_USAGE_BASED]&.first&.to_i
         end
       end

--- a/lib/new_relic/agent/llm/response_headers.rb
+++ b/lib/new_relic/agent/llm/response_headers.rb
@@ -50,8 +50,8 @@ module NewRelic
           self.request_id = headers[X_REQUEST_ID]&.first
           self.response_organization = headers[OPENAI_ORGANIZATION]&.first
           self.llm_version = headers[OPENAI_VERSION]&.first
-          self.ratelimit_limit_requests = headers[X_RATELIMIT_LIMIT_REQUESTS]&.first&.to_i
-          self.ratelimit_limit_tokens = headers[X_RATELIMIT_LIMIT_TOKENS]&.first&.to_i
+          self.ratelimit_limit_requests = headers[X_RATELIMIT_LIMIT_REQUESTS]&.first.to_i
+          self.ratelimit_limit_tokens = headers[X_RATELIMIT_LIMIT_TOKENS]&.first.to_i
           remaining_headers(headers)
           reset_headers(headers)
           tokens_usage_based_headers(headers)
@@ -60,8 +60,8 @@ module NewRelic
         private
 
         def remaining_headers(headers)
-          self.ratelimit_remaining_requests = headers[X_RATELIMIT_REMAINING_REQUESTS]&.first&.to_i
-          self.ratelimit_remaining_tokens = headers[X_RATELIMIT_REMAINING_TOKENS]&.first&.to_i
+          self.ratelimit_remaining_requests = headers[X_RATELIMIT_REMAINING_REQUESTS]&.first.to_i
+          self.ratelimit_remaining_tokens = headers[X_RATELIMIT_REMAINING_TOKENS]&.first.to_i
         end
 
         def reset_headers(headers)
@@ -70,9 +70,9 @@ module NewRelic
         end
 
         def tokens_usage_based_headers(headers)
-          self.ratelimit_limit_tokens_usage_based = headers[X_RATELIMIT_LIMIT_TOKENS_USAGE_BASED]&.first&.to_i
+          self.ratelimit_limit_tokens_usage_based = headers[X_RATELIMIT_LIMIT_TOKENS_USAGE_BASED]&.first.to_i
           self.ratelimit_reset_tokens_usage_based = headers[X_RATELIMIT_RESET_TOKENS_USAGE_BASED]&.first
-          self.ratelimit_remaining_tokens_usage_based = headers[X_RATELIMIT_REMAINING_TOKENS_USAGE_BASED]&.first&.to_i
+          self.ratelimit_remaining_tokens_usage_based = headers[X_RATELIMIT_REMAINING_TOKENS_USAGE_BASED]&.first.to_i
         end
       end
     end

--- a/lib/new_relic/agent/llm/response_headers.rb
+++ b/lib/new_relic/agent/llm/response_headers.rb
@@ -6,25 +6,25 @@ module NewRelic
   module Agent
     module Llm
       module ResponseHeaders
-        ATTRIBUTES = %i[response_organization llm_version rate_limit_requests
-          rate_limit_tokens rate_limit_remaining_requests
-          rate_limit_remaining_tokens rate_limit_reset_requests
-          rate_limit_reset_tokens rate_limit_limit_tokens_usage_based
-          rate_limit_reset_tokens_usage_based
-          rate_limit_remaining_tokens_usage_based]
+        ATTRIBUTES = %i[response_organization llm_version ratelimit_limit_requests
+          ratelimit_limit_tokens ratelimit_remaining_requests
+          ratelimit_remaining_tokens ratelimit_reset_requests
+          ratelimit_reset_tokens ratelimit_limit_tokens_usage_based
+          ratelimit_reset_tokens_usage_based
+          ratelimit_remaining_tokens_usage_based]
 
         ATTRIBUTE_NAME_EXCEPTIONS = {
           response_organization: 'response.organization',
           llm_version: 'response.headers.llm_version',
-          rate_limit_requests: 'response.headers.ratelimitLimitRequests',
-          rate_limit_tokens: 'response.headers.ratelimitLimitTokens',
-          rate_limit_remaining_requests: 'response.headers.ratelimitRemainingRequests',
-          rate_limit_remaining_tokens: 'response.headers.ratelimitRemainingTokens',
-          rate_limit_reset_requests: 'response.headers.ratelimitResetRequests',
-          rate_limit_reset_tokens: 'response.headers.ratelimitResetTokens',
-          rate_limit_limit_tokens_usage_based: 'response.headers.ratelimitLimitTokensUsageBased',
-          rate_limit_reset_tokens_usage_based: 'response.headers.ratelimitResetTokensUsageBased',
-          rate_limit_remaining_tokens_usage_based: 'response.headers.ratelimitRemainingTokensUsageBased'
+          ratelimit_limit_requests: 'response.headers.ratelimitLimitRequests',
+          ratelimit_limit_tokens: 'response.headers.ratelimitLimitTokens',
+          ratelimit_remaining_requests: 'response.headers.ratelimitRemainingRequests',
+          ratelimit_remaining_tokens: 'response.headers.ratelimitRemainingTokens',
+          ratelimit_reset_requests: 'response.headers.ratelimitResetRequests',
+          ratelimit_reset_tokens: 'response.headers.ratelimitResetTokens',
+          ratelimit_limit_tokens_usage_based: 'response.headers.ratelimitLimitTokensUsageBased',
+          ratelimit_reset_tokens_usage_based: 'response.headers.ratelimitResetTokensUsageBased',
+          ratelimit_remaining_tokens_usage_based: 'response.headers.ratelimitRemainingTokensUsageBased'
         }
 
         OPENAI_ORGANIZATION = 'openai-organization'
@@ -50,8 +50,8 @@ module NewRelic
           self.request_id = headers[X_REQUEST_ID]&.first
           self.response_organization = headers[OPENAI_ORGANIZATION]&.first
           self.llm_version = headers[OPENAI_VERSION]&.first
-          self.rate_limit_requests = headers[X_RATELIMIT_LIMIT_REQUESTS]&.first&.to_i
-          self.rate_limit_tokens = headers[X_RATELIMIT_LIMIT_TOKENS]&.first&.to_i
+          self.ratelimit_limit_requests = headers[X_RATELIMIT_LIMIT_REQUESTS]&.first&.to_i
+          self.ratelimit_limit_tokens = headers[X_RATELIMIT_LIMIT_TOKENS]&.first&.to_i
           remaining_headers(headers)
           reset_headers(headers)
           tokens_usage_based_headers(headers)
@@ -60,19 +60,19 @@ module NewRelic
         private
 
         def remaining_headers(headers)
-          self.rate_limit_remaining_requests = headers[X_RATELIMIT_REMAINING_REQUESTS]&.first&.to_i
-          self.rate_limit_remaining_tokens = headers[X_RATELIMIT_REMAINING_TOKENS]&.first&.to_i
+          self.ratelimit_remaining_requests = headers[X_RATELIMIT_REMAINING_REQUESTS]&.first&.to_i
+          self.ratelimit_remaining_tokens = headers[X_RATELIMIT_REMAINING_TOKENS]&.first&.to_i
         end
 
         def reset_headers(headers)
-          self.rate_limit_reset_requests = headers[X_RATELIMIT_RESET_REQUESTS]&.first
-          self.rate_limit_reset_tokens = headers[X_RATELIMIT_RESET_TOKENS]&.first
+          self.ratelimit_reset_requests = headers[X_RATELIMIT_RESET_REQUESTS]&.first
+          self.ratelimit_reset_tokens = headers[X_RATELIMIT_RESET_TOKENS]&.first
         end
 
         def tokens_usage_based_headers(headers)
-          self.rate_limit_limit_tokens_usage_based = headers[X_RATELIMIT_LIMIT_TOKENS_USAGE_BASED]&.first
-          self.rate_limit_reset_tokens_usage_based = headers[X_RATELIMIT_RESET_TOKENS_USAGE_BASED]&.first&.to_i
-          self.rate_limit_remaining_tokens_usage_based = headers[X_RATELIMIT_REMAINING_TOKENS_USAGE_BASED]&.first&.to_i
+          self.ratelimit_limit_tokens_usage_based = headers[X_RATELIMIT_LIMIT_TOKENS_USAGE_BASED]&.first
+          self.ratelimit_reset_tokens_usage_based = headers[X_RATELIMIT_RESET_TOKENS_USAGE_BASED]&.first&.to_i
+          self.ratelimit_remaining_tokens_usage_based = headers[X_RATELIMIT_REMAINING_TOKENS_USAGE_BASED]&.first&.to_i
         end
       end
     end

--- a/lib/new_relic/agent/llm/response_headers.rb
+++ b/lib/new_relic/agent/llm/response_headers.rb
@@ -9,7 +9,10 @@ module NewRelic
         ATTRIBUTES = %i[response_organization llm_version rate_limit_requests
           rate_limit_tokens rate_limit_remaining_requests
           rate_limit_remaining_tokens rate_limit_reset_requests
-          rate_limit_reset_tokens]
+          rate_limit_reset_tokens rate_limit_limit_tokens_usage_based
+          rate_limit_reset_tokens_usage_based
+          rate_limit_remaining_tokens_usage_based]
+
         ATTRIBUTE_NAME_EXCEPTIONS = {
           response_organization: 'response.organization',
           llm_version: 'response.headers.llm_version',
@@ -18,7 +21,10 @@ module NewRelic
           rate_limit_remaining_requests: 'response.headers.ratelimitRemainingRequests',
           rate_limit_remaining_tokens: 'response.headers.ratelimitRemainingTokens',
           rate_limit_reset_requests: 'response.headers.ratelimitResetRequests',
-          rate_limit_reset_tokens: 'response.headers.ratelimitResetTokens'
+          rate_limit_reset_tokens: 'response.headers.ratelimitResetTokens',
+          rate_limit_limit_tokens_usage_based: 'response.headers.ratelimitLimitTokensUsageBased',
+          rate_limit_reset_tokens_usage_based: 'response.headers.ratelimitResetTokensUsageBased',
+          rate_limit_remaining_tokens_usage_based: 'response.headers.ratelimitRemainingTokensUsageBased'
         }
 
         OPENAI_ORGANIZATION = 'openai-organization'
@@ -29,6 +35,9 @@ module NewRelic
         X_RATELIMIT_REMAINING_TOKENS = 'x-ratelimit-remaining-tokens'
         X_RATELIMIT_RESET_REQUESTS = 'x-ratelimit-reset-requests'
         X_RATELIMIT_RESET_TOKENS = 'x-ratelimit-reset-tokens'
+        X_RATELIMIT_LIMIT_TOKENS_USAGE_BASED = 'x-ratelimit-limit-tokens-usage-based'
+        X_RATELIMIT_RESET_TOKENS_USAGE_BASED = 'x-ratelimit-reset-tokens-usage-based'
+        X_RATELIMIT_REMAINING_TOKENS_USAGE_BASED = 'x-ratelimit-remaining-tokens-usage-based'
         X_REQUEST_ID = 'x-request-id'
 
         attr_accessor(*ATTRIBUTES)
@@ -43,10 +52,27 @@ module NewRelic
           self.llm_version = headers[OPENAI_VERSION]&.first
           self.rate_limit_requests = headers[X_RATELIMIT_LIMIT_REQUESTS]&.first
           self.rate_limit_tokens = headers[X_RATELIMIT_LIMIT_TOKENS]&.first
+          remaining_headers(headers)
+          reset_headers(headers)
+          tokens_usage_based_headers(headers)
+        end
+
+        private
+
+        def remaining_headers(headers)
           self.rate_limit_remaining_requests = headers[X_RATELIMIT_REMAINING_REQUESTS]&.first
           self.rate_limit_remaining_tokens = headers[X_RATELIMIT_REMAINING_TOKENS]&.first
+        end
+
+        def reset_headers(headers)
           self.rate_limit_reset_requests = headers[X_RATELIMIT_RESET_REQUESTS]&.first
           self.rate_limit_reset_tokens = headers[X_RATELIMIT_RESET_TOKENS]&.first
+        end
+
+        def tokens_usage_based_headers(headers)
+          self.rate_limit_limit_tokens_usage_based = headers[X_RATELIMIT_LIMIT_TOKENS_USAGE_BASED]&.first
+          self.rate_limit_reset_tokens_usage_based = headers[X_RATELIMIT_RESET_TOKENS_USAGE_BASED]&.first
+          self.rate_limit_remaining_tokens_usage_based = headers[X_RATELIMIT_REMAINING_TOKENS_USAGE_BASED]&.first
         end
       end
     end

--- a/test/new_relic/agent/llm/chat_completion_summary_test.rb
+++ b/test/new_relic/agent/llm/chat_completion_summary_test.rb
@@ -62,15 +62,15 @@ module NewRelic::Agent::Llm
         summary.duration = '500'
         summary.error = 'true'
         summary.llm_version = '2022-01-01'
-        summary.ratelimit_limit_requests = 100
-        summary.ratelimit_limit_tokens = 101
-        summary.ratelimit_reset_tokens = '102'
-        summary.ratelimit_reset_requests = '103'
-        summary.ratelimit_remaining_tokens = 104
-        summary.ratelimit_remaining_requests = 105
-        summary.ratelimit_limit_tokens_usage_based = '106'
-        summary.ratelimit_reset_tokens_usage_based = 107
-        summary.ratelimit_remaining_tokens_usage_based = 108
+        summary.ratelimit_limit_requests = 200
+        summary.ratelimit_limit_tokens = 40000
+        summary.ratelimit_reset_tokens = '180ms'
+        summary.ratelimit_reset_requests = '11m32.334s'
+        summary.ratelimit_remaining_tokens = 39880
+        summary.ratelimit_remaining_requests = 198
+        summary.ratelimit_limit_tokens_usage_based = 40000
+        summary.ratelimit_reset_tokens_usage_based = '180ms'
+        summary.ratelimit_remaining_tokens_usage_based = 39880
 
         summary.record
         _, events = NewRelic::Agent.agent.custom_event_aggregator.harvest!
@@ -94,15 +94,15 @@ module NewRelic::Agent::Llm
         assert_equal '500', attributes['duration']
         assert_equal 'true', attributes['error']
         assert_equal '2022-01-01', attributes['response.headers.llm_version']
-        assert_equal 100, attributes['response.headers.ratelimitLimitRequests']
-        assert_equal 101, attributes['response.headers.ratelimitLimitTokens']
-        assert_equal '102', attributes['response.headers.ratelimitResetTokens']
-        assert_equal '103', attributes['response.headers.ratelimitResetRequests']
-        assert_equal 104, attributes['response.headers.ratelimitRemainingTokens']
-        assert_equal 105, attributes['response.headers.ratelimitRemainingRequests']
-        assert_equal '106', attributes['response.headers.ratelimitLimitTokensUsageBased']
-        assert_equal 107, attributes['response.headers.ratelimitResetTokensUsageBased']
-        assert_equal 108, attributes['response.headers.ratelimitRemainingTokensUsageBased']
+        assert_equal 200, attributes['response.headers.ratelimitLimitRequests']
+        assert_equal 40000, attributes['response.headers.ratelimitLimitTokens']
+        assert_equal '180ms', attributes['response.headers.ratelimitResetTokens']
+        assert_equal '11m32.334s', attributes['response.headers.ratelimitResetRequests']
+        assert_equal 39880, attributes['response.headers.ratelimitRemainingTokens']
+        assert_equal 198, attributes['response.headers.ratelimitRemainingRequests']
+        assert_equal 40000, attributes['response.headers.ratelimitLimitTokensUsageBased']
+        assert_equal '180ms', attributes['response.headers.ratelimitResetTokensUsageBased']
+        assert_equal 39880, attributes['response.headers.ratelimitRemainingTokensUsageBased']
       end
     end
 

--- a/test/new_relic/agent/llm/chat_completion_summary_test.rb
+++ b/test/new_relic/agent/llm/chat_completion_summary_test.rb
@@ -62,15 +62,15 @@ module NewRelic::Agent::Llm
         summary.duration = '500'
         summary.error = 'true'
         summary.llm_version = '2022-01-01'
-        summary.rate_limit_requests = 100
-        summary.rate_limit_tokens = 101
-        summary.rate_limit_reset_tokens = '102'
-        summary.rate_limit_reset_requests = '103'
-        summary.rate_limit_remaining_tokens = 104
-        summary.rate_limit_remaining_requests = 105
-        summary.rate_limit_limit_tokens_usage_based = '106'
-        summary.rate_limit_reset_tokens_usage_based = 107
-        summary.rate_limit_remaining_tokens_usage_based = 108
+        summary.ratelimit_limit_requests = 100
+        summary.ratelimit_limit_tokens = 101
+        summary.ratelimit_reset_tokens = '102'
+        summary.ratelimit_reset_requests = '103'
+        summary.ratelimit_remaining_tokens = 104
+        summary.ratelimit_remaining_requests = 105
+        summary.ratelimit_limit_tokens_usage_based = '106'
+        summary.ratelimit_reset_tokens_usage_based = 107
+        summary.ratelimit_remaining_tokens_usage_based = 108
 
         summary.record
         _, events = NewRelic::Agent.agent.custom_event_aggregator.harvest!

--- a/test/new_relic/agent/llm/chat_completion_summary_test.rb
+++ b/test/new_relic/agent/llm/chat_completion_summary_test.rb
@@ -62,12 +62,15 @@ module NewRelic::Agent::Llm
         summary.duration = '500'
         summary.error = 'true'
         summary.llm_version = '2022-01-01'
-        summary.rate_limit_requests = '100'
-        summary.rate_limit_tokens = '101'
+        summary.rate_limit_requests = 100
+        summary.rate_limit_tokens = 101
         summary.rate_limit_reset_tokens = '102'
         summary.rate_limit_reset_requests = '103'
-        summary.rate_limit_remaining_tokens = '104'
-        summary.rate_limit_remaining_requests = '105'
+        summary.rate_limit_remaining_tokens = 104
+        summary.rate_limit_remaining_requests = 105
+        summary.rate_limit_limit_tokens_usage_based = '106'
+        summary.rate_limit_reset_tokens_usage_based = 107
+        summary.rate_limit_remaining_tokens_usage_based = 108
 
         summary.record
         _, events = NewRelic::Agent.agent.custom_event_aggregator.harvest!
@@ -91,12 +94,15 @@ module NewRelic::Agent::Llm
         assert_equal '500', attributes['duration']
         assert_equal 'true', attributes['error']
         assert_equal '2022-01-01', attributes['response.headers.llm_version']
-        assert_equal '100', attributes['response.headers.ratelimitLimitRequests']
-        assert_equal '101', attributes['response.headers.ratelimitLimitTokens']
+        assert_equal 100, attributes['response.headers.ratelimitLimitRequests']
+        assert_equal 101, attributes['response.headers.ratelimitLimitTokens']
         assert_equal '102', attributes['response.headers.ratelimitResetTokens']
         assert_equal '103', attributes['response.headers.ratelimitResetRequests']
-        assert_equal '104', attributes['response.headers.ratelimitRemainingTokens']
-        assert_equal '105', attributes['response.headers.ratelimitRemainingRequests']
+        assert_equal 104, attributes['response.headers.ratelimitRemainingTokens']
+        assert_equal 105, attributes['response.headers.ratelimitRemainingRequests']
+        assert_equal '106', attributes['response.headers.ratelimitLimitTokensUsageBased']
+        assert_equal 107, attributes['response.headers.ratelimitResetTokensUsageBased']
+        assert_equal 108, attributes['response.headers.ratelimitRemainingTokensUsageBased']
       end
     end
 

--- a/test/new_relic/agent/llm/embedding_test.rb
+++ b/test/new_relic/agent/llm/embedding_test.rb
@@ -54,12 +54,15 @@ module NewRelic::Agent::Llm
         embedding.duration = '500'
         embedding.error = 'true'
         embedding.llm_version = '2022-01-01'
-        embedding.rate_limit_requests = '100'
-        embedding.rate_limit_tokens = '101'
+        embedding.rate_limit_requests = 100
+        embedding.rate_limit_tokens = 101
         embedding.rate_limit_reset_tokens = '102'
         embedding.rate_limit_reset_requests = '103'
-        embedding.rate_limit_remaining_tokens = '104'
-        embedding.rate_limit_remaining_requests = '105'
+        embedding.rate_limit_remaining_tokens = 104
+        embedding.rate_limit_remaining_requests = 105
+        embedding.rate_limit_limit_tokens_usage_based = '106'
+        embedding.rate_limit_reset_tokens_usage_based = 107
+        embedding.rate_limit_remaining_tokens_usage_based = 108
 
         embedding.record
         _, events = NewRelic::Agent.agent.custom_event_aggregator.harvest!
@@ -80,12 +83,15 @@ module NewRelic::Agent::Llm
         assert_equal '500', attributes['duration']
         assert_equal 'true', attributes['error']
         assert_equal '2022-01-01', attributes['response.headers.llm_version']
-        assert_equal '100', attributes['response.headers.ratelimitLimitRequests']
-        assert_equal '101', attributes['response.headers.ratelimitLimitTokens']
+        assert_equal 100, attributes['response.headers.ratelimitLimitRequests']
+        assert_equal 101, attributes['response.headers.ratelimitLimitTokens']
         assert_equal '102', attributes['response.headers.ratelimitResetTokens']
         assert_equal '103', attributes['response.headers.ratelimitResetRequests']
-        assert_equal '104', attributes['response.headers.ratelimitRemainingTokens']
-        assert_equal '105', attributes['response.headers.ratelimitRemainingRequests']
+        assert_equal 104, attributes['response.headers.ratelimitRemainingTokens']
+        assert_equal 105, attributes['response.headers.ratelimitRemainingRequests']
+        assert_equal '106', attributes['response.headers.ratelimitLimitTokensUsageBased']
+        assert_equal 107, attributes['response.headers.ratelimitResetTokensUsageBased']
+        assert_equal 108, attributes['response.headers.ratelimitRemainingTokensUsageBased']
       end
     end
 

--- a/test/new_relic/agent/llm/embedding_test.rb
+++ b/test/new_relic/agent/llm/embedding_test.rb
@@ -54,15 +54,15 @@ module NewRelic::Agent::Llm
         embedding.duration = '500'
         embedding.error = 'true'
         embedding.llm_version = '2022-01-01'
-        embedding.rate_limit_requests = 100
-        embedding.rate_limit_tokens = 101
-        embedding.rate_limit_reset_tokens = '102'
-        embedding.rate_limit_reset_requests = '103'
-        embedding.rate_limit_remaining_tokens = 104
-        embedding.rate_limit_remaining_requests = 105
-        embedding.rate_limit_limit_tokens_usage_based = '106'
-        embedding.rate_limit_reset_tokens_usage_based = 107
-        embedding.rate_limit_remaining_tokens_usage_based = 108
+        embedding.ratelimit_limit_requests = 100
+        embedding.ratelimit_limit_tokens = 101
+        embedding.ratelimit_reset_tokens = '102'
+        embedding.ratelimit_reset_requests = '103'
+        embedding.ratelimit_remaining_tokens = 104
+        embedding.ratelimit_remaining_requests = 105
+        embedding.ratelimit_limit_tokens_usage_based = '106'
+        embedding.ratelimit_reset_tokens_usage_based = 107
+        embedding.ratelimit_remaining_tokens_usage_based = 108
 
         embedding.record
         _, events = NewRelic::Agent.agent.custom_event_aggregator.harvest!

--- a/test/new_relic/agent/llm/embedding_test.rb
+++ b/test/new_relic/agent/llm/embedding_test.rb
@@ -54,15 +54,15 @@ module NewRelic::Agent::Llm
         embedding.duration = '500'
         embedding.error = 'true'
         embedding.llm_version = '2022-01-01'
-        embedding.ratelimit_limit_requests = 100
-        embedding.ratelimit_limit_tokens = 101
-        embedding.ratelimit_reset_tokens = '102'
-        embedding.ratelimit_reset_requests = '103'
-        embedding.ratelimit_remaining_tokens = 104
-        embedding.ratelimit_remaining_requests = 105
-        embedding.ratelimit_limit_tokens_usage_based = '106'
-        embedding.ratelimit_reset_tokens_usage_based = 107
-        embedding.ratelimit_remaining_tokens_usage_based = 108
+        embedding.ratelimit_limit_requests = 200
+        embedding.ratelimit_limit_tokens = 40000
+        embedding.ratelimit_reset_tokens = '180ms'
+        embedding.ratelimit_reset_requests = '11m32.334s'
+        embedding.ratelimit_remaining_tokens = 39880
+        embedding.ratelimit_remaining_requests = 198
+        embedding.ratelimit_limit_tokens_usage_based = 40000
+        embedding.ratelimit_reset_tokens_usage_based = '180ms'
+        embedding.ratelimit_remaining_tokens_usage_based = 39880
 
         embedding.record
         _, events = NewRelic::Agent.agent.custom_event_aggregator.harvest!
@@ -83,15 +83,15 @@ module NewRelic::Agent::Llm
         assert_equal '500', attributes['duration']
         assert_equal 'true', attributes['error']
         assert_equal '2022-01-01', attributes['response.headers.llm_version']
-        assert_equal 100, attributes['response.headers.ratelimitLimitRequests']
-        assert_equal 101, attributes['response.headers.ratelimitLimitTokens']
-        assert_equal '102', attributes['response.headers.ratelimitResetTokens']
-        assert_equal '103', attributes['response.headers.ratelimitResetRequests']
-        assert_equal 104, attributes['response.headers.ratelimitRemainingTokens']
-        assert_equal 105, attributes['response.headers.ratelimitRemainingRequests']
-        assert_equal '106', attributes['response.headers.ratelimitLimitTokensUsageBased']
-        assert_equal 107, attributes['response.headers.ratelimitResetTokensUsageBased']
-        assert_equal 108, attributes['response.headers.ratelimitRemainingTokensUsageBased']
+        assert_equal 200, attributes['response.headers.ratelimitLimitRequests']
+        assert_equal 40000, attributes['response.headers.ratelimitLimitTokens']
+        assert_equal '180ms', attributes['response.headers.ratelimitResetTokens']
+        assert_equal '11m32.334s', attributes['response.headers.ratelimitResetRequests']
+        assert_equal 39880, attributes['response.headers.ratelimitRemainingTokens']
+        assert_equal 198, attributes['response.headers.ratelimitRemainingRequests']
+        assert_equal 40000, attributes['response.headers.ratelimitLimitTokensUsageBased']
+        assert_equal '180ms', attributes['response.headers.ratelimitResetTokensUsageBased']
+        assert_equal 39880, attributes['response.headers.ratelimitRemainingTokensUsageBased']
       end
     end
 

--- a/test/new_relic/agent/llm/response_headers_test.rb
+++ b/test/new_relic/agent/llm/response_headers_test.rb
@@ -51,15 +51,15 @@ module NewRelic::Agent::Llm
       event.populate_openai_response_headers(openai_response_headers_hash)
 
       assert_equal '2020-10-01', event.llm_version
-      assert_equal 200, event.rate_limit_requests
-      assert_equal 150000, event.rate_limit_tokens
-      assert_equal 199, event.rate_limit_remaining_requests
-      assert_equal 149990, event.rate_limit_remaining_tokens
-      assert_equal '7m12s', event.rate_limit_reset_requests
-      assert_equal '4ms', event.rate_limit_reset_tokens
-      assert_equal '4', event.rate_limit_limit_tokens_usage_based
-      assert_equal 2, event.rate_limit_reset_tokens_usage_based
-      assert_equal 1, event.rate_limit_remaining_tokens_usage_based
+      assert_equal 200, event.ratelimit_limit_requests
+      assert_equal 150000, event.ratelimit_limit_tokens
+      assert_equal 199, event.ratelimit_remaining_requests
+      assert_equal 149990, event.ratelimit_remaining_tokens
+      assert_equal '7m12s', event.ratelimit_reset_requests
+      assert_equal '4ms', event.ratelimit_reset_tokens
+      assert_equal '4', event.ratelimit_limit_tokens_usage_based
+      assert_equal 2, event.ratelimit_reset_tokens_usage_based
+      assert_equal 1, event.ratelimit_remaining_tokens_usage_based
     end
   end
 end

--- a/test/new_relic/agent/llm/response_headers_test.rb
+++ b/test/new_relic/agent/llm/response_headers_test.rb
@@ -32,9 +32,9 @@ module NewRelic::Agent::Llm
        "x-ratelimit-reset-requests" => ["7m12s"],
        "x-ratelimit-reset-tokens" => ["4ms"],
        # The following *-tokens-usage-based entries are best guesses to fulfill the spec. We haven't been able to create a request that returns these headers.
-       "x-ratelimit-limit-tokens-usage-based" => ["4"],
-       "x-ratelimit-reset-tokens-usage-based" => ["2"],
-       "x-ratelimit-remaining-tokens-usage-based" => ["1"],
+       "x-ratelimit-limit-tokens-usage-based" => ["40000"],
+       "x-ratelimit-reset-tokens-usage-based" => ["180ms"],
+       "x-ratelimit-remaining-tokens-usage-based" => ["39880"],
        "x-request-id" => ["123abc456"],
        "cf-cache-status" => ["DYNAMIC"],
        "set-cookie" =>
@@ -57,9 +57,9 @@ module NewRelic::Agent::Llm
       assert_equal 149990, event.ratelimit_remaining_tokens
       assert_equal '7m12s', event.ratelimit_reset_requests
       assert_equal '4ms', event.ratelimit_reset_tokens
-      assert_equal '4', event.ratelimit_limit_tokens_usage_based
-      assert_equal 2, event.ratelimit_reset_tokens_usage_based
-      assert_equal 1, event.ratelimit_remaining_tokens_usage_based
+      assert_equal 40000, event.ratelimit_limit_tokens_usage_based
+      assert_equal '180ms', event.ratelimit_reset_tokens_usage_based
+      assert_equal 39880, event.ratelimit_remaining_tokens_usage_based
     end
   end
 end

--- a/test/new_relic/agent/llm/response_headers_test.rb
+++ b/test/new_relic/agent/llm/response_headers_test.rb
@@ -51,15 +51,15 @@ module NewRelic::Agent::Llm
       event.populate_openai_response_headers(openai_response_headers_hash)
 
       assert_equal '2020-10-01', event.llm_version
-      assert_equal '200', event.rate_limit_requests
-      assert_equal '150000', event.rate_limit_tokens
-      assert_equal '199', event.rate_limit_remaining_requests
-      assert_equal '149990', event.rate_limit_remaining_tokens
+      assert_equal 200, event.rate_limit_requests
+      assert_equal 150000, event.rate_limit_tokens
+      assert_equal 199, event.rate_limit_remaining_requests
+      assert_equal 149990, event.rate_limit_remaining_tokens
       assert_equal '7m12s', event.rate_limit_reset_requests
       assert_equal '4ms', event.rate_limit_reset_tokens
       assert_equal '4', event.rate_limit_limit_tokens_usage_based
-      assert_equal '2', event.rate_limit_reset_tokens_usage_based
-      assert_equal '1', event.rate_limit_remaining_tokens_usage_based
+      assert_equal 2, event.rate_limit_reset_tokens_usage_based
+      assert_equal 1, event.rate_limit_remaining_tokens_usage_based
     end
   end
 end

--- a/test/new_relic/agent/llm/response_headers_test.rb
+++ b/test/new_relic/agent/llm/response_headers_test.rb
@@ -31,6 +31,10 @@ module NewRelic::Agent::Llm
        "x-ratelimit-remaining-tokens" => ["149990"],
        "x-ratelimit-reset-requests" => ["7m12s"],
        "x-ratelimit-reset-tokens" => ["4ms"],
+       # The following *-tokens-usage-based entries are best guesses to fulfill the spec. We haven't been able to create a request that returns these headers.
+       "x-ratelimit-limit-tokens-usage-based" => ["4"],
+       "x-ratelimit-reset-tokens-usage-based" => ["2"],
+       "x-ratelimit-remaining-tokens-usage-based" => ["1"],
        "x-request-id" => ["123abc456"],
        "cf-cache-status" => ["DYNAMIC"],
        "set-cookie" =>
@@ -53,6 +57,9 @@ module NewRelic::Agent::Llm
       assert_equal '149990', event.rate_limit_remaining_tokens
       assert_equal '7m12s', event.rate_limit_reset_requests
       assert_equal '4ms', event.rate_limit_reset_tokens
+      assert_equal '4', event.rate_limit_limit_tokens_usage_based
+      assert_equal '2', event.rate_limit_reset_tokens_usage_based
+      assert_equal '1', event.rate_limit_remaining_tokens_usage_based
     end
   end
 end


### PR DESCRIPTION
LlmEmbedding and LlmChatCompletionSummary events generated by OpenAI have attributes pulled from response headers.

The following response headers should be captured if they're available:
* response.headers.ratelimitLimitTokensUsageBased
* response.headers.ratelimitResetTokensUsageBased
* response.headers.ratelimitRemainingTokensUsageBased

We haven't been able to craft a request that returns these headers.

In addition, this PR updates the data types of the response headers to match [the spec (internal)](https://source.datanerd.us/agents/agent-specs/blob/main/LLMs.md#response-headers).

Closes #2461 