### PR TITLE
Update ChatCompletionSummary attribute datatypes

### DIFF
--- a/lib/new_relic/agent/instrumentation/ruby_openai/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/ruby_openai/instrumentation.rb
@@ -67,9 +67,9 @@ module NewRelic::Agent::Instrumentation
     def create_chat_completion_summary(parameters)
       NewRelic::Agent::Llm::ChatCompletionSummary.new(
         vendor: VENDOR,
-        request_max_tokens: parameters[:max_tokens] || parameters['max_tokens'],
+        request_max_tokens: (parameters[:max_tokens] || parameters['max_tokens'])&.to_i,
         request_model: parameters[:model] || parameters['model'],
-        temperature: parameters[:temperature] || parameters['temperature'],
+        temperature: (parameters[:temperature] || parameters['temperature'])&.to_f,
         metadata: llm_custom_attributes
       )
     end


### PR DESCRIPTION
While doing an audit on the response header datatypes, I thought I'd check the other event types. It looks like only `request.temperature` and `request.max_tokens` needed updates.

Since these values come from the user, we can't be certain of the data type.

In the spec, `request.temperature` can be a float or an integer. To simplify the logic, I'm always assigning it as a float because a float is more specific than an integer. `request.max_tokens` must be an integer.

The LLM event tests already use the correct datatypes.