### PR TITLE
Send full llm content

### DIFF
--- a/lib/new_relic/agent/custom_event_aggregator.rb
+++ b/lib/new_relic/agent/custom_event_aggregator.rb
@@ -17,8 +17,6 @@ module NewRelic
       MAX_ATTRIBUTE_COUNT = 64
       MAX_ATTRIBUTE_SIZE = 4095
       MAX_NAME_SIZE = 255
-      INPUT = 'input'
-      CONTENT = 'content'
 
       named :CustomEventAggregator
       capacity_key :'custom_insights_events.max_samples_stored'
@@ -72,18 +70,13 @@ module NewRelic
             key = key[0, MAX_NAME_SIZE]
           end
 
-          # value is limited to 4095 expect for LLM content-related events
+          # value is limited to 4095 except for LLM content-related events
           if val.is_a?(String) && val.length > MAX_ATTRIBUTE_SIZE
-            val = val[0, MAX_ATTRIBUTE_SIZE] unless llm_exempt_event_attribute?(type, key)
+            val = val[0, MAX_ATTRIBUTE_SIZE] unless NewRelic::Agent::LLM.llm_exempt_event_attribute?(type, key)
           end
 
           new_result[key] = val
         end
-      end
-
-      def llm_exempt_event_attribute?(type, key)
-        (type == NewRelic::Agent::Llm::Embedding::EVENT_NAME && key == INPUT) ||
-          (type == NewRelic::Agent::Llm::ChatCompletionMessage::EVENT_NAME && key == CONTENT)
       end
 
       def after_initialize

--- a/lib/new_relic/agent/custom_event_aggregator.rb
+++ b/lib/new_relic/agent/custom_event_aggregator.rb
@@ -17,9 +17,7 @@ module NewRelic
       MAX_ATTRIBUTE_COUNT = 64
       MAX_ATTRIBUTE_SIZE = 4095
       MAX_NAME_SIZE = 255
-      EXEMPT_EMBEDDING = 'LlmEmbedding'
       INPUT = 'input'
-      EXEMPT_CHAT_MESSAGE = 'LlmChatCompletionMessage'
       CONTENT = 'content'
 
       named :CustomEventAggregator
@@ -84,7 +82,8 @@ module NewRelic
       end
 
       def llm_exempt_event_attribute?(type, key)
-        (type == EXEMPT_EMBEDDING && key == INPUT) || (type == EXEMPT_CHAT_MESSAGE && key == CONTENT)
+        (type == NewRelic::Agent::Llm::Embedding::EVENT_NAME && key == INPUT) ||
+          (type == NewRelic::Agent::Llm::ChatCompletionMessage::EVENT_NAME && key == CONTENT)
       end
 
       def after_initialize

--- a/lib/new_relic/agent/custom_event_aggregator.rb
+++ b/lib/new_relic/agent/custom_event_aggregator.rb
@@ -83,7 +83,7 @@ module NewRelic
         end
       end
 
-      def llm_exempt_event_attribute? (type, key)
+      def llm_exempt_event_attribute?(type, key)
         (type == EXEMPT_EMBEDDING && key == INPUT) || (type == EXEMPT_CHAT_MESSAGE && key == CONTENT)
       end
 

--- a/lib/new_relic/agent/custom_event_aggregator.rb
+++ b/lib/new_relic/agent/custom_event_aggregator.rb
@@ -72,7 +72,7 @@ module NewRelic
 
           # value is limited to 4095 except for LLM content-related events
           if val.is_a?(String) && val.length > MAX_ATTRIBUTE_SIZE
-            val = val[0, MAX_ATTRIBUTE_SIZE] unless NewRelic::Agent::LLM.llm_exempt_event_attribute?(type, key)
+            val = val[0, MAX_ATTRIBUTE_SIZE] unless NewRelic::Agent::LLM.exempt_event_attribute?(type, key)
           end
 
           new_result[key] = val

--- a/lib/new_relic/agent/llm.rb
+++ b/lib/new_relic/agent/llm.rb
@@ -14,13 +14,13 @@ module NewRelic
       INPUT = 'input'
       CONTENT = 'content'
 
-      def self.llm_instrumentation_enabled?
+      def self.instrumentation_enabled?
         NewRelic::Agent.config[:'ai_monitoring.enabled']
       end
 
       # LLM content-related attributes are exempt from the 4095 byte limit
-      def self.llm_exempt_event_attribute?(type, key)
-        return false unless llm_instrumentation_enabled?
+      def self.exempt_event_attribute?(type, key)
+        return false unless instrumentation_enabled?
 
         (type == NewRelic::Agent::Llm::Embedding::EVENT_NAME && key == INPUT) ||
           (type == NewRelic::Agent::Llm::ChatCompletionMessage::EVENT_NAME && key == CONTENT)

--- a/lib/new_relic/agent/llm.rb
+++ b/lib/new_relic/agent/llm.rb
@@ -7,3 +7,24 @@ require_relative 'llm/chat_completion_message'
 require_relative 'llm/chat_completion_summary'
 require_relative 'llm/embedding'
 require_relative 'llm/response_headers'
+
+module NewRelic
+  module Agent
+    class LLM
+      INPUT = 'input'
+      CONTENT = 'content'
+
+      def self.llm_instrumentation_enabled?
+        NewRelic::Agent.config[:'ai_monitoring.enabled']
+      end
+
+      # LLM content-related attributes are exempt from the 4095 byte limit
+      def self.llm_exempt_event_attribute?(type, key)
+        return false unless llm_instrumentation_enabled?
+
+        (type == NewRelic::Agent::Llm::Embedding::EVENT_NAME && key == INPUT) ||
+          (type == NewRelic::Agent::Llm::ChatCompletionMessage::EVENT_NAME && key == CONTENT)
+      end
+    end
+  end
+end

--- a/test/new_relic/agent/custom_event_aggregator_test.rb
+++ b/test/new_relic/agent/custom_event_aggregator_test.rb
@@ -97,7 +97,7 @@ module NewRelic::Agent
       assert_equal(expected, actual)
     end
 
-    def test_does_not_truncates_llm_embedding_input_attribute
+    def test_does_not_truncate_llm_embedding_input_attribute
       params = {'input' => 'a' * 5000}
       expected = {'input' => 'a' * 5000}
 
@@ -107,7 +107,7 @@ module NewRelic::Agent
       assert_equal(expected, actual)
     end
 
-    def test_does_not_truncates_llm_chat_message_content_attribute
+    def test_does_not_truncate_llm_chat_message_content_attribute
       params = {'content' => 'a' * 5000}
       expected = {'content' => 'a' * 5000}
 

--- a/test/new_relic/agent/custom_event_aggregator_test.rb
+++ b/test/new_relic/agent/custom_event_aggregator_test.rb
@@ -98,8 +98,8 @@ module NewRelic::Agent
     end
 
     def test_does_not_truncates_llm_embedding_input_attribute
-      params = { 'input' => 'a' * 5000 }
-      expected = { 'input' => 'a' * 5000 }
+      params = {'input' => 'a' * 5000}
+      expected = {'input' => 'a' * 5000}
 
       @aggregator.record(:LlmEmbedding, params)
       actual = @aggregator.harvest![1].first[1]
@@ -108,8 +108,8 @@ module NewRelic::Agent
     end
 
     def test_does_not_truncates_llm_chat_message_content_attribute
-      params = { 'content' => 'a' * 5000 }
-      expected = { 'content' => 'a' * 5000 }
+      params = {'content' => 'a' * 5000}
+      expected = {'content' => 'a' * 5000}
 
       @aggregator.record(:LlmChatCompletionMessage, params)
       actual = @aggregator.harvest![1].first[1]

--- a/test/new_relic/agent/custom_event_aggregator_test.rb
+++ b/test/new_relic/agent/custom_event_aggregator_test.rb
@@ -97,6 +97,26 @@ module NewRelic::Agent
       assert_equal(expected, actual)
     end
 
+    def test_does_not_truncates_llm_embedding_input_attribute
+      params = { 'input' => 'a' * 5000 }
+      expected = { 'input' => 'a' * 5000 }
+
+      @aggregator.record(:LlmEmbedding, params)
+      actual = @aggregator.harvest![1].first[1]
+
+      assert_equal(expected, actual)
+    end
+
+    def test_does_not_truncates_llm_chat_message_content_attribute
+      params = { 'content' => 'a' * 5000 }
+      expected = { 'content' => 'a' * 5000 }
+
+      @aggregator.record(:LlmChatCompletionMessage, params)
+      actual = @aggregator.harvest![1].first[1]
+
+      assert_equal(expected, actual)
+    end
+
     def test_lowering_limit_truncates_buffer
       orig_max_samples = NewRelic::Agent.config[:'custom_insights_events.max_samples_stored']
 


### PR DESCRIPTION
The `content` attribute on `LlmChatCompletionMessage` and the `input` attribute on `LlmEmbedding` events are exempt from truncation rules. They can be over 4096 bytes and entire the value must be sent to the collector.

Spec: https://source.datanerd.us/agents/agent-specs/pull/664 (internal)

closes #2448