### PR TITLE
OpenAI: Final spec review/changes

### DIFF
--- a/lib/new_relic/agent.rb
+++ b/lib/new_relic/agent.rb
@@ -421,6 +421,10 @@ module NewRelic
       metadata: NewRelic::EMPTY_HASH)
 
       record_api_supportability_metric(:record_llm_feedback_event)
+      unless NewRelic::Agent.config[:'distributed_tracing.enabled']
+        return NewRelic::Agent.logger.error('Distributed tracing must be enabled to record LLM feedback')
+      end
+
       feedback_message_event = {
         'trace_id': trace_id,
         'rating': rating,

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -361,11 +361,11 @@ module NewRelic
           DESCRIPTION
         },
         :'ai_monitoring.enabled' => {
-          :default => true,
+          :default => false,
           :public => true,
           :type => Boolean,
           :allowed_from_server => false,
-          :description => 'If `false`, all LLM (OpenAI only for now) instrumentation will be disabled and no metrics, events, or spans will be sent. AI Monitoring is automatically disabled if `high_security` mode is enabled.'
+          :description => 'If `false`, all LLM instrumentation (OpenAI only for now) will be disabled and no metrics, events, or spans will be sent. AI Monitoring is automatically disabled if `high_security` mode is enabled.'
         },
         :'ai_monitoring.record_content.enabled' => {
           :default => true,
@@ -373,7 +373,7 @@ module NewRelic
           :type => Boolean,
           :allowed_from_server => false,
           :description => <<~DESCRIPTION
-            If `false`, LLM (OpenAI only for now) instrumentation will not capture input and output content on specific LLM events.
+            If `false`, LLM instrumentation (OpenAI only for now) will not capture input and output content on specific LLM events.
 
             The excluded attributes include:
               * `content` from LlmChatCompletionMessage events

--- a/lib/new_relic/agent/llm/llm_event.rb
+++ b/lib/new_relic/agent/llm/llm_event.rb
@@ -17,7 +17,6 @@ module NewRelic
         # and the string version expected by the UI as the value.
         ATTRIBUTE_NAME_EXCEPTIONS = {response_model: 'response.model'}
         INGEST_SOURCE = 'Ruby'
-        LLM = :llm
         ERROR_ATTRIBUTE_STATUS_CODE = 'http.statusCode'
         ERROR_ATTRIBUTE_CODE = 'error.code'
         ERROR_ATTRIBUTE_PARAM = 'error.param'
@@ -28,7 +27,7 @@ module NewRelic
         attr_accessor(*ATTRIBUTES)
 
         def self.set_llm_agent_attribute_on_transaction
-          NewRelic::Agent::Transaction.add_agent_attribute(LLM, true, NewRelic::Agent::AttributeFilter::DST_TRANSACTION_EVENTS)
+          NewRelic::Agent::Transaction.add_agent_attribute(:llm, true, NewRelic::Agent::AttributeFilter::DST_TRANSACTION_EVENTS)
         end
 
         # This initialize method is used for all subclasses.

--- a/lib/new_relic/agent/llm/response_headers.rb
+++ b/lib/new_relic/agent/llm/response_headers.rb
@@ -15,7 +15,7 @@ module NewRelic
 
         ATTRIBUTE_NAME_EXCEPTIONS = {
           response_organization: 'response.organization',
-          llm_version: 'response.headers.llm_version',
+          llm_version: 'response.headers.llmVersion',
           ratelimit_limit_requests: 'response.headers.ratelimitLimitRequests',
           ratelimit_limit_tokens: 'response.headers.ratelimitLimitTokens',
           ratelimit_remaining_requests: 'response.headers.ratelimitRemainingRequests',

--- a/test/multiverse/suites/ruby_openai/config/newrelic.yml
+++ b/test/multiverse/suites/ruby_openai/config/newrelic.yml
@@ -17,3 +17,5 @@ development:
     stack_trace_threshold: 0.5
     transaction_threshold: 1.0
   capture_params: false
+  #AI Monitoring is disabled by default. We want to enabled it for testing
+  ai_monitoring.enabled: true 

--- a/test/multiverse/suites/ruby_openai/ruby_openai_instrumentation_test.rb
+++ b/test/multiverse/suites/ruby_openai/ruby_openai_instrumentation_test.rb
@@ -6,7 +6,7 @@ require_relative 'openai_helpers'
 
 class RubyOpenAIInstrumentationTest < Minitest::Test
   include OpenAIHelpers
-  def setup
+  def setup # ai_monitoring.enabled is false by default. We've enabled it in this suite's newrelic.yml for testing
     @aggregator = NewRelic::Agent.agent.custom_event_aggregator
     NewRelic::Agent.remove_instance_variable(:@llm_token_count_callback) if NewRelic::Agent.instance_variable_defined?(:@llm_token_count_callback)
   end
@@ -145,8 +145,8 @@ class RubyOpenAIInstrumentationTest < Minitest::Test
     _, events = @aggregator.harvest!
     summary_event = events.find { |event| event[0]['type'] == NewRelic::Agent::Llm::ChatCompletionSummary::EVENT_NAME }
 
-    assert_equal '1993', summary_event[1]['conversation_id']
-    assert_equal 'Steven Spielberg', summary_event[1]['JurassicPark']
+    assert_equal '1993', summary_event[1]['llm.conversation_id']
+    assert_equal 'Steven Spielberg', summary_event[1]['llm.JurassicPark']
     refute summary_event[1]['trex']
   end
 
@@ -164,8 +164,8 @@ class RubyOpenAIInstrumentationTest < Minitest::Test
     _, events = @aggregator.harvest!
     embedding_event = events.find { |event| event[0]['type'] == NewRelic::Agent::Llm::Embedding::EVENT_NAME }
 
-    assert_equal '1997', embedding_event[1]['conversation_id']
-    assert_equal 'Steven Spielberg', embedding_event[1]['TheLostWorld']
+    assert_equal '1997', embedding_event[1]['llm.conversation_id']
+    assert_equal 'Steven Spielberg', embedding_event[1]['llm.TheLostWorld']
     refute embedding_event[1]['fruit']
   end
 
@@ -184,8 +184,8 @@ class RubyOpenAIInstrumentationTest < Minitest::Test
     message_events = events.filter { |event| event[0]['type'] == NewRelic::Agent::Llm::ChatCompletionMessage::EVENT_NAME }
 
     message_events.each do |event|
-      assert_equal '2001', event[1]['conversation_id']
-      assert_equal 'Joe Johnston', event[1]['JurassicParkIII']
+      assert_equal '2001', event[1]['llm.conversation_id']
+      assert_equal 'Joe Johnston', event[1]['llm.JurassicParkIII']
       refute event[1]['Pterosaur']
     end
   end

--- a/test/new_relic/agent/custom_event_aggregator_test.rb
+++ b/test/new_relic/agent/custom_event_aggregator_test.rb
@@ -98,23 +98,27 @@ module NewRelic::Agent
     end
 
     def test_does_not_truncate_llm_embedding_input_attribute
-      params = {'input' => 'a' * 5000}
-      expected = {'input' => 'a' * 5000}
+      with_config(:'ai_monitoring.enabled' => true) do
+        params = {'input' => 'a' * 5000}
+        expected = {'input' => 'a' * 5000}
 
-      @aggregator.record(:LlmEmbedding, params)
-      actual = @aggregator.harvest![1].first[1]
+        @aggregator.record(:LlmEmbedding, params)
+        actual = @aggregator.harvest![1].first[1]
 
-      assert_equal(expected, actual)
+        assert_equal(expected, actual)
+      end
     end
 
     def test_does_not_truncate_llm_chat_message_content_attribute
-      params = {'content' => 'a' * 5000}
-      expected = {'content' => 'a' * 5000}
+      with_config(:'ai_monitoring.enabled' => true) do
+        params = {'content' => 'a' * 5000}
+        expected = {'content' => 'a' * 5000}
 
-      @aggregator.record(:LlmChatCompletionMessage, params)
-      actual = @aggregator.harvest![1].first[1]
+        @aggregator.record(:LlmChatCompletionMessage, params)
+        actual = @aggregator.harvest![1].first[1]
 
-      assert_equal(expected, actual)
+        assert_equal(expected, actual)
+      end
     end
 
     def test_lowering_limit_truncates_buffer

--- a/test/new_relic/agent/llm/chat_completion_summary_test.rb
+++ b/test/new_relic/agent/llm/chat_completion_summary_test.rb
@@ -93,7 +93,7 @@ module NewRelic::Agent::Llm
         assert_equal 'Ruby', attributes['ingest_source']
         assert_equal '500', attributes['duration']
         assert_equal 'true', attributes['error']
-        assert_equal '2022-01-01', attributes['response.headers.llm_version']
+        assert_equal '2022-01-01', attributes['response.headers.llmVersion']
         assert_equal 200, attributes['response.headers.ratelimitLimitRequests']
         assert_equal 40000, attributes['response.headers.ratelimitLimitTokens']
         assert_equal '180ms', attributes['response.headers.ratelimitResetTokens']

--- a/test/new_relic/agent/llm/embedding_test.rb
+++ b/test/new_relic/agent/llm/embedding_test.rb
@@ -84,7 +84,7 @@ module NewRelic::Agent::Llm
         assert_equal '500', attributes['duration']
         assert_equal 'true', attributes['error']
         assert_equal 10, attributes['token_count']
-        assert_equal '2022-01-01', attributes['response.headers.llm_version']
+        assert_equal '2022-01-01', attributes['response.headers.llmVersion']
         assert_equal 200, attributes['response.headers.ratelimitLimitRequests']
         assert_equal 40000, attributes['response.headers.ratelimitLimitTokens']
         assert_equal '180ms', attributes['response.headers.ratelimitResetTokens']


### PR DESCRIPTION
Some finishing touches after walking through the spec:
- DT needs to be enabled in order to use the record_feedback API
- `ai_monitoring.enabled` should be `false` by default
- Small refactors for recording metrics
- We no longer need to drop the `llm.` prefix from custom attributes
- Because AI monitoring is diabled by default, we enabled it in `newrelic.yml` for testing