### PR TITLE
serverless updates, including support for v1 payload formats

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1249,6 +1249,7 @@ Style/MethodCallWithArgsParentheses:
     - add_dependency
     - add_development_dependency
     - catch
+    - debug
     - expect
     - fail
     - gem

--- a/lib/new_relic/agent.rb
+++ b/lib/new_relic/agent.rb
@@ -625,7 +625,7 @@ module NewRelic
         return
       end
 
-      if NewRelic::Agent.agent.serverless?
+      if NewRelic::Agent.agent&.serverless?
         ::NewRelic::Agent.logger.warn('Custom attributes are not supported in serverless mode')
         return
       end

--- a/lib/new_relic/agent/new_relic_service.rb
+++ b/lib/new_relic/agent/new_relic_service.rb
@@ -143,6 +143,10 @@ module NewRelic
       end
 
       def metric_data(stats_hash)
+        # The serverless payload parser wants a different format (so do the
+        # agent specs)
+        return NewRelic::Agent.agent.serverless_handler.metric_data(stats_hash) if NewRelic::Agent.agent.serverless?
+
         timeslice_start = stats_hash.started_at
         timeslice_end = stats_hash.harvested_at || Process.clock_gettime(Process::CLOCK_REALTIME)
         metric_data_array = build_metric_data_array(stats_hash)

--- a/lib/new_relic/agent/new_relic_service.rb
+++ b/lib/new_relic/agent/new_relic_service.rb
@@ -143,8 +143,7 @@ module NewRelic
       end
 
       def metric_data(stats_hash)
-        # The serverless payload parser wants a different format (so do the
-        # agent specs)
+        # let the serverless handler handle serialization
         return NewRelic::Agent.agent.serverless_handler.metric_data(stats_hash) if NewRelic::Agent.agent.serverless?
 
         timeslice_start = stats_hash.started_at
@@ -158,6 +157,9 @@ module NewRelic
       end
 
       def error_data(unsent_errors)
+        # let the serverless handler handle serialization
+        return NewRelic::Agent.agent.serverless_handler.error_data(unsent_errors) if NewRelic::Agent.agent.serverless?
+
         invoke_remote(:error_data, [@agent_id, unsent_errors],
           :item_count => unsent_errors.size)
       end

--- a/lib/new_relic/agent/serverless_handler.rb
+++ b/lib/new_relic/agent/serverless_handler.rb
@@ -78,7 +78,7 @@ module NewRelic
         payload_hash = {'metadata' => metadata, 'data' => @payloads}
         json = NewRelic::Agent.agent.service.marshaller.dump(payload_hash)
         gzipped = NewRelic::Agent::NewRelicService::Encoders::Compressed::Gzip.encode(json)
-        base64_encoded = NewRelic::Base64.encode64(gzipped)
+        base64_encoded = NewRelic::Base64.strict_encode64(gzipped)
         array = [VERSION, LAMBDA_MARKER, base64_encoded]
         string = ::JSON.dump(array)
 

--- a/lib/new_relic/agent/serverless_handler.rb
+++ b/lib/new_relic/agent/serverless_handler.rb
@@ -81,7 +81,7 @@ module NewRelic
       end
 
       def error_data(errors)
-        store_payload([nil, :error_data, errors.map(&:to_collector_array)])
+        store_payload(:error_data, [nil, errors.map(&:to_collector_array)])
       end
 
       private

--- a/lib/new_relic/agent/serverless_handler.rb
+++ b/lib/new_relic/agent/serverless_handler.rb
@@ -84,7 +84,10 @@ module NewRelic
 
         return puts string unless use_named_pipe?
 
-        File.open(NAMED_PIPE, 'w') { |f| f.puts string }
+        File.write(NAMED_PIPE, string)
+
+        NewRelic::Agent.logger.debug "Wrote serverless payload to #{NAMED_PIPE}\n" \
+          "BEGIN PAYLOAD>>>\n#{string}\n<<<END PAYLOAD"
       end
 
       def use_named_pipe?

--- a/lib/new_relic/agent/serverless_handler.rb
+++ b/lib/new_relic/agent/serverless_handler.rb
@@ -16,7 +16,7 @@ module NewRelic
       EXECUTION_ENVIRONMENT = "AWS_Lambda_ruby#{RUBY_VERSION.rpartition('.').first}".freeze
       LAMBDA_MARKER = 'NR_LAMBDA_MONITORING'
       LAMBDA_ENVIRONMENT_VARIABLE = 'AWS_LAMBDA_FUNCTION_NAME'
-      METHOD_BLOCKLIST = %i[agent_command_results connect get_agent_commands log_event_data preconnect profile_data
+      METHOD_BLOCKLIST = %i[agent_command_results connect get_agent_commands preconnect profile_data
         shutdown].freeze
       NAMED_PIPE = '/tmp/newrelic-telemetry'
       SUPPORTABILITY_METRIC = 'Supportability/AWSLambda/HandlerInvocation'
@@ -78,6 +78,10 @@ module NewRelic
         return if payload.last.empty?
 
         store_payload(:metric_data, payload)
+      end
+
+      def error_data(errors)
+        store_payload(:error_data, errors.map(&:to_collector_array))
       end
 
       private

--- a/lib/new_relic/agent/serverless_handler.rb
+++ b/lib/new_relic/agent/serverless_handler.rb
@@ -81,7 +81,7 @@ module NewRelic
       end
 
       def error_data(errors)
-        store_payload(:error_data, errors.map(&:to_collector_array))
+        store_payload([nil, :error_data, errors.map(&:to_collector_array)])
       end
 
       private

--- a/test/new_relic/agent/serverless_handler_test.rb
+++ b/test/new_relic/agent/serverless_handler_test.rb
@@ -69,6 +69,11 @@ module NewRelic::Agent
           end
         end
 
+        errors = output.last['data']['error_data'].last
+
+        assert_equal 1, errors.size
+        assert_equal 'lambda_function', errors.first[1]
+        assert_equal 'Kaboom!', errors.first[2]
         assert_equal 'Kaboom!', output.last['data']['error_event_data'].last.first.first['error.message']
       end
 

--- a/test/new_relic/agent/serverless_handler_test.rb
+++ b/test/new_relic/agent/serverless_handler_test.rb
@@ -72,6 +72,16 @@ module NewRelic::Agent
         assert_equal 'Kaboom!', output.last['data']['error_event_data'].last.first.first['error.message']
       end
 
+      def test_log_events_are_reported
+        output = with_output do
+          handler.invoke_lambda_function_with_new_relic(method_name: :customer_lambda_function,
+            event: {simulate_logging: true},
+            context: testing_context)
+        end
+
+        assert_match 'languidly', output.last['data']['log_event_data'].first['logs'].first['message']
+      end
+
       def test_customer_function_lives_within_a_namespace
         context = testing_context
         output = with_output do

--- a/test/new_relic/agent/serverless_handler_test.rb
+++ b/test/new_relic/agent/serverless_handler_test.rb
@@ -56,7 +56,7 @@ module NewRelic::Agent
         end
         context.verify
 
-        assert_equal 4, output.last['metric_data'].size
+        assert_equal 4, output.last['data']['metric_data'].size
         assert_match(/lambda_function/, output.to_s)
       end
 
@@ -69,30 +69,7 @@ module NewRelic::Agent
           end
         end
 
-        assert_equal 'Kaboom!', output.last['error_event_data'].last.first.first['error.message']
-      end
-
-      def test_log_events_and_reported
-        output = with_output do
-          handler.invoke_lambda_function_with_new_relic(method_name: :customer_lambda_function,
-            event: {simulate_logging: true},
-            context: testing_context)
-        end
-
-        assert_match 'languidly', output.last['log_event_data'].first['logs'].first['message']
-      end
-
-      def test_errors_and_logs_at_the_same_time_man
-        output = with_output do
-          assert_raises RuntimeError do
-            handler.invoke_lambda_function_with_new_relic(method_name: :customer_lambda_function,
-              event: {simulate_exception: true, simulate_logging: true},
-              context: testing_context)
-          end
-        end
-
-        assert_equal 1, output.last['error_data'].last.size
-        assert_equal 1, output.last['log_event_data'].first['logs'].size
+        assert_equal 'Kaboom!', output.last['data']['error_event_data'].last.first.first['error.message']
       end
 
       def test_customer_function_lives_within_a_namespace
@@ -107,7 +84,7 @@ module NewRelic::Agent
         end
         context.verify
 
-        assert_equal 4, output.last['metric_data'].size
+        assert_equal 4, output.last['data']['metric_data'].size
         assert_match(/lambda_function/, output.to_s)
       end
 

--- a/test/new_relic/agent/serverless_handler_test.rb
+++ b/test/new_relic/agent/serverless_handler_test.rb
@@ -255,6 +255,23 @@ module NewRelic::Agent
         refute fresh_handler.send(:add_agent_attributes)
       end
 
+      def test_custom_attributes_arent_supported_when_serverless
+        skip_unless_minitest5_or_above
+
+        attrs = {cool_id: 'James', server: 'less', current_time: Time.now.to_s}
+        tl_current_mock = Minitest::Mock.new
+        tl_current_mock.expect :add_custom_attributes, -> { attribute_set_attempted = true }, [attrs]
+
+        attribute_set_attempted = false
+        in_transaction do
+          Transaction.stub :tl_current, tl_current_mock do
+            ::NewRelic::Agent.add_custom_attributes(attrs)
+          end
+        end
+
+        refute attribute_set_attempted
+      end
+
       private
 
       def handler


### PR DESCRIPTION
- Default to serverless output payload format v2, but support v1 via an env var being set
- Use custom formatting for `metric_data` and `error_data`
- Don't allow custom attributes with serverless
- misc serverless improvements