### PR TITLE
Reorder dispatchers check

### DIFF
--- a/lib/new_relic/local_environment.rb
+++ b/lib/new_relic/local_environment.rb
@@ -60,21 +60,21 @@ module NewRelic
 
     def discover_dispatcher
       dispatchers = %w[
+        puma
+        sidekiq
+        falcon
+        delayed_job
+        unicorn
         passenger
+        resque
         torquebox
         trinidad
         glassfish
-        resque
-        sidekiq
-        delayed_job
-        puma
         thin
         mongrel
         litespeed
-        unicorn
         webrick
         fastcgi
-        falcon
       ]
       while dispatchers.any? && @discovered_dispatcher.nil?
         send('check_for_' + (dispatchers.shift))


### PR DESCRIPTION
Reorders dispatches based on suggestion from [#2387](https://github.com/newrelic/newrelic-ruby-agent/issues/2387). We want to increase chances of early-exiting this loop that checks which dispatcher is at play by moving more popular/ prevlant dispatchers to the top of the list.

closes [#2387](https://github.com/newrelic/newrelic-ruby-agent/issues/2387)