### PR TITLE
Event attribute validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ## dev
 
-Version <dev> adds the request_temperature attribute to chat completions in ruby-openai instrumentation.
+Version <dev> adds the 'request.temperature' attribute to chat completion summaries in ruby-openai instrumentation.
 
-- **Bugfix: Add request_temperature to ruby-openai chat completions**
+- **Bugfix: Add 'request.temperature' to ruby-openai chat completion summaries**
 
-  Previously, the agent was not reporting the `request_temperature` attribute on chat completion events through ruby-openai instrumentation. We are now reporting this attribute.
+  Previously, the agent was not reporting the `request.temperature` attribute on `LlmChatCompletionSummary` events through ruby-openai instrumentation. We are now reporting this attribute.
 
 ## v9.8.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## dev
 
-Version <dev> adds the request_temperatue attribute to chat completions in ruby-openai instrumentation.
+Version <dev> adds the request_temperature attribute to chat completions in ruby-openai instrumentation.
 
 - **Bugfix: Add request_temperature to ruby-openai chat completions**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # New Relic Ruby Agent Release Notes
 
+## dev
+
+Version <dev> adds the request_temperatue attribute to chat completions in ruby-openai instrumentation.
+
+- **Bugfix: Add request_temperature to ruby-openai chat completions**
+
+  Previously, the agent was not reporting the `request_temperature` attribute on chat completion events through ruby-openai instrumentation. We are now reporting this attribute.
+
 ## v9.8.0
 
 Version 9.8.0 introduces instrumentation for ruby-openai, adds the option to store tracer state on the thread-level, hardens the browser agent insertion logic to better proactively anticipate errors, and prevents excpetions from being raised in the Active Support Broadcast logger instrumentation.

--- a/lib/new_relic/agent/instrumentation/ruby_openai/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/ruby_openai/instrumentation.rb
@@ -68,7 +68,7 @@ module NewRelic::Agent::Instrumentation
         vendor: VENDOR,
         request_max_tokens: (parameters[:max_tokens] || parameters['max_tokens'])&.to_i,
         request_model: parameters[:model] || parameters['model'],
-        temperature: (parameters[:temperature] || parameters['temperature'])&.to_f,
+        request_temperature: (parameters[:temperature] || parameters['temperature'])&.to_f,
         metadata: llm_custom_attributes
       )
     end
@@ -128,7 +128,6 @@ module NewRelic::Agent::Instrumentation
     def update_chat_completion_messages(messages, response, summary)
       messages += create_chat_completion_response_messages(response, messages.size, summary.id)
       response_id = response['id'] || NewRelic::Agent::GuidGenerator.generate_guid
-
       messages.each do |message|
         message.id = "#{response_id}-#{message.sequence}"
         message.request_id = summary.request_id

--- a/test/multiverse/suites/ruby_openai/ruby_openai_instrumentation_test.rb
+++ b/test/multiverse/suites/ruby_openai/ruby_openai_instrumentation_test.rb
@@ -68,8 +68,30 @@ class RubyOpenAIInstrumentationTest < Minitest::Test
     summary_events = events.filter { |event| event[0]['type'] == NewRelic::Agent::Llm::ChatCompletionSummary::EVENT_NAME }
 
     assert_equal 1, summary_events.length
+  end
 
-    # TODO: Write tests that validate the event has the correct attributes
+  def test_chat_completion_events_assign_all_attributes
+    in_transaction do
+      stub_post_request do
+        client.chat(parameters: chat_params)
+      end
+    end
+    _, events = @aggregator.harvest!
+    summary_events = events.filter { |event| event[0]['type'] == NewRelic::Agent::Llm::ChatCompletionSummary::EVENT_NAME }
+    attributes = summary_events[0][1]
+
+    assert attributes['id']
+    assert attributes['span_id']
+    assert attributes['trace_id']
+    assert attributes['response.model']
+    assert attributes['vendor']
+    assert attributes['ingest_source']
+    assert attributes['request_max_tokens']
+    assert attributes['response.number_of_messages']
+    assert attributes['request.model']
+    assert attributes['response.choices.finish_reason']
+    assert attributes['request.temperature']
+    assert attributes['duration']
   end
 
   def test_chat_completion_records_message_events
@@ -82,7 +104,31 @@ class RubyOpenAIInstrumentationTest < Minitest::Test
     message_events = events.filter { |event| event[0]['type'] == NewRelic::Agent::Llm::ChatCompletionMessage::EVENT_NAME }
 
     assert_equal 5, message_events.length
-    # TODO: Write tests that validate the event has the correct attributes
+  end
+
+  def test_message_events_assign_all_attributes
+    in_transaction do
+      stub_post_request do
+        client.chat(parameters: chat_params)
+      end
+    end
+    _, events = @aggregator.harvest!
+    message_events = events.filter { |event| event[0]['type'] == NewRelic::Agent::Llm::ChatCompletionMessage::EVENT_NAME }
+
+    message_events.each do |event|
+      attributes = event[1]
+
+      assert attributes['id']
+      assert attributes['span_id']
+      assert attributes['trace_id']
+      assert attributes['response.model']
+      assert attributes['vendor']
+      assert attributes['ingest_source']
+      assert attributes['content']
+      assert attributes['role']
+      assert attributes['sequence']
+      assert attributes['completion_id']
+    end
   end
 
   def test_segment_error_captured_if_raised
@@ -150,6 +196,32 @@ class RubyOpenAIInstrumentationTest < Minitest::Test
     refute summary_event[1]['trex']
   end
 
+  def test_embedding_events_assign_all_attributes
+    in_transaction do
+      stub_post_request do
+        client.embeddings(parameters: embeddings_params)
+      end
+    end
+    _, events = @aggregator.harvest!
+    embedding_event = events.find { |event| event[0]['type'] == NewRelic::Agent::Llm::Embedding::EVENT_NAME }
+    attributes = embedding_event[1]
+  
+    # 'token_count' is assigned via a callback API and tested in
+    # test_embeddings_token_count_assigned_by_callback_if_present
+
+    # 'error' is only assigned in the presence of an error and tested in
+    # test_embedding_event_sets_error_true_if_raised
+    assert attributes['id']
+    assert attributes['span_id']
+    assert attributes['trace_id']
+    assert attributes['response.model']
+    assert attributes['vendor']
+    assert attributes['ingest_source']
+    assert attributes['input']
+    assert attributes['request.model']
+    assert attributes['duration']
+  end
+
   def test_llm_custom_attributes_added_to_embedding_events
     in_transaction do
       NewRelic::Agent.add_custom_attributes({
@@ -158,7 +230,7 @@ class RubyOpenAIInstrumentationTest < Minitest::Test
         'triceratops' => 'herbivore'
       })
       stub_post_request do
-        client.embeddings(parameters: chat_params)
+        client.embeddings(parameters: embeddings_params)
       end
     end
     _, events = @aggregator.harvest!

--- a/test/multiverse/suites/ruby_openai/ruby_openai_instrumentation_test.rb
+++ b/test/multiverse/suites/ruby_openai/ruby_openai_instrumentation_test.rb
@@ -83,7 +83,7 @@ class RubyOpenAIInstrumentationTest < Minitest::Test
     refute_empty attributes['id']
     refute_empty attributes['span_id']
     refute_empty attributes['trace_id']
-    refute_empty attributes['response.model']
+    assert_equal 'gpt-3.5-turbo-0613', attributes['response.model']
     refute_empty attributes['vendor']
     refute_empty attributes['ingest_source']
     refute_empty attributes['request.model']

--- a/test/multiverse/suites/ruby_openai/ruby_openai_instrumentation_test.rb
+++ b/test/multiverse/suites/ruby_openai/ruby_openai_instrumentation_test.rb
@@ -80,16 +80,16 @@ class RubyOpenAIInstrumentationTest < Minitest::Test
     summary_events = events.filter { |event| event[0]['type'] == NewRelic::Agent::Llm::ChatCompletionSummary::EVENT_NAME }
     attributes = summary_events[0][1]
 
-    assert attributes['id']
-    assert attributes['span_id']
-    assert attributes['trace_id']
-    assert attributes['response.model']
-    assert attributes['vendor']
-    assert attributes['ingest_source']
+    refute_empty attributes['id']
+    refute_empty attributes['span_id']
+    refute_empty attributes['trace_id']
+    refute_empty attributes['response.model']
+    refute_empty attributes['vendor']
+    refute_empty attributes['ingest_source']
+    refute_empty attributes['request.model']
+    refute_empty attributes['response.choices.finish_reason']
     assert attributes['request_max_tokens']
     assert attributes['response.number_of_messages']
-    assert attributes['request.model']
-    assert attributes['response.choices.finish_reason']
     assert attributes['request.temperature']
     assert attributes['duration']
   end
@@ -118,16 +118,16 @@ class RubyOpenAIInstrumentationTest < Minitest::Test
     message_events.each do |event|
       attributes = event[1]
 
-      assert attributes['id']
-      assert attributes['span_id']
-      assert attributes['trace_id']
-      assert attributes['response.model']
-      assert attributes['vendor']
-      assert attributes['ingest_source']
-      assert attributes['content']
-      assert attributes['role']
+      refute_empty attributes['id']
+      refute_empty attributes['span_id']
+      refute_empty attributes['trace_id']
+      refute_empty attributes['response.model']
+      refute_empty attributes['vendor']
+      refute_empty attributes['ingest_source']
+      refute_empty attributes['content']
+      refute_empty attributes['role']
+      refute_empty attributes['completion_id']
       assert attributes['sequence']
-      assert attributes['completion_id']
     end
   end
 
@@ -211,14 +211,14 @@ class RubyOpenAIInstrumentationTest < Minitest::Test
 
     # 'error' is only assigned in the presence of an error and tested in
     # test_embedding_event_sets_error_true_if_raised
-    assert attributes['id']
-    assert attributes['span_id']
-    assert attributes['trace_id']
-    assert attributes['response.model']
-    assert attributes['vendor']
-    assert attributes['ingest_source']
-    assert attributes['input']
-    assert attributes['request.model']
+
+    refute_empty attributes['span_id']
+    refute_empty attributes['trace_id']
+    refute_empty attributes['response.model']
+    refute_empty attributes['vendor']
+    refute_empty attributes['ingest_source']
+    refute_empty attributes['input']
+    refute_empty attributes['request.model']
     assert attributes['duration']
   end
 

--- a/test/multiverse/suites/ruby_openai/ruby_openai_instrumentation_test.rb
+++ b/test/multiverse/suites/ruby_openai/ruby_openai_instrumentation_test.rb
@@ -205,7 +205,7 @@ class RubyOpenAIInstrumentationTest < Minitest::Test
     _, events = @aggregator.harvest!
     embedding_event = events.find { |event| event[0]['type'] == NewRelic::Agent::Llm::Embedding::EVENT_NAME }
     attributes = embedding_event[1]
-  
+
     # 'token_count' is assigned via a callback API and tested in
     # test_embeddings_token_count_assigned_by_callback_if_present
 


### PR DESCRIPTION
Add tests to validate the desired attributed exist on chat completion, message, and embedding events. 

Through testing, it was discovered that the `request_temperature` on chat completion events was not being assigned. That has been fix and a CHANGELOG reflects this change.

closes #2440 