### PR TITLE
remove 'config' dir from project root

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -1,5 +1,0 @@
-# This config is used when setting up a basic rails environment for running the
-# unit tests.
-test:
-  database: ':memory:'
-  adapter: 'sqlite3'


### PR DESCRIPTION
remove the `config` dir from the project root and insist that all Rails based tests that would be looking for a `config` directory make use of the `config` subdirectories beneath `test/` instead.

resolves #2501 