### PR TITLE
Require OpenStruct where missing in tests

### DIFF
--- a/test/multiverse/suites/curb/curb_test.rb
+++ b/test/multiverse/suites/curb/curb_test.rb
@@ -4,6 +4,7 @@
 
 require 'curb'
 require 'newrelic_rpm'
+require 'ostruct'
 require 'http_client_test_cases'
 require 'new_relic/agent/http_clients/curb_wrappers'
 

--- a/test/multiverse/suites/httpx/httpx_instrumentation_test.rb
+++ b/test/multiverse/suites/httpx/httpx_instrumentation_test.rb
@@ -4,6 +4,7 @@
 
 require 'httpx'
 require 'newrelic_rpm'
+require 'ostruct'
 require 'http_client_test_cases'
 require 'uri'
 require_relative '../../../../lib/new_relic/agent/http_clients/httpx_wrappers'

--- a/test/multiverse/suites/rake/instrumentation_test.rb
+++ b/test/multiverse/suites/rake/instrumentation_test.rb
@@ -2,6 +2,7 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
+require 'ostruct'
 require_relative '../../../../lib/new_relic/agent/instrumentation/rake/instrumentation'
 
 class RakeInstrumentationTest < Minitest::Test

--- a/test/multiverse/suites/stripe/stripe_instrumentation_test.rb
+++ b/test/multiverse/suites/stripe/stripe_instrumentation_test.rb
@@ -3,8 +3,9 @@
 # frozen_string_literal: true
 
 require 'json'
-require 'stripe'
 require 'net/http'
+require 'ostruct'
+require 'stripe'
 
 class StripeInstrumentation < Minitest::Test
   API_KEY = '123456789'

--- a/test/new_relic/helper_test.rb
+++ b/test/new_relic/helper_test.rb
@@ -2,6 +2,7 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
+require 'ostruct'
 require_relative '../test_helper'
 
 # tests NewRelic::Helper


### PR DESCRIPTION
Rake removed its requirement of OpenStruct in version 13.2.0. This caused our stripe multiverse suite to fail.

Since our tests were executed using Rake, we were able to use OpenStruct without a require in the file.

Now, OpenStruct is explicitly required in all the files it is used.

See: https://github.com/ruby/rake/pull/545 

Resolves #2548 