### PR TITLE
Fix unused variable warnings in unit tests

### DIFF
--- a/test/new_relic/agent/llm/feedback_test.rb
+++ b/test/new_relic/agent/llm/feedback_test.rb
@@ -30,7 +30,7 @@ module NewRelic::Agent::Llm
         NewRelic::Agent.record_llm_feedback_event(trace_id: @trace_id, rating: 5,
           category: 'Helpful', message: 'Looks good!', metadata: {'pop' => 'tart', 'toaster' => 'strudel'})
         _, events = NewRelic::Agent.agent.custom_event_aggregator.harvest!
-        type, attributes = events[0]
+        _, attributes = events[0]
 
         assert_equal 'Helpful', attributes['category']
         assert_equal 'Looks good!', attributes['message']
@@ -77,7 +77,7 @@ module NewRelic::Agent::Llm
         in_transaction do
           NewRelic::Agent.record_llm_feedback_event(trace_id: @trace_id, rating: 5)
           _, events = NewRelic::Agent.agent.custom_event_aggregator.harvest!
-          type, attributes = events[0]
+          _, attributes = events[0]
 
           assert_nil attributes
         end

--- a/test/new_relic/agent/serverless_handler_test.rb
+++ b/test/new_relic/agent/serverless_handler_test.rb
@@ -276,10 +276,10 @@ module NewRelic::Agent
         skip_unless_minitest5_or_above
 
         attrs = {cool_id: 'James', server: 'less', current_time: Time.now.to_s}
+        attribute_set_attempted = false
         tl_current_mock = Minitest::Mock.new
         tl_current_mock.expect :add_custom_attributes, -> { attribute_set_attempted = true }, [attrs]
 
-        attribute_set_attempted = false
         in_transaction do
           Transaction.stub :tl_current, tl_current_mock do
             ::NewRelic::Agent.add_custom_attributes(attrs)


### PR DESCRIPTION
When I was running some tests locally for #2546, I noticed we had a few "unused variable" warnings. This PR fixes those warnings.

Closes #2554 