### PR TITLE
Resolve unused argument warnings in test

### DIFF
--- a/test/new_relic/agent/instrumentation/rails/action_dispatch_subscriber.rb
+++ b/test/new_relic/agent/instrumentation/rails/action_dispatch_subscriber.rb
@@ -83,7 +83,6 @@ module NewRelic::Agent::Instrumentation
       skip_unless_minitest5_or_above
 
       exception_object = StandardError.new
-      noticed = false
       segment = MiniTest::Mock.new
       segment.expect :notice_error, nil, [exception_object]
       SUBSCRIBER.stub(:pop_segment, segment, [ID]) do

--- a/test/new_relic/agent/instrumentation/rails/active_support_subscriber.rb
+++ b/test/new_relic/agent/instrumentation/rails/active_support_subscriber.rb
@@ -84,7 +84,7 @@ module NewRelic
 
         def test_key_recorded_as_attribute_on_traces
           key = 'blades'
-          txn = in_transaction('test') do
+          in_transaction('test') do
             generate_event('cache_read.active_support', key: key, hit: false)
           end
 
@@ -95,7 +95,7 @@ module NewRelic
         end
 
         def test_hit_recorded_as_attribute_on_traces
-          txn = in_transaction('test') do
+          in_transaction('test') do
             generate_event('cache_read.active_support', DEFAULT_PARAMS.merge(hit: false))
           end
 
@@ -107,7 +107,7 @@ module NewRelic
         end
 
         def test_super_operation_recorded_as_attribute_on_traces
-          txn = in_transaction('test') do
+          in_transaction('test') do
             generate_event('cache_read.active_support', DEFAULT_PARAMS.merge(super_operation: nil))
           end
 


### PR DESCRIPTION
I saw a few unused args warning when I was running some of the Rails unit tests. This PR fixes them.