### PR TITLE
improve nonce unit test

### DIFF
--- a/test/new_relic/rack/browser_monitoring_test.rb
+++ b/test/new_relic/rack/browser_monitoring_test.rb
@@ -51,8 +51,7 @@ if defined?(Rack::Test)
       end
 
       def self.skip_nonce?
-        # norails envs have ActionDispatch, so also check for Rails
-        !defined?(nonce_constant) || !defined?(Rails)
+        !defined?(Rails) || "#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}".to_f < 5.2
       end
 
       def call(env)
@@ -78,7 +77,7 @@ if defined?(Rack::Test)
 
       def apply_nonce(env)
         return unless @@use_nonce
-        return unless defined?(ActionDispatch::ContentSecurityPolicy::Request)
+        return unless defined?(self.class.nonce_constant)
 
         env[self.class.nonce_constant] = self.class.canned_nonce
       end

--- a/test/new_relic/rack/browser_monitoring_test.rb
+++ b/test/new_relic/rack/browser_monitoring_test.rb
@@ -50,6 +50,11 @@ if defined?(Rack::Test)
         ActionDispatch::ContentSecurityPolicy::Request::NONCE
       end
 
+      def self.skip_nonce?
+        # norails envs have ActionDispatch, so also check for Rails
+        !defined?(nonce_constant) || !defined?(Rails)
+      end
+
       def call(env)
         apply_nonce(env)
         advance_process_time(0.1)
@@ -159,7 +164,7 @@ if defined?(Rack::Test)
     end
 
     def test_with_nonce
-      skip 'We currently only test nonce when a Rails constant is defined' unless defined?(TestApp.nonce_constant)
+      skip 'We currently only test nonce when a Rails constant is defined' if TestApp.skip_nonce?
 
       begin
         setup_nonce
@@ -174,7 +179,7 @@ if defined?(Rack::Test)
     end
 
     def test_without_nonce
-      skip 'We currently only test nonce when a Rails constant is defined' unless defined?(TestApp.nonce_constant)
+      skip 'We currently only test nonce when a Rails constant is defined' if TestApp.skip_nonce?
 
       get('/')
 

--- a/test/new_relic/rack/browser_monitoring_test.rb
+++ b/test/new_relic/rack/browser_monitoring_test.rb
@@ -161,14 +161,16 @@ if defined?(Rack::Test)
     def test_with_nonce
       skip 'We currently only test nonce when a Rails constant is defined' unless defined?(TestApp.nonce_constant)
 
-      setup_nonce
+      begin
+        setup_nonce
 
-      get('/')
+        get('/')
 
-      assert_match(/nonce="#{Regexp.escape(TestApp.canned_nonce)}"/m, last_response.body,
-        "Expected the response body to contain a nonce value of #{TestApp.canned_nonce}, got: #{last_response.body}")
-    ensure
-      teardown_nonce unless defined?(Rails)
+        assert_match(/nonce="#{Regexp.escape(TestApp.canned_nonce)}"/m, last_response.body,
+          "Expected the response body to contain a nonce value of #{TestApp.canned_nonce}, got: #{last_response.body}")
+      ensure
+        teardown_nonce
+      end
     end
 
     def test_without_nonce


### PR DESCRIPTION
- check for the exact ActionDispatch constant, not Rails
- escape the random characters ('+', etc.) that may interfere with regex matching
- use ///m for regex