### PR TITLE
CI: require sqlite3 < 2 for Rails v6.1

### DIFF
--- a/test/environments/rails61/Gemfile
+++ b/test/environments/rails61/Gemfile
@@ -24,7 +24,7 @@ platforms :ruby, :rbx do
   elsif RUBY_VERSION < '2.7'
     gem 'sqlite3', '< 1.6'
   else
-    gem 'sqlite3'
+    gem 'sqlite3', '< 2'
   end
 end
 


### PR DESCRIPTION
Have the `rails61` environment stick to `sqlite3` v1