### PR TITLE
require sqlite3 < v2 for Rails 6.0

### DIFF
--- a/test/environments/rails60/Gemfile
+++ b/test/environments/rails60/Gemfile
@@ -25,7 +25,7 @@ platforms :ruby, :rbx do
   elsif RUBY_VERSION < '2.7'
     gem 'sqlite3', '~> 1.5.4'
   else
-    gem 'sqlite3'
+    gem 'sqlite3', '< 2'
   end
 end
 


### PR DESCRIPTION
Seemingly both Rails v6.0 and v6.1 cause issues with the new `sqlite3` v2.