### PR TITLE
async_http: newer versions require Ruby 3+

### DIFF
--- a/test/multiverse/suites/async_http/Envfile
+++ b/test/multiverse/suites/async_http/Envfile
@@ -9,8 +9,8 @@ suite_condition('async-http needs native C extensions') do
 end
 
 ASYNC_HTTP_VERSIONS = [
-  [nil, 2.5],
-  ['0.59.0', 2.5]
+  [nil, 3.0],
+  ['0.60.2', 2.5]
 ]
 
 def gem_list(async_http_version = nil)


### PR DESCRIPTION
The `async_http` gem changed it's Ruby version requirement from v0+ to v3+ starting with v0.61. Stop testing the latest version with anything less than Ruby 3.