### PR TITLE
async-http: Use v0.59 for Ruby 2

### DIFF
--- a/test/multiverse/suites/async_http/Envfile
+++ b/test/multiverse/suites/async_http/Envfile
@@ -10,7 +10,7 @@ end
 
 ASYNC_HTTP_VERSIONS = [
   [nil, 3.0],
-  ['0.60.2', 2.5]
+  ['0.59.0', 2.5]
 ]
 
 def gem_list(async_http_version = nil)


### PR DESCRIPTION
While async-http v0.60 is itself ok with Ruby 2, it's dependency on a newer async version is not.