### PR TITLE
ActiveSupport notifications: allowlist event names

### DIFF
--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -1427,6 +1427,11 @@ module NewRelic
             on caching. Any event name not included in this list will be ignored by the agent. Provide complete event
             names such as 'cache_fetch_hit.active_support'. Do not provide asterisks or regex patterns, and do not
             escape any characters with backslashes.
+
+            For a complete list of all possible Active Support event names, see the
+            [list of caching names](https://guides.rubyonrails.org/active_support_instrumentation.html#active-support-—-caching)
+            and the [list of messages names](https://guides.rubyonrails.org/active_support_instrumentation.html#active-support-—-messages)
+            from the official Rails documentation.
           ACTIVE_SUPPORT_EVENTS
         },
         :'instrumentation.active_support_broadcast_logger' => {

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -1429,8 +1429,8 @@ module NewRelic
             escape any characters with backslashes.
 
             For a complete list of all possible Active Support event names, see the
-            [list of caching names](https://guides.rubyonrails.org/active_support_instrumentation.html#active-support-—-caching)
-            and the [list of messages names](https://guides.rubyonrails.org/active_support_instrumentation.html#active-support-—-messages)
+            [list of caching names](https://edgeguides.rubyonrails.org/active_support_instrumentation.html#active-support-caching)
+            and the [list of messages names](https://edgeguides.rubyonrails.org/active_support_instrumentation.html#active-support-messages)
             from the official Rails documentation.
           ACTIVE_SUPPORT_EVENTS
         },

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -4,6 +4,7 @@
 
 require 'forwardable'
 require_relative '../../constants'
+require_relative '../instrumentation/active_support_subscriber'
 
 module NewRelic
   module Agent
@@ -1415,6 +1416,19 @@ module NewRelic
           :description => 'Configures the TCP/IP port for the trace observer Host'
         },
         # Instrumentation
+        :'instrumentation.active_support_notifications.active_support_events' => {
+          :default => NewRelic::Agent::Instrumentation::ActiveSupportSubscriber::EVENT_NAME_TO_METHOD_NAME.keys,
+          :public => true,
+          :type => Array,
+          :allowed_from_server => false,
+          :description => <<~ACTIVE_SUPPORT_EVENTS.chomp.tr("\n", ' ')
+            An allowlist array of Active Support notifications events specific to the Active Support library
+            itself that the agent should subscribe to. The Active Support library specific events focus primarily
+            on caching. Any event name not included in this list will be ignored by the agent. Provide complete event
+            names such as 'cache_fetch_hit.active_support'. Do not provide asterisks or regex patterns, and do not
+            escape any characters with backslashes.
+          ACTIVE_SUPPORT_EVENTS
+        },
         :'instrumentation.active_support_broadcast_logger' => {
           :default => instrumentation_value_from_boolean(:'application_logging.enabled'),
           :documentation_default => 'auto',

--- a/lib/new_relic/agent/instrumentation/active_support.rb
+++ b/lib/new_relic/agent/instrumentation/active_support.rb
@@ -18,6 +18,10 @@ DependencyDetection.defer do
       !NewRelic::Agent::Instrumentation::ActiveSupportSubscriber.subscribed?
   end
 
+  depends_on do
+    !NewRelic::Agent.config[EVENT_NAMES_PARAMETER].empty?
+  end
+
   executes do
     NewRelic::Agent.logger.info('Installing ActiveSupport instrumentation')
   end

--- a/lib/new_relic/agent/instrumentation/active_support.rb
+++ b/lib/new_relic/agent/instrumentation/active_support.rb
@@ -7,6 +7,8 @@ require 'new_relic/agent/instrumentation/active_support_subscriber'
 DependencyDetection.defer do
   named :active_support
 
+  EVENT_NAMES_PARAMETER = :'instrumentation.active_support_notifications.active_support_events'
+
   depends_on do
     !NewRelic::Agent.config[:disable_active_support]
   end
@@ -21,7 +23,8 @@ DependencyDetection.defer do
   end
 
   executes do
-    ActiveSupport::Notifications.subscribe(/\.active_support$/,
+    event_names = NewRelic::Agent.config[EVENT_NAMES_PARAMETER].map { |n| Regexp.escape(n) }.join('|')
+    ActiveSupport::Notifications.subscribe(/\A(?:#{event_names})\z/,
       NewRelic::Agent::Instrumentation::ActiveSupportSubscriber.new)
   end
 end

--- a/lib/new_relic/agent/instrumentation/active_support_subscriber.rb
+++ b/lib/new_relic/agent/instrumentation/active_support_subscriber.rb
@@ -31,8 +31,20 @@ module NewRelic
 
         def metric_name(name, payload)
           store = payload[:store]
-          method = EVENT_NAME_TO_METHOD_NAME.fetch(name, name.delete_prefix('cache_').delete_suffix('.active_support'))
+          method = method_name(name)
           "Ruby/ActiveSupport#{"/#{store}" if store}/#{method}"
+        end
+
+        def method_name(name)
+          # TODO: OLD RUBIES - remove the <= 2.4 path once 2.5+ is required
+          if RUBY_VERSION.to_f <= 2.4
+            # String#delete_prefix requires Ruby 2.5+
+            # rubocop:disable Performance/DeleteSuffix
+            EVENT_NAME_TO_METHOD_NAME.fetch(name, name.sub(/\Acache_/, '').sub(/\.active_support\z/, ''))
+            # rubocop:enable Performance/DeleteSuffix
+          else
+            EVENT_NAME_TO_METHOD_NAME.fetch(name, name.delete_prefix('cache_').delete_suffix('.active_support'))
+          end
         end
       end
     end

--- a/lib/new_relic/agent/instrumentation/active_support_subscriber.rb
+++ b/lib/new_relic/agent/instrumentation/active_support_subscriber.rb
@@ -2,7 +2,7 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
-require 'new_relic/agent/instrumentation/notifications_subscriber'
+require_relative 'notifications_subscriber'
 
 module NewRelic
   module Agent

--- a/test/new_relic/agent/instrumentation/rails/active_support_subscriber.rb
+++ b/test/new_relic/agent/instrumentation/rails/active_support_subscriber.rb
@@ -75,11 +75,12 @@ module NewRelic
         end
 
         def test_failsafe_if_event_does_not_match_expected_pattern
+          name = 'charcuterie_build_a_board_workshop'
           in_transaction('test') do
-            generate_event('charcuterie_build_a_board_workshop')
+            generate_event(name)
           end
 
-          assert_metrics_recorded "#{METRIC_PREFIX}#{DEFAULT_STORE}/Unknown"
+          assert_metrics_recorded "#{METRIC_PREFIX}#{DEFAULT_STORE}/#{name}"
         end
 
         def test_key_recorded_as_attribute_on_traces


### PR DESCRIPTION
Added a new :'instrumentation.active_support_notifications.active_support_events' configuration parameter to permit a user defined allowlist of Active Support notifications event names for the agent to subscribe to that are related to the Active Support library itself.

Event names that are not included on the list will be ignored by the agent