### PR TITLE
Tighten regex logic

### DIFF
--- a/.github/workflows/scripts/setup_bundler
+++ b/.github/workflows/scripts/setup_bundler
@@ -20,7 +20,7 @@ function using_old_ruby {
   #   '2.7.7'  => false, starts with "2", next digit is "7"
   #   '3.1.3'  => false, does not start with "2"
   echo "DEBUG: RUBY_VERSION = $RUBY_VERSION"
-  [[ $RUBY_VERSION =~ 2.[^67] ]]
+  [[ $RUBY_VERSION =~ ^2\.[^67] ]]
 }
 
 function update_to_desired_rubygems_version {
@@ -28,7 +28,7 @@ function update_to_desired_rubygems_version {
   # correctly install Bundler 1.17 for the multiverse test suite
   # Rubies < 2.3 need to use update_rubygems,
   # newer Rubies can use 'gem update --system'
-  if [[ $RUBY_VERSION =~ 2.[^7] ]]; then
+  if [[ $RUBY_VERSION =~ ^2\.[^7] ]]; then
     echo "DEBUG: running 'gem update --system 3.0.6 --force'"
     gem update --system 3.0.6 --force >/dev/null
   else
@@ -58,7 +58,7 @@ function install_desired_bundler_version {
 }
 
 function configure_bundler {
-  if ! [[ $RUBY_VERSION =~ 2.4 ]]; then
+  if ! [[ $RUBY_VERSION =~ ^2\.4 ]]; then
     echo "DEBUG: Ruby is not at version 2.4.x, skipping 'bundler config'"
     return
   fi
@@ -75,14 +75,14 @@ function install_ruby_version_specific_gems {
   fi
 
   # for some reason, ruby 3.0 fails unless 3.1.0 is installed before it bundles for rails_prepend suite/rails 7
-  if [[ $RUBY_VERSION =~ 3.0 ]]; then 
+  if [[ $RUBY_VERSION =~ ^3\.0 ]]; then 
     echo "DEBUG: running 'gem install digest'"
     gem install --default digest:3.1.0
     echo "installed digest 3.1.0"
   fi
 
   # for some reason, ruby 2.7+ fails unless strscan 3.0.4 is installed
-  if [[ $RUBY_VERSION = 3.* || $RUBY_VERSION =~ 2.7 ]]; then 
+  if [[ $RUBY_VERSION =~ ^3\. || $RUBY_VERSION =~ ^2\.7 ]]; then 
     echo "DEBUG: running 'gem install strscan'"
     gem install --default strscan:3.0.4
     echo "installed strscan 3.0.4"


### PR DESCRIPTION
Where we use `=~`, can lead to unintended matches. This PR adds some additional lockdown. Previously, `=~ 2.4` could match `3.2.4`. We're now being more specific (ex: `=~ ^2\.4`) with how we are matching.