### PR TITLE
bugfix: Rake 'console' shouldn't require Pry

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -134,5 +134,5 @@ task :console do
   require 'pry' if ENV['ENABLE_PRY']
   require 'newrelic_rpm'
   ARGV.clear
-  Pry.start
+  ENV['ENABLE_PRY'] ? Pry.start : binding.irb # rubocop:disable Lint/Debugger
 end


### PR DESCRIPTION
The Rake 'console' target should not require Pry and instead fall back to `binding.irb` when Pry is unavailable

resolves #2634 