### PR TITLE
Disable testing rails edge

### DIFF
--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -76,13 +76,13 @@ jobs:
                 "rails": "norails,rails61,rails60,rails70"
               },
               "3.1.5": {
-                "rails": "norails,rails61,rails70,railsedge"
+                "rails": "norails,rails61,rails70"
               },
               "3.2.4": {
-                "rails": "norails,rails61,rails70,railsedge"
+                "rails": "norails,rails61,rails70"
               },
               "3.3.1": {
-                "rails": "norails,rails61,rails70,railsedge"
+                "rails": "norails,rails61,rails70"
               }
             }
 

--- a/test/multiverse/suites/active_record_pg/Envfile
+++ b/test/multiverse/suites/active_record_pg/Envfile
@@ -22,7 +22,7 @@ ACTIVERECORD_VERSIONS = [
   ['5.0.0', 2.4, 2.7]
 ]
 
-unshift_rails_edge(ACTIVERECORD_VERSIONS)
+# unshift_rails_edge(ACTIVERECORD_VERSIONS)
 
 def gem_list(activerecord_version = nil)
   <<~RB

--- a/test/multiverse/suites/active_support_broadcast_logger/Envfile
+++ b/test/multiverse/suites/active_support_broadcast_logger/Envfile
@@ -11,7 +11,7 @@ ACTIVE_SUPPORT_VERSIONS = [
   ['7.1.0', 2.7]
 ]
 
-unshift_rails_edge(ACTIVE_SUPPORT_VERSIONS)
+# unshift_rails_edge(ACTIVE_SUPPORT_VERSIONS)
 
 def gem_list(activesupport_version = nil)
   <<-RB

--- a/test/multiverse/suites/rails/Envfile
+++ b/test/multiverse/suites/rails/Envfile
@@ -14,7 +14,7 @@ RAILS_VERSIONS = [
   ['4.2.11', 2.4, 2.4]
 ]
 
-unshift_rails_edge(RAILS_VERSIONS)
+# unshift_rails_edge(RAILS_VERSIONS)
 
 def haml_rails(rails_version = nil)
   if rails_version && (

--- a/test/multiverse/suites/rails_prepend/Envfile
+++ b/test/multiverse/suites/rails_prepend/Envfile
@@ -14,7 +14,7 @@ RAILS_VERSIONS = [
   ['4.2.0', 2.4, 2.4]
 ]
 
-unshift_rails_edge(RAILS_VERSIONS)
+# unshift_rails_edge(RAILS_VERSIONS)
 
 def gem_list(rails_version = nil)
   # earlier thor errors, uncertain if they persist


### PR DESCRIPTION
rails edge updated to rails 8.0 alpha, which causes a lot of our tests to fail. We will disable rails edge testing for now and create an issue for supporting rails 8.0