### PR TITLE
CI: test with Ruby v3.4.0-preview1

### DIFF
--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Configure git
         run: 'git config --global init.defaultBranch main'
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # tag v4.1.2
-      - uses: ruby/setup-ruby@1198b074305f9356bd56dd4b311757cc0dab2f1c # tag v1.175.1
+      - uses: ruby/setup-ruby@943103cae7d3f1bb1e4951d5fcc7928b40e4b742 # tag v1.177.1
         with:
           ruby-version: '3.3'
       - run: bundle
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: [2.4.10, 2.5.9, 2.6.10, 2.7.8, 3.0.7, 3.1.5, 3.2.4, 3.3.1]
+        ruby-version: [2.4.10, 2.5.9, 2.6.10, 2.7.8, 3.0.7, 3.1.5, 3.2.4, 3.3.1, 3.4.0-preview1]
 
     steps:
       - name: Configure git
@@ -50,7 +50,7 @@ jobs:
         run: sudo apt-get update; sudo apt-get install -y --no-install-recommends libcurl4-nss-dev libsasl2-dev libxslt1-dev
 
       - name: Install Ruby ${{ matrix.ruby-version }}
-        uses: ruby/setup-ruby@1198b074305f9356bd56dd4b311757cc0dab2f1c # tag v1.175.1
+        uses: ruby/setup-ruby@943103cae7d3f1bb1e4951d5fcc7928b40e4b742 # tag v1.177.1
         with:
           ruby-version: ${{ matrix.ruby-version }}
 
@@ -82,6 +82,9 @@ jobs:
                 "rails": "norails,rails61,rails70"
               },
               "3.3.1": {
+                "rails": "norails,rails61,rails70"
+              },
+              "3.4.0-preview1": {
                 "rails": "norails,rails61,rails70"
               }
             }
@@ -200,7 +203,7 @@ jobs:
       fail-fast: false
       matrix:
         multiverse: [agent, ai, background, background_2, database, frameworks, httpclients, httpclients_2, rails, rest]
-        ruby-version: [2.4.10, 2.5.9, 2.6.10, 2.7.8, 3.0.7, 3.1.5, 3.2.4, 3.3.1]
+        ruby-version: [2.4.10, 2.5.9, 2.6.10, 2.7.8, 3.0.7, 3.1.5, 3.2.4, 3.3.1, 3.4.0-preview1]
     steps:
       - name: Configure git
         run: 'git config --global init.defaultBranch main'
@@ -213,7 +216,7 @@ jobs:
         run: sudo apt-get update; sudo apt-get install -y --no-install-recommends libcurl4-nss-dev libsasl2-dev libxslt1-dev
 
       - name: Install Ruby ${{ matrix.ruby-version }}
-        uses: ruby/setup-ruby@1198b074305f9356bd56dd4b311757cc0dab2f1c # tag v1.175.1
+        uses: ruby/setup-ruby@943103cae7d3f1bb1e4951d5fcc7928b40e4b742 # tag v1.177.1
         with:
           ruby-version: ${{ matrix.ruby-version }}
 
@@ -278,14 +281,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: [2.7.8, 3.0.7, 3.1.5, 3.2.4, 3.3.1]
+        ruby-version: [2.7.8, 3.0.7, 3.1.5, 3.2.4, 3.3.1, 3.4.0-preview1]
     steps:
       - name: Configure git
         run: 'git config --global init.defaultBranch main'
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # tag v4.1.2
 
       - name: Install Ruby ${{ matrix.ruby-version }}
-        uses: ruby/setup-ruby@1198b074305f9356bd56dd4b311757cc0dab2f1c # tag v1.175.1
+        uses: ruby/setup-ruby@943103cae7d3f1bb1e4951d5fcc7928b40e4b742 # tag v1.177.1
         with:
           ruby-version: ${{ matrix.ruby-version }}
 

--- a/lib/new_relic/agent/instrumentation/elasticsearch/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/elasticsearch/instrumentation.rb
@@ -88,8 +88,8 @@ module NewRelic::Agent::Instrumentation
     private
 
     def nr_operation
-      operation_index = caller_locations.index { |line| line.to_s.match?(OPERATION_PATTERN) }
-      return unless operation_index && caller_locations[operation_index].to_s =~ INSTANCE_METHOD_PATTERN
+      location = caller_locations.detect { |loc| loc.to_s.match?(OPERATION_PATTERN) }
+      return unless location && location.to_s =~ INSTANCE_METHOD_PATTERN
 
       Regexp.last_match(1)
     end

--- a/lib/new_relic/agent/instrumentation/elasticsearch/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/elasticsearch/instrumentation.rb
@@ -54,7 +54,7 @@ module NewRelic::Agent::Instrumentation
     #
     #   index
 
-    INSTANCE_METHOD_PATTERN = /:in (?:`|')(?:.+#)([^']+)'\z/.freeze
+    INSTANCE_METHOD_PATTERN = /:in (?:`|')(?:.+#)?([^']+)'\z/.freeze
 
     INSTRUMENTATION_NAME = NewRelic::Agent.base_name(name)
 

--- a/lib/new_relic/agent/instrumentation/elasticsearch/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/elasticsearch/instrumentation.rb
@@ -8,6 +8,54 @@ module NewRelic::Agent::Instrumentation
   module Elasticsearch
     PRODUCT_NAME = 'Elasticsearch'
     OPERATION = 'perform_request'
+
+    # Pattern to use with client caller location strings. Look for a location
+    # that contains '/lib/elasticsearch/api/' and is NOT followed by the
+    # string held in the OPERATION constant
+    OPERATION_PATTERN = %r{/lib/elasticsearch/api/(?!.+#{OPERATION})}.freeze
+
+    # Use the OPERATION_PATTERN pattern to find the appropriate caller location
+    # that will contain the client instance method (example: 'search') and
+    # return that method name.
+    #
+    # A Ruby caller location matching the OPERATION_PATTERN will contain an
+    # elasticsearch client instance method name (such as "search"), and that
+    # method name will be used as the operation name.
+    #
+    # With Ruby < 3.4 the method name is listed as:
+    #
+    #   `search'
+    #
+    # with an opening backtick and a closing single tick. And only the
+    # method name itself is listed.
+    #
+    # With Ruby 3.4+ the method name is listed as:
+    #
+    #   'Elasticsearch::API::Actions#search'
+    #
+    # with opening and closing single ticks and the class defining the
+    # instance method listed.
+    #
+    # (?:) = ?: prevents capturing
+    # (?:`|') = allow ` or '
+    # (?:.+#) = allow the class name and '#' prefix to exist but ignore it
+    # ([^']+)' = after the opening ` or ', capturing everything up to the
+    #            closing '.  [^']+ = one or more characters that are not '
+    #
+    # Example Ruby 3.3.1 input:
+    #
+    #   /Users/fallwith/.rubies/ruby-3.3.1/lib/ruby/gems/3.3.0/gems/elasticsearch-api-7.17.10/lib/elasticsearch/api/actions/index.rb:74:in `index'
+    #
+    # Example Ruby 3.4.0-preview1 input:
+    #
+    #   /Users/fallwith/.rubies/ruby-3.4.0-preview1/lib/ruby/gems/3.4.0+0/gems/elasticsearch-api-7.17.10/lib/elasticsearch/api/actions/index.rb:74:in 'Elasticsearch::API::Actions#index'
+    #
+    # Example output for both Rubies:
+    #
+    #   index
+
+    INSTANCE_METHOD_PATTERN = /:in (?:`|')(?:.+#)([^']+)'\z/.freeze
+
     INSTRUMENTATION_NAME = NewRelic::Agent.base_name(name)
 
     # We need the positional arguments `params` and `body`
@@ -40,13 +88,10 @@ module NewRelic::Agent::Instrumentation
     private
 
     def nr_operation
-      operation_index = caller_locations.index do |line|
-        string = line.to_s
-        string.include?('lib/elasticsearch/api') && !string.include?(OPERATION)
-      end
-      return nil unless operation_index
+      operation_index = caller_locations.index { |line| line.to_s.match?(OPERATION_PATTERN) }
+      return unless operation_index && caller_locations[operation_index].to_s =~ INSTANCE_METHOD_PATTERN
 
-      caller_locations[operation_index].to_s.split('`')[-1].gsub(/\W/, '')
+      Regexp.last_match(1)
     end
 
     def nr_reported_query(query)

--- a/lib/sequel/extensions/new_relic_instrumentation.rb
+++ b/lib/sequel/extensions/new_relic_instrumentation.rb
@@ -78,8 +78,9 @@ module Sequel
     end
 
     THREAD_SAFE_CONNECTION_POOL_CLASSES = [
-      (defined?(::Sequel::ThreadedConnectionPool) && ::Sequel::ThreadedConnectionPool)
-    ].freeze
+      (defined?(::Sequel::ThreadedConnectionPool) && ::Sequel::ThreadedConnectionPool),
+      (defined?(::Sequel::TimedQueueConnectionPool) && RUBY_VERSION >= '3.4' && ::Sequel::TimedQueueConnectionPool)
+    ].compact.freeze
 
     def explainer_for(sql)
       proc do |*|

--- a/test/agent_helper.rb
+++ b/test/agent_helper.rb
@@ -1039,3 +1039,7 @@ def first_call_for(subject)
 
   items.first
 end
+
+def ruby_version_float
+  RUBY_VERSION.split('.')[0..1].join('.').to_f
+end

--- a/test/environments/norails/Gemfile
+++ b/test/environments/norails/Gemfile
@@ -22,3 +22,8 @@ gem 'simplecov' if ENV['VERBOSE_TEST_OUTPUT']
 
 gem 'warning'
 gem 'loofah', '~> 2.20.0' if RUBY_VERSION >= '2.4.0' && RUBY_VERSION < '2.5.0'
+
+if RUBY_VERSION.split('.')[0..1].join('.').to_f >= 3.4
+  gem 'mutex_m'
+  gem 'ostruct'
+end

--- a/test/environments/rails61/Gemfile
+++ b/test/environments/rails61/Gemfile
@@ -39,3 +39,10 @@ end
 
 gem 'simplecov' if ENV['VERBOSE_TEST_OUTPUT']
 gem 'warning'
+
+if RUBY_VERSION.split('.')[0..1].join('.').to_f >= 3.4
+  gem 'base64'
+  gem 'bigdecimal'
+  gem 'mutex_m'
+  gem 'ostruct'
+end

--- a/test/environments/rails70/Gemfile
+++ b/test/environments/rails70/Gemfile
@@ -25,3 +25,10 @@ end
 
 gem 'simplecov' if ENV['VERBOSE_TEST_OUTPUT']
 gem 'warning'
+
+if RUBY_VERSION.split('.')[0..1].join('.').to_f >= 3.4
+  gem 'base64'
+  gem 'bigdecimal'
+  gem 'mutex_m'
+  gem 'ostruct'
+end

--- a/test/multiverse/lib/multiverse/envfile.rb
+++ b/test/multiverse/lib/multiverse/envfile.rb
@@ -10,6 +10,13 @@ module Multiverse
     attr_reader :before, :after, :mode, :skip_message, :omit_collector
     attr_reader :instrumentation_permutations
 
+    RUBY34_PLUS_GEMS = <<~NON_BUILTIN_GEMS
+      gem 'base64'
+      gem 'bigdecimal'
+      gem 'mutex_m'
+      gem 'ostruct'
+    NON_BUILTIN_GEMS
+
     def initialize(file_path, options = {})
       self.file_path = file_path
       @instrumentation_permutations = ['chain']
@@ -61,7 +68,15 @@ module Multiverse
 
     def gemfile(content)
       content = strip_leading_spaces(content)
-      @gemfiles.push(content) unless content.nil? || content.empty?
+      return if content.nil? || content.empty?
+
+      @gemfiles.push(add_ruby34_plus_gems(content))
+    end
+
+    def add_ruby34_plus_gems(content)
+      return content unless RUBY_VERSION.split('.')[0..1].join('.').to_f >= 3.4
+
+      content + RUBY34_PLUS_GEMS
     end
 
     def ruby3_gem_sorted_set

--- a/test/multiverse/suites/elasticsearch/elasticsearch_instrumentation_test.rb
+++ b/test/multiverse/suites/elasticsearch/elasticsearch_instrumentation_test.rb
@@ -2,6 +2,22 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
+###
+#
+# NOTE: to locally mirror the hosted CI system, spin up an Elasticsearch v7
+#       Docker container mapped to local port 9200 and an Elasticsearch v8
+#       container mapped to local port 9250.
+#
+#       Step 1: define these shell aliases:
+#
+#         alias elastic8='docker run --rm --name elasticsearch -p 9250:9200 -p 9300:9300 -e "discovery.type=single-node" -e "xpack.security.enabled=false" -e "xpack.security.enrollment.enabled=false" docker.elastic.co/elasticsearch/elasticsearch:8.13.4'
+#
+#         alias elastic7='docker run --rm --name elasticsearch -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch:7.16.2'
+#
+#       Step 2: run 'elastic7' in one terminal/shell and 'elastic8' in another
+#
+###
+
 require 'elasticsearch'
 require 'socket'
 

--- a/test/multiverse/suites/rails/Envfile
+++ b/test/multiverse/suites/rails/Envfile
@@ -46,6 +46,7 @@ def gem_list(rails_version = nil)
     gem 'minitest', '#{minitest_rails_version(rails_version)}'
     gem 'erubis' if RUBY_PLATFORM.eql?('java')
     gem 'loofah', '~> 2.20.0' if RUBY_VERSION >= '2.4.0' && RUBY_VERSION < '2.5.0'
+    gem 'drb' if RUBY_VERSION >= '3.4.0'
   RB
 end
 

--- a/test/multiverse/suites/rails_prepend/Envfile
+++ b/test/multiverse/suites/rails_prepend/Envfile
@@ -28,6 +28,7 @@ def gem_list(rails_version = nil)
     gem 'erubis', '~> 2.7.0' if RUBY_PLATFORM.eql?('java')
     #{thor}
     gem 'loofah', '~> 2.20.0' if RUBY_VERSION >= '2.4.0' && RUBY_VERSION < '2.5.0'
+    gem 'drb' if RUBY_VERSION >= '3.4.0'
   RB
 end
 

--- a/test/new_relic/agent/agent_logger_test.rb
+++ b/test/new_relic/agent/agent_logger_test.rb
@@ -251,9 +251,9 @@ class AgentLoggerTest < Minitest::Test
   end
 
   def test_log_exception_gets_backtrace_for_system_stack_error
-    # This facility compensates for poor SystemStackError traces on MRI.
-    # JRuby raises errors with good backtraces, so skip this test.
-    return if NewRelic::LanguageSupport.jruby?
+    # This facility compensates for poor SystemStackError traces on MRI < v3.4.
+    # JRuby and MRI v3.4+ raise errors with good backtraces, so skip this test.
+    return if NewRelic::LanguageSupport.jruby? || ruby_version_float >= 3.4
 
     logger = create_basic_logger
 


### PR DESCRIPTION
- Introduce nightly testing against Ruby v3.4.0-preview1
- Update elasticsearch instrumentation to be Ruby 3.4+ compatible
- Update various test environment `Gemfile` files to include gems that were previously included with Ruby as part of the default installation but are no longer included with Ruby 3.4 or 3.5.

resolves #2636 
resolves #2665 
resolves #2670
resolves #2672