### PR TITLE
Limit ffi version for Rubies below 2.7

### DIFF
--- a/test/multiverse/suites/ethon/Envfile
+++ b/test/multiverse/suites/ethon/Envfile
@@ -13,7 +13,14 @@ def gem_list(ethon_version = nil)
   <<~GEM_LIST
     gem 'ethon'#{ethon_version}
     gem 'rack'
+    gem 'ffi'#{ffi_version}
   GEM_LIST
+end
+
+# ffi version 1.17.0+ requires rubygems >= 3.3.22
+# The highest version compatible with Ruby 2.5/2.6 is 3.0.6
+def ffi_version
+   ", '< 1.17.0'" if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.7')
 end
 
 create_gemfiles(ETHON_VERSIONS)

--- a/test/multiverse/suites/httprb/Envfile
+++ b/test/multiverse/suites/httprb/Envfile
@@ -24,8 +24,14 @@ def gem_list(httprb_version = nil)
   <<~RB
     gem 'http'#{httprb_version}
     gem 'rack'
-
+    gem 'ffi'#{ffi_version}
   RB
+end
+
+# ffi version 1.17.0+ requires rubygems >= 3.3.22
+# The highest version compatible with Ruby 2.5/2.6 is 3.0.6
+def ffi_version
+   ", '< 1.17.0'" if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.7')
 end
 
 create_gemfiles(HTTPRB_VERSIONS)

--- a/test/multiverse/suites/typhoeus/Envfile
+++ b/test/multiverse/suites/typhoeus/Envfile
@@ -21,8 +21,14 @@ def gem_list(typhoeus_version = nil)
     gem 'typhoeus'#{typhoeus_version}
     gem 'ethon' if RUBY_PLATFORM == 'java'
     gem 'rack'
-
+    gem 'ffi'#{ffi_version}
   RB
+end
+
+# ffi version 1.17.0+ requires rubygems >= 3.3.22
+# The highest version compatible with Ruby 2.5/2.6 is 3.0.6
+def ffi_version
+   ", '< 1.17.0'" if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.7')
 end
 
 create_gemfiles(TYPHOEUS_VERSIONS)


### PR DESCRIPTION
ffi version 1.17.0 requires a version of Ruby gems that is incompatible with Ruby 2.5 and Ruby 2.6. This caused bundling to fail for our ethon, typheous, and HTTP.rb suites.

Link to example failure: https://github.com/newrelic/newrelic-ruby-agent/actions/runs/9353651649/job/25744692956#step:12:5133 