### PR TITLE
Bugfix: Dynamodb instrumentation access_key_id error on some credential classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 Version <dev> fixes a bug related to the new DynamoDB instrumentation.
 
 - **Bugfix: DynamoDB instrumentation logging errors when trying to get account_id**
-  When trying to access data needed to add the account_id to the dynamodb span, the agent was encountering an error when certain credentials classes were in use. This has been fixed. Thanks to [@kichik](https://github.com/kichik) for bringing this to our attention. [PR#2767](https://github.com/newrelic/newrelic-ruby-agent/pull/2681)
+
+    When trying to access data needed to add the `account_id` to the DynamoDB span, the agent encountered an error when certain credentials classes were used. This has been fixed. Thanks to [@kichik](https://github.com/kichik) for bringing this to our attention. [PR#2864](https://github.com/newrelic/newrelic-ruby-agent/pull/2684)
 
 
 ## v9.10.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # New Relic Ruby Agent Release Notes
 
+## dev
+
+Version <dev> fixes a bug related to the new DynamoDB instrumentation.
+
+- **Bugfix: DynamoDB instrumentation logging errors when trying to get account_id**
+  When trying to access data needed to add the account_id to the dynamodb span, the agent was encountering an error when certain credentials classes were in use. This has been fixed. Thanks to [@kichik](https://github.com/kichik) for bringing this to our attention. [PR#2767](https://github.com/newrelic/newrelic-ruby-agent/pull/2681)
+
+
 ## v9.10.1
 
 - **Bugfix: Incompatibility with Bootstrap**

--- a/lib/new_relic/agent/aws.rb
+++ b/lib/new_relic/agent/aws.rb
@@ -19,6 +19,8 @@ module NewRelic
         return unless access_key_id
 
         NewRelic::Agent::Aws.convert_access_key_to_account_id(access_key_id)
+      rescue => e
+        NewRelic::Agent.logger.debug("Failed to create account id: #{e}")
       end
 
       def self.convert_access_key_to_account_id(access_key)

--- a/lib/new_relic/agent/aws.rb
+++ b/lib/new_relic/agent/aws.rb
@@ -9,8 +9,11 @@ module NewRelic
       HEX_MASK = '7fffffffff80'
 
       def self.create_arn(service, resource, config)
+        access_key_id = config&.credentials&.credentials&.access_key_id if config&.credentials&.credentials&.respond_to?(:access_key_id)
+        return unless access_key_id
+
         region = config.region
-        account_id = NewRelic::Agent::Aws.convert_access_key_to_account_id(config.credentials.access_key_id)
+        account_id = NewRelic::Agent::Aws.convert_access_key_to_account_id(access_key_id)
 
         "arn:aws:#{service}:#{region}:#{account_id}:#{resource}"
       rescue => e

--- a/lib/new_relic/agent/aws.rb
+++ b/lib/new_relic/agent/aws.rb
@@ -8,16 +8,17 @@ module NewRelic
       CHARACTERS = %w[A B C D E F G H I J K L M N O P Q R S T U V W X Y Z 2 3 4 5 6 7].freeze
       HEX_MASK = '7fffffffff80'
 
-      def self.create_arn(service, resource, config)
-        access_key_id = config&.credentials&.credentials&.access_key_id if config&.credentials&.credentials&.respond_to?(:access_key_id)
-        return unless access_key_id
-
-        region = config.region
-        account_id = NewRelic::Agent::Aws.convert_access_key_to_account_id(access_key_id)
-
+      def self.create_arn(service, resource, region, account_id)
         "arn:aws:#{service}:#{region}:#{account_id}:#{resource}"
       rescue => e
         NewRelic::Agent.logger.warn("Failed to create ARN: #{e}")
+      end
+
+      def self.get_account_id(config)
+        access_key_id = config&.credentials&.credentials&.access_key_id if config&.credentials&.credentials&.respond_to?(:access_key_id)
+        return unless access_key_id
+
+        NewRelic::Agent::Aws.convert_access_key_to_account_id(access_key_id)
       end
 
       def self.convert_access_key_to_account_id(access_key)

--- a/lib/new_relic/agent/aws.rb
+++ b/lib/new_relic/agent/aws.rb
@@ -15,7 +15,7 @@ module NewRelic
       end
 
       def self.get_account_id(config)
-        access_key_id = config&.credentials&.credentials&.access_key_id if config&.credentials&.credentials&.respond_to?(:access_key_id)
+        access_key_id = config.credentials.credentials.access_key_id if config&.credentials&.credentials&.respond_to?(:access_key_id)
         return unless access_key_id
 
         NewRelic::Agent::Aws.convert_access_key_to_account_id(access_key_id)

--- a/lib/new_relic/agent/instrumentation/dynamodb/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/dynamodb/instrumentation.rb
@@ -50,7 +50,9 @@ module NewRelic::Agent::Instrumentation
     end
 
     def nr_account_id
-      @nr_account_id ||= NewRelic::Agent::Aws.get_account_id(config)
+      return @nr_account_id if defined?(@nr_account_id)
+
+      @nr_account_id = NewRelic::Agent::Aws.get_account_id(config)
     end
 
     def get_arn(params)

--- a/lib/new_relic/agent/instrumentation/dynamodb/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/dynamodb/instrumentation.rb
@@ -49,10 +49,14 @@ module NewRelic::Agent::Instrumentation
       @nr_captured_request = yield
     end
 
-    def get_arn(params)
-      return unless params[:table_name]
+    def nr_account_id
+      @nr_account_id ||= NewRelic::Agent::Aws.get_account_id(config)
+    end
 
-      NewRelic::Agent::Aws.create_arn(PRODUCT.downcase, "table/#{params[:table_name]}", config)
+    def get_arn(params)
+      return unless params[:table_name] && nr_account_id
+
+      NewRelic::Agent::Aws.create_arn(PRODUCT.downcase, "table/#{params[:table_name]}", config&.region, nr_account_id)
     end
   end
 end

--- a/test/multiverse/suites/dynamodb/dynamodb_instrumentation_test.rb
+++ b/test/multiverse/suites/dynamodb/dynamodb_instrumentation_test.rb
@@ -7,6 +7,8 @@ require 'aws-sdk-dynamodb'
 class DynamodbInstrumentationTest < Minitest::Test
   def setup
     Aws.config.update(stub_responses: true)
+    NewRelic::Agent::Aws.stubs(:create_arn).returns('test-arn')
+    NewRelic::Agent::Aws.stubs(:get_account_id).returns('123456789')
     @stats_engine = NewRelic::Agent.instance.stats_engine
   end
 
@@ -22,7 +24,6 @@ class DynamodbInstrumentationTest < Minitest::Test
   def test_all_attributes_added_to_segment
     client = create_client
     Seahorse::Client::Http::Response.any_instance.stubs(:headers).returns({'x-amzn-requestid' => '1234321'})
-    NewRelic::Agent::Aws.stubs(:create_arn).returns('test-arn')
 
     in_transaction do |txn|
       client.query({

--- a/test/new_relic/agent/aws_test.rb
+++ b/test/new_relic/agent/aws_test.rb
@@ -9,6 +9,7 @@ class AwsTest < Minitest::Test
     config = mock
     config.stubs(:region).returns('us-test-region-1')
     mock_credentials = mock
+    mock_credentials.stubs(:credentials).returns(mock_credentials)
     mock_credentials.stubs(:access_key_id).returns('AKIAIOSFODNN7EXAMPLE') # this is a fake access key id from aws docs
     config.stubs(:credentials).returns(mock_credentials)
 

--- a/test/new_relic/agent/aws_test.rb
+++ b/test/new_relic/agent/aws_test.rb
@@ -6,19 +6,26 @@ require_relative '../../test_helper'
 
 class AwsTest < Minitest::Test
   def test_create_arn
+    service = 'test-service'
+    region = 'us-test-region-1'
+    account_id = '123456789'
+    resource = 'test/test-resource'
+    arn = NewRelic::Agent::Aws.create_arn(service, resource, region, account_id)
+
+    expected = 'arn:aws:test-service:us-test-region-1:123456789:test/test-resource'
+
+    assert_equal expected, arn
+  end
+
+  def test_get_account_id
     config = mock
-    config.stubs(:region).returns('us-test-region-1')
     mock_credentials = mock
     mock_credentials.stubs(:credentials).returns(mock_credentials)
     mock_credentials.stubs(:access_key_id).returns('AKIAIOSFODNN7EXAMPLE') # this is a fake access key id from aws docs
     config.stubs(:credentials).returns(mock_credentials)
 
-    service = 'test-service'
-    resource = 'test/test-resource'
-    arn = NewRelic::Agent::Aws.create_arn(service, resource, config)
+    account_id = NewRelic::Agent::Aws.get_account_id(config)
 
-    expected = 'arn:aws:test-service:us-test-region-1:36315003739:test/test-resource'
-
-    assert_equal expected, arn
+    assert_equal 36315003739, account_id
   end
 end


### PR DESCRIPTION
Not all aws credentials are credentials, but they do all seem to include credentials, so I've updated it to do credentials.credentials instead, which should work. I also added more safety/checks so that it won't cause an error and will just simply not try to make an arn if it doesn't have access to the necessary info.