### PR TITLE
Update instrumentation generator

### DIFF
--- a/lib/tasks/instrumentation_generator/instrumentation.thor
+++ b/lib/tasks/instrumentation_generator/instrumentation.thor
@@ -31,15 +31,16 @@ class Instrumentation < Thor
 
   def scaffold(name)
     @name = name
+    @snake_name = snake_name(@name)
     @method = options[:method] if options[:method]
     @args = options[:args] if options[:args]
     @class_name = ::NewRelic::LanguageSupport.camelize(name)
-    base_path = "#{INSTRUMENTATION_ROOT}#{name.downcase}"
+    base_path = "#{INSTRUMENTATION_ROOT}#{@snake_name}"
 
     empty_directory(base_path)
     create_instrumentation_files(base_path)
-    append_to_default_source(name)
-    append_to_newrelic_yml(name)
+    append_to_default_source(@name, @snake_name)
+    # append_to_newrelic_yml(@name, @snake_name) # This is now done on release, we don't need it anymore, but leaving it to be sure.
     create_tests(name)
   end
 
@@ -69,52 +70,59 @@ class Instrumentation < Thor
   def create_tests(name)
     @name = name
     @instrumentation_method_global_erb_snippet = '<%= $instrumentation_method %>'
-    base_path = "#{MULTIVERSE_SUITE_ROOT}#{@name.downcase}"
+    @snake_name = snake_name(@name)
+    base_path = "#{MULTIVERSE_SUITE_ROOT}#{@snake_name}"
     empty_directory(base_path)
     template('templates/Envfile.tt', "#{base_path}/Envfile")
-    template('templates/test.tt', "#{base_path}/#{@name.downcase}_instrumentation_test.rb")
+    template('templates/test.tt', "#{base_path}/#{@snake_name}_instrumentation_test.rb")
 
     empty_directory("#{base_path}/config")
     template('templates/newrelic.yml.tt', "#{base_path}/config/newrelic.yml")
   end
 
-  def append_to_default_source(name)
+  def append_to_default_source(name, snake_name)
     insert_into_file(
       DEFAULT_SOURCE_LOCATION,
-      config_block(name.downcase),
+      config_block(name, snake_name),
       after: ":description => 'Controls auto-instrumentation of bunny at start-up. May be one of: `auto`, `prepend`, `chain`, `disabled`.'
         },\n"
     )
   end
 
-  def append_to_newrelic_yml(name)
+  def append_to_newrelic_yml(name, snake_name)
     insert_into_file(
       NEWRELIC_YML_LOCATION,
-      yaml_block(name),
+      yaml_block(name, snake_name),
       after: "# instrumentation.bunny: auto\n"
     )
   end
 
-  def config_block(name)
-    <<~CONFIG
-      :'instrumentation.#{name.downcase}' => {
-        :default => 'auto',
-        :public => true,
-        :type => String,
-        :dynamic_name => true,
-        :allowed_from_server => false,
-        :description => 'Controls auto-instrumentation of the #{name} library at start-up. May be one of [auto|prepend|chain|disabled].'
-      },
+  def config_block(name, snake_name)
+    # Don't change to <<~
+    # We want to preserve the whitespace so the config is correctly indented
+    <<-CONFIG
+        :'instrumentation.#{snake_name}' => {
+          :default => 'auto',
+          :public => true,
+          :type => String,
+          :dynamic_name => true,
+          :allowed_from_server => false,
+          :description => 'Controls auto-instrumentation of the #{name} library at start-up. May be one of `auto`, `prepend`, `chain`, `disabled`.'
+        },
     CONFIG
   end
 
-  def yaml_block(name)
+  def yaml_block(name, snake_name)
     <<~HEREDOC
 
       # Controls auto-instrumentation of #{name} at start-up.
       # May be one of [auto|prepend|chain|disabled]
-      # instrumentation.#{name.downcase}: auto
+      # instrumentation.#{snake_name}: auto
     HEREDOC
+  end
+
+  def snake_name(name)
+    name.downcase.gsub('-', '_')
   end
 end
 

--- a/lib/tasks/instrumentation_generator/instrumentation.thor
+++ b/lib/tasks/instrumentation_generator/instrumentation.thor
@@ -122,7 +122,7 @@ class Instrumentation < Thor
   end
 
   def snake_name(name)
-    name.downcase.gsub('-', '_')
+    name.downcase.tr('-', '_')
   end
 end
 

--- a/lib/tasks/instrumentation_generator/templates/dependency_detection.tt
+++ b/lib/tasks/instrumentation_generator/templates/dependency_detection.tt
@@ -2,12 +2,12 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
-require_relative '<%= @name.downcase %>/instrumentation'
-require_relative '<%= @name.downcase %>/chain'
-require_relative '<%= @name.downcase %>/prepend'
+require_relative '<%= @snake_name.downcase %>/instrumentation'
+require_relative '<%= @snake_name.downcase %>/chain'
+require_relative '<%= @snake_name.downcase %>/prepend'
 
 DependencyDetection.defer do
-  named :<%= @name.match?(/\-|\_/) ? "'#{@name.downcase}'" : @name.downcase %>
+  named :<%= @name.match?(/\-|\_/) ? "'#{@snake_name}'" : @name.downcase %>
 
   depends_on do
     # The class that needs to be defined to prepend/chain onto. This can be used

--- a/lib/tasks/instrumentation_generator/templates/newrelic.yml.tt
+++ b/lib/tasks/instrumentation_generator/templates/newrelic.yml.tt
@@ -6,7 +6,7 @@ development:
   monitor_mode: true
   license_key: bootstrap_newrelic_admin_license_key_000
   instrumentation:
-    <%= @name.downcase %>: <%= @instrumentation_method_global_erb_snippet %>
+    <%= @snake_name %>: <%= @instrumentation_method_global_erb_snippet %>
   app_name: test
   log_level: debug
   host: 127.0.0.1


### PR DESCRIPTION
Our generator task hasn't been very compatible with gems that have hyphens in their names. This takes care of a few glitches I ran into while generating content for redis-clustering.

It also stops adding to the newrelic.yml file, since we have automation to update that file now. However, I stopped short of removing that code entirely.