### PR TITLE
Remove `Rails::Command::RakeCommand` from `autostart.denylisted_constants` default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # New Relic Ruby Agent Release Notes
 
+<dev>
+
+Version <dev> reverts a change to the default value of `autostart.denylisted_constants`.
+
+- **Bugfix: Revert changes to `autostart.denylisted_constants`**
+
+  The default value for the `autostart.denylisted_constants` configuration was changed in 9.10.0 to include `Rails::Command::RunnerCommand` and `Rails::Command::RakeCommand`. This prevented the agent from starting in a background job environment for some users. Rather than include `RunnerCommand` and `RakeCommand` in the default, we encourage users who do not want the agent to run in these contexts to add these constants to the configuration. Thank you [@edariedl](https://github.com/edariedl) for reporting this issue. [BUG#2677](https://github.com/newrelic/newrelic-ruby-agent/issues/2677)
+
 ## v9.10.1
 
 - **Bugfix: Incompatibility with Bootstrap**
@@ -11,7 +19,7 @@ Version 9.10.1 fixes an incompatibility between the agent and the [Bootstrap](ht
 Version 9.10.0 introduces instrumentation for DynamoDB, adds a new feature to automatically apply nonces from the Rails content security policy, fixes a bug that would cause an expected error to negatively impact a transaction's Apdex, and fixes the agent's autostart logic so that by default `rails runner` and `rails db` commands will not cause the agent to start.
 
 - **Feature: Add instrumentation for DynamoDB**
-  
+
     The agent has added instrumentation for the aws-sdk-dynamodb gem. The agent will now record datastore spans for DynamoDB client calls made with the aws-sdk-dynamodb gem.  [PR#2642](https://github.com/newrelic/newrelic-ruby-agent/pull/2642)
 
 - **Feature: Automatically apply nonces from the Rails content security policy**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,18 @@
 
 <dev>
 
-Version <dev> reverts a change to the default value of `autostart.denylisted_constants`.
+Version <dev> removes `Rails::Command::RakeCommand` from the default list of denylisted constants.
 
-- **Bugfix: Revert changes to `autostart.denylisted_constants`**
+- **Bugfix: Remove Rails::Command::RakeCommand from the default list of autostart.denylisted_constants**
 
-  The default value for the `autostart.denylisted_constants` configuration was changed in 9.10.0 to include `Rails::Command::RunnerCommand` and `Rails::Command::RakeCommand`. This prevented the agent from starting in a background job environment for some users. Rather than include `RunnerCommand` and `RakeCommand` in the default, we encourage users who do not want the agent to run in these contexts to add these constants to the configuration. Thank you [@edariedl](https://github.com/edariedl) for reporting this issue. [BUG#2677](https://github.com/newrelic/newrelic-ruby-agent/issues/2677)
+  The default value for the `autostart.denylisted_constants` configuration was changed in 9.10.0 to include `Rails::Command::RunnerCommand` and `Rails::Command::RakeCommand`. The inclusion of `Rails::Command::RakeCommand` prevented the agent from starting automatically when Solid Queue was started using `bin/rails solid_queue:start`. We recognize there are many commands nested within `Rails::Command::RakeCommand` and have decided to remove it from the default list. We encourage users who do not want the agent to run on `Rails::Command::RakeCommand` to add the constant to their configuration. This can be accomplished by adding the following to your `newrelic.yml` file:
+
+  ```yaml
+    autostart.denylisted_constants: "Rails::Command::ConsoleCommand,Rails::Command::CredentialsCommand,Rails::Command::Db::System::ChangeCommand,Rails::Command::DbConsoleCommand,Rails::Command::DestroyCommand,Rails::Command::DevCommand,Rails::Command::EncryptedCommand,Rails::Command::GenerateCommand,Rails::Command::InitializersCommand,Rails::Command::NotesCommand,Rails::Command::RakeCommand,Rails::Command::RoutesCommand,Rails::Command::RunnerCommand,Rails::Command::SecretsCommand,Rails::Console,Rails::DBConsole"
+  ```
+
+  Thank you, [@edariedl](https://github.com/edariedl), for reporting this issue. [Issue#2677](https://github.com/newrelic/newrelic-ruby-agent/issues/2677) [PR#2694](https://github.com/newrelic/newrelic-ruby-agent/pull/2694)
+
 
 ## v9.10.1
 

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -1082,9 +1082,7 @@ module NewRelic
             Rails::Command::GenerateCommand
             Rails::Command::InitializersCommand
             Rails::Command::NotesCommand
-            Rails::Command::RakeCommand
             Rails::Command::RoutesCommand
-            Rails::Command::RunnerCommand
             Rails::Command::SecretsCommand
             Rails::Console
             Rails::DBConsole].join(','),

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -1083,6 +1083,7 @@ module NewRelic
             Rails::Command::InitializersCommand
             Rails::Command::NotesCommand
             Rails::Command::RoutesCommand
+            Rails::Command::RunnerCommand
             Rails::Command::SecretsCommand
             Rails::Console
             Rails::DBConsole].join(','),


### PR DESCRIPTION
The inclusion of `Rails::Command::RakeCommand` prevented the agent from starting for background jobs in an application with ActiveJob and Solid Queue. Solid Queue uses a rake task to start, which can be invoked from Rails binstubs that leverage `Rails::Command::RakeCommand`. 

We encourage users who do not want the agent to run with `rails db:*`, or other rake tasks defined in Rails to include the constant in their `autostart.denylisted_constants` configuration. We are continuing to investigate options to be more specific about excluding rake tasks in modern versions of Rails.

Relates to #2677
Relates to #2691 