### PR TITLE
Remove branch coverage check from PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -357,3 +357,4 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           resultPath: lib/coverage_results/.last_run.json
           failedThreshold: 93.5
+          failedThresholdBranch: 50

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -357,4 +357,3 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           resultPath: lib/coverage_results/.last_run.json
           failedThreshold: 93.5
-          failedThresholdBranch: 71.5


### PR DESCRIPTION
Branch coverage is wonky and not counting things correctly. We plan to look into it further in the future, but for now lets just not have branch coverage block PRs. I first tried removing the branch coverage but that didnt' seem to do anything somehow, so instead I lowered the value.