### PR TITLE
SecurityInterface: Windows compatibility fix

### DIFF
--- a/lib/new_relic/control/security_interface.rb
+++ b/lib/new_relic/control/security_interface.rb
@@ -61,14 +61,14 @@ module NewRelic
       def security_agent_metric(setting)
         NewRelic::Agent.record_metric_once(SUPPORTABILITY_PREFIX_SECURITY_AGENT + setting)
       end
-    end
 
-    # preflight checks to perform before the security agent is initialized
-    def preflight
-      return unless ENV['OS'].to_s.match?('Windows') # preflight is currently only needed for Windows OSes
+      # preflight checks to perform before the security agent is initialized
+      def preflight
+        return unless ENV['OS'].to_s.match?('Windows') # preflight is currently only needed for Windows OSes
 
-      Timeout::timeout(PREFLIGHT_TIMEOUT_SECS) do
-        sleep 0.1 until NewRelic::Agent.agent.connected?
+        Timeout::timeout(PREFLIGHT_TIMEOUT_SECS) do
+          sleep 0.1 until NewRelic::Agent.agent.connected?
+        end
       end
     end
   end


### PR DESCRIPTION
Some unknown (concurrency or threading?) issue specific to Windows is causing the APM instrumentation logic to not be properly completed prior to the security agent being initialized.

A known fix is poll until `#connected?` responds with `true`, so let's place that check in the `SecurityInterface` as a preflight check.