### PR TITLE
add gha:update_versions Rake task

### DIFF
--- a/.github/versions.yml
+++ b/.github/versions.yml
@@ -1,0 +1,26 @@
+---
+# This file is consumed by lib/tasks/gha.rake
+ruby/setup-ruby:
+  :tag: v1.177.1
+  :sha: 943103cae7d3f1bb1e4951d5fcc7928b40e4b742
+actions/checkout:
+  :tag: v4.1.2
+  :sha: 9bb56186c3b09b4f86b1c65136769dd318469633
+nga333/variable-mapper:
+  :tag: v0.3.0
+  :sha: 3681b75f5c6c00162721168fb91ab74925eaebcb
+actions/cache:
+  :tag: v3.3.1
+  :sha: 88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
+nick-fields/retry:
+  :tag: v2.8.3
+  :sha: 943e742917ac94714d2f408a0e8320f2d1fcafcd
+technote-space/workflow-conclusion-action:
+  :tag: v3.0.3
+  :sha: 45ce8e0eb155657ab8ccf346ade734257fd196a5
+voxmedia/github-action-slack-notify-build:
+  :tag: v1.6.0
+  :sha: 3665186a8c1a022b28a1dbe0954e73aa9081ea9e
+Mercymeilya/last-workflow-status:
+  :tag: v0.3.3
+  :sha: 3418710aefe8556d73b6f173a0564d38bcfd9a43

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Configure git
         run: 'git config --global init.defaultBranch main'
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # tag v4.1.2
-      - uses: ruby/setup-ruby@1198b074305f9356bd56dd4b311757cc0dab2f1c # tag v1.175.1
+      - uses: ruby/setup-ruby@943103cae7d3f1bb1e4951d5fcc7928b40e4b742 # tag v1.177.1
         with:
           ruby-version: '3.3'
       - run: bundle
@@ -49,7 +49,7 @@ jobs:
         run: sudo apt-get update; sudo apt-get install -y --no-install-recommends libcurl4-nss-dev libsasl2-dev libxslt1-dev
 
       - name: Install Ruby ${{ matrix.ruby-version }}
-        uses: ruby/setup-ruby@1198b074305f9356bd56dd4b311757cc0dab2f1c # tag v1.175.1
+        uses: ruby/setup-ruby@943103cae7d3f1bb1e4951d5fcc7928b40e4b742 # tag v1.177.1
         with:
           ruby-version: ${{ matrix.ruby-version }}
 
@@ -204,7 +204,7 @@ jobs:
         run: sudo apt-get update; sudo apt-get install -y --no-install-recommends libcurl4-nss-dev libsasl2-dev libxslt1-dev
 
       - name: Install Ruby ${{ matrix.ruby-version }}
-        uses: ruby/setup-ruby@1198b074305f9356bd56dd4b311757cc0dab2f1c # tag v1.175.1
+        uses: ruby/setup-ruby@943103cae7d3f1bb1e4951d5fcc7928b40e4b742 # tag v1.177.1
         with:
           ruby-version: ${{ matrix.ruby-version }}
 
@@ -297,7 +297,7 @@ jobs:
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # tag v4.1.2
 
       - name: Install Ruby ${{ matrix.ruby-version }}
-        uses: ruby/setup-ruby@1198b074305f9356bd56dd4b311757cc0dab2f1c # tag v1.175.1
+        uses: ruby/setup-ruby@943103cae7d3f1bb1e4951d5fcc7928b40e4b742 # tag v1.177.1
         with:
           ruby-version: ${{ matrix.ruby-version }}
 
@@ -337,7 +337,7 @@ jobs:
       - name: Configure git
         run: 'git config --global init.defaultBranch main'
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # tag v4.1.2
-      - uses: ruby/setup-ruby@1198b074305f9356bd56dd4b311757cc0dab2f1c # tag v1.175.1
+      - uses: ruby/setup-ruby@943103cae7d3f1bb1e4951d5fcc7928b40e4b742 # tag v1.177.1
         with:
           ruby-version: '3.3'
       - run: bundle

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -316,8 +316,8 @@ jobs:
     runs-on: ubuntu-22.04
     if: always()
     steps:
-      - uses: technote-space/workflow-conclusion-action@45ce8e0eb155657ab8ccf346ade734257fd196a5 # tag v3.0.3
-      - uses: voxmedia/github-action-slack-notify-build@3665186a8c1a022b28a1dbe0954e73aa9081ea9e # v1.6.0
+      - uses: technote-space/workflow-conclusion-action@45ce8e0eb155657ab8ccf346ade734257fd196a5a # tag v3.0.3
+      - uses: voxmedia/github-action-slack-notify-build@3665186a8c1a022b28a1dbe0954e73aa9081ea9e # tag v1.6.0
         if: ${{ env.WORKFLOW_CONCLUSION == 'failure' && github.event_name != 'workflow_dispatch' }}
         env:
           SLACK_BOT_TOKEN: ${{ secrets.RUBY_GITHUB_ACTIONS_BOT_WEBHOOK }}
@@ -333,13 +333,13 @@ jobs:
     runs-on: ubuntu-22.04
     if: always()
     steps:
-      - uses: technote-space/workflow-conclusion-action@45ce8e0eb155657ab8ccf346ade734257fd196a5 # tag v3.0.3
+      - uses: technote-space/workflow-conclusion-action@45ce8e0eb155657ab8ccf346ade734257fd196a5a # tag v3.0.3
       - run: echo ${{ github.event_name }}
       - uses: Mercymeilya/last-workflow-status@3418710aefe8556d73b6f173a0564d38bcfd9a43 # tag v0.3.3
         id: last_status
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: voxmedia/github-action-slack-notify-build@3665186a8c1a022b28a1dbe0954e73aa9081ea9e # v1.6.0
+      - uses: voxmedia/github-action-slack-notify-build@3665186a8c1a022b28a1dbe0954e73aa9081ea9e # tag v1.6.0
         if: ${{ env.WORKFLOW_CONCLUSION == 'success' && steps.last_status.outputs.last_status == 'failure' && github.event_name != 'workflow_dispatch' }}
         env:
           SLACK_BOT_TOKEN: ${{ secrets.RUBY_GITHUB_ACTIONS_BOT_WEBHOOK }}

--- a/.github/workflows/ci_jruby.yml
+++ b/.github/workflows/ci_jruby.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # tag v4.1.2
 
       - name: Install JRuby
-        uses: ruby/setup-ruby@cacc9f1c0b3f4eb8a16a6bb0ed10897b43b9de49 # tag v1.176.0
+        uses: ruby/setup-ruby@943103cae7d3f1bb1e4951d5fcc7928b40e4b742 # tag v1.177.1
         with:
           ruby-version: jruby-9.4.7.0
 
@@ -49,7 +49,7 @@ jobs:
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # tag v4.1.2
 
       - name: Install JRuby
-        uses: ruby/setup-ruby@cacc9f1c0b3f4eb8a16a6bb0ed10897b43b9de49 # tag v1.176.0
+        uses: ruby/setup-ruby@943103cae7d3f1bb1e4951d5fcc7928b40e4b742 # tag v1.177.1
         with:
           ruby-version: jruby-9.4.7.0
 

--- a/.github/workflows/config_docs.yml
+++ b/.github/workflows/config_docs.yml
@@ -15,7 +15,7 @@ jobs:
       pull-requests: write
     steps:
     - name: Install Ruby 3.3
-      uses: ruby/setup-ruby@1198b074305f9356bd56dd4b311757cc0dab2f1c # tag v1.175.1
+      uses: ruby/setup-ruby@943103cae7d3f1bb1e4951d5fcc7928b40e4b742 # tag v1.177.1
       with:
         ruby-version: 3.3
 

--- a/.github/workflows/performance_tests.yml
+++ b/.github/workflows/performance_tests.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # tag v4.1.2
         with:
           ref: 'main'
-      - uses: ruby/setup-ruby@1198b074305f9356bd56dd4b311757cc0dab2f1c # tag v1.175.1
+      - uses: ruby/setup-ruby@943103cae7d3f1bb1e4951d5fcc7928b40e4b742 # tag v1.177.1
         with:
           ruby-version: '3.3'
       - run: bundle

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -11,7 +11,7 @@ jobs:
       pull-requests: write
     steps:
     - name: Install Ruby 3.3
-      uses: ruby/setup-ruby@1198b074305f9356bd56dd4b311757cc0dab2f1c # tag v1.175.1
+      uses: ruby/setup-ruby@943103cae7d3f1bb1e4951d5fcc7928b40e4b742 # tag v1.177.1
       with:
         ruby-version: 3.3
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       with:
         fetch-depth: 0
 
-    - uses: ruby/setup-ruby@1198b074305f9356bd56dd4b311757cc0dab2f1c # tag v1.175.1
+    - uses: ruby/setup-ruby@943103cae7d3f1bb1e4951d5fcc7928b40e4b742 # tag v1.177.1
       with:
         ruby-version: 3.3
 

--- a/.github/workflows/release_notes.yml
+++ b/.github/workflows/release_notes.yml
@@ -13,7 +13,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: ruby/setup-ruby@1198b074305f9356bd56dd4b311757cc0dab2f1c # tag v1.175.1
+      - uses: ruby/setup-ruby@943103cae7d3f1bb1e4951d5fcc7928b40e4b742 # tag v1.177.1
         with:
           ruby-version: 3.3
       - name: Checkout code

--- a/.github/workflows/release_pr.yml
+++ b/.github/workflows/release_pr.yml
@@ -14,7 +14,7 @@ jobs:
       pull-requests: write
     steps:
     - name: Install Ruby 3.3
-      uses: ruby/setup-ruby@1198b074305f9356bd56dd4b311757cc0dab2f1c # tag v1.175.1
+      uses: ruby/setup-ruby@943103cae7d3f1bb1e4951d5fcc7928b40e4b742 # tag v1.177.1
       with:
         ruby-version: 3.3
 

--- a/.github/workflows/slack_notifications.yml
+++ b/.github/workflows/slack_notifications.yml
@@ -8,7 +8,7 @@ jobs:
   gem_notifications:
     runs-on: ubuntu-22.04
     steps:
-      - uses: ruby/setup-ruby@1198b074305f9356bd56dd4b311757cc0dab2f1c # tag v1.175.1
+      - uses: ruby/setup-ruby@943103cae7d3f1bb1e4951d5fcc7928b40e4b742 # tag v1.177.1
         with:
           ruby-version: 3.3
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # tag v4.1.2
@@ -45,7 +45,7 @@ jobs:
   cve_notifications:
     runs-on: ubuntu-22.04
     steps:
-      - uses: ruby/setup-ruby@1198b074305f9356bd56dd4b311757cc0dab2f1c # tag v1.175.1
+      - uses: ruby/setup-ruby@943103cae7d3f1bb1e4951d5fcc7928b40e4b742 # tag v1.177.1
         with:
           ruby-version: 3.3
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # tag v4.1.2

--- a/lib/tasks/gha.rake
+++ b/lib/tasks/gha.rake
@@ -1,0 +1,31 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+require 'yaml'
+require_relative 'helpers/version_bump'
+
+# gha = GitHub Actions
+namespace :gha do
+  # See .github/versions.yml
+  desc 'Update 3rd party action versions across all workflows'
+  task :update_versions do
+    gh_dir = File.expand_path('../../../.github', __FILE__)
+    info = YAML.load_file(File.join(gh_dir, 'versions.yml'))
+    workflows = Dir.glob(File.join(gh_dir, 'workflows', '*.yml'))
+    workflows.each do |workflow|
+      original = File.read(workflow)
+      modified = original.dup
+      info.each do |action, settings|
+        modified.gsub!(/uses: #{action}.*$/, "uses: #{action}@#{settings[:sha]} # tag #{settings[:tag]}")
+      end
+
+      if original != modified
+        File.open(workflow, 'w') { |f| f.puts modified }
+        puts "Updated #{workflow} with changes"
+      else
+        puts "#{workflow} remains unchanged"
+      end
+    end
+  end
+end


### PR DESCRIPTION
to simplify 3rd party GitHub Actions versions specified across our various workflow files, put the versions in a `versions.yml` file and define a new `gha:update_versions` rake task to automatically reconcile the workflows with the versions specified

resolves #2702 