### PR TITLE
set `expected: true` for matching status codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,20 @@
 # New Relic Ruby Agent Release Notes
 
+## dev
+
+Version <dev> fixes a bug related to expected errors not bearing a "true" value for the "expected" attribute if expected as a result of an HTTP status code match.
+
+- **Bugfix: HTTP status code based expected errors will now have an "expected" value of "true"**
+
+    Previously when an error was treated as expected by the agent as a result of a matching HTTP status code being found in the :'error_collector.expected_status_codes' configuration setting, the error would not appear with an "expected" attribute value of "true" in the errors in the errors inbox. [PR#2710](https://github.com/newrelic/newrelic-ruby-agent/pull/2710)
+
 ## v9.10.2
 
 Version 9.10.2 fixes a bug related to the new DynamoDB instrumentation and removes `Rails::Command::RakeCommand` from the default list of denylisted constants.
 
 - **Bugfix: DynamoDB instrumentation logging errors when trying to get account_id**
 
-    When trying to access data needed to add the `account_id` to the DynamoDB span, the agent encountered an error when certain credentials classes were used. This has been fixed. Thanks to [@kichik](https://github.com/kichik) for bringing this to our attention. [PR#2864](https://github.com/newrelic/newrelic-ruby-agent/pull/2684)
+    When trying to access data needed to add the `account_id` to the DynamoDB span, the agent encountered an error when certain credentials classes were used. This has been fixed. Thanks to [@kichik](https://github.com/kichik) for bringing this to our attention. [PR#2684](https://github.com/newrelic/newrelic-ruby-agent/pull/2684)
 
 - **Bugfix: Remove Rails::Command::RakeCommand from the default list of autostart.denylisted_constants**
 


### PR DESCRIPTION
previously, errors that were noticed and treated as expected because the HTTP status code matched the list configured via
`:'error_collector.expected_status_codes'` would not actually end up with their `expected` attribute set to a `true` value.

the relevant agent error processing behavior has been updated so that `expected: true` should always be applied to all errors that are treated as expected by the agent.

resolves #2708