### PR TITLE
CI: Lock down Rack for old Grape v1.x versions

### DIFF
--- a/test/multiverse/suites/grape/Envfile
+++ b/test/multiverse/suites/grape/Envfile
@@ -19,13 +19,15 @@ def activesupport_version(grape_version)
   ", '< 7.1'" if grape_version&.include?('1.5')
 end
 
+# Grape v1.x expects Rack to deliver `rack/auth/digest/md5`, but Rack
+# stopped offering that class in Rack v3.1.0
+def rack_version(grape_version)
+  ", '~> 3.0.11'" if grape_version&.start_with('1.')
+end
+
 def gem_list(grape_version = nil)
-  # TODO: Grape <= v2.0 seems incompatible with Rack v3.1.0+ owing to the fact
-  #       that Grape expects Rack to deliver `rack/auth/digest/md5` and Rack
-  #       no longer offers that class. We should be able to constrain Rack for
-  #       only certain Grape versions once a Grape fix is in place.
   <<~RB
-    gem 'rack', '~> 3.0.11'
+    gem 'rack'#{rack_version(grape_version)}
     gem 'rack-test', '>= 0.8.0'
     gem 'grape'#{grape_version}
 

--- a/test/multiverse/suites/grape/Envfile
+++ b/test/multiverse/suites/grape/Envfile
@@ -22,7 +22,7 @@ end
 # Grape v1.x expects Rack to deliver `rack/auth/digest/md5`, but Rack
 # stopped offering that class in Rack v3.1.0
 def rack_version(grape_version)
-  ", '~> 3.0.11'" if grape_version&.start_with('1.')
+  ", '~> 3.0.11'" if grape_version&.start_with?('1.')
 end
 
 def gem_list(grape_version = nil)

--- a/test/multiverse/suites/grape/Envfile
+++ b/test/multiverse/suites/grape/Envfile
@@ -20,8 +20,12 @@ def activesupport_version(grape_version)
 end
 
 def gem_list(grape_version = nil)
+  # TODO: Grape <= v2.0 seems incompatible with Rack v3.1.0+ owing to the fact
+  #       that Grape expects Rack to deliver `rack/auth/digest/md5` and Rack
+  #       no longer offers that class. We should be able to constrain Rack for
+  #       only certain Grape versions once a Grape fix is in place.
   <<~RB
-    gem 'rack'
+    gem 'rack', '~> 3.0.11'
     gem 'rack-test', '>= 0.8.0'
     gem 'grape'#{grape_version}
 

--- a/test/multiverse/suites/grape/Envfile
+++ b/test/multiverse/suites/grape/Envfile
@@ -22,7 +22,7 @@ end
 # Grape v1.x expects Rack to deliver `rack/auth/digest/md5`, but Rack
 # stopped offering that class in Rack v3.1.0
 def rack_version(grape_version)
-  ", '~> 3.0.11'" if grape_version&.start_with?('1.')
+  ", '~> 3.0.11'" if grape_version.to_s.sub(/^[^\d]+/, '').start_with?('1.')
 end
 
 def gem_list(grape_version = nil)


### PR DESCRIPTION
Grape v1.x versions unhappy with the new Rack version. Let's lock down Rack when testing those versions.