### PR TITLE
mutex_m and ostruct as dev dependencies

### DIFF
--- a/newrelic_rpm.gemspec
+++ b/newrelic_rpm.gemspec
@@ -56,6 +56,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'minitest', "#{RUBY_VERSION >= '2.7.0' ? '5.3.3' : '4.7.5'}"
   s.add_development_dependency 'minitest-stub-const', '0.6'
   s.add_development_dependency 'mocha', '~> 1.16'
+  s.add_development_dependency 'mutex_m' # used by Minitest, not included in Rubies above v3.3
+  s.add_development_dependency 'ostruct' # used by Rack, not included in Rubies above v3.4
   s.add_development_dependency 'pry' if ENV['ENABLE_PRY']
   s.add_development_dependency 'rack'
   s.add_development_dependency 'rake', '12.3.3'


### PR DESCRIPTION
For Ruby v3.4/3.5 compatibility, declare `mutex_m` and `ostruct` as dev dependencies