### PR TITLE
CI: stop checking for / testing against Rack v1

### DIFF
--- a/test/multiverse/suites/rack/builder_map_test.rb
+++ b/test/multiverse/suites/rack/builder_map_test.rb
@@ -58,33 +58,27 @@ if NewRelic::Agent::Instrumentation::RackHelpers.rack_version_supported?
           run(PrefixAppTwo.new)
         end
 
-        # Rack versions prior to 1.4 did not support combining map and run at the
-        # top-level in the same Rack::Builder.
-        if Rack::VERSION[1] >= 4
-          run(ExampleApp.new)
-        end
+        run(ExampleApp.new)
       end
     end
 
-    if Rack::VERSION[1] >= 4
-      def test_metrics_for_default_prefix
-        get('/')
+    def test_metrics_for_default_prefix
+      get('/')
 
-        assert_metrics_recorded_exclusive([
-          'Apdex',
-          'ApdexAll',
-          'HttpDispatcher',
-          'Middleware/all',
-          'Controller/Rack/BuilderMapTest::ExampleApp/call',
-          'Apdex/Rack/BuilderMapTest::ExampleApp/call',
-          'Middleware/Rack/BuilderMapTest::MiddlewareOne/call',
-          'Middleware/Rack/BuilderMapTest::MiddlewareTwo/call',
-          'Nested/Controller/Rack/BuilderMapTest::ExampleApp/call',
-          ['Middleware/Rack/BuilderMapTest::MiddlewareOne/call', 'Controller/Rack/BuilderMapTest::ExampleApp/call'],
-          ['Middleware/Rack/BuilderMapTest::MiddlewareTwo/call', 'Controller/Rack/BuilderMapTest::ExampleApp/call'],
-          ['Nested/Controller/Rack/BuilderMapTest::ExampleApp/call', 'Controller/Rack/BuilderMapTest::ExampleApp/call']
-        ])
-      end
+      assert_metrics_recorded_exclusive([
+        'Apdex',
+        'ApdexAll',
+        'HttpDispatcher',
+        'Middleware/all',
+        'Controller/Rack/BuilderMapTest::ExampleApp/call',
+        'Apdex/Rack/BuilderMapTest::ExampleApp/call',
+        'Middleware/Rack/BuilderMapTest::MiddlewareOne/call',
+        'Middleware/Rack/BuilderMapTest::MiddlewareTwo/call',
+        'Nested/Controller/Rack/BuilderMapTest::ExampleApp/call',
+        ['Middleware/Rack/BuilderMapTest::MiddlewareOne/call', 'Controller/Rack/BuilderMapTest::ExampleApp/call'],
+        ['Middleware/Rack/BuilderMapTest::MiddlewareTwo/call', 'Controller/Rack/BuilderMapTest::ExampleApp/call'],
+        ['Nested/Controller/Rack/BuilderMapTest::ExampleApp/call', 'Controller/Rack/BuilderMapTest::ExampleApp/call']
+      ])
     end
 
     def test_metrics_for_mapped_prefix

--- a/test/multiverse/suites/rack/builder_map_test.rb
+++ b/test/multiverse/suites/rack/builder_map_test.rb
@@ -62,25 +62,6 @@ if NewRelic::Agent::Instrumentation::RackHelpers.rack_version_supported?
       end
     end
 
-    def test_metrics_for_default_prefix
-      get('/')
-
-      assert_metrics_recorded_exclusive([
-        'Apdex',
-        'ApdexAll',
-        'HttpDispatcher',
-        'Middleware/all',
-        'Controller/Rack/BuilderMapTest::ExampleApp/call',
-        'Apdex/Rack/BuilderMapTest::ExampleApp/call',
-        'Middleware/Rack/BuilderMapTest::MiddlewareOne/call',
-        'Middleware/Rack/BuilderMapTest::MiddlewareTwo/call',
-        'Nested/Controller/Rack/BuilderMapTest::ExampleApp/call',
-        ['Middleware/Rack/BuilderMapTest::MiddlewareOne/call', 'Controller/Rack/BuilderMapTest::ExampleApp/call'],
-        ['Middleware/Rack/BuilderMapTest::MiddlewareTwo/call', 'Controller/Rack/BuilderMapTest::ExampleApp/call'],
-        ['Nested/Controller/Rack/BuilderMapTest::ExampleApp/call', 'Controller/Rack/BuilderMapTest::ExampleApp/call']
-      ])
-    end
-
     def test_metrics_for_mapped_prefix
       get('/prefix1')
 

--- a/test/multiverse/suites/rack/url_map_test.rb
+++ b/test/multiverse/suites/rack/url_map_test.rb
@@ -71,7 +71,7 @@ if NewRelic::Agent::Instrumentation::RackHelpers.version_supported?
       end
     end
 
-    if defined?(Rack) && Rack::VERSION[1] >= 4
+    if defined?(Rack)
       def test_metrics_for_default_prefix
         get('/')
 

--- a/test/multiverse/suites/rack/url_map_test.rb
+++ b/test/multiverse/suites/rack/url_map_test.rb
@@ -71,29 +71,6 @@ if NewRelic::Agent::Instrumentation::RackHelpers.version_supported?
       end
     end
 
-    if defined?(Rack)
-      def test_metrics_for_default_prefix
-        get('/')
-
-        assert_metrics_recorded_exclusive([
-          'Apdex',
-          'ApdexAll',
-          'HttpDispatcher',
-          'Middleware/all',
-          'Controller/Rack/UrlMapTest::ExampleApp/call',
-          'Apdex/Rack/UrlMapTest::ExampleApp/call',
-          'Middleware/Rack/UrlMapTest::MiddlewareOne/call',
-          'Middleware/Rack/UrlMapTest::MiddlewareTwo/call',
-          nested_controller_metric,
-          'Nested/Controller/Rack/UrlMapTest::ExampleApp/call',
-          ['Middleware/Rack/UrlMapTest::MiddlewareOne/call', 'Controller/Rack/UrlMapTest::ExampleApp/call'],
-          ['Middleware/Rack/UrlMapTest::MiddlewareTwo/call', 'Controller/Rack/UrlMapTest::ExampleApp/call'],
-          ['Nested/Controller/Rack/UrlMapTest::ExampleApp/call', 'Controller/Rack/UrlMapTest::ExampleApp/call'],
-          [nested_controller_metric, 'Controller/Rack/UrlMapTest::ExampleApp/call']
-        ], :ignore_filter => /^(Supportability|Logging)/)
-      end
-    end
-
     def test_metrics_for_mapped_prefix
       get('/prefix1')
 


### PR DESCRIPTION
- assume all Rack testing will now involve a Rack at or above v1.4
- stop checking for `Rack::VERSION`, as modern Rack uses `Rack.release`
- remove 2 tests specific to Rack v1.
