### PR TITLE
Stripe: do not include path ids in metric names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,15 @@
 
 ## dev
 
-Version <dev> fixes a bug related to expected errors not bearing a "true" value for the "expected" attribute if expected as a result of an HTTP status code match.
+Version <dev> fixes a bug related to expected errors not bearing a "true" value for the "expected" attribute if expected as a result of an HTTP status code match and changes the way Stripe instrumentation metrics are named to prevent high-cardinality issues.
 
 - **Bugfix: HTTP status code based expected errors will now have an "expected" value of "true"**
 
     Previously when an error was treated as expected by the agent as a result of a matching HTTP status code being found in the :'error_collector.expected_status_codes' configuration setting, the error would not appear with an "expected" attribute value of "true" in the errors in the errors inbox. [PR#2710](https://github.com/newrelic/newrelic-ruby-agent/pull/2710)
+
+- **Bugfix: Stripe metric names will no longer include full request paths to limit the unique name count**
+
+    The Stripe instrumentation introduced in agent version v9.5.0 produced instrumentation metric names that used the full Stripe request path. For any significant Stripe usage, this could quickly lead to very large number of distinct metric names. Now only the API version and the category part of the request path are included in the metric name which still includes the "Stripe" opener and method (ex: "get") closer. Thanks to [@jdelStrother](https://github.com/jdelStrother) and [@jsneedles](https://github.com/jsneedles) for bringing this issue to our attention and providing terrific information explaining the problem and potential paths to resolution. [PR#2716](https://github.com/newrelic/newrelic-ruby-agent/pull/2716)
 
 ## v9.10.2
 


### PR DESCRIPTION
When naming Stripe metrics, include only the first two (API version and category) portions of the path and not the id. Continue to start the metric name with "Stripe" and end it with the method (ex: "get"). This will prevent metric name exhaustion resulting from regular Stripe usage.

Given a 'get' request performed against a path of
'/v1/payment_methods/pm_8675309', the metric name will now be 'Stripe/v1/payment_methods/get'.

resolves #2654
resolves #2709