### PR TITLE
CI: Grape Envfile tweaks

### DIFF
--- a/test/multiverse/suites/grape/Envfile
+++ b/test/multiverse/suites/grape/Envfile
@@ -5,7 +5,7 @@
 instrumentation_methods :chain, :prepend
 
 GRAPE_VERSIONS = [
-  [nil, 2.5],
+  [nil, 2.6],
   ['1.6', 2.5],
   ['1.5.3', 2.4, 3.0]
 ]
@@ -22,7 +22,7 @@ end
 # Grape v1.x expects Rack to deliver `rack/auth/digest/md5`, but Rack
 # stopped offering that class in Rack v3.1.0
 def rack_version(grape_version)
-  ", '~> 3.0.11'" if grape_version.to_s.sub(/^[^\d]+/, '').start_with?('1.')
+  ", '~> 3.0.11'" if grape_version.to_s.gsub(/[^\d]+/, '').start_with?('1.')
 end
 
 def gem_list(grape_version = nil)

--- a/test/multiverse/suites/grape/Envfile
+++ b/test/multiverse/suites/grape/Envfile
@@ -19,12 +19,12 @@ def activesupport_version(grape_version)
   ", '< 7.1'" if grape_version&.include?('1.5')
 end
 
-# Grape v1.x expects Rack to deliver `rack/auth/digest/md5`, but Rack
-# stopped offering that class in Rack v3.1.0. Give Rack v3.0 to old
-# Grapes and old Rubies (for which a nil Grape version value will result in a
-# v1.x Grape version)
+# Grape v1.x relies on Rack to deliver `rack/auth/digest/md5`, but Rack versions
+# above 3.0 do not. Grape v2.x has no such reliance. If the Grape version in
+# play is nil (signifying "latest") and the Ruby version is not v2.x, go ahead
+# and permit the usage of the latest Rack. Otherwise, pin Rack to v3.0.
 def rack_version(grape_version)
-  ", '~> 3.0.11'" if grape_version.to_s.gsub(/[^\d]+/, '').start_with?('1.') || RUBY_VERSION.start_with?('2.')
+  ", '~> 3.0.11'" if grape_version || RUBY_VERSION.start_with?('2.')
 end
 
 def gem_list(grape_version = nil)

--- a/test/multiverse/suites/grape/Envfile
+++ b/test/multiverse/suites/grape/Envfile
@@ -20,9 +20,11 @@ def activesupport_version(grape_version)
 end
 
 # Grape v1.x expects Rack to deliver `rack/auth/digest/md5`, but Rack
-# stopped offering that class in Rack v3.1.0
+# stopped offering that class in Rack v3.1.0. Give Rack v3.0 to old
+# Grapes and old Rubies (for which a nil Grape version value will result in a
+# v1.x Grape version)
 def rack_version(grape_version)
-  ", '~> 3.0.11'" if grape_version.to_s.gsub(/[^\d]+/, '').start_with?('1.')
+  ", '~> 3.0.11'" if grape_version.to_s.gsub(/[^\d]+/, '').start_with?('1.') || RUBY_VERSION.start_with?('2.')
 end
 
 def gem_list(grape_version = nil)


### PR DESCRIPTION
For Grape...

- Simplify the logic to pin Grape v1 to use Rack v3.0 while accommodating `nil` versions (signifying "latest") and looking at the Ruby version in play
- Require (as Grape itself does) Ruby v2.6+ for using the latest Grape