### PR TITLE
CI: update GHA nick-fields/retry to v3.0.0

### DIFF
--- a/.github/versions.yml
+++ b/.github/versions.yml
@@ -13,8 +13,8 @@ actions/cache:
   :tag: v3.3.1
   :sha: 88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
 nick-fields/retry:
-  :tag: v2.8.3
-  :sha: 943e742917ac94714d2f408a0e8320f2d1fcafcd
+  :tag: v3.0.0
+  :sha: 7152eba30c6575329ac0576536151aca5a72780e
 technote-space/workflow-conclusion-action:
   :tag: v3.0.3
   :sha: 45ce8e0eb155657ab8ccf346ade734257fd196a5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
           CI_FOR_PR: true
 
       - name: Run Unit Tests
-        uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd # tag v2.8.3
+        uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # tag v3.0.0
         with:
           timeout_minutes: 30
           max_attempts: 2
@@ -232,7 +232,7 @@ jobs:
 
 
       - name: Wait for/Check Mysql
-        uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd # tag v2.8.3
+        uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # tag v3.0.0
         with:
           timeout_minutes: 1
           max_attempts: 20
@@ -244,7 +244,7 @@ jobs:
 
 
       - name: Run Multiverse Tests
-        uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd # tag v2.8.3
+        uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # tag v3.0.0
         with:
           timeout_minutes: 60
           max_attempts: 2
@@ -305,7 +305,7 @@ jobs:
         run: bundle install
 
       - name: Run Multiverse Tests
-        uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd # tag v2.8.3
+        uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # tag v3.0.0
         with:
           timeout_minutes: 15
           max_attempts: 2

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -112,7 +112,7 @@ jobs:
           RAILS_VERSION: ${{ env.rails }}
 
       - name: Run Unit Tests
-        uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd # tag v2.8.3
+        uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # tag v3.0.0
         with:
           timeout_minutes: 30
           max_attempts: 2
@@ -243,7 +243,7 @@ jobs:
 
 
       - name: Wait for/Check Mysql
-        uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd # tag v2.8.3
+        uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # tag v3.0.0
         with:
           timeout_minutes: 1
           max_attempts: 20
@@ -255,7 +255,7 @@ jobs:
 
 
       - name: Run Multiverse Tests
-        uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd # tag v2.8.3
+        uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # tag v3.0.0
         with:
           timeout_minutes: 60
           max_attempts: 2
@@ -296,7 +296,7 @@ jobs:
         run: bundle install
 
       - name: Run Multiverse Tests
-        uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd # tag v2.8.3
+        uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # tag v3.0.0
         with:
           timeout_minutes: 15
           max_attempts: 2

--- a/.github/workflows/ci_jruby.yml
+++ b/.github/workflows/ci_jruby.yml
@@ -24,7 +24,7 @@ jobs:
         run: bundle install
 
       - name: Run Unit Tests
-        uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd # tag v2.8.3
+        uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # tag v3.0.0
         with:
           timeout_minutes: 30
           max_attempts: 2
@@ -57,7 +57,7 @@ jobs:
         run: bundle install
 
       - name: Run Multiverse Tests
-        uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd # tag v2.8.3
+        uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # tag v3.0.0
         with:
           timeout_minutes: 20
           max_attempts: 3


### PR DESCRIPTION
Update nick-fields/retry to v3.0.0 to use Node v20 and eliminate related Node v16 deprecation warnings

resolves #2584 