### PR TITLE
Add space before \ in span_events.max_samples_stored description

### DIFF
--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -1991,7 +1991,7 @@ module NewRelic
           :allowed_from_server => true,
           :description => <<~DESC
             * Defines the maximum number of span events reported from a single harvest. Any Integer between `1` and `10000` is valid.'
-            * When configuring the agent for [AI monitoring](/docs/ai-monitoring/intro-to-ai-monitoring), set to max value `10000`.\
+            * When configuring the agent for [AI monitoring](/docs/ai-monitoring/intro-to-ai-monitoring), set to max value `10000`. \
             This ensures the agent captures the maximum amount of distributed traces.
           DESC
         },


### PR DESCRIPTION
Small typo from last config doc update