### PR TITLE
CI: Grape v2.1.0 related updates

### DIFF
--- a/test/multiverse/suites/grape/Envfile
+++ b/test/multiverse/suites/grape/Envfile
@@ -5,7 +5,8 @@
 instrumentation_methods :chain, :prepend
 
 GRAPE_VERSIONS = [
-  [nil, 2.6],
+  [nil, 2.7],
+  ['2.0.0', 2.6],
   ['1.6', 2.5],
   ['1.5.3', 2.4, 3.0]
 ]

--- a/test/multiverse/suites/grape/grape_test_api.rb
+++ b/test/multiverse/suites/grape/grape_test_api.rb
@@ -55,7 +55,8 @@ class GrapeTestApi < Grape::API
 
   resource :grape_ape_fail_rescue do
     rescue_from :all do |e|
-      error_response({message: "rescued from #{e.class.name}"})
+      err = {message: "rescued from #{e.class.name}"}
+      Gem::Version.new(Grape::VERSION) >= Gem::Version.new('2.1.0') ? error!(err) : error_response(err)
     end
 
     post do


### PR DESCRIPTION
- Enforce Ruby v2.7+ for the latest version of Grape, which has dropped support for Ruby v2.6 in Grape v2.1.0.
- Add a version entry for Grape v2.0.0.
- Conditionally use `error!` instead of `error_response` for Grape v2.1+

resolves #2723