### PR TITLE
log decorator: support hashes

### DIFF
--- a/lib/new_relic/agent/local_log_decorator.rb
+++ b/lib/new_relic/agent/local_log_decorator.rb
@@ -12,6 +12,8 @@ module NewRelic
         return message unless decorating_enabled?
 
         metadata = NewRelic::Agent.linking_metadata
+        return message.merge!(metadata) if message.is_a?(Hash) && !message.frozen?
+
         formatted_metadata = " NR-LINKING|#{metadata[ENTITY_GUID_KEY]}|#{metadata[HOSTNAME_KEY]}|" \
                              "#{metadata[TRACE_ID_KEY]}|#{metadata[SPAN_ID_KEY]}|" \
                              "#{escape_entity_name(metadata[ENTITY_NAME_KEY])}|"

--- a/lib/new_relic/agent/local_log_decorator.rb
+++ b/lib/new_relic/agent/local_log_decorator.rb
@@ -12,7 +12,10 @@ module NewRelic
         return message unless decorating_enabled?
 
         metadata = NewRelic::Agent.linking_metadata
-        return message.merge!(metadata) if message.is_a?(Hash) && !message.frozen?
+        if message.is_a?(Hash)
+          message.merge!(metadata) unless message.frozen?
+          return
+        end
 
         formatted_metadata = " NR-LINKING|#{metadata[ENTITY_GUID_KEY]}|#{metadata[HOSTNAME_KEY]}|" \
                              "#{metadata[TRACE_ID_KEY]}|#{metadata[SPAN_ID_KEY]}|" \

--- a/test/new_relic/agent/local_log_decorator_test.rb
+++ b/test/new_relic/agent/local_log_decorator_test.rb
@@ -119,6 +119,13 @@ module NewRelic::Agent
           assert_equal expected, hash, "Expected hash to be decorated. Wanted >>#{expected}<<, got >>#{hash}<<"
         end
       end
+
+      def test_returns_early_with_frozen_hashes
+        hash = {'dennis' => 'gnasher'}.freeze
+        expected = hash.dup
+        LocalLogDecorator.decorate(hash)
+        assert_equal expected, hash, 'Expected no errors and no hash modifications for a frozen hash'
+      end
     end
   end
 end


### PR DESCRIPTION
if the log decorator is given a hash, merge the metadata into the hash