### PR TITLE
Lockdown Elasticsearch instrumentation to 7+

### DIFF
--- a/lib/new_relic/agent/instrumentation/elasticsearch.rb
+++ b/lib/new_relic/agent/instrumentation/elasticsearch.rb
@@ -10,7 +10,8 @@ DependencyDetection.defer do
   named :elasticsearch
 
   depends_on do
-    defined?(Elasticsearch)
+    defined?(Elasticsearch) &&
+      Gem::Version.create(Elasticsearch::VERSION) >= Gem::Version.create('7.0.0')
   end
 
   executes do


### PR DESCRIPTION
The Ruby agent officially supports Elasticsearch versions 7+, but didn't prevent versions less than 7 from being instrumented because there were no known issues. With #2730, it looks like this may have changed when the agent changed the endpoint it reached out to for the cluster name ([commit](https://github.com/newrelic/newrelic-ruby-agent/commit/1bafa1753810246bce96261fede60d3d9868b8cb)).

We typically only install instrumentation of supported library versions and Elasticsearch should be the same. This PR prevents instrumentation from installing on versions less than 7.