### PR TITLE
Replace `<DoNotTranslate>` with `<DNT>`

### DIFF
--- a/lib/tasks/helpers/config.html.erb
+++ b/lib/tasks/helpers/config.html.erb
@@ -76,7 +76,7 @@ When running the Ruby agent in a Rails app, the agent first looks for the `NEW_R
 When you edit the config file, be sure to:
 
 * Indent only with two spaces.
-* Indent only where relevant, in sections such as <DoNotTranslate>**`error_collector`**</DoNotTranslate>.
+* Indent only where relevant, in sections such as <DNT>**`error_collector`**</DNT>.
 
 If you do not indent correctly, the agent may throw an `Unable to parse configuration file` error on startup.
 

--- a/lib/tasks/helpers/config.html.erb
+++ b/lib/tasks/helpers/config.html.erb
@@ -76,7 +76,7 @@ When running the Ruby agent in a Rails app, the agent first looks for the `NEW_R
 When you edit the config file, be sure to:
 
 * Indent only with two spaces.
-* Indent only where relevant, in sections such as <DNT>**`error_collector`**</DNT>.
+* Indent only where relevant, in sections such as **`error_collector`**.
 
 If you do not indent correctly, the agent may throw an `Unable to parse configuration file` error on startup.
 

--- a/lib/tasks/helpers/format.rb
+++ b/lib/tasks/helpers/format.rb
@@ -69,7 +69,7 @@ module Format
 
   def format_description(value)
     description = ''
-    description += '<DoNotTranslate>**DEPRECATED**</DoNotTranslate> ' if value[:deprecated]
+    description += '<DNT>**DEPRECATED**</DNT> ' if value[:deprecated]
     description += value[:description]
     description
   end


### PR DESCRIPTION
The docs team is replacing `<DoNotTranslate>` with `<DNT>`. We need to update this file to ensure we remain compatiable with docs parsing.