### PR TITLE
Introduce Rails v7.2 test environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
                 "rails": "norails,rails42,rails52"
               },
               "3.3.4": {
-                "rails": "norails,rails61,rails71"
+                "rails": "norails,rails61,rails72"
               }
             }
 

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -76,16 +76,16 @@ jobs:
                 "rails": "norails,rails61,rails60,rails70,rails71"
               },
               "3.1.6": {
-                "rails": "norails,rails61,rails70,rails71"
+                "rails": "norails,rails61,rails70,rails71,rails72"
               },
               "3.2.4": {
-                "rails": "norails,rails61,rails70,rails71"
+                "rails": "norails,rails61,rails70,rails71,rails72"
               },
               "3.3.4": {
-                "rails": "norails,rails61,rails70,rails71"
+                "rails": "norails,rails61,rails70,rails71,rails72"
               },
               "3.4.0-preview1": {
-                "rails": "norails,rails61,rails70,rails71"
+                "rails": "norails,rails61,rails70,rails71,rails72"
               }
             }
 

--- a/test/environments/rails72/Gemfile
+++ b/test/environments/rails72/Gemfile
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+gem 'rails', '~> 7.2.0.beta2'
+gem 'bootsnap', '>= 1.4.4', require: false
+
+gem 'minitest', '5.2.3'
+gem 'minitest-stub-const', '~> 0.6'
+gem 'mocha', '~> 1.16', require: false
+
+platforms :ruby, :rbx do
+  gem 'mysql2', '>= 0.5.4'
+  gem 'sqlite3', '~> 1.4'
+end
+
+gem 'newrelic_rpm', path: '../../..'
+
+group :development do
+  if ENV['ENABLE_PRY']
+    gem 'pry', '~> 0.9.12'
+    gem 'pry-nav'
+  end
+end
+
+gem 'simplecov' if ENV['VERBOSE_TEST_OUTPUT']
+gem 'warning'
+
+if RUBY_VERSION.split('.')[0..1].join('.').to_f >= 3.4
+  gem 'base64'
+  gem 'bigdecimal'
+  gem 'mutex_m'
+  gem 'ostruct'
+end

--- a/test/environments/rails72/Rakefile
+++ b/test/environments/rails72/Rakefile
@@ -1,0 +1,17 @@
+# This file is distributed under new relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/license for complete details.
+# frozen_string_literal: true
+
+# Add your own tasks in files placed in lib/tasks ending in .rake,
+# for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
+
+require_relative '../../warning_test_helper'
+
+require_relative 'config/application'
+
+Rails.application.load_tasks
+
+require 'tasks/all'
+
+Rake::Task['default'].clear
+task :default => [:'test:newrelic']

--- a/test/environments/rails72/app/controllers/application_controller.rb
+++ b/test/environments/rails72/app/controllers/application_controller.rb
@@ -1,0 +1,6 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+class ApplicationController < ActionController::Base
+end

--- a/test/environments/rails72/app/controllers/no_method_controller.rb
+++ b/test/environments/rails72/app/controllers/no_method_controller.rb
@@ -1,0 +1,7 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+require_relative 'application_controller'
+
+class NoMethodController < ApplicationController; end

--- a/test/environments/rails72/config/application.rb
+++ b/test/environments/rails72/config/application.rb
@@ -1,0 +1,20 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+require_relative 'boot'
+
+require 'rails/all'
+
+# Require the gems listed in Gemfile, including any gems
+# you've limited to :test, :development, or :production.
+Bundler.require(*Rails.groups)
+
+module RpmTestApp
+  class Application < Rails::Application
+    # Initialize configuration defaults for originally generated Rails version.
+    config.load_defaults(7.2)
+    config.eager_load = false
+    config.filter_parameters += [:password]
+  end
+end

--- a/test/environments/rails72/config/boot.rb
+++ b/test/environments/rails72/config/boot.rb
@@ -1,0 +1,8 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
+
+require 'bundler/setup' # Set up gems listed in the Gemfile.
+require 'bootsnap/setup' # Speed up boot time by caching expensive operations.

--- a/test/environments/rails72/config/database.yml
+++ b/test/environments/rails72/config/database.yml
@@ -1,0 +1,30 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+mysql: &mysql
+  adapter: mysql2
+  username: root
+  password: <%= ENV['MYSQL_PASSWORD'] %>
+  host: localhost
+  database: <%= db = "#{ENV['RUBY_VERSION']}#{ENV['BRANCH']}"; db.empty? ? "rails_blog" : db %>
+
+sqlite3: &sqlite3
+<% if defined?(JRuby) %>
+  adapter: jdbcsqlite3
+<% else %>
+  adapter: sqlite3
+<% end %>
+  database: db/all.sqlite3
+  pool: 5
+  timeout: 5000
+  host: localhost
+
+development:
+  <<: *sqlite3
+
+test:
+  <<: *sqlite3
+
+production:
+  <<: *sqlite3

--- a/test/environments/rails72/config/environment.rb
+++ b/test/environments/rails72/config/environment.rb
@@ -1,0 +1,9 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+# Load the Rails application.
+require_relative 'application'
+
+# Initialize the Rails application.
+Rails.application.initialize!

--- a/test/environments/rails72/config/initializers/test.rb
+++ b/test/environments/rails72/config/initializers/test.rb
@@ -1,0 +1,20 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+require 'new_relic/agent/method_tracer'
+
+class Bloodhound < ActiveRecord::Base
+  include ::NewRelic::Agent::MethodTracer
+
+  def sniff
+    puts 'When a bloodhound sniffs a scent article (a piece of clothing or item touched only by the subject), ' \
+    "air rushes through its nasal cavity and chemical vapors — or odors — lodge in the mucus and bombard the dog's " \
+    'scent receptors. ' \
+    'Source: https://www.pbs.org/wnet/nature/underdogs-the-bloodhounds-amazing-sense-of-smell/350/'
+  end
+
+  add_method_tracer :sniff
+end
+
+Rails.application.config.active_record.timestamped_migrations = false

--- a/test/environments/rails72/db/schema.rb
+++ b/test/environments/rails72/db/schema.rb
@@ -1,0 +1,5 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+# File is required to exist by Rails

--- a/test/new_relic/agent/instrumentation/rails/active_job_subscriber.rb
+++ b/test/new_relic/agent/instrumentation/rails/active_job_subscriber.rb
@@ -30,6 +30,11 @@ module NewRelic::Agent::Instrumentation
     ID = 71741
     SUBSCRIBER = NewRelic::Agent::Instrumentation::ActiveJobSubscriber.new
 
+    def setup
+      # https://github.com/rails/rails/issues/37270
+      (ActiveJob::Base.descendants << ActiveJob::Base).each(&:disable_test_adapter)
+    end
+
     def test_segment_naming_with_unknown_method
       assert_equal 'Ruby/ActiveJob/default/Unknown',
         SUBSCRIBER.send(:metric_name, 'indecipherable', {job: TestJob.new})

--- a/test/new_relic/agent/instrumentation/rails/active_job_subscriber.rb
+++ b/test/new_relic/agent/instrumentation/rails/active_job_subscriber.rb
@@ -32,9 +32,7 @@ module NewRelic::Agent::Instrumentation
 
     def setup
       # https://github.com/rails/rails/issues/37270
-      (ActiveJob::Base.descendants << ActiveJob::Base).each do |b|
-        b.disable_test_adapter if b.respond_to?(:disable_test_adapter)
-      end
+      (ActiveJob::Base.descendants << ActiveJob::Base).each { |b| b.disable_test_adapter rescue nil }
     end
 
     def test_segment_naming_with_unknown_method

--- a/test/new_relic/agent/instrumentation/rails/active_job_subscriber.rb
+++ b/test/new_relic/agent/instrumentation/rails/active_job_subscriber.rb
@@ -109,7 +109,7 @@ module NewRelic::Agent::Instrumentation
         assert segment
 
         if defined?(Rails) && Rails.respond_to?(:version) && Gem::Version.new(Rails.version) >= Gem::Version.new('7.1')
-          assert_matches(/ActiveJob::QueueAdapters::(?:Test|Async)Adapter/, segment.params[:adapter].class.name)
+          assert_match(/ActiveJob::QueueAdapters::(?:Test|Async)Adapter/, segment.params[:adapter].class.name)
         else
           assert_equal 'ActiveJob::QueueAdapters::AsyncAdapter', segment.params[:adapter].class.name
         end

--- a/test/new_relic/agent/instrumentation/rails/active_job_subscriber.rb
+++ b/test/new_relic/agent/instrumentation/rails/active_job_subscriber.rb
@@ -32,7 +32,9 @@ module NewRelic::Agent::Instrumentation
 
     def setup
       # https://github.com/rails/rails/issues/37270
-      (ActiveJob::Base.descendants << ActiveJob::Base).each(&:disable_test_adapter)
+      (ActiveJob::Base.descendants << ActiveJob::Base).each do |b|
+        b.disable_test_adapter if b.respond_to?(:disable_test_adapter)
+      end
     end
 
     def test_segment_naming_with_unknown_method


### PR DESCRIPTION
Start CI testing against Rails v7.2 (in beta currently), which requires Ruby v3.1+