### PR TITLE
Fix for HTTPX 1.3.0 test failure

### DIFF
--- a/test/multiverse/suites/httpx/httpx_instrumentation_test.rb
+++ b/test/multiverse/suites/httpx/httpx_instrumentation_test.rb
@@ -33,7 +33,15 @@ class HTTPXInstrumentationTest < Minitest::Test
     request = Minitest::Mock.new
     request.expect :response, :the_response
     2.times { request.expect :hash, 1138 }
-    responses = {request => ::HTTPX::ErrorResponse.new(request, StandardError.new, {})}
+
+    error = if Gem::Version.new(::HTTPX::VERSION) >= Gem::Version.new('1.3.0')
+      request.expect :options, ::HTTPX::Options.new({})
+      ::HTTPX::ErrorResponse.new(request, StandardError.new)
+    else
+      ::HTTPX::ErrorResponse.new(request, StandardError.new, {})
+    end
+    responses = {request => error}
+
     segment = Minitest::Mock.new
     def segment.notice_error(_error); end
     def segment.process_response_headers(_wrappep); end


### PR DESCRIPTION
When HTTPX 1.3.0 released, it caused one of our tests to fail, due to a change in the way the `HTTPX::ErrorResponse` class needs to be created. Previously you would pass in a hash that would be converted to an options object. Now, instead you do not pass in anything for options, and instead it uses the options present on the request object. 