### PR TITLE
Pin protobuf version to < 4 for infinite tracing

### DIFF
--- a/infinite_tracing/CHANGELOG.md
+++ b/infinite_tracing/CHANGELOG.md
@@ -1,5 +1,9 @@
 # New Relic Infinite Tracing for Ruby Agent Release Notes #
 
+  ## v9.12.0
+
+  * Pin google-protobuf dependency to < 4.0 due to compatibility issues with version 4+.
+
   ## v8.9.0
 
   * **Bugfix: Infinite Tracing hung on connection restart**

--- a/infinite_tracing/newrelic-infinite_tracing.gemspec
+++ b/infinite_tracing/newrelic-infinite_tracing.gemspec
@@ -73,6 +73,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'newrelic_rpm', NewRelic::VERSION::STRING
   s.add_dependency 'grpc', '~> 1.34'
+  s.add_dependency 'google-protobuf', '< 4.0'
 
   s.add_development_dependency 'rake', '12.3.3'
   s.add_development_dependency 'rb-inotify'


### PR DESCRIPTION
Grpc gem released a new version that no longer pins the google-protobuf version to 3.25. This resulted in a lot of test failures in infinite tracing. To resolve this issue, we've added a pinned dependency to infinite tracing gemspec to keep google-protobuf < 4. 