### PR TITLE
Run url test only on its own

### DIFF
--- a/.github/workflows/ci_special.yml
+++ b/.github/workflows/ci_special.yml
@@ -1,0 +1,80 @@
+name: URL Test CI
+
+on:
+  schedule:
+    - cron: '0 9 * * *'
+  workflow_dispatch:
+
+jobs:
+  unit_tests:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Configure git
+        run: 'git config --global init.defaultBranch main'
+      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # tag v4.1.2
+
+        # - curl is needed for Curb
+        # - xslt is needed for older Nokogiris, RUBY_VERSION < 2.5
+        # - sasl is needed for memcached
+      - name: Install OS packages
+        run: sudo apt-get update; sudo apt-get install -y --no-install-recommends libcurl4-nss-dev libsasl2-dev libxslt1-dev
+
+      - name: Install Ruby 3.4.0-preview1
+        uses: ruby/setup-ruby@2a9a743e19810b9f3c38060637daf594dbd7b37f # tag v1.186.0
+        with:
+          ruby-version: 3.4.0-preview1
+
+      - name: Setup bundler
+        run: ./.github/workflows/scripts/setup_bundler
+        env:
+          RUBY_VERSION: 3.4.0-preview1
+
+      - name: Run Unit Tests
+        uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # tag v3.0.0
+        with:
+          timeout_minutes: 30
+          max_attempts: 2
+          command:  TEST=test/new_relic/healthy_urls_test bundle exec rake test
+        env:
+          VERBOSE_TEST_OUTPUT: true
+          SPECIAL_CI: true
+
+
+  notify_slack_fail:
+    name: Notify slack fail
+    needs: [unit_tests]
+    runs-on: ubuntu-22.04
+    if: always()
+    steps:
+      - uses: technote-space/workflow-conclusion-action@45ce8e0eb155657ab8ccf346ade734257fd196a5 # tag v3.0.3
+      - uses: voxmedia/github-action-slack-notify-build@3665186a8c1a022b28a1dbe0954e73aa9081ea9e # tag v1.6.0
+        if: ${{ env.WORKFLOW_CONCLUSION == 'failure' && github.event_name != 'workflow_dispatch' }}
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.RUBY_GITHUB_ACTIONS_BOT_WEBHOOK }}
+        with:
+          channel: ruby-agent-notifications
+          status: FAILED
+          color: danger
+
+
+  notify_slack_success:
+    name: Notify slack success
+    needs: [unit_tests]
+    runs-on: ubuntu-22.04
+    if: always()
+    steps:
+      - uses: technote-space/workflow-conclusion-action@45ce8e0eb155657ab8ccf346ade734257fd196a5 # tag v3.0.3
+      - run: echo ${{ github.event_name }}
+      - uses: Mercymeilya/last-workflow-status@3418710aefe8556d73b6f173a0564d38bcfd9a43 # tag v0.3.3
+        id: last_status
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: voxmedia/github-action-slack-notify-build@3665186a8c1a022b28a1dbe0954e73aa9081ea9e # tag v1.6.0
+        if: ${{ env.WORKFLOW_CONCLUSION == 'success' && steps.last_status.outputs.last_status == 'failure' && github.event_name != 'workflow_dispatch' }}
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.RUBY_GITHUB_ACTIONS_BOT_WEBHOOK }}
+        with:
+          channel: ruby-agent-notifications
+          status: SUCCESS
+          color: good

--- a/test/helpers/misc.rb
+++ b/test/helpers/misc.rb
@@ -131,6 +131,12 @@ def skip_unless_ci_cron
   skip 'This test only runs as part of the CI cron workflow'
 end
 
+def skip_unless_special_ci
+  return if ENV['SPECIAL_CI']
+
+  skip 'This test only runs as part of the special CI workflow'
+end
+
 def agent_root
   @agent_root ||= File.expand_path('../../..', __FILE__).freeze
 end

--- a/test/new_relic/healthy_urls_test.rb
+++ b/test/new_relic/healthy_urls_test.rb
@@ -70,8 +70,7 @@ class HealthyUrlsTest < Minitest::Test
   DEBUG = false
 
   def test_all_urls
-    skip_unless_ci_cron
-    skip_unless_newest_ruby
+    skip_unless_special_ci
 
     urls = gather_urls
     errors = urls.each_with_object({}) do |(url, _files), hash|


### PR DESCRIPTION
Due to random URL test issues that happen, let's move it out into it's own run that will notify us when it's messed up, instead of running with the regular CI tests. This will help us know at a quick glance that the failure is URL related, and also won't cause failures when running the ci cron for unrelated reason.