### PR TITLE
Revert spacing changes

### DIFF
--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -388,14 +388,13 @@ module NewRelic
           :type => Boolean,
           :allowed_from_server => false,
           :description => <<~DESCRIPTION
-            If `false`, LLM instrumentation (OpenAI only for now) will not capture input and output content on specific
-              LLM events.
+            If `false`, LLM instrumentation (OpenAI only for now) will not capture input and output content on specific LLM events.
 
               The excluded attributes include:
                 * `content` from LlmChatCompletionMessage events
                 * `input` from LlmEmbedding events
 
-            This is an optional security setting to prevent recording sensitive data sent to and received from your LLMs.
+              This is an optional security setting to prevent recording sensitive data sent to and received from your LLMs.
           DESCRIPTION
         },
         # this is only set via server side config
@@ -441,16 +440,10 @@ module NewRelic
           :type => Boolean,
           :allowed_from_server => false,
           :description => <<~DESCRIPTION
-            When `true`, the agent captures HTTP request parameters and attaches them to transaction traces, traced
-              errors, and [`TransactionError` events](/attribute-dictionary?attribute_name=&events_tids%5B%5D=8241).
+            When `true`, the agent captures HTTP request parameters and attaches them to transaction traces, traced errors, and [`TransactionError` events](/attribute-dictionary?attribute_name=&events_tids%5B%5D=8241).
 
                 <Callout variant="caution">
-                  When using the `capture_params` setting, the Ruby agent will not attempt to filter secret information.
-                    `Recommendation:` To filter secret information from request parameters, use the
-                    [`attributes.include` setting](/docs/agents/ruby-agent/attributes/enable-disable-attributes-ruby)
-                    instead. For more information, see the
-                    <a href="/docs/agents/ruby-agent/attributes/ruby-attribute-examples#ex_req_params">Ruby attribute
-                    examples</a>.
+                  When using the `capture_params` setting, the Ruby agent will not attempt to filter secret information. `Recommendation:` To filter secret information from request parameters, use the [`attributes.include` setting](/docs/agents/ruby-agent/attributes/enable-disable-attributes-ruby) instead. For more information, see the <a href="/docs/agents/ruby-agent/attributes/ruby-attribute-examples#ex_req_params">Ruby attribute examples</a>.
                 </Callout>
           DESCRIPTION
         },
@@ -487,14 +480,12 @@ module NewRelic
           :type => Boolean,
           :allowed_from_server => false,
           :description => <<~DESC
-            The exit handler that sends all cached data to the collector before shutting down is forcibly installed.
-              This is true even when it detects scenarios where it generally should not be. The known use case for this
-              option is when Sinatra runs as an embedded service within another framework. The agent detects the Sinatra
-              app and skips the `at_exit` handler as a result. Sinatra classically runs the entire application in an
-              `at_exit` block and would otherwise misbehave if the agent's `at_exit` handler was also installed in those
-              circumstances.
-
-            **Note:** `send_data_on_exit` should also be set to `true` in tandem with this setting.
+            The exit handler that sends all cached data to the collector before shutting down is forcibly installed. \
+            This is true even when it detects scenarios where it generally should not be. The known use case for this \
+            option is when Sinatra runs as an embedded service within another framework. The agent detects the Sinatra \
+            app and skips the `at_exit` handler as a result. Sinatra classically runs the entire application in an \
+            `at_exit` block and would otherwise misbehave if the agent's `at_exit` handler was also installed in those \
+            circumstances. Note: `send_data_on_exit` should also be set to `true` in tandem with this setting.
           DESC
         },
         :high_security => {
@@ -732,9 +723,7 @@ module NewRelic
           :allowed_from_server => true,
           :dynamic_name => true,
           :description => <<~DESCRIPTION
-            A map of error classes to a list of messages. When an error of one of the classes specified here occurs, if
-              its error message contains one of the strings corresponding to it here, that error will be treated as
-              expected.
+            A map of error classes to a list of messages. When an error of one of the classes specified here occurs, if its error message contains one of the strings corresponding to it here, that error will be treated as expected.
 
               <Callout variant="caution">
                 This option can't be set via environment variable.
@@ -757,8 +746,7 @@ module NewRelic
           :allowed_from_server => true,
           :dynamic_name => true,
           :description => <<~DESCRIPTION
-            A map of error classes to a list of messages. When an error of one of the classes specified here occurs, if
-              its error message contains one of the strings corresponding to it here, that error will be ignored.
+            A map of error classes to a list of messages. When an error of one of the classes specified here occurs, if its error message contains one of the strings corresponding to it here, that error will be ignored.
 
               <Callout variant="caution">
                 This option can't be set via environment variable.
@@ -844,14 +832,11 @@ module NewRelic
           :description => <<~DESCRIPTION
             Sets the minimum level a log event must have to be forwarded to New Relic.
 
-            This is based on the integer values of Ruby's `Logger::Severity` constants:
-              https://github.com/ruby/ruby/blob/master/lib/logger/severity.rb
+            This is based on the integer values of Ruby's `Logger::Severity` constants: https://github.com/ruby/ruby/blob/master/lib/logger/severity.rb
 
-            The intention is to forward logs with the level given to the configuration, as well as any logs with a
-              higher level of severity.
+            The intention is to forward logs with the level given to the configuration, as well as any logs with a higher level of severity.
 
-            For example, setting this value to "debug" will forward all log events to New Relic. Setting this value to
-              "error" will only forward log events with the levels "error", "fatal", and "unknown".
+            For example, setting this value to "debug" will forward all log events to New Relic. Setting this value to "error" will only forward log events with the levels "error", "fatal", and "unknown".
 
             Valid values (ordered lowest to highest):
               * "debug"
@@ -1305,12 +1290,10 @@ module NewRelic
           :type => Boolean,
           :allowed_from_server => false,
           :description => <<~DESCRIPTION
-            If `true`, the agent won't wrap third-party middlewares in instrumentation (regardless of whether they are
-              installed via `Rack::Builder` or Rails).
+            If `true`, the agent won't wrap third-party middlewares in instrumentation (regardless of whether they are installed via `Rack::Builder` or Rails).
 
               <Callout variant="important">
-                When middleware instrumentation is disabled, if an application is using middleware that could alter the
-                  response code, the HTTP status code reported on the transaction may not reflect the altered value.
+                When middleware instrumentation is disabled, if an application is using middleware that could alter the response code, the HTTP status code reported on the transaction may not reflect the altered value.
               </Callout>
           DESCRIPTION
         },
@@ -1348,20 +1331,12 @@ module NewRelic
           :type => Boolean,
           :allowed_from_server => false,
           :description => <<~DESCRIPTION
-            If `true`, disables agent middleware for Sinatra. This middleware is responsible for advanced feature
-              support such as
-              [cross application tracing](/docs/apm/transactions/cross-application-traces/cross-application-tracing),
-              [page load timing](/docs/browser/new-relic-browser/getting-started/new-relic-browser), and
-              [error collection](/docs/apm/applications-menu/events/view-apm-error-analytics).
+            If `true`, disables agent middleware for Sinatra. This middleware is responsible for advanced feature support such as [cross application tracing](/docs/apm/transactions/cross-application-traces/cross-application-tracing), [page load timing](/docs/browser/new-relic-browser/getting-started/new-relic-browser), and [error collection](/docs/apm/applications-menu/events/view-apm-error-analytics).
 
                 <Callout variant="important">
-                  Cross application tracing is deprecated in favor of
-                    [distributed tracing](/docs/apm/distributed-tracing/getting-started/introduction-distributed-tracing).
-                    Distributed tracing is on by default for Ruby agent versions 8.0.0 and above. Middlewares are not
-                    required to support distributed tracing.
+                  Cross application tracing is deprecated in favor of [distributed tracing](/docs/apm/distributed-tracing/getting-started/introduction-distributed-tracing). Distributed tracing is on by default for Ruby agent versions 8.0.0 and above. Middlewares are not required to support distributed tracing.
 
-                  To continue using cross application tracing, update the following options in your `newrelic.yml`
-                    configuration file:
+                  To continue using cross application tracing, update the following options in your `newrelic.yml` configuration file:
 
                   ```yaml
                   # newrelic.yml
@@ -1643,7 +1618,7 @@ module NewRelic
           :type => String,
           :dynamic_name => true,
           :allowed_from_server => false,
-          :description => 'Controls auto-instrumentation of the LogStasher library at start-up. May be one of [auto|prepend|chain|disabled].'
+          :description => 'Controls auto-instrumentation of the LogStasher library at start-up. May be one of: `auto`, `prepend`, `chain`, `disabled`.'
         },
         :'instrumentation.memcache' => {
           :default => 'auto',
@@ -1786,7 +1761,6 @@ module NewRelic
         },
         :'instrumentation.stripe' => {
           :default => 'enabled',
-          :documentation_default => 'auto',
           :public => true,
           :type => String,
           :allowed_from_server => false,
@@ -1952,13 +1926,9 @@ module NewRelic
           :type => Boolean,
           :allowed_from_server => false,
           :transform => proc { |bool| NewRelic::Agent::ServerlessHandler.env_var_set? || bool },
-          :description => <<~DESC
-            If `true`, the agent will operate in a streamlined mode suitable for use with short-lived serverless
-              functions. NOTE: Only AWS Lambda functions are supported currently and this option is not intended for use
-              without
-              [New Relic's Ruby Lambda layer based instrumentation](https://docs.newrelic.com/docs/serverless-function-monitoring/aws-lambda-monitoring/instrument-lambda-function/instrument-your-own/)
-              offering.
-          DESC
+          :description => 'If `true`, the agent will operate in a streamlined mode suitable for use with short-lived ' \
+                          'serverless functions. NOTE: Only AWS Lambda functions are supported currently and this ' \
+                          "option is not intended for use without [New Relic's Ruby Lambda layer](https://docs.newrelic.com/docs/serverless-function-monitoring/aws-lambda-monitoring/get-started/monitoring-aws-lambda-serverless-monitoring/) offering."
         },
         # Sidekiq
         :'sidekiq.args.include' => {
@@ -2053,10 +2023,9 @@ module NewRelic
           :type => Integer,
           :allowed_from_server => true,
           :description => <<~DESC
-            * Defines the maximum number of span events reported from a single harvest. Any Integer between `1` and
-              `10000` is valid.
-            * When configuring the agent for [AI monitoring](/docs/ai-monitoring/intro-to-ai-monitoring), set to max
-              value `10000`. This ensures the agent captures the maximum amount of distributed traces.
+            * Defines the maximum number of span events reported from a single harvest. Any Integer between `1` and `10000` is valid.'
+            * When configuring the agent for [AI monitoring](/docs/ai-monitoring/intro-to-ai-monitoring), set to max value `10000`.\
+            This ensures the agent captures the maximum amount of distributed traces.
           DESC
         },
         # Strip exception messages

--- a/newrelic.yml
+++ b/newrelic.yml
@@ -39,8 +39,7 @@ common: &default_settings
   # ai_monitoring.enabled: false
 
   # If false, LLM instrumentation (OpenAI only for now) will not capture input and
-  # output content on specific
-  # LLM events.
+  # output content on specific LLM events.
   # The excluded attributes include:
   # * content from LlmChatCompletionMessage events
   # * input from LlmEmbedding events
@@ -70,12 +69,10 @@ common: &default_settings
   # This is based on the integer values of Ruby's Logger::Severity constants:
   # https://github.com/ruby/ruby/blob/master/lib/logger/severity.rb
   # The intention is to forward logs with the level given to the configuration, as
-  # well as any logs with a
-  # higher level of severity.
+  # well as any logs with a higher level of severity.
   # For example, setting this value to "debug" will forward all log events to New
-  # Relic. Setting this value to
-  # "error" will only forward log events with the levels "error", "fatal", and
-  # "unknown".
+  # Relic. Setting this value to "error" will only forward log events with the
+  # levels "error", "fatal", and "unknown".
   # Valid values (ordered lowest to highest):
   # * "debug"
   # * "info"
@@ -162,17 +159,11 @@ common: &default_settings
   # capture_memcache_keys: false
 
   # When true, the agent captures HTTP request parameters and attaches them to
-  # transaction traces, traced
-  # errors, and TransactionError events.
+  # transaction traces, traced errors, and TransactionError events.
   # When using the capture_params setting, the Ruby agent will not attempt to
-  # filter secret information.
-  # Recommendation: To filter secret information from request parameters, use the
-  # attributes.include setting
-  # instead. For more information, see the
-  # <a
-  # href="/docs/agents/ruby-agent/attributes/ruby-attribute-examples#ex_req_params">Ruby
-  # attribute
-  # examples</a>.
+  # filter secret information. Recommendation: To filter secret information from
+  # request parameters, use the attributes.include setting instead. For more
+  # information, see the Ruby attribute examples.
   # capture_params: false
 
   # If true, the agent will clear Tracer::State in Agent.drop_buffered_data.
@@ -251,12 +242,10 @@ common: &default_settings
   # disable_memory_sampler: false
 
   # If true, the agent won't wrap third-party middlewares in instrumentation
-  # (regardless of whether they are
-  # installed via Rack::Builder or Rails).
+  # (regardless of whether they are installed via Rack::Builder or Rails).
   # When middleware instrumentation is disabled, if an application is using
-  # middleware that could alter the
-  # response code, the HTTP status code reported on the transaction may not
-  # reflect the altered value.
+  # middleware that could alter the response code, the HTTP status code reported
+  # on the transaction may not reflect the altered value.
   # disable_middleware_instrumentation: false
 
   # If true, disables agent middleware for Roda. This middleware is responsible
@@ -274,19 +263,13 @@ common: &default_settings
   # disable_sidekiq: false
 
   # If true, disables agent middleware for Sinatra. This middleware is responsible
-  # for advanced feature
-  # support such as
-  # cross application tracing,
-  # page load timing, and
-  # error collection.
-  # Cross application tracing is deprecated in favor of
-  # distributed tracing.
+  # for advanced feature support such as cross application tracing, page load
+  # timing, and error collection.
+  # Cross application tracing is deprecated in favor of distributed tracing.
   # Distributed tracing is on by default for Ruby agent versions 8.0.0 and above.
-  # Middlewares are not
-  # required to support distributed tracing.
+  # Middlewares are not required to support distributed tracing.
   # To continue using cross application tracing, update the following options in
-  # your newrelic.yml
-  # configuration file:
+  # your newrelic.yml configuration file:
   # ``yaml
   # # newrelic.yml
   # cross_application_tracer:
@@ -336,10 +319,8 @@ common: &default_settings
   # error_collector.expected_classes: []
 
   # A map of error classes to a list of messages. When an error of one of the
-  # classes specified here occurs, if
-  # its error message contains one of the strings corresponding to it here, that
-  # error will be treated as
-  # expected.
+  # classes specified here occurs, if its error message contains one of the
+  # strings corresponding to it here, that error will be treated as expected.
   # This option can't be set via environment variable.
   # error_collector.expected_messages: {}
 
@@ -353,9 +334,8 @@ common: &default_settings
   # error_collector.ignore_classes: ["ActionController::RoutingError", "Sinatra::NotFound"]
 
   # A map of error classes to a list of messages. When an error of one of the
-  # classes specified here occurs, if
-  # its error message contains one of the strings corresponding to it here, that
-  # error will be ignored.
+  # classes specified here occurs, if its error message contains one of the
+  # strings corresponding to it here, that error will be ignored.
   # This option can't be set via environment variable.
   # error_collector.ignore_messages: {}
 
@@ -377,17 +357,13 @@ common: &default_settings
   # exclude_newrelic_header: false
 
   # The exit handler that sends all cached data to the collector before shutting
-  # down is forcibly installed.
-  # This is true even when it detects scenarios where it generally should not be.
-  # The known use case for this
-  # option is when Sinatra runs as an embedded service within another framework.
-  # The agent detects the Sinatra
-  # app and skips the at_exit handler as a result. Sinatra classically runs the
-  # entire application in an
-  # at_exit block and would otherwise misbehave if the agent's at_exit handler was
-  # also installed in those
-  # circumstances.
-  # **Note:** send_data_on_exit should also be set to true in tandem with this
+  # down is forcibly installed. This is true even when it detects scenarios where
+  # it generally should not be. The known use case for this option is when Sinatra
+  # runs as an embedded service within another framework. The agent detects the
+  # Sinatra app and skips the at_exit handler as a result. Sinatra classically
+  # runs the entire application in an at_exit block and would otherwise misbehave
+  # if the agent's at_exit handler was also installed in those circumstances.
+  # Note: send_data_on_exit should also be set to true in tandem with this
   # setting.
   # force_install_exit_handler: false
 
@@ -510,7 +486,7 @@ common: &default_settings
   # instrumentation.logger: auto
 
   # Controls auto-instrumentation of the LogStasher library at start-up. May be
-  # one of [auto|prepend|chain|disabled].
+  # one of: auto, prepend, chain, disabled.
   # instrumentation.logstasher: auto
 
   # Controls auto-instrumentation of dalli gem for Memcache at start-up. May be
@@ -578,7 +554,7 @@ common: &default_settings
 
   # Controls auto-instrumentation of Stripe at startup. May be one of: enabled,
   # disabled.
-  # instrumentation.stripe: auto
+  # instrumentation.stripe: enabled
 
   # Controls auto-instrumentation of the Thread class at start-up to allow the
   # agent to correctly nest spans inside of an asynchronous transaction. This does
@@ -707,12 +683,9 @@ common: &default_settings
   # send_data_on_exit: true
 
   # If true, the agent will operate in a streamlined mode suitable for use with
-  # short-lived serverless
-  # functions. NOTE: Only AWS Lambda functions are supported currently and this
-  # option is not intended for use
-  # without
-  # New Relic's Ruby Lambda layer based instrumentation
-  # offering.
+  # short-lived serverless functions. NOTE: Only AWS Lambda functions are
+  # supported currently and this option is not intended for use without New
+  # Relic's Ruby Lambda layer offering.
   # serverless_mode.enabled: false
 
   # An array of strings that will collectively serve as a denylist for filtering
@@ -768,11 +741,9 @@ common: &default_settings
   # span_events.enabled: true
 
   # * Defines the maximum number of span events reported from a single harvest.
-  # Any Integer between 1 and
-  # 10000 is valid.
-  # * When configuring the agent for AI monitoring, set to max
-  # value 10000. This ensures the agent captures the maximum amount of distributed
-  # traces.
+  # Any Integer between 1 and 10000 is valid.'
+  # * When configuring the agent for AI monitoring, set to max value 10000.This
+  # ensures the agent captures the maximum amount of distributed traces.
   # span_events.max_samples_stored: 2000
 
   # Sets the maximum number of span events to buffer when streaming to the trace


### PR DESCRIPTION
Previously, config descriptions were edited to adhere to a 120 character line length.

This caused problems for some descriptions when the newrelic.yml file was generated.

The newrelic.yml task handles its own line lengths. We should revisit this another time.

Relates to changes made in https://github.com/newrelic/newrelic-ruby-agent/pull/2770/