### PR TITLE
Add Security Agent comments to `newrelic.yml`

### DIFF
--- a/lib/tasks/helpers/newrelicyml.rb
+++ b/lib/tasks/helpers/newrelicyml.rb
@@ -9,9 +9,6 @@ module NewRelicYML
   DEFAULTS = NewRelic::Agent::Configuration::DEFAULTS
   # Skip because not configurable via yml
   SKIP = [:'defer_rails_initialization']
-  SECURITY_AGENT_DEFAULTS = [:'security.agent.enabled', :'security.enabled', :'security.mode',
-    :'security.validator_service_url', :'security.detection.rci.enabled', :'security.detection.rxss.enabled',
-    :'security.detection.deserialization.enabled', :'security.application_info.port', :'security.request.body_limit']
   # Don't evaluate Procs, instead use set values
   PROCS = {:'config_path' => 'newrelic.yml',
            :'process_host.display_name' => 'default hostname',
@@ -68,8 +65,8 @@ module NewRelicYML
   #
   #   NOTE: All "security.*" configuration parameters are related only to the
   #         security agent, and all other configuration parameters that may
-  #         have "security" in the name some where are related to the APM agent.
-  #
+  #         have "security" in the name somewhere are related to the APM agent.
+  
   SECURITY
 
   SECURITY_END = <<-SECURITY
@@ -106,7 +103,7 @@ module NewRelicYML
 
       next unless public_config?(value) && !deprecated?(value)
 
-      if SECURITY_AGENT_DEFAULTS.include?(key)
+      if key.start_with?('security.')
         description, default = build_config(key, value)
         security_configs[key] = {description: description, default: default}
         next

--- a/lib/tasks/helpers/newrelicyml.rb
+++ b/lib/tasks/helpers/newrelicyml.rb
@@ -102,8 +102,10 @@ module NewRelicYML
       next if CRITICAL.include?(key) || SKIP.include?(key)
 
       next unless public_config?(value) && !deprecated?(value)
-
-      if key.start_with?('security.')
+      
+      # TODO: OLD RUBIES < 2.6
+      # Remove `to_s`. `start_with?` doesn't accept symbols in Ruby <2.6
+      if key.to_s.start_with?('security.')
         description, default = build_config(key, value)
         security_configs[key] = {description: description, default: default}
         next

--- a/lib/tasks/helpers/newrelicyml.rb
+++ b/lib/tasks/helpers/newrelicyml.rb
@@ -102,7 +102,7 @@ module NewRelicYML
       next if CRITICAL.include?(key) || SKIP.include?(key)
 
       next unless public_config?(value) && !deprecated?(value)
-      
+
       # TODO: OLD RUBIES < 2.6
       # Remove `to_s`. `start_with?` doesn't accept symbols in Ruby <2.6
       if key.to_s.start_with?('security.')

--- a/newrelic.yml
+++ b/newrelic.yml
@@ -881,8 +881,8 @@ common: &default_settings
   #
   #   NOTE: All "security.*" configuration parameters are related only to the
   #         security agent, and all other configuration parameters that may
-  #         have "security" in the name some where are related to the APM agent.
-  #
+  #         have "security" in the name somewhere are related to the APM agent.
+  
   # If true, the security agent is loaded (a Ruby 'require' is performed)
   # security.agent.enabled: false
 

--- a/newrelic.yml
+++ b/newrelic.yml
@@ -645,60 +645,6 @@ common: &default_settings
   # ignoring specific transactions.
   # rules.ignore_url_regexes: []
 
-  # BEGIN security agent
-  #
-  #   NOTE: At this time, the security agent is intended for use only within
-  #         a dedicated security testing environment with data that can tolerate
-  #         modification or deletion. The security agent is available as a
-  #         separate Ruby gem, newrelic_security. It is recommended that this
-  #         separate gem only be introduced to a security testing environment
-  #         by leveraging Bundler grouping like so:
-  #
-  #         # Gemfile
-  #         gem 'newrelic_rpm'               # New Relic APM observability agent
-  #         gem 'newrelic-infinite_tracing'  # New Relic Infinite Tracing
-  #
-  #         group :security do
-  #           gem 'newrelic_security', require: false # New Relic security agent
-  #         end
-  #
-  #   NOTE: All "security.*" configuration parameters are related only to the
-  #         security agent, and all other configuration parameters that may
-  #         have "security" in the name some where are related to the APM agent.
-  #
-
-  # If true, the security agent is loaded (a Ruby 'require' is performed)
-  # security.agent.enabled: false
-
-  # The port the application is listening on. This setting is mandatory for
-  # Passenger servers. Other servers should be detected by default.
-  # security.application_info.port: nil
-
-  # If true, enables deserialization detection
-  # security.detection.deserialization.enabled: true
-
-  # If true, enables RCI (remote code injection) detection
-  # security.detection.rci.enabled: true
-
-  # If true, enables RXSS (reflected cross-site scripting) detection
-  # security.detection.rxss.enabled: true
-
-  # If true, the security agent is started (the agent runs in its event loop)
-  # security.enabled: false
-
-  # Defines the mode for the security agent to operate in. Currently only IAST is
-  # supported
-  # security.mode: IAST
-
-  # Defines the request body limit to process in security events (in KB). The
-  # default value is 300, for 300KB.
-  # security.request.body_limit: 300
-
-  # Defines the endpoint URL for posting security-related data
-  # security.validator_service_url: wss://csec.nr-data.net
-
-  # END security agent
-
   # Applies Language Agent Security Policy settings.
   # security_policies_token: ""
 
@@ -915,6 +861,59 @@ common: &default_settings
   # If true, the agent automatically detects that it is running in a Pivotal Cloud
   # Foundry environment.
   # utilization.detect_pcf: true
+
+  # BEGIN security agent
+  #
+  #   NOTE: At this time, the security agent is intended for use only within
+  #         a dedicated security testing environment with data that can tolerate
+  #         modification or deletion. The security agent is available as a
+  #         separate Ruby gem, newrelic_security. It is recommended that this
+  #         separate gem only be introduced to a security testing environment
+  #         by leveraging Bundler grouping like so:
+  #
+  #         # Gemfile
+  #         gem 'newrelic_rpm'               # New Relic APM observability agent
+  #         gem 'newrelic-infinite_tracing'  # New Relic Infinite Tracing
+  #
+  #         group :security do
+  #           gem 'newrelic_security', require: false # New Relic security agent
+  #         end
+  #
+  #   NOTE: All "security.*" configuration parameters are related only to the
+  #         security agent, and all other configuration parameters that may
+  #         have "security" in the name some where are related to the APM agent.
+  #
+  # If true, the security agent is loaded (a Ruby 'require' is performed)
+  # security.agent.enabled: false
+
+  # The port the application is listening on. This setting is mandatory for
+  # Passenger servers. Other servers should be detected by default.
+  # security.application_info.port: nil
+
+  # If true, enables deserialization detection
+  # security.detection.deserialization.enabled: true
+
+  # If true, enables RCI (remote code injection) detection
+  # security.detection.rci.enabled: true
+
+  # If true, enables RXSS (reflected cross-site scripting) detection
+  # security.detection.rxss.enabled: true
+
+  # If true, the security agent is started (the agent runs in its event loop)
+  # security.enabled: false
+
+  # Defines the mode for the security agent to operate in. Currently only IAST is
+  # supported
+  # security.mode: IAST
+
+  # Defines the request body limit to process in security events (in KB). The
+  # default value is 300, for 300KB.
+  # security.request.body_limit: 300
+
+  # Defines the endpoint URL for posting security-related data
+  # security.validator_service_url: wss://csec.nr-data.net
+
+  # END security agent
 
 # Environment-specific settings are in this section.
 # RAILS_ENV or RACK_ENV (as appropriate) is used to determine the environment.

--- a/test/new_relic/newrelicyml_test.rb
+++ b/test/new_relic/newrelicyml_test.rb
@@ -103,30 +103,41 @@ class NewRelicYMLTest < Minitest::Test
       :default => 'newrelic.yml',
       :public => true,
       :description => 'Config path'
+    },
+    :'security.firethorn' => {
+      :default => false,
+      :public => true,
+      :description => 'Thorny shrub.'
     }
   }
 
   def final_config_hash
-    config_hash = {
-      :begonia => {
-        :description => '  # If true, green with white polka dots.',
-        :default => 'nil'
+    config_hash = [
+      {
+        :begonia => {
+          :description => '  # If true, green with white polka dots.',
+          :default => 'nil'
+        },
+        :config_path => {
+          :description => '  # Config path',
+          :default => 'newrelic.yml'
+        },
+        :lily => {
+          :description => '  # White flowers.',
+          :default => 2
+        },
+        :monstera => {
+          :description => '  # Leafy and pretty.',
+          :default => '""'
+        }
       },
-      :config_path => {
-        :description => '  # Config path',
-        :default => 'newrelic.yml'
-      },
-      :lily => {
-        :description => '  # White flowers.',
-        :default => 2
-      },
-      :monstera => {
-        :description => '  # Leafy and pretty.',
-        :default => '""'
+      {
+        :'security.firethorn' => {
+          :description => '  # Thorny shrub.',
+          :default => false
+        }
       }
-    }
-
-    config_hash
+    ]
   end
 
   def final_string
@@ -142,6 +153,32 @@ class NewRelicYMLTest < Minitest::Test
 
   # Leafy and pretty.
   # monstera: ""
+
+  # BEGIN security agent
+  #
+  #   NOTE: At this time, the security agent is intended for use only within
+  #         a dedicated security testing environment with data that can tolerate
+  #         modification or deletion. The security agent is available as a
+  #         separate Ruby gem, newrelic_security. It is recommended that this
+  #         separate gem only be introduced to a security testing environment
+  #         by leveraging Bundler grouping like so:
+  #
+  #         # Gemfile
+  #         gem 'newrelic_rpm'               # New Relic APM observability agent
+  #         gem 'newrelic-infinite_tracing'  # New Relic Infinite Tracing
+  #
+  #         group :security do
+  #           gem 'newrelic_security', require: false # New Relic security agent
+  #         end
+  #
+  #   NOTE: All "security.*" configuration parameters are related only to the
+  #         security agent, and all other configuration parameters that may
+  #         have "security" in the name somewhere are related to the APM agent.
+  
+  # Thorny shrub.
+  # security.firethorn: false
+
+  # END security agent
 
     YML
   end


### PR DESCRIPTION
Update `newrelic.yml` generator to include Security agent comments and regroup security configs at the bottom of the file.

Test coverage: 100%