### PR TITLE
Update spacing for configs to aid translation tool

### DIFF
--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -1164,9 +1164,10 @@ module NewRelic
           :type => Integer,
           :allowed_from_server => true,
           :dynamic_name => true,
+          # Keep the extra two-space indent before the second bullet to appease translation tool
           :description => <<~DESC
             * Specify a maximum number of custom events to buffer in memory at a time.
-            * When configuring the agent for [AI monitoring](/docs/ai-monitoring/intro-to-ai-monitoring), \
+              * When configuring the agent for [AI monitoring](/docs/ai-monitoring/intro-to-ai-monitoring), \
             set to max value `100000`. This ensures the agent captures the maximum amount of LLM events.
           DESC
         },
@@ -2052,11 +2053,11 @@ module NewRelic
           :public => true,
           :type => Integer,
           :allowed_from_server => true,
+          # Keep the extra two-space indent before the second bullet to appease translation tool
           :description => <<~DESC
-            * Defines the maximum number of span events reported from a single harvest. Any Integer between `1` and
-              `10000` is valid.
-            * When configuring the agent for [AI monitoring](/docs/ai-monitoring/intro-to-ai-monitoring), set to max
-              value `10000`. This ensures the agent captures the maximum amount of distributed traces.
+            * Defines the maximum number of span events reported from a single harvest. Any Integer between `1` and `10000` is valid.'
+              * When configuring the agent for [AI monitoring](/docs/ai-monitoring/intro-to-ai-monitoring), set to max value `10000`.\
+            This ensures the agent captures the maximum amount of distributed traces.
           DESC
         },
         # Strip exception messages


### PR DESCRIPTION
Docs Eng recently updated the mdx to html serializer for sending content to be translated. These spaces are needed to keep them happy. See: https://github.com/newrelic/docs-website/pull/18153/files#diff-9c4509bca32c1d4f10736558876f41a21c9b2e0032ffe68cbc9311d4bdcb0f30L1421