### PR TITLE
Grape padrino framework detection

### DIFF
--- a/lib/new_relic/agent/agent_helpers/connect.rb
+++ b/lib/new_relic/agent/agent_helpers/connect.rb
@@ -102,7 +102,6 @@ module NewRelic
             event_harvest_config,
             environment_for_connect
           )
-          puts "sending environment report : #{environment_for_connect.inspect}"
           connect_response = @service.connect(request_builder.connect_payload)
 
           response_handler = ::NewRelic::Agent::Connect::ResponseHandler.new(self, Agent.config)

--- a/lib/new_relic/agent/agent_helpers/connect.rb
+++ b/lib/new_relic/agent/agent_helpers/connect.rb
@@ -102,6 +102,7 @@ module NewRelic
             event_harvest_config,
             environment_for_connect
           )
+          puts "sending environment report : #{environment_for_connect.inspect}"
           connect_response = @service.connect(request_builder.connect_payload)
 
           response_handler = ::NewRelic::Agent::Connect::ResponseHandler.new(self, Agent.config)

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -130,8 +130,10 @@ module NewRelic
                 ::NewRelic::Agent.logger.warn("Detected untested Rails version #{Rails::VERSION::STRING}")
                 :rails_notifications
               end
+            when defined?(::Padrino) && defined?(::Padrino::PathRouter::Router) then :padrino
             when defined?(::Sinatra) && defined?(::Sinatra::Base) then :sinatra
             when defined?(::Roda) then :roda
+            when defined?(::Grape) then :grape
             when defined?(::NewRelic::IA) then :external
             else :ruby
             end

--- a/lib/new_relic/control/frameworks/grape.rb
+++ b/lib/new_relic/control/frameworks/grape.rb
@@ -1,0 +1,20 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+require 'new_relic/control/frameworks/ruby'
+module NewRelic
+  class Control
+    module Frameworks
+      # Contains basic control logic for Grape
+      class Grape < NewRelic::Control::Frameworks::Ruby
+        protected
+
+        def install_shim
+          super
+          ::Grape::API::Instance.class_eval { include NewRelic::Agent::Instrumentation::ControllerInstrumentation::Shim }
+        end
+      end
+    end
+  end
+end

--- a/lib/new_relic/control/frameworks/grape.rb
+++ b/lib/new_relic/control/frameworks/grape.rb
@@ -8,12 +8,6 @@ module NewRelic
     module Frameworks
       # Contains basic control logic for Grape
       class Grape < NewRelic::Control::Frameworks::Ruby
-        protected
-
-        def install_shim
-          super
-          ::Grape::API::Instance.class_eval { include NewRelic::Agent::Instrumentation::ControllerInstrumentation::Shim }
-        end
       end
     end
   end

--- a/lib/new_relic/control/frameworks/padrino.rb
+++ b/lib/new_relic/control/frameworks/padrino.rb
@@ -7,13 +7,7 @@ module NewRelic
   class Control
     module Frameworks
       # Contains basic control logic for Padrino
-      class Padrino < NewRelic::Control::Frameworks::Ruby
-        protected
-
-        def install_shim
-          super
-          ::Padrino::PathRouter::Router.class_eval { include NewRelic::Agent::Instrumentation::ControllerInstrumentation::Shim }
-        end
+      class Padrino < NewRelic::Control::Frameworks::Sinatra
       end
     end
   end

--- a/lib/new_relic/control/frameworks/padrino.rb
+++ b/lib/new_relic/control/frameworks/padrino.rb
@@ -2,7 +2,7 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
-require 'new_relic/control/frameworks/ruby'
+require 'new_relic/control/frameworks/sinatra'
 module NewRelic
   class Control
     module Frameworks

--- a/lib/new_relic/control/frameworks/padrino.rb
+++ b/lib/new_relic/control/frameworks/padrino.rb
@@ -1,0 +1,20 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+require 'new_relic/control/frameworks/ruby'
+module NewRelic
+  class Control
+    module Frameworks
+      # Contains basic control logic for Padrino
+      class Padrino < NewRelic::Control::Frameworks::Ruby
+        protected
+
+        def install_shim
+          super
+          ::Padrino::PathRouter::Router.class_eval { include NewRelic::Agent::Instrumentation::ControllerInstrumentation::Shim }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Grape and Padrino framework detection for environment report. 
  This information is required for newrelic_security to show on UI whether application is supported or not.