### PR TITLE
Add tests to verify framework detection

### DIFF
--- a/test/multiverse/suites/grape/grape_test.rb
+++ b/test/multiverse/suites/grape/grape_test.rb
@@ -19,6 +19,10 @@ class GrapeTest < Minitest::Test
       Rack::Builder.app { run(GrapeTestApi.new) }
     end
 
+    def test_framework_assignment
+      assert_equal(:grape, NewRelic::Agent.config[:framework])
+    end
+
     def test_nonexistent_route
       get('/not_grape_ape')
 

--- a/test/multiverse/suites/padrino/padrino_test.rb
+++ b/test/multiverse/suites/padrino/padrino_test.rb
@@ -39,6 +39,10 @@ class PadrinoRoutesTest < Minitest::Test
     mocha_teardown
   end
 
+  def test_framework_assignment
+    assert_equal(:padrino, NewRelic::Agent.config[:framework])
+  end
+
   def test_tracing_is_involved
     klass = ENV['MULTIVERSE_INSTRUMENTATION_METHOD'] == 'chain' ? ::PadrinoTestApp : ::Padrino::Application
     klass.any_instance.expects(:invoke_route_with_tracing)

--- a/test/multiverse/suites/roda/roda_instrumentation_test.rb
+++ b/test/multiverse/suites/roda/roda_instrumentation_test.rb
@@ -46,6 +46,10 @@ class RodaInstrumentationTest < Minitest::Test
     RodaTestApp
   end
 
+  def test_framework_assignment
+    assert_equal(:roda, NewRelic::Agent.config[:framework])
+  end
+
   def test_http_verb_request_no_request_method
     fake_request = Struct.new('FakeRequest', :path).new
     name = NewRelic::Agent::Instrumentation::Roda::TransactionNamer.transaction_name(fake_request)


### PR DESCRIPTION
Tests added for Grape, Padrino and Roda. Rails and Sinatra framework detection is already evaluated in the unit tests.

(Tests will fail until #2789 is merged)