### PR TITLE
Revert falcon detection changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Version <dev> updates framework detection and fixes Falcon dispatcher detection.
 
 - **Bugfix: Fix Falcon dispatcher detection**
 
-  Previously, we tried to use the object space to determine whether the [Falcon web server](https://github.com/socketry/falcon) was in use. However, Falcon is not added to the object space until after the environment report is generated, resulting in a `nil` dispatcher. Now, we revert to an earlier strategy that discovered the dispatcher using `File.basename($0)`. Thank you,[@prateeksen](https://github.com/prateeksen) for reporting this issue and researching the problem. [Issue#2778](https://github.com/newrelic/newrelic-ruby-agent/issues/2778) [PR#2795](https://github.com/newrelic/newrelic-ruby-agent/pull/2795)
+  Previously, we tried to use the object space to determine whether the [Falcon web server](https://github.com/socketry/falcon) was in use. However, Falcon is not added to the object space until after the environment report is generated, resulting in a `nil` dispatcher. Now, we revert to an earlier strategy that discovered the dispatcher using `File.basename`. Thank you,[@prateeksen](https://github.com/prateeksen) for reporting this issue and researching the problem. [Issue#2778](https://github.com/newrelic/newrelic-ruby-agent/issues/2778) [PR#2795](https://github.com/newrelic/newrelic-ruby-agent/pull/2795)
 
 ## v9.12.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,15 @@
 
 ## dev
 
-Version <dev> updates framework detection.
+Version <dev> updates framework detection and fixes Falcon dispatcher detection.
 
 - **Feature: Improve framework detection accuracy for Grape and Padrino**
 
   Previously, applications using the Grape framework would set `ruby` as their framework within the Environment Report. Now, Grape applications will be set to `grape`. Similarly, applications using the Padrino framework would be set to `sinatra`. Now, they will be set to `padrino`. This will help the New Relic security agent compatibility checks. Thank you, [@prateeksen](https://github.com/prateeksen) for making this change. [Issue#2777](https://github.com/newrelic/newrelic-ruby-agent/issues/2777) [PR#2789](https://github.com/newrelic/newrelic-ruby-agent/pull/2789)
+
+- **Bugfix: Fix Falcon dispatcher detection**
+
+  Previously, we tried to use the object space to determine whether the [Falcon web server](https://github.com/socketry/falcon) was in use. However, Falcon is not added to the object space until after the environment report is generated, resulting in a `nil` dispatcher. Now, we revert to an earlier strategy that discovered the dispatcher using `File.basename($0)`. Thank you,[@prateeksen](https://github.com/prateeksen) for reporting this issue and researching the problem. [Issue#2778](https://github.com/newrelic/newrelic-ruby-agent/issues/2778) [PR#2795](https://github.com/newrelic/newrelic-ruby-agent/pull/2795)
 
 ## v9.12.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Version <dev> updates framework detection and fixes Falcon dispatcher detection.
 
 - **Bugfix: Fix Falcon dispatcher detection**
 
-  Previously, we tried to use the object space to determine whether the [Falcon web server](https://github.com/socketry/falcon) was in use. However, Falcon is not added to the object space until after the environment report is generated, resulting in a `nil` dispatcher. Now, we revert to an earlier strategy that discovered the dispatcher using `File.basename`. Thank you,[@prateeksen](https://github.com/prateeksen) for reporting this issue and researching the problem. [Issue#2778](https://github.com/newrelic/newrelic-ruby-agent/issues/2778) [PR#2795](https://github.com/newrelic/newrelic-ruby-agent/pull/2795)
+  Previously, we tried to use the object space to determine whether the [Falcon web server](https://github.com/socketry/falcon) was in use. However, Falcon is not added to the object space until after the environment report is generated, resulting in a `nil` dispatcher. Now, we revert to an earlier strategy that discovered the dispatcher using `File.basename`. Thank you, [@prateeksen](https://github.com/prateeksen) for reporting this issue and researching the problem. [Issue#2778](https://github.com/newrelic/newrelic-ruby-agent/issues/2778) [PR#2795](https://github.com/newrelic/newrelic-ruby-agent/pull/2795)
 
 ## v9.12.0
 

--- a/lib/new_relic/local_environment.rb
+++ b/lib/new_relic/local_environment.rb
@@ -142,10 +142,9 @@ module NewRelic
     end
 
     def check_for_falcon
-      return unless defined?(::Falcon::Server) &&
-        NewRelic::LanguageSupport.object_space_usable?
-
-      @discovered_dispatcher = :falcon if find_class_in_object_space(::Falcon::Server)
+      if defined?(::Falcon::Server) && File.basename($0) == 'falcon'
+        @discovered_dispatcher = :falcon
+      end
     end
 
     def check_for_delayed_job

--- a/test/new_relic/local_environment_test.rb
+++ b/test/new_relic/local_environment_test.rb
@@ -25,6 +25,23 @@ class NewRelic::LocalEnvironmentTest < Minitest::Test
     end
   end
 
+  def test_falcon
+    falcon_file = File.expand_path('../../../../bin/falcon', __FILE__)
+    opn = $PROGRAM_NAME
+    $PROGRAM_NAME = falcon_file
+
+    with_constant_defined(:'::Falcon') do
+      with_constant_defined(:'::Falcon::Server') do
+        e = NewRelic::Agent.reset_config
+        e = NewRelic::LocalEnvironment.new
+
+        assert_equal :falcon, e.discovered_dispatcher
+      end
+    end
+  ensure
+    $PROGRAM_NAME = opn
+  end
+
   def test_not_resque
     combinations = [['notrake', 'resque:work', {'QUEUE' => '*'}],
       ['rake', 'notresque:work', {'QUEUE' => '*'}],


### PR DESCRIPTION
The `Falcon::Server` class is loaded into the object space after the environment report is sent by the agent. However, evaluating `File.basename($0)` returns 'falcon' in time.

This was our initial approach: https://github.com/newrelic/newrelic-ruby-agent/commit/ebc74b53c76dffa1b3d1ce3520807dde27c3c667 

Closes #2778 