### PR TITLE
Remove deprecation messages for completed actions

### DIFF
--- a/lib/new_relic/agent/instrumentation/active_merchant.rb
+++ b/lib/new_relic/agent/instrumentation/active_merchant.rb
@@ -35,17 +35,4 @@ DependencyDetection.defer do
       end
     end
   end
-
-  executes do
-    next unless Gem::Version.new(ActiveMerchant::VERSION) < Gem::Version.new('1.65.0')
-
-    deprecation_msg = 'The Ruby agent is dropping support for ActiveMerchant versions below 1.65.0 ' \
-      'in version 9.0.0. Please upgrade your ActiveMerchant version to continue receiving full support. ' \
-
-    NewRelic::Agent.logger.log_once(
-      :warn,
-      :deprecated_active_merchant_version,
-      deprecation_msg
-    )
-  end
 end

--- a/lib/new_relic/agent/instrumentation/delayed_job_instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/delayed_job_instrumentation.rb
@@ -93,23 +93,4 @@ DependencyDetection.defer do
       chain_instrument NewRelic::Agent::Instrumentation::DelayedJob::Chain
     end
   end
-
-  executes do
-    next unless delayed_job_version < Gem::Version.new('4.1.0')
-
-    deprecation_msg = 'Instrumentation for DelayedJob versions below 4.1.0 is deprecated.' \
-      'It will stop being monitored in version 9.0.0. ' \
-      'Please upgrade your DelayedJob version to continue receiving full support. ' \
-
-    NewRelic::Agent.logger.log_once(
-      :warn,
-      :deprecated_delayed_job_version,
-      deprecation_msg
-    )
-  end
-
-  def delayed_job_version
-    # the following line needs else branch coverage
-    Gem.loaded_specs['delayed_job'].version if Gem.loaded_specs['delayed_job'] # rubocop:disable Style/SafeNavigation
-  end
 end

--- a/lib/new_relic/agent/instrumentation/excon.rb
+++ b/lib/new_relic/agent/instrumentation/excon.rb
@@ -33,22 +33,6 @@ DependencyDetection.defer do
     end
   end
 
-  executes do
-    next unless Gem::Version.new(Excon::VERSION) < Gem::Version.new('0.56.0')
-
-    deprecation_msg = 'Instrumentation for Excon versions below 0.56.0 is deprecated.' \
-      'They will stop being monitored in version 9.0.0. ' \
-      'Please upgrade your Excon version to continue receiving full support. '
-
-    NewRelic::Agent.logger.log_once(
-      :warn,
-      :deprecated_excon_version,
-      deprecation_msg
-    )
-
-    NewRelic::Agent.record_metric('Supportability/Deprecated/Excon', 1)
-  end
-
   def install_excon_instrumentation(excon_version)
     require 'new_relic/agent/distributed_tracing/cross_app_tracing'
     require 'new_relic/agent/http_clients/excon_wrappers'

--- a/lib/new_relic/agent/instrumentation/sidekiq.rb
+++ b/lib/new_relic/agent/instrumentation/sidekiq.rb
@@ -41,18 +41,4 @@ DependencyDetection.defer do
       end
     end
   end
-
-  executes do
-    next unless Gem::Version.new(Sidekiq::VERSION) < Gem::Version.new('5.0.0')
-
-    deprecation_msg = 'Instrumentation for Sidekiq versions below 5.0.0 is deprecated ' \
-      'and will be dropped entirely in a future major New Relic Ruby agent release.' \
-      'Please upgrade your Sidekiq version to continue receiving full support. '
-
-    NewRelic::Agent.logger.log_once(
-      :warn,
-      :deprecated_sidekiq_version,
-      deprecation_msg
-    )
-  end
 end

--- a/lib/new_relic/agent/instrumentation/sinatra.rb
+++ b/lib/new_relic/agent/instrumentation/sinatra.rb
@@ -42,17 +42,4 @@ DependencyDetection.defer do
       chain_instrument NewRelic::Agent::Instrumentation::Sinatra::Build::Chain
     end
   end
-
-  executes do
-    next unless Gem::Version.new(Sinatra::VERSION) < Gem::Version.new('2.0.0')
-
-    deprecation_msg = 'The Ruby agent is dropping support for Sinatra versions below 2.0.0 ' \
-      'in version 9.0.0. Please upgrade your Sinatra version to continue receiving full compatibility. ' \
-
-    NewRelic::Agent.logger.log_once(
-      :warn,
-      :deprecated_sinatra_version,
-      deprecation_msg
-    )
-  end
 end


### PR DESCRIPTION
The versions mentioned in the deprecation messages have already been removed from our testing matrix.
