### PR TITLE
Fix instrumentation generator

### DIFF
--- a/lib/tasks/instrumentation_generator/instrumentation.thor
+++ b/lib/tasks/instrumentation_generator/instrumentation.thor
@@ -103,7 +103,7 @@ class Instrumentation < Thor
     <<-CONFIG
         :'instrumentation.#{snake_name}' => {
           :default => 'auto',
-          :documentation_default => 'auto'
+          :documentation_default => 'auto',
           :public => true,
           :type => String,
           :dynamic_name => true,

--- a/lib/tasks/instrumentation_generator/templates/dependency_detection.tt
+++ b/lib/tasks/instrumentation_generator/templates/dependency_detection.tt
@@ -12,16 +12,16 @@ DependencyDetection.defer do
   depends_on do
     # The class that needs to be defined to prepend/chain onto. This can be used
     # to determine whether the library is installed.
-    defined?(::<%= @class_name %>)
+    defined?(<%= @class_name %>)
     # Add any additional requirements to verify whether this instrumentation
     # should be installed
   end
 
   executes do
-    ::NewRelic::Agent.logger.info('Installing <%= @name.downcase %> instrumentation')
+    NewRelic::Agent.logger.info('Installing <%= @name.downcase %> instrumentation')
 
     if use_prepend?
-      prepend_instrument ::<%= @class_name %>, NewRelic::Agent::Instrumentation::<%= @class_name %>::Prepend
+      prepend_instrument <%= @class_name %>, NewRelic::Agent::Instrumentation::<%= @class_name %>::Prepend
     else
       chain_instrument NewRelic::Agent::Instrumentation::<%= @class_name %>::Chain
     end


### PR DESCRIPTION
This PR resolves two problems with the instrumentation generator that were discovered during #2796 

* Rubocop has stricter checks on using :: to prefix a class now It consistently fails on files generated from this template
* There's a syntax error due to a missing comma in the config HEREDOC
