### PR TITLE
CI fixes

### DIFF
--- a/test/multiverse/suites/delayed_job/Envfile
+++ b/test/multiverse/suites/delayed_job/Envfile
@@ -32,10 +32,15 @@ boilerplate_gems = <<~SQLITE
 SQLITE
 
 if RUBY_VERSION >= '2.6.0'
+  # delayed_job depends on activesupport and activesupport >= v7.2.0 depends on
+  # securerandom >= 0.3, which may conflict with the "already activated"
+  # (built in for Ruby < v3.4.0) version of securerandom, so just declare a
+  # top-level >= 0.3 dependency.
   gemfile <<~RB
     gem 'delayed_job'
     gem 'i18n'
     #{boilerplate_gems}
+    gem 'securerandom', '>= 0.3'
   RB
 
   # As of 6/13/22 delayed_job_active_record was not compatible with Rails 7

--- a/test/multiverse/suites/sidekiq/sidekiq_with_redis_test.rb
+++ b/test/multiverse/suites/sidekiq/sidekiq_with_redis_test.rb
@@ -36,6 +36,14 @@ class SidekiqWithRedisTest < MiniTest::Test
   def test_redis_client_pipelined_calls_work
     skip 'Testing conducted only using Sidekiq v7.0+ with redis not yet bundled' unless sidekiq_without_redis?
 
+    # With GitHub Actions the use of bundler/inline has repeatedly produced odd
+    # errors related to Bundler being unable to clean up the installed redis
+    # gem given that its directory's permissions are too open (0777). Given that
+    # this test is only useful as a regression test when we are actively
+    # iterating on redis gem instrumentation, it is prohibited from being ran
+    # in an automated CI context and expected to be ran manually by developers.
+    skip if ENV.fetch('CI', nil)
+
     gemfile do
       source 'https://rubygems.org'
 


### PR DESCRIPTION
- Don't perform the bundler/inline based Sidekiq regression test under GHA
- Prevent "already activated" securerandom Bundler errors when testing with the latest delayed_job gem which will grab activesupport v7.2.0