### PR TITLE
Bugfix: don't use `return` in Redis detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## dev
 
-Version <dev> adds experimental OpenSearch instrumentation, updates framework detection, fixes Falcon dispatcher detection, and addresses a JRuby specific concurrency issue.
+Version <dev> adds experimental OpenSearch instrumentation, updates framework detection, fixes Falcon dispatcher detection, fixes a bug with Redis instrumentation installation, and addresses a JRuby specific concurrency issue.
 
 - **Feature: Add experimental OpenSearch instrumentation**
 
@@ -15,6 +15,10 @@ Version <dev> adds experimental OpenSearch instrumentation, updates framework de
 - **Bugfix: Fix Falcon dispatcher detection**
 
   Previously, we tried to use the object space to determine whether the [Falcon web server](https://github.com/socketry/falcon) was in use. However, Falcon is not added to the object space until after the environment report is generated, resulting in a `nil` dispatcher. Now, we revert to an earlier strategy that discovered the dispatcher using `File.basename`. Thank you, [@prateeksen](https://github.com/prateeksen) for reporting this issue and researching the problem. [Issue#2778](https://github.com/newrelic/newrelic-ruby-agent/issues/2778) [PR#2795](https://github.com/newrelic/newrelic-ruby-agent/pull/2795)
+
+- **Bugfix: Fix for a Redis instrumentation error when Redis::Cluster::Client is present**
+
+  The Redis instrumentation previously contained a bug that would cause it to error out when `Redis::Cluster::Client` was present, owing to the use of a Ruby `return` outside of a method. Thanks very much to [@jdelStrother](https://github.com/jdelStrother) for not only reporting this bug but pointing us to the root cause as well. [Issue#2814](https://github.com/newrelic/newrelic-ruby-agent/issues/2814) [PR#2816](https://github.com/newrelic/newrelic-ruby-agent/pull/2816)
 
 - **Bugfix: Address JRuby concurrency issue with config hash accessing**
 

--- a/lib/new_relic/agent/instrumentation/redis.rb
+++ b/lib/new_relic/agent/instrumentation/redis.rb
@@ -36,14 +36,16 @@ DependencyDetection.defer do
       RedisClient.register(NewRelic::Agent::Instrumentation::RedisClient::Middleware)
 
       if defined?(Redis::Cluster::Client)
-        return RedisClient.register(NewRelic::Agent::Instrumentation::RedisClient::ClusterMiddleware)
+        RedisClient.register(NewRelic::Agent::Instrumentation::RedisClient::ClusterMiddleware)
       end
     end
 
-    if use_prepend?
-      prepend_instrument Redis::Client, NewRelic::Agent::Instrumentation::Redis::Prepend
-    else
-      chain_instrument NewRelic::Agent::Instrumentation::Redis::Chain
+    unless defined?(Redis::Cluster::Client)
+      if use_prepend?
+        prepend_instrument Redis::Client, NewRelic::Agent::Instrumentation::Redis::Prepend
+      else
+        chain_instrument NewRelic::Agent::Instrumentation::Redis::Chain
+      end
     end
   end
 end

--- a/test/multiverse/lib/multiverse/gem_manifest.rb
+++ b/test/multiverse/lib/multiverse/gem_manifest.rb
@@ -66,7 +66,7 @@ module Multiverse
 
     def gems_from_gemfile_body(body, path)
       body.split("\n").each do |line|
-        next if line.empty? || line.match?(/(?:^\s*(?:#|if|else|end))|newrelic_(?:rpm|prepender)/)
+        next if line.empty? || line.match?(/(?:^\s*(?:#|if|else|end))|newrelic_(?:rpm|prepender)|# non-gem line/)
 
         if line =~ /.*gem\s+['"]([^'"]+)['"](?:,\s+['"]([^'"]+)['"])?/
           gem = Regexp.last_match(1)

--- a/test/multiverse/suites/redis/Envfile
+++ b/test/multiverse/suites/redis/Envfile
@@ -29,4 +29,14 @@ if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.7.0')
     gem 'rack'
     gem 'redis-clustering'
   RB
+
+  # regression test for dependency detection bug
+  # https://github.com/newrelic/newrelic-ruby-agent/issues/2814
+  gemfile <<~GEMFILE
+    gem 'rack'
+    gem 'redis-clustering'
+
+    require 'redis'
+    ::Redis::Cluster.const_set(:Client, 'phony client definition')
+  GEMFILE
 end

--- a/test/multiverse/suites/redis/Envfile
+++ b/test/multiverse/suites/redis/Envfile
@@ -36,7 +36,7 @@ if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.7.0')
     gem 'rack'
     gem 'redis-clustering'
 
-    require 'redis'
-    ::Redis::Cluster.const_set(:Client, 'phony client definition')
+    require 'redis'                                                 # non-gem line
+    ::Redis::Cluster.const_set(:Client, 'phony client definition')  # non-gem line
   GEMFILE
 end

--- a/test/multiverse/suites/redis/redis_instrumentation_test.rb
+++ b/test/multiverse/suites/redis/redis_instrumentation_test.rb
@@ -468,6 +468,20 @@ if NewRelic::Agent::Datastores::Redis.is_supported_version?
       end
     end
 
+    # regression test for dependency detection bug
+    # https://github.com/newrelic/newrelic-ruby-agent/issues/2814
+    def test_having_a_redis_cluster_client_does_not_cause_an_error
+      skip_unless_minitest5_or_above
+      skip unless defined?(::Redis::Cluster::Client)
+
+      log_data = File.read(File.join(File.dirname(__FILE__), 'log', 'newrelic_agent.log'))
+      contains_error = log_data.match?('LocalJumpError')
+
+      refute contains_error, "Expected the agent log to be free of 'LocalJumpError' errors"
+    end
+
+    private
+
     def client
       if Gem::Version.new(Redis::VERSION).segments[0] < 4
         :client


### PR DESCRIPTION
- Bugfix for https://github.com/newrelic/newrelic-ruby-agent/issues/2814
- Added relevant regression test (with logic taking place in `Gemfile` before the instrumentation is loaded)

resolves #2814