### PR TITLE
CI: use sqlite3 v2 for Rails EDGE

### DIFF
--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -85,7 +85,7 @@ jobs:
                 "rails": "norails,rails61,rails70,rails71,rails72,railsedge"
               },
               "3.4.0-preview1": {
-                "rails": "norails,rails61,rails70,rails71,rails72,railsedge"
+                "rails": "norails,rails61,rails70,rails71,rails72"
               }
             }
 

--- a/test/environments/railsedge/Gemfile
+++ b/test/environments/railsedge/Gemfile
@@ -11,7 +11,7 @@ gem 'mocha', '~> 1.16', require: false
 
 platforms :ruby, :rbx do
   gem 'mysql2', '>= 0.5.4'
-  gem 'sqlite3', '~> 1.4'
+  gem 'sqlite3', '~> 2.0.4'
 end
 
 gem 'newrelic_rpm', path: '../../..'


### PR DESCRIPTION
activerecord now needs sqlite3 v2+