### PR TITLE
ServerlessHandler: error handling for URI parsing

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1250,6 +1250,7 @@ Style/MethodCallWithArgsParentheses:
     - add_development_dependency
     - catch
     - debug
+    - error
     - exit
     - expect
     - fail

--- a/lib/new_relic/agent/serverless_handler.rb
+++ b/lib/new_relic/agent/serverless_handler.rb
@@ -186,13 +186,18 @@ module NewRelic
       def http_uri(info)
         return unless info[:host] && info[:path]
 
-        url_str = "https://#{info[:host]}:#{info[:port]}#{info[:path]}"
+        url_str = "https://#{info[:host]}"
+        url_str += ":#{info[:port]}" unless info[:host].match?(':')
+        url_str += "#{info[:path]}"
+
         if info[:query_parameters]
           qp = info[:query_parameters].map { |k, v| "#{k}=#{v}" }.join('&')
           url_str += "?#{qp}"
         end
 
         URI.parse(url_str)
+      rescue StandardError => e
+        NewRelic::Agent.logger.error "ServerlessHandler failed to parse the source HTTP URI: #{e}"
       end
 
       def info_for_api_gateway_v2

--- a/test/new_relic/agent/serverless_handler_test.rb
+++ b/test/new_relic/agent/serverless_handler_test.rb
@@ -423,9 +423,9 @@ module NewRelic::Agent
         refute_empty metadata[:agent_language]
       end
 
-      # when testing locally with (the Node.js tool) serverless or whatnot, the
-      # base host value may contain ':3000', so make sure the constructed URI
-      # doesn't end up as 'https://localhost:3000:443'
+      # when testing locally without AWS the base host value may contain
+      # ':3000' so make sure the constructed URI doesn't end up as
+      # 'https://localhost:3000:443'
       def test_http_uri_with_existing_port
         info = {:host => 'localhost:3000',
                 :port => 443,


### PR DESCRIPTION
To address issues with the recent serverless enhancements discovered through local dev testing with the Node.js tool 'serverless':

- Don't append a port value to a URI string that already contains one
- If the URI string construction or parsing fails for any reason, log an error and return `nil` so that further processing of the function invocation is not impacted

These issues are thought to only be reproducible outside of AWS, but it's good to be proactive with a bit of extra caution.