### PR TITLE
Bundler version conditions

### DIFF
--- a/lib/new_relic/agent/instrumentation/grape.rb
+++ b/lib/new_relic/agent/instrumentation/grape.rb
@@ -19,9 +19,14 @@ DependencyDetection.defer do
 
   depends_on do
     begin
-      if defined?(Bundler) && Bundler.rubygems.all_specs.map(&:name).include?('newrelic-grape')
-        NewRelic::Agent.logger.info('Not installing New Relic supported Grape instrumentation because the third party newrelic-grape gem is present')
-        false
+      if defined?(Bundler) &&
+          if Bundler::VERSION >= '2' && Bundler.rubygems.installed_specs.map(&:name).include?('newrelic-grape')
+            NewRelic::Agent.logger.info('Not installing New Relic supported Grape instrumentation because the third party newrelic-grape gem is present')
+            false
+          elsif Bundler.rubygems.all_specs.map(&:name).include?('newrelic-grape')
+            NewRelic::Agent.logger.info('Not installing New Relic supported Grape instrumentation because the third party newrelic-grape gem is present')
+            false
+          end
       else
         true
       end

--- a/lib/new_relic/control/frameworks/rails4.rb
+++ b/lib/new_relic/control/frameworks/rails4.rb
@@ -9,8 +9,10 @@ module NewRelic
     module Frameworks
       class Rails4 < NewRelic::Control::Frameworks::Rails3
         def rails_gem_list
-          Bundler.rubygems.all_specs.map do |gem|
-            "#{gem.name} (#{gem.version})"
+          if Bundler::VERSION >= '2'
+            Bundler.rubygems.installed_specs.map { |gem| "#{gem.name} (#{gem.version})" }
+          else
+            Bundler.rubygems.all_specs.map { |gem| "#{gem.name} (#{gem.version})" }
           end
         end
 

--- a/lib/new_relic/environment_report.rb
+++ b/lib/new_relic/environment_report.rb
@@ -44,7 +44,11 @@ module NewRelic
     ####################################
     report_on('Gems') do
       begin
-        Bundler.rubygems.all_specs.map { |gem| "#{gem.name}(#{gem.version})" }
+        if Bundler::VERSION >= '2'
+          Bundler.rubygems.installed_specs.map { |gem| "#{gem.name}(#{gem.version})" }
+        else
+          Bundler.rubygems.all_specs.map { |gem| "#{gem.name}(#{gem.version})" }
+        end
       rescue
         # There are certain rubygem, bundler, rails combinations (e.g. gem
         # 1.6.2, rails 2.3, bundler 1.2.3) where the code above throws an error

--- a/lib/new_relic/language_support.rb
+++ b/lib/new_relic/language_support.rb
@@ -88,7 +88,12 @@ module NewRelic
     end
 
     def bundled_gem?(gem_name)
-      defined?(Bundler) && Bundler.rubygems.all_specs.map(&:name).include?(gem_name)
+      defined?(Bundler) &&
+        if Bundler::VERSION >= '2'
+          Bundler.rubygems.installed_specs.map(&:name).include?(gem_name)
+        else
+          Bundler.rubygems.all_specs.map(&:name).include?(gem_name)
+        end
     rescue => e
       ::NewRelic::Agent.logger.info("Could not determine if third party #{gem_name} gem is installed", e)
       false


### PR DESCRIPTION
Bundler 2+ deprecated `all_specs` in favor of `installed_specs` and emits warnings when `all_specs` is used. We still support Bundler 1, so need to keep `all_specs` around while using `installed_specs` when appropriate. 

Checking for the version proved faster in benchmarking than checking to see if `installed_specs` is define.