### PR TITLE
CI: Healthy URL checker tweaks

### DIFF
--- a/test/helpers/misc.rb
+++ b/test/helpers/misc.rb
@@ -131,8 +131,11 @@ def skip_unless_ci_cron
   skip 'This test only runs as part of the CI cron workflow'
 end
 
+# If in a CI (non local dev) context, skip unless operating within the
+# special CI context. When in a local dev context or in a special CI context,
+# permit the test(s) to run.
 def skip_unless_special_ci
-  return if ENV['SPECIAL_CI']
+  return if ENV.fetch('CI', nil).nil? || ENV.fetch('SPECIAL_CI', nil)
 
   skip 'This test only runs as part of the special CI workflow'
 end

--- a/test/new_relic/healthy_urls_test.rb
+++ b/test/new_relic/healthy_urls_test.rb
@@ -65,7 +65,7 @@ class HealthyUrlsTest < Minitest::Test
   FILE_PATTERN = /(?:^(?:#{FILENAMES.join('|')})$)|\.(?:#{EXTENSIONS.join('|')})$/.freeze
   IGNORED_FILE_PATTERN = %r{/(?:coverage|test)/}.freeze
   URL_PATTERN = %r{(https?://.*?)[^a-zA-Z0-9/\.\-_#]}.freeze
-  IGNORED_URL_PATTERN = %r{(?:\{|\(|\$|169\.254|\.\.\.|learn\.|metadata\.google|honeyryderchuck\.gitlab\.io/httpx|http://#)}
+  IGNORED_URL_PATTERN = %r{(?:\{|\(|\$|169\.254|\.\.\.|learn\.|metadata\.google|honeyryderchuck\.gitlab\.io/httpx|https?://#)}
   TIMEOUT = 5
   DEBUG = false
 
@@ -103,7 +103,7 @@ class HealthyUrlsTest < Minitest::Test
         next unless line =~ URL_PATTERN
 
         url = Regexp.last_match(1).sub(%r{(?:/|\.)$}, '')
-        urls[url] << file if real_url?(url)
+        urls[url] << file if urls.key?(url) || real_url?(url)
       end
     end
   end


### PR DESCRIPTION
- Update the `skip_unless_special_ci` helper to only perform the skip when in a CI context; allowing things to run in a local dev context
- Don't bother performing the "ignore" regex check against a URL that has already previously been tested
- In addition to ignoring 'http://#', ignore 'https://#' as well