### PR TITLE
Comment out Dynamodb ARN attribute

### DIFF
--- a/lib/new_relic/agent/instrumentation/dynamodb/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/dynamodb/instrumentation.rb
@@ -31,8 +31,9 @@ module NewRelic::Agent::Instrumentation
         collection: args[0][:table_name]
       )
 
-      arn = get_arn(args[0])
-      segment&.add_agent_attribute('cloud.resource_id', arn) if arn
+      # TODO: Update this when it has been decided how to handle account id for ARN
+      # arn = get_arn(args[0])
+      # segment&.add_agent_attribute('cloud.resource_id', arn) if arn
 
       @nr_captured_request = nil # clear request just in case
       begin

--- a/test/multiverse/suites/dynamodb/dynamodb_instrumentation_test.rb
+++ b/test/multiverse/suites/dynamodb/dynamodb_instrumentation_test.rb
@@ -42,7 +42,8 @@ class DynamodbInstrumentationTest < Minitest::Test
     assert_equal 'us-east-2', span[2]['aws.region']
     assert_equal 'query', span[2]['aws.operation']
     assert_equal '1234321', span[2]['aws.requestId']
-    assert_equal 'test-arn', span[2]['cloud.resource_id']
+    # TODO: Uncomment this when the ARN is added to the segment
+    # assert_equal 'test-arn', span[2]['cloud.resource_id']
   end
 
   def test_create_table_table_name_operation


### PR DESCRIPTION
Since it's currently undecided how we want to handle getting the account id for the ARN, we are going to comment out this code and come back to it when we decide whether we are going to do things differently or continue doing this.