### PR TITLE
Kafka instrumentation: code loading logic fix

### DIFF
--- a/lib/new_relic/agent/instrumentation/rdkafka.rb
+++ b/lib/new_relic/agent/instrumentation/rdkafka.rb
@@ -2,10 +2,6 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
-require_relative 'rdkafka/instrumentation'
-require_relative 'rdkafka/chain'
-require_relative 'rdkafka/prepend'
-
 DependencyDetection.defer do
   named :rdkafka
 
@@ -15,6 +11,10 @@ DependencyDetection.defer do
 
   executes do
     NewRelic::Agent.logger.info('Installing rdkafka instrumentation')
+
+    require_relative 'rdkafka/instrumentation'
+    require_relative 'rdkafka/chain'
+    require_relative 'rdkafka/prepend'
 
     if use_prepend?
       prepend_instrument Rdkafka::Config, NewRelic::Agent::Instrumentation::RdkafkaConfig::Prepend


### PR DESCRIPTION
Make sure that the `Rdkafka` class based instrumentation is not attempted on systems without it present by relocating the `require_relative` statements into the conditionally executed block.
