### PR TITLE
Lockdown Boolean configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,16 @@ Version <dev> adds Apache Kafka instrumentation for the rdkafka and ruby-kafka g
 
 [PR#2851](https://github.com/newrelic/newrelic-ruby-agent/pull/2851)
 
+  - **Bugfix: Corrected Boolean coercion for `newrelic.yml` configuration**
+
+  Previously, any String assigned to New Relic configurations expecting a Boolean value were evaluated as `true`. This could lead to unexpected behavior. For example, setting `application_logging.enabled: 'false'` in `newrelic.yml` would incorrectly evaluate to `application_logging.enabled: true` due to the truthy nature of Strings. 
+
+  Now, the agent strictly interprets Boolean configuration values. It recognizes both actual Boolean values and certain Strings/Symbols:
+  - `'true'`, `'yes'`, or `'on'` (evaluates to `true`)
+  - `'false'`, `'no'`, or `'off'` (evaluates to `false`)
+
+  Any other inputs will revert to the setting's default configuration value. [PR#2847](https://github.com/newrelic/newrelic-ruby-agent/pull/2847)
+
 - **Bugfix: Jruby not saving configuration values correctly in configuration manager**
 
   Previously, a change made to fix a different JRuby bug caused the agent to not save configuration values correctly in the configuration manager when running on JRuby. This has been fixed. [PR#2848](https://github.com/newrelic/newrelic-ruby-agent/pull/2848)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@ Version <dev> adds Apache Kafka instrumentation for the rdkafka and ruby-kafka g
 
 [PR#2851](https://github.com/newrelic/newrelic-ruby-agent/pull/2851)
 
-  - **Bugfix: Corrected Boolean coercion for `newrelic.yml` configuration**
+- **Bugfix: Corrected Boolean coercion for `newrelic.yml` configuration**
 
   Previously, any String assigned to New Relic configurations expecting a Boolean value were evaluated as `true`. This could lead to unexpected behavior. For example, setting `application_logging.enabled: 'false'` in `newrelic.yml` would incorrectly evaluate to `application_logging.enabled: true` due to the truthy nature of Strings. 
 

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -794,8 +794,7 @@ module NewRelic
         },
         # Browser monitoring
         :'browser_monitoring.auto_instrument' => {
-          # :default => value_of(:'rum.enabled'),
-          :default => true,
+          :default => value_of(:'rum.enabled'),
           :documentation_default => true,
           :public => true,
           :type => Boolean,
@@ -804,8 +803,7 @@ module NewRelic
         },
         # CSP nonce
         :'browser_monitoring.content_security_policy_nonce' => {
-          # :default => value_of(:'rum.enabled'),
-          :default => true,
+          :default => value_of(:'rum.enabled'),
           :documentation_default => true,
           :public => true,
           :type => Boolean,

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -74,7 +74,9 @@ module NewRelic
         end
 
         def self.boolean_for(key, value)
-          BOOLEAN_MAP.fetch(value.to_s, nil)
+          string_value = (value.respond_to?(:call) ? value.call : value).to_s
+
+          BOOLEAN_MAP.fetch(string_value, nil)
         end
 
         def self.default_for(key)
@@ -792,7 +794,8 @@ module NewRelic
         },
         # Browser monitoring
         :'browser_monitoring.auto_instrument' => {
-          :default => value_of(:'rum.enabled'),
+          # :default => value_of(:'rum.enabled'),
+          :default => true,
           :documentation_default => true,
           :public => true,
           :type => Boolean,
@@ -801,7 +804,8 @@ module NewRelic
         },
         # CSP nonce
         :'browser_monitoring.content_security_policy_nonce' => {
-          :default => value_of(:'rum.enabled'),
+          # :default => value_of(:'rum.enabled'),
+          :default => true,
           :documentation_default => true,
           :public => true,
           :type => Boolean,
@@ -2223,7 +2227,7 @@ module NewRelic
           :description => 'Enable or disable debugging version of JavaScript agent loader for browser monitoring instrumentation.'
         },
         :'browser_monitoring.ssl_for_http' => {
-          :default => nil,
+          :default => false,
           :allow_nil => true,
           :public => false,
           :type => Boolean,

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -35,6 +35,15 @@ module NewRelic
       end
 
       class DefaultSource
+        BOOLEAN_MAP = {
+          'true' => true,
+          'yes' => true,
+          'on' => true,
+          'false' => false,
+          'no' => false,
+          'off' => false
+        }.freeze
+
         attr_reader :defaults
 
         extend Forwardable
@@ -62,6 +71,10 @@ module NewRelic
 
         def self.allowlist_for(key)
           value_from_defaults(key, :allowlist)
+        end
+
+        def self.boolean_for(key, value)
+          BOOLEAN_MAP.fetch(value.to_s, nil)
         end
 
         def self.default_for(key)

--- a/lib/new_relic/agent/javascript_instrumentor.rb
+++ b/lib/new_relic/agent/javascript_instrumentor.rb
@@ -164,9 +164,8 @@ module NewRelic
 
       def add_ssl_for_http(data)
         ssl_for_http = NewRelic::Agent.config[:'browser_monitoring.ssl_for_http']
-        unless ssl_for_http.nil?
-          data[SSL_FOR_HTTP_KEY] = ssl_for_http
-        end
+
+        data[SSL_FOR_HTTP_KEY] = ssl_for_http if ssl_for_http
       end
 
       def add_attributes(data, txn)

--- a/test/new_relic/agent/configuration/default_source_test.rb
+++ b/test/new_relic/agent/configuration/default_source_test.rb
@@ -140,12 +140,6 @@ module NewRelic::Agent::Configuration
       end
     end
 
-    def test_application_logging_enabled_default
-      with_config(:'application_logging.enabled' => :foo) do
-        assert_equal :foo, NewRelic::Agent.config['application_logging.enabled']
-      end
-    end
-
     def test_agent_attribute_settings_convert_comma_delimited_strings_into_an_arrays
       types = %w[transaction_tracer. transaction_events. error_collector. browser_monitoring.]
       types << ''

--- a/test/new_relic/agent/configuration/default_source_test.rb
+++ b/test/new_relic/agent/configuration/default_source_test.rb
@@ -285,6 +285,81 @@ module NewRelic::Agent::Configuration
       end
     end
 
+    def test_boolean_configs_accepts_yes_on_and_true_as_strings
+      key = :'send_data_on_exit'
+      default = ::NewRelic::Agent::Configuration::DefaultSource.default_for(key)
+      config_array = %w[yes on true]
+
+      config_array.each do |value|
+        with_config(key => value) do
+          assert NewRelic::Agent.config[key]
+        end
+      end
+    end
+
+    def test_boolean_configs_accepts_yes_on_and_true_as_symbols
+      key = :'send_data_on_exit'
+      default = ::NewRelic::Agent::Configuration::DefaultSource.default_for(key)
+      config_array = %i[yes on true]
+
+      config_array.each do |value|
+        with_config(key => value) do
+          assert NewRelic::Agent.config[key]
+        end
+      end
+    end
+
+    def test_boolean_configs_accepts_no_off_and_false_as_strings
+      key = :'send_data_on_exit'
+      default = ::NewRelic::Agent::Configuration::DefaultSource.default_for(key)
+      config_array = %w[no off false]
+
+      config_array.each do |value|
+        with_config(key => value) do
+          refute NewRelic::Agent.config[key]
+        end
+      end
+    end
+
+    def test_boolean_configs_accepts_no_off_and_false_as_strings_as_symbols
+      key = :'send_data_on_exit'
+      default = ::NewRelic::Agent::Configuration::DefaultSource.default_for(key)
+      config_array = %i[no off false]
+
+      config_array.each do |value|
+        with_config(key => value) do
+          refute NewRelic::Agent.config[key]
+        end
+      end
+    end
+
+    def test_enforce_boolean_uses_defult_on_invalid_value
+      key = :'send_data_on_exit' # default value is `true`
+      default = ::NewRelic::Agent::Configuration::DefaultSource.default_for(key)
+
+      with_config(key => 'invalid_value') do
+        assert NewRelic::Agent.config[key]
+      end
+    end
+
+    def test_enforce_boolean_logs_warning_on_invalid_value
+      key = :'send_data_on_exit'
+      default = ::NewRelic::Agent::Configuration::DefaultSource.default_for(key)
+
+      with_config(key => 'yikes!') do
+        expects_logging(:warn, includes("Invalid value 'yikes!' for #{key}, applying default value of '#{default}'"))
+      end
+    end
+
+    def test_boolean_config_evaluates_proc_configs
+      key = :agent_enabled # default value is a proc
+      default = ::NewRelic::Agent::Configuration::DefaultSource.default_for(key)
+
+      with_config(key => 'off') do
+        refute NewRelic::Agent.config[key]
+      end
+    end
+
     def get_config_value_class(value)
       type = value.class
 

--- a/test/new_relic/agent/configuration/default_source_test.rb
+++ b/test/new_relic/agent/configuration/default_source_test.rb
@@ -285,14 +285,6 @@ module NewRelic::Agent::Configuration
       end
     end
 
-    def test_boolean_configs_accepts_yes_on_and_true_as_strings
-      key = :'send_data_on_exit'
-      default = ::NewRelic::Agent::Configuration::DefaultSource.default_for(key)
-      config_array = %w[yes on true]
-
-      config_array.each do |value|
-        with_config(key => value) do
-          assert NewRelic::Agent.config[key]
     def test_automatic_custom_instrumentation_method_list_supports_an_array
       key = :automatic_custom_instrumentation_method_list
       list = %w[Beano::Roger#dodge Beano::Gnasher.gnash]
@@ -304,14 +296,6 @@ module NewRelic::Agent::Configuration
       end
     end
 
-    def test_boolean_configs_accepts_yes_on_and_true_as_symbols
-      key = :'send_data_on_exit'
-      default = ::NewRelic::Agent::Configuration::DefaultSource.default_for(key)
-      config_array = %i[yes on true]
-
-      config_array.each do |value|
-        with_config(key => value) do
-          assert NewRelic::Agent.config[key]
     def test_automatic_custom_instrumentation_method_list_supports_a_comma_delmited_string
       key = :automatic_custom_instrumentation_method_list
       list = %w[Beano::Roger#dodge Beano::Gnasher.gnash]
@@ -323,14 +307,37 @@ module NewRelic::Agent::Configuration
       end
     end
 
-    def test_boolean_configs_accepts_no_off_and_false_as_strings
+    def test_boolean_configs_accepts_yes_on_and_true_as_strings
       key = :'send_data_on_exit'
       default = ::NewRelic::Agent::Configuration::DefaultSource.default_for(key)
-      config_array = %w[no off false]
+      config_array = %w[yes on true]
 
       config_array.each do |value|
         with_config(key => value) do
-          refute NewRelic::Agent.config[key]
+          assert NewRelic::Agent.config[key], "The '#{value}' value failed to evaluate as truthy!"
+        end
+      end
+    end
+
+    def test_boolean_configs_accepts_yes_on_and_true_as_symbols
+      key = :'send_data_on_exit'
+      default = ::NewRelic::Agent::Configuration::DefaultSource.default_for(key)
+      config_array = %i[yes on true]
+
+      config_array.each do |value|
+        with_config(key => value) do
+          assert NewRelic::Agent.config[key], "The '#{value}' value failed to evaluate as truthy!"
+        end
+      end
+    end
+
+    def test_boolean_configs_accepts_no_off_and_false_as_strings
+      key = :'send_data_on_exit'
+      default = ::NewRelic::Agent::Configuration::DefaultSource.default_for(key)
+
+      %w[no off false].each do |value|
+        with_config(key => value) do
+          refute NewRelic::Agent.config[key], "The '#{value}' value failed to evaluate as falsey!"
         end
       end
     end
@@ -338,11 +345,10 @@ module NewRelic::Agent::Configuration
     def test_boolean_configs_accepts_no_off_and_false_as_strings_as_symbols
       key = :'send_data_on_exit'
       default = ::NewRelic::Agent::Configuration::DefaultSource.default_for(key)
-      config_array = %i[no off false]
 
-      config_array.each do |value|
+      %i[no off false].each do |value|
         with_config(key => value) do
-          refute NewRelic::Agent.config[key]
+          refute NewRelic::Agent.config[key], "The '#{value}' value failed to evaluate as falsey!"
         end
       end
     end

--- a/test/new_relic/agent/configuration/default_source_test.rb
+++ b/test/new_relic/agent/configuration/default_source_test.rb
@@ -309,7 +309,6 @@ module NewRelic::Agent::Configuration
 
     def test_boolean_configs_accepts_yes_on_and_true_as_strings
       key = :'send_data_on_exit'
-      default = ::NewRelic::Agent::Configuration::DefaultSource.default_for(key)
       config_array = %w[yes on true]
 
       config_array.each do |value|
@@ -321,7 +320,6 @@ module NewRelic::Agent::Configuration
 
     def test_boolean_configs_accepts_yes_on_and_true_as_symbols
       key = :'send_data_on_exit'
-      default = ::NewRelic::Agent::Configuration::DefaultSource.default_for(key)
       config_array = %i[yes on true]
 
       config_array.each do |value|
@@ -333,7 +331,6 @@ module NewRelic::Agent::Configuration
 
     def test_boolean_configs_accepts_no_off_and_false_as_strings
       key = :'send_data_on_exit'
-      default = ::NewRelic::Agent::Configuration::DefaultSource.default_for(key)
 
       %w[no off false].each do |value|
         with_config(key => value) do
@@ -344,7 +341,6 @@ module NewRelic::Agent::Configuration
 
     def test_boolean_configs_accepts_no_off_and_false_as_strings_as_symbols
       key = :'send_data_on_exit'
-      default = ::NewRelic::Agent::Configuration::DefaultSource.default_for(key)
 
       %i[no off false].each do |value|
         with_config(key => value) do
@@ -355,7 +351,6 @@ module NewRelic::Agent::Configuration
 
     def test_enforce_boolean_uses_defult_on_invalid_value
       key = :'send_data_on_exit' # default value is `true`
-      default = ::NewRelic::Agent::Configuration::DefaultSource.default_for(key)
 
       with_config(key => 'invalid_value') do
         assert NewRelic::Agent.config[key]
@@ -373,7 +368,6 @@ module NewRelic::Agent::Configuration
 
     def test_boolean_config_evaluates_proc_configs
       key = :agent_enabled # default value is a proc
-      default = ::NewRelic::Agent::Configuration::DefaultSource.default_for(key)
 
       with_config(key => 'off') do
         refute NewRelic::Agent.config[key]


### PR DESCRIPTION
Enforces configs of type Boolean to contain either a boolean or a string/symbol of `true`, `false`, `yes`, `no`, `on`, or `off`

closes #2838