### PR TITLE
Fix JRuby config manager bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,15 @@
 
 ## dev
 
-Version <dev> adds instrumentation for the rdkafka gem.
+Version <dev> adds instrumentation for the rdkafka gem and fixes a JRuby bug in the configuration manager.
 
 - **Feature: Add instrumentation for the rdkafka gem**
 
   The agent now has instrumentation for the rdkafka gem and will record message broker segments for produce and consume calls made using this gem. [PR#2824](https://github.com/newrelic/newrelic-ruby-agent/pull/2824)
+
+- **Bugfix: Jruby not saving configuration values correctly in configuration manager**
+
+  Previously, a change made to fix a different JRuby bug caused the agent to not save configuration values correctly in the configuration manager when running on JRuby. This has been fixed. [PR#2848](https://github.com/newrelic/newrelic-ruby-agent/pull/2848)
 
 
 ## v9.13.0

--- a/lib/new_relic/agent/configuration/manager.rb
+++ b/lib/new_relic/agent/configuration/manager.rb
@@ -388,7 +388,7 @@ module NewRelic
           # modified. The hash really only needs to be modified for the benefit
           # of the security agent, so if JRuby is in play and the security agent
           # is not, don't attempt to modify the hash at all and return early.
-          return @cache if NewRelic::LanguageSupport.jruby? && !Agent.config[:'security.agent.enabled']
+          return new_cache if NewRelic::LanguageSupport.jruby? && !Agent.config[:'security.agent.enabled']
 
           @lock.synchronize do
             preserved = @cache.dup.select { |_k, v| DEPENDENCY_DETECTION_VALUES.include?(v) }


### PR DESCRIPTION
A previous change made to resolve a JRuby concurrency error inadvertently caused a new bug in the agent handling the configuration values when resetting the cache. 

resolves https://github.com/newrelic/newrelic-ruby-agent/issues/2846