### PR TITLE
unit tests: scope to files, favor the shortest

### DIFF
--- a/test/script/run_tests
+++ b/test/script/run_tests
@@ -144,15 +144,48 @@ run_unit_tests() {
   fi
 }
 
+# from a given space/newline delimited string of file paths, return the
+# shortest path
+#
+# so if "bert agent" is invoked and all of these files match 'agent":
+#
+# new_relic/agent/rpm_agent_test.rb
+# new_relic/agent/agent_test.rb
+# new_relic/agent/distributed_tracing/trace_context_cross_agent_test.rb
+# new_relic/agent/distributed_tracing/distributed_tracing_cross_agent_test.rb
+# new_relic/agent/commands/agent_command_router_test.rb
+# new_relic/agent/commands/agent_command_test.rb
+# new_relic/agent/threading/agent_thread_test.rb
+# new_relic/agent/agent_logger_test.rb
+# new_relic/agent_test.rb
+# new_relic/rack/agent_hooks_test.rb
+# new_relic/rack/agent_middleware_test.rb
+#
+# then favor new_relic/agent_test.rb
+shortest_test_file() {
+  files="$1"
+  shortest=1138000
+  desired=""
+  for file in $files; do
+    len=${#file}
+    if (( "$len" < "$shortest" )); then
+      shortest=$len
+      desired=$file
+    fi
+  done
+  printf $desired
+}
+
 # If the first argument doesn't contain a slash or start with test_
 # then assume it is a partial filename match. Find the file.
 find_test_file() {
   if [[ "$1" != */* && "$1" != test* ]]; then
-    file=$(find "test/$2" -name "*$1*" -print -quit)
-    if [[ "$file" == "" ]]; then
+    files=$(find "test/$2" -type f -name "*$1*" -print)
+    if [[ "$files" == "" ]]; then
       echo "Could not find a file match for '$1'"
       exit
     else
+      file=$(shortest_test_file "$files")
       echo "Testing against file '$file'..."
       TEST="$file"
     fi


### PR DESCRIPTION
I invoked `bert agent`, with a desire to run the tests located at `test/new_relic/agent_test.rb`. Instead the tests located at `test/new_relic/agent/rpm_agent_test.rb` were ran instead. This is because we were previously simply grabbing the very first `find` command.

Now, all results obtained by the `find` command will be considered, and the one with the shortest file path will be chosen.

In future we may want to detect the presence of `fzf` and prompt the human tester when multiple results are found, but for now this seems to yield pretty desirable behavior while still permitting the human to add more characters to the input string if they wish to disambiguate between multiple matches themselves.

Also, the `find` command was updated to only focus on files and not directories.