### PR TITLE
Apply method tracers automatically via config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## dev
 
 
-Version <dev> adds Apache Kafka instrumentation for the rdkafka and ruby-kafka gems, introduces a configuration based automatic way to add custom instrumentation method tracers, and fixes a JRuby bug in the configuration manager.
+Version <dev> adds Apache Kafka instrumentation for the rdkafka and ruby-kafka gems, introduces a configuration-based, automatic way to add custom instrumentation method tracers, and fixes a JRuby bug in the configuration manager.
 
 - **Feature: Add Apache Kafka instrumentation for the rdkafka and ruby-kafka gems**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,16 +21,17 @@ Version <dev> adds Apache Kafka instrumentation for the rdkafka and ruby-kafka g
 
   ```
   module MyCompany
-      class Image
+    class Image
       def render_png
-          # code to render a PNG
+        # code to render a PNG
       end
-      end
-      class User
+    end
+
+    class User
       def self.notify
-          # code to notify users
+        # code to notify users
       end
-      end
+    end
   end
   ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Version <dev> adds Apache Kafka instrumentation for the rdkafka and ruby-kafka g
 
   Use fully qualified class names (using the `::` delimiter) that include any module or class namespacing.
 
-  Here is some Ruby source code that defines a `render_png` instance method for an `Image` class and and a `notify` class method for a `User` class, both within a `MyCompany` module namespace:
+  Here is some Ruby source code that defines a `render_png` instance method for an `Image` class and a `notify` class method for a `User` class, both within a `MyCompany` module namespace:
 
   ```
   module MyCompany

--- a/lib/new_relic/agent.rb
+++ b/lib/new_relic/agent.rb
@@ -85,6 +85,10 @@ module NewRelic
     # An exception that forces an agent to stop reporting until its mongrel is restarted.
     class ForceDisconnectException < StandardError; end
 
+    # Error handling for the automated custom instrumentation tracer logic
+    class AutomaticTracerParseException < StandardError; end
+    class AutomaticTracerTraceException < StandardError; end
+
     # An exception that forces an agent to restart.
     class ForceRestartException < StandardError
       def message
@@ -109,6 +113,9 @@ module NewRelic
     # placeholder name used when we cannot determine a transaction's name
     UNKNOWN_METRIC = '(unknown)'.freeze
     LLM_FEEDBACK_MESSAGE = 'LlmFeedbackMessage'
+    # give the observed app time to load the code that automatic tracers have
+    # been configured for
+    AUTOMATIC_TRACER_MAX_ATTEMPTS = 60 # 60 = try about twice a second for 30 seconds
 
     attr_reader :error_group_callback
     attr_reader :llm_token_count_callback
@@ -161,6 +168,86 @@ module NewRelic
           @tracer_queue << [receiver, method_name, metric_name, options]
         end
       end
+    end
+
+    def self.add_automatic_method_tracers(arr)
+      return unless arr
+      return arr if arr.respond_to?(:empty?) && arr.empty?
+
+      arr = arr.split(/\s*,\s*/) if arr.is_a?(String)
+
+      add_tracers_once_methods_are_defined(arr.dup)
+
+      arr
+    end
+
+    # spawn a thread that will attempt to establish a tracer for each of the
+    # configured methods. the thread will continue to keep trying with each
+    # tracer until one of the following happens:
+    #   - the tracer is successfully established
+    #   - the configured method string couldn't be parsed
+    #   - establishing a tracer for a successfully parsed string failed
+    #   - the maximum number of attempts has been reached
+    # the thread will only be spawned once per agent initialization, to account
+    # for configuration reloading scenarios.
+    def self.add_tracers_once_methods_are_defined(notations)
+      # this class method can be invoked multiple times at agent startup, so
+      # we return asap here instead of using a traditional memoization of
+      # waiting for the method's body to finish being executed
+      if defined?(@add_tracers_once_methods_are_defined)
+        return
+      else
+        @add_tracers_once_methods_are_defined = true
+      end
+
+      Thread.new do
+        AUTOMATIC_TRACER_MAX_ATTEMPTS.times do
+          notations.delete_if { |notation| prep_tracer_for(notation) }
+
+          break if notations.empty?
+
+          sleep 0.5
+        end
+      end
+    end
+
+    # returns `true` if the notation string has either been successfully
+    # processed or raised an error during processing. returns `false` if the
+    # string seems good but the (customer) code to be traced has not yet been
+    # loaded into the Ruby VM
+    def self.prep_tracer_for(fully_qualified_method_notation)
+      delimiters = fully_qualified_method_notation.scan(/\.|#/)
+      raise AutomaticTracerParseException.new("Expected exactly one '.' or '#' delimiter.") unless delimiters.size == 1
+
+      delimiter = delimiters.first
+      namespace, method_name = fully_qualified_method_notation.split(delimiter)
+      unless namespace && !namespace.empty?
+        raise AutomaticTracerParseException.new("Nothing found to the left of the #{delimiter} delimiter.")
+      end
+      unless method_name && !method_name.empty?
+        raise AutomaticTracerParseException.new("Nothing found to the right of the #{delimiter} delimiter.")
+      end
+
+      begin
+        klass = ::NewRelic::LanguageSupport.constantize(namespace)
+        return false unless klass
+
+        klass_to_trace = delimiter.eql?('.') ? klass.singleton_class : klass
+        add_or_defer_method_tracer(klass_to_trace, method_name, nil, {})
+      rescue StandardError => e
+        raise AutomaticTracerTraceException.new("#{e.class} - #{e.message}")
+      end
+
+      true
+    rescue AutomaticTracerParseException => e
+      NewRelic::Agent.logger.error('Unable to parse out a usable method name to trace. Expected a valid, fully ' \
+                                   "qualified method notation. Got: '#{fully_qualified_method_notation}'. " \
+                                   "Error: #{e.message}")
+      true
+    rescue AutomaticTracerTraceException => e
+      NewRelic::Agent.logger.error('Unable to automatically apply a tracer to method ' \
+                                   "'#{fully_qualified_method_notation}'. Error: #{e.message}")
+      true
     end
 
     def add_deferred_method_tracers_now

--- a/lib/new_relic/agent.rb
+++ b/lib/new_relic/agent.rb
@@ -170,6 +170,7 @@ module NewRelic
       end
     end
 
+    # @api private
     def self.add_automatic_method_tracers(arr)
       return unless arr
       return arr if arr.respond_to?(:empty?) && arr.empty?
@@ -190,6 +191,8 @@ module NewRelic
     #   - the maximum number of attempts has been reached
     # the thread will only be spawned once per agent initialization, to account
     # for configuration reloading scenarios.
+    #
+    # @api private
     def self.add_tracers_once_methods_are_defined(notations)
       # this class method can be invoked multiple times at agent startup, so
       # we return asap here instead of using a traditional memoization of
@@ -215,6 +218,8 @@ module NewRelic
     # processed or raised an error during processing. returns `false` if the
     # string seems good but the (customer) code to be traced has not yet been
     # loaded into the Ruby VM
+    #
+    # @api private
     def self.prep_tracer_for(fully_qualified_method_notation)
       delimiters = fully_qualified_method_notation.scan(/\.|#/)
       raise AutomaticTracerParseException.new("Expected exactly one '.' or '#' delimiter.") unless delimiters.size == 1
@@ -250,6 +255,7 @@ module NewRelic
       true
     end
 
+    # @api private
     def add_deferred_method_tracers_now
       @tracer_lock.synchronize do
         @tracer_queue.each do |receiver, method_name, metric_name, options|

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -1137,6 +1137,52 @@ module NewRelic
           :allowed_from_server => false,
           :description => 'If `false`, custom attributes will not be sent on events.'
         },
+        :automatic_custom_instrumentation_method_list => {
+          :default => NewRelic::EMPTY_ARRAY,
+          :public => true,
+          :type => Array,
+          :allowed_from_server => false,
+          :transform => proc { |arr| NewRelic::Agent.add_automatic_method_tracers(arr) },
+          :description => <<~DESCRIPTION
+            An array of `CLASS#METHOD` (for instance methods) and/or `CLASS.METHOD` (for class methods) strings representing Ruby methods for the agent to add custom instrumentation to automatically without the need for altering any of the source code that defines the methods.
+
+            Use fully qualified class names (using the `::` delimiter) that include any module or class namespacing.
+
+            Here is some Ruby source code that defines a `render_png` instance method for an `Image` class and and a `notify` class method for a `User` class, both within a `MyCompany` module namespace:
+
+            ```
+            module MyCompany
+              class Image
+                def render_png
+                  # code to render a PNG
+                end
+              end
+
+              class User
+                def self.notify
+                  # code to notify users
+                end
+              end
+            end
+            ```
+
+            Given that source code, the `newrelic.yml` config file might request instrumentation for both of these methods like so:
+
+            ```
+            automatic_custom_instrumentation_method_list:
+              - MyCompany::Image#render_png
+              - MyCompany::User.notify
+            ```
+
+            That configuration example uses YAML array syntax to specify both methods. Alternatively, a comma-delimited string can be used instead:
+
+            ```
+            automatic_custom_instrumentation_method_list: 'MyCompany::Image#render_png, MyCompany::User.notify'
+            ```
+
+            Whitespace around the comma(s) in the list is optional. When configuring the agent with a list of methods via the `NEW_RELIC_AUTOMATIC_CUSTOM_INSTRUMENTATION_METHOD_LIST` environment variable, this comma-delimited string format should be used.
+          DESCRIPTION
+        },
         # Custom events
         :'custom_insights_events.enabled' => {
           :default => true,

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -1144,7 +1144,7 @@ module NewRelic
           :allowed_from_server => false,
           :transform => proc { |arr| NewRelic::Agent.add_automatic_method_tracers(arr) },
           :description => <<~DESCRIPTION
-            An array of `CLASS#METHOD` (for instance methods) and/or `CLASS.METHOD` (for class methods) strings representing Ruby methods for the agent to add custom instrumentation to automatically without the need for altering any of the source code that defines the methods.
+            An array of `CLASS#METHOD` (for instance methods) and/or `CLASS.METHOD` (for class methods) strings representing Ruby methods for the agent to automatically add custom instrumentation to without the need for altering any of the source code that defines the methods.
 
             Use fully qualified class names (using the `::` delimiter) that include any module or class namespacing.
 

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -1180,7 +1180,11 @@ module NewRelic
             automatic_custom_instrumentation_method_list: 'MyCompany::Image#render_png, MyCompany::User.notify'
             ```
 
-            Whitespace around the comma(s) in the list is optional. When configuring the agent with a list of methods via the `NEW_RELIC_AUTOMATIC_CUSTOM_INSTRUMENTATION_METHOD_LIST` environment variable, this comma-delimited string format should be used.
+            Whitespace around the comma(s) in the list is optional. When configuring the agent with a list of methods via the `NEW_RELIC_AUTOMATIC_CUSTOM_INSTRUMENTATION_METHOD_LIST` environment variable, this comma-delimited string format should be used:
+
+            ```
+            export NEW_RELIC_AUTOMATIC_CUSTOM_INSTRUMENTATION_METHOD_LIST='MyCompany::Image#render_png, MyCompany::User.notify'
+            ```
           DESCRIPTION
         },
         # Custom events

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -1148,7 +1148,7 @@ module NewRelic
 
             Use fully qualified class names (using the `::` delimiter) that include any module or class namespacing.
 
-            Here is some Ruby source code that defines a `render_png` instance method for an `Image` class and and a `notify` class method for a `User` class, both within a `MyCompany` module namespace:
+            Here is some Ruby source code that defines a `render_png` instance method for an `Image` class and a `notify` class method for a `User` class, both within a `MyCompany` module namespace:
 
             ```
             module MyCompany

--- a/lib/new_relic/agent/configuration/environment_source.rb
+++ b/lib/new_relic/agent/configuration/environment_source.rb
@@ -92,7 +92,11 @@ module NewRelic
           elsif type == Symbol
             self[config_key] = value.to_sym
           elsif type == Array
-            self[config_key] = value.split(/\s*,\s*/)
+            self[config_key] = if DEFAULTS[config_key].key?(:transform)
+              DEFAULTS[config_key][:transform].call(value)
+            else
+              value.split(/\s*,\s*/)
+            end
           elsif type == NewRelic::Agent::Configuration::Boolean
             if /false|off|no/i.match?(value)
               self[config_key] = false

--- a/test/new_relic/agent/configuration/default_source_test.rb
+++ b/test/new_relic/agent/configuration/default_source_test.rb
@@ -291,6 +291,28 @@ module NewRelic::Agent::Configuration
       end
     end
 
+    def test_automatic_custom_instrumentation_method_list_supports_an_array
+      key = :automatic_custom_instrumentation_method_list
+      list = %w[Beano::Roger#dodge Beano::Gnasher.gnash]
+      NewRelic::Agent.stub :add_tracers_once_methods_are_defined, nil do
+        with_config(key => list) do
+          assert_equal list, NewRelic::Agent.config[key],
+            "Expected '#{key}' to be configured with the unmodified original list"
+        end
+      end
+    end
+
+    def test_automatic_custom_instrumentation_method_list_supports_a_comma_delmited_string
+      key = :automatic_custom_instrumentation_method_list
+      list = %w[Beano::Roger#dodge Beano::Gnasher.gnash]
+      NewRelic::Agent.stub :add_tracers_once_methods_are_defined, nil do
+        with_config(key => list.join('                                          ,')) do
+          assert_equal list, NewRelic::Agent.config[key],
+            "Expected '#{key}' to be configured with the given string converted into an array"
+        end
+      end
+    end
+
     def get_config_value_class(value)
       type = value.class
 

--- a/test/new_relic/agent/configuration/environment_source_test.rb
+++ b/test/new_relic/agent/configuration/environment_source_test.rb
@@ -161,6 +161,8 @@ module NewRelic::Agent::Configuration
     end
 
     def test_array_based_params_use_the_transform_proc_when_present
+      skip_unless_minitest5_or_above
+
       arr = %w[James Jessie Meowth]
 
       env_var = 'NEW_RELIC_AUTOMATIC_CUSTOM_INSTRUMENTATION_METHOD_LIST'

--- a/test/new_relic/agent/configuration/environment_source_test.rb
+++ b/test/new_relic/agent/configuration/environment_source_test.rb
@@ -160,6 +160,18 @@ module NewRelic::Agent::Configuration
       assert_equal %w[hi bye], @environment_source[:'attributes.include']
     end
 
+    def test_array_based_params_use_the_transform_proc_when_present
+      arr = %w[James Jessie Meowth]
+
+      env_var = 'NEW_RELIC_AUTOMATIC_CUSTOM_INSTRUMENTATION_METHOD_LIST'
+      param = :automatic_custom_instrumentation_method_list
+      ENV.stub(:[], arr.join(','), [env_var]) do
+        @environment_source.set_key_by_type(param, env_var)
+      end
+
+      assert_equal arr, @environment_source[param]
+    end
+
     def test_set_key_with_new_relic_prefix
       assert_applied_string('NEW_RELIC_LICENSE_KEY', :license_key)
     end

--- a/test/new_relic/agent/configuration/orphan_configuration_test.rb
+++ b/test/new_relic/agent/configuration/orphan_configuration_test.rb
@@ -8,6 +8,9 @@ class OrphanedConfigTest < Minitest::Test
   include NewRelic::TestHelpers::FileSearching
   include NewRelic::TestHelpers::ConfigScanning
 
+  # :automatic_custom_instrumentation_method_list - the tranform proc handles all processing, no other reference exists
+  IGNORED_KEYS = %i[automatic_custom_instrumentation_method_list]
+
   def setup
     @default_keys = ::NewRelic::Agent::Configuration::DEFAULTS.keys
   end
@@ -38,8 +41,16 @@ class OrphanedConfigTest < Minitest::Test
     # This indicates that these keys are referenced and implemented in
     # an external gem, so we don't expect any explicit references to them
     # in the core gem's code.
+    #
+
+    # Remove any of the following types of keys
+    # - "external" keys: these are expected to only be leveraged by "external" code bases (Infinite Tracing, CSEC)
+    # - "deprecated" keys: these are supported for a time and have their values set on new param names used in code
+    # - "ignored" keys: special cased params defined by a constant above
     @default_keys.delete_if do |key_name|
-      NewRelic::Agent::Configuration::DEFAULTS[key_name][:external] || NewRelic::Agent::Configuration::DEFAULTS[key_name][:deprecated]
+      NewRelic::Agent::Configuration::DEFAULTS[key_name][:external] ||
+        NewRelic::Agent::Configuration::DEFAULTS[key_name][:deprecated] ||
+        IGNORED_KEYS.include?(key_name)
     end
 
     assert_empty @default_keys

--- a/test/new_relic/agent_test.rb
+++ b/test/new_relic/agent_test.rb
@@ -771,6 +771,8 @@ module NewRelic
     end
 
     def test_prep_tracer_handles_a_failed_tracer_add_attempt
+      skip_unless_minitest5_or_above
+
       notation = "Monk's.Blend"
       NewRelic::LanguageSupport.stub :constantize, -> { raise 'kaboom' }, [notation] do
         result = with_logger_expectation(:error, /Unable to automatically apply .*#{notation}/) do
@@ -782,6 +784,8 @@ module NewRelic
     end
 
     def test_prep_tracer_for_traces_a_class_method
+      skip_unless_minitest5_or_above
+
       notation = 'A::Short.hike'
       NewRelic::LanguageSupport.stub :constantize, TesterClass, [notation] do
         NewRelic::Agent.stub :add_or_defer_method_tracer, nil, [TesterClass.singleton_class, 'hike', nil, {}] do
@@ -793,6 +797,8 @@ module NewRelic
     end
 
     def test_prep_tracer_for_traces_an_instance_method
+      skip_unless_minitest5_or_above
+
       notation = 'A::Short#hike'
       NewRelic::LanguageSupport.stub :constantize, TesterClass, [notation] do
         NewRelic::Agent.stub :add_or_defer_method_tracer, nil, [TesterClass, 'hike', nil, {}] do

--- a/test/new_relic/agent_test.rb
+++ b/test/new_relic/agent_test.rb
@@ -12,6 +12,8 @@ module NewRelic
   class MainAgentTest < Minitest::Test
     include NewRelic::Agent::MethodTracer
 
+    class TesterClass; end
+
     def setup
       NewRelic::Agent.drop_buffered_data
       NewRelic::Agent.reset_config
@@ -698,6 +700,109 @@ module NewRelic
       assert_equal name, NewRelic::Agent.base_name(name)
     end
 
+    def test_add_automatic_method_tracers_short_circuits_with_a_nil_method_list
+      assert_nil NewRelic::Agent.add_automatic_method_tracers(nil)
+    end
+
+    def test_add_automatic_method_tracers_returns_early_when_given_an_empty_method_list
+      arr = []
+
+      assert_equal arr, NewRelic::Agent.add_automatic_method_tracers(arr)
+    end
+
+    # as of 2024-09-12, the agent doesn't natively permit a configuration
+    # parameter to accept either an array (definable only in the YAML file) or
+    # a comma-delimited string (definable in YAML or via an env var), so this
+    # method permits it by handling the `String#split` call itself.
+    def test_add_automatic_method_tracers_handles_a_comma_delimited_string
+      arr = %w[Astarion Gale Shadowheart]
+      # don't actually spawn the thread to add custom instrumentation
+      NewRelic::Agent.stub :add_tracers_once_methods_are_defined, nil do
+        assert_equal arr, NewRelic::Agent.add_automatic_method_tracers(arr.join(','))
+      end
+    end
+
+    # treat the configured list as immutable and operate on a dupe of the list
+    # when iterating over it and removing entries that have been processed
+    def test_add_automatic_method_tracers_processes_a_dupe_of_the_methods_array
+      arr = %w[Andy Barney]
+      dupe_object_id = nil
+      NewRelic::Agent.stub :add_tracers_once_methods_are_defined, proc { |a| dupe_object_id = a.object_id } do
+        result = NewRelic::Agent.add_automatic_method_tracers(arr)
+
+        assert_same arr, result
+        assert dupe_object_id
+        refute_equal arr.object_id, dupe_object_id
+      end
+    end
+
+    def test_prep_tracer_for_handles_a_non_delimited_notation
+      notation = 'StringWithoutADelimiter'
+      result = with_logger_expectation(:error, /Unable to parse out .*#{notation}.* Expected exactly/) do
+        NewRelic::Agent.prep_tracer_for(notation)
+      end
+
+      assert result # `true`, we're not going to try processing this notation again
+    end
+
+    def test_prep_tracer_for_handles_a_missing_namespace
+      notation = '.method_name'
+      result = with_logger_expectation(:error, /Unable to parse out .*#{notation}.* to the left of/) do
+        NewRelic::Agent.prep_tracer_for(notation)
+      end
+
+      assert result # `true`, we're not going to try processing this notation again
+    end
+
+    def test_prep_tracer_for_handles_a_missing_method_name
+      notation = 'namespace#'
+      result = with_logger_expectation(:error, /Unable to parse out .*#{notation}.* to the right of/) do
+        NewRelic::Agent.prep_tracer_for(notation)
+      end
+
+      assert result # `true`, we're not going to try processing this notation again
+    end
+
+    def test_prep_tracer_for_returns_false_if_the_notation_is_find_but_the_method_cannot_be_found_yet
+      notation = 'AGoodModuleNameSpace::AClass#a_method' # good syntax but undefined
+      result = NewRelic::Agent.prep_tracer_for(notation)
+
+      refute result # `false`, we're going to try processing this notation again later
+    end
+
+    def test_prep_tracer_handles_a_failed_tracer_add_attempt
+      notation = "Monk's.Blend"
+      NewRelic::LanguageSupport.stub :constantize, -> { raise 'kaboom' }, [notation] do
+        result = with_logger_expectation(:error, /Unable to automatically apply .*#{notation}/) do
+          NewRelic::Agent.prep_tracer_for(notation)
+        end
+
+        assert result # `true`, we're not going to try processing this notation again
+      end
+    end
+
+    def test_prep_tracer_for_traces_a_class_method
+      notation = 'A::Short.hike'
+      NewRelic::LanguageSupport.stub :constantize, TesterClass, [notation] do
+        NewRelic::Agent.stub :add_or_defer_method_tracer, nil, [TesterClass.singleton_class, 'hike', nil, {}] do
+          result = NewRelic::Agent.prep_tracer_for(notation)
+
+          assert result # `true`, we're not going to try processing this notation again
+        end
+      end
+    end
+
+    def test_prep_tracer_for_traces_an_instance_method
+      notation = 'A::Short#hike'
+      NewRelic::LanguageSupport.stub :constantize, TesterClass, [notation] do
+        NewRelic::Agent.stub :add_or_defer_method_tracer, nil, [TesterClass, 'hike', nil, {}] do
+          result = NewRelic::Agent.prep_tracer_for(notation)
+
+          assert result # `true`, we're not going to try processing this notation again
+        end
+      end
+    end
+
     private
 
     def with_unstarted_agent
@@ -730,6 +835,14 @@ module NewRelic
 
       NewRelic::Control.stubs(:instance).returns(control)
       control
+    end
+
+    def with_logger_expectation(log_level, expected_regex, &block)
+      logger = MiniTest::Mock.new
+      logger.expect log_level, nil, [expected_regex]
+      result = NewRelic::Agent.stub(:logger, logger) { yield }
+      logger.verify
+      result
     end
   end
 end


### PR DESCRIPTION
A new `:automatic_custom_instrumentation_method_list` configuration parameter has been added to permit the user to define a list of namespaced method name strings representing methods that the agent should automatically add custom instrumentation tracers to.

resolves #2701