### PR TITLE
Update min bundler version for installed_specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 ## dev
 
-
-Version <dev> adds Apache Kafka instrumentation for the rdkafka and ruby-kafka gems, introduces a configuration-based, automatic way to add custom instrumentation method tracers, and fixes a JRuby bug in the configuration manager.
+Version <dev> adds Apache Kafka instrumentation for the rdkafka and ruby-kafka gems, introduces a configuration-based, automatic way to add custom instrumentation method tracers, and fixes a JRuby bug in the configuration manager, and fixes a bug related to `Bundler.rubygems.installed_specs`.
 
 - **Feature: Add Apache Kafka instrumentation for the rdkafka and ruby-kafka gems**
 
@@ -61,6 +60,9 @@ Version <dev> adds Apache Kafka instrumentation for the rdkafka and ruby-kafka g
 
   Previously, a change made to fix a different JRuby bug caused the agent to not save configuration values correctly in the configuration manager when running on JRuby. This has been fixed. [PR#2848](https://github.com/newrelic/newrelic-ruby-agent/pull/2848)
 
+- **Bugfix: Update condition to verify Bundler.rubygems.installed_specs is available**
+
+  To address a recent Bundler deprecation warning, we started using `Bundler.rubygems.installed_specs` instead of `Bundler.rubygems.all_specs` in environments that seemed appropriate. We discovered the version constraint we used was too low.
 
 ## v9.13.0
 
@@ -68,11 +70,11 @@ Version 9.13.0 enhances support for AWS Lambda functions, adds experimental Open
 
 - **Feature: Enhance AWS Lambda function instrumentation**
 
-When utilized via the latest [New Relic Ruby layer for AWS Lambda](https://layers.newrelic-external.com/), the agent now offers enhanced support for AWS Lambda function instrumentation. 
-* The agent's instrumentation for AWS Lambda functions now supports distributed tracing. 
-* Web-triggered invocations are now identified as being "web"-based when an API Gateway call is involved, with support for both API Gateway versions 1.0 and 2.0. 
-* Web-based calls have the HTTP method, URI, and status code recorded. 
-* The agent now recognizes and reports on 12 separate AWS resources that are capable of triggering a Lambda function invocation: ALB, API Gateway V1, API Gateway V2, CloudFront, CloudWatch Scheduler, DynamoStreams, Firehose, Kinesis, S3, SES, SNS, and SQS. 
+When utilized via the latest [New Relic Ruby layer for AWS Lambda](https://layers.newrelic-external.com/), the agent now offers enhanced support for AWS Lambda function instrumentation.
+* The agent's instrumentation for AWS Lambda functions now supports distributed tracing.
+* Web-triggered invocations are now identified as being "web"-based when an API Gateway call is involved, with support for both API Gateway versions 1.0 and 2.0.
+* Web-based calls have the HTTP method, URI, and status code recorded.
+* The agent now recognizes and reports on 12 separate AWS resources that are capable of triggering a Lambda function invocation: ALB, API Gateway V1, API Gateway V2, CloudFront, CloudWatch Scheduler, DynamoStreams, Firehose, Kinesis, S3, SES, SNS, and SQS.
 * The type of the triggering resource and its ARN will be recorded for each resource, and for many of them, extra resource-specific attributes will be recorded as well. For example, Lambda function invocations triggered by S3 bucket activity will now result in the S3 bucket name being recorded.
 [PR#2811](https://github.com/newrelic/newrelic-ruby-agent/pull/2811)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## dev
 
-Version <dev> adds Apache Kafka instrumentation for the rdkafka and ruby-kafka gems, introduces a configuration-based, automatic way to add custom instrumentation method tracers, and fixes a JRuby bug in the configuration manager, and fixes a bug related to `Bundler.rubygems.installed_specs`.
+Version <dev> adds Apache Kafka instrumentation for the rdkafka and ruby-kafka gems, introduces a configuration-based, automatic way to add custom instrumentation method tracers, fixes a JRuby bug in the configuration manager, and fixes a bug related to `Bundler.rubygems.installed_specs`.
 
 - **Feature: Add Apache Kafka instrumentation for the rdkafka and ruby-kafka gems**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@ Version <dev> adds Apache Kafka instrumentation for the rdkafka and ruby-kafka g
 
 - **Bugfix: Update condition to verify Bundler.rubygems.installed_specs is available**
 
-  To address a recent Bundler deprecation warning, we started using `Bundler.rubygems.installed_specs` instead of `Bundler.rubygems.all_specs` in environments that seemed appropriate. We discovered the version constraint we used was too low.
+  To address a recent Bundler deprecation warning, we started using `Bundler.rubygems.installed_specs` instead of `Bundler.rubygems.all_specs` in environments that seemed appropriate. We discovered the version constraint we used was too low. Now, rather than check the version, we check for the method using `respond_to?`.
 
 ## v9.13.0
 

--- a/lib/new_relic/agent/instrumentation/grape.rb
+++ b/lib/new_relic/agent/instrumentation/grape.rb
@@ -20,7 +20,7 @@ DependencyDetection.defer do
   depends_on do
     begin
       if defined?(Bundler) &&
-          ((Gem::Version.new(Bundler::VERSION) >= Gem::Version.new('2.5.12') && Bundler.rubygems.installed_specs.map(&:name).include?('newrelic-grape')) ||
+          ((Bundler.rubygems.respond_to?(:installed_specs) && Bundler.rubygems.installed_specs.map(&:name).include?('newrelic-grape')) ||
             Bundler.rubygems.all_specs.map(&:name).include?('newrelic-grape'))
         NewRelic::Agent.logger.info('Not installing New Relic supported Grape instrumentation because the third party newrelic-grape gem is present')
         false

--- a/lib/new_relic/agent/instrumentation/grape.rb
+++ b/lib/new_relic/agent/instrumentation/grape.rb
@@ -20,7 +20,7 @@ DependencyDetection.defer do
   depends_on do
     begin
       if defined?(Bundler) &&
-          ((Gem::Version.new(Bundler::VERSION) >= Gem::Version.new('2.0.0') && Bundler.rubygems.installed_specs.map(&:name).include?('newrelic-grape')) ||
+          ((Gem::Version.new(Bundler::VERSION) >= Gem::Version.new('2.5.12') && Bundler.rubygems.installed_specs.map(&:name).include?('newrelic-grape')) ||
             Bundler.rubygems.all_specs.map(&:name).include?('newrelic-grape'))
         NewRelic::Agent.logger.info('Not installing New Relic supported Grape instrumentation because the third party newrelic-grape gem is present')
         false

--- a/lib/new_relic/control/frameworks/rails4.rb
+++ b/lib/new_relic/control/frameworks/rails4.rb
@@ -9,7 +9,7 @@ module NewRelic
     module Frameworks
       class Rails4 < NewRelic::Control::Frameworks::Rails3
         def rails_gem_list
-          if Gem::Version.new(Bundler::VERSION) >= Gem::Version.new('2.0.0')
+          if Gem::Version.new(Bundler::VERSION) >= Gem::Version.new('2.5.12')
             Bundler.rubygems.installed_specs.map { |gem| "#{gem.name} (#{gem.version})" }
           else
             Bundler.rubygems.all_specs.map { |gem| "#{gem.name} (#{gem.version})" }

--- a/lib/new_relic/control/frameworks/rails4.rb
+++ b/lib/new_relic/control/frameworks/rails4.rb
@@ -9,7 +9,7 @@ module NewRelic
     module Frameworks
       class Rails4 < NewRelic::Control::Frameworks::Rails3
         def rails_gem_list
-          if Gem::Version.new(Bundler::VERSION) >= Gem::Version.new('2.5.12')
+          if Bundler.rubygems.respond_to?(:installed_specs)
             Bundler.rubygems.installed_specs.map { |gem| "#{gem.name} (#{gem.version})" }
           else
             Bundler.rubygems.all_specs.map { |gem| "#{gem.name} (#{gem.version})" }

--- a/lib/new_relic/environment_report.rb
+++ b/lib/new_relic/environment_report.rb
@@ -44,7 +44,7 @@ module NewRelic
     ####################################
     report_on('Gems') do
       begin
-        if Gem::Version.new(Bundler::VERSION) >= Gem::Version.new('2.5.12')
+        if Bundler.rubygems.respond_to?(:installed_specs)
           Bundler.rubygems.installed_specs.map { |gem| "#{gem.name}(#{gem.version})" }
         else
           Bundler.rubygems.all_specs.map { |gem| "#{gem.name}(#{gem.version})" }

--- a/lib/new_relic/environment_report.rb
+++ b/lib/new_relic/environment_report.rb
@@ -44,7 +44,7 @@ module NewRelic
     ####################################
     report_on('Gems') do
       begin
-        if Gem::Version.new(Bundler::VERSION) >= Gem::Version.new('2.0.0')
+        if Gem::Version.new(Bundler::VERSION) >= Gem::Version.new('2.5.12')
           Bundler.rubygems.installed_specs.map { |gem| "#{gem.name}(#{gem.version})" }
         else
           Bundler.rubygems.all_specs.map { |gem| "#{gem.name}(#{gem.version})" }

--- a/lib/new_relic/language_support.rb
+++ b/lib/new_relic/language_support.rb
@@ -90,7 +90,7 @@ module NewRelic
     def bundled_gem?(gem_name)
       return false unless defined?(Bundler)
 
-      if Gem::Version.new(Bundler::VERSION) >= Gem::Version.new('2.0.0')
+      if Gem::Version.new(Bundler::VERSION) >= Gem::Version.new('2.5.12')
         Bundler.rubygems.installed_specs.map(&:name).include?(gem_name)
       else
         Bundler.rubygems.all_specs.map(&:name).include?(gem_name)

--- a/lib/new_relic/language_support.rb
+++ b/lib/new_relic/language_support.rb
@@ -90,7 +90,7 @@ module NewRelic
     def bundled_gem?(gem_name)
       return false unless defined?(Bundler)
 
-      if Gem::Version.new(Bundler::VERSION) >= Gem::Version.new('2.5.12')
+      if Bundler.rubygems.respond_to?(:installed_specs)
         Bundler.rubygems.installed_specs.map(&:name).include?(gem_name)
       else
         Bundler.rubygems.all_specs.map(&:name).include?(gem_name)


### PR DESCRIPTION
The `Bundler::RubygemsIntegration.installed_specs` method was added in version 2.5.12. This PR updates the check to see if `Bundler.rubygems` responds to `installed_specs`.

2.5.11: https://github.com/rubygems/rubygems/blame/bundler-v2.5.11/bundler/lib/bundler/rubygems_integration.rb#L471 (all_specs only)
2.5.12: https://github.com/rubygems/rubygems/blame/bundler-v2.5.12/bundler/lib/bundler/rubygems_integration.rb#L479 (both all_specs and installed_specs)