### PR TITLE
Use `media_type` instead of `content_type` when avaliable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## dev
 
-Version <dev> adds Apache Kafka instrumentation for the rdkafka and ruby-kafka gems, introduces a configuration-based, automatic way to add custom instrumentation method tracers, fixes a JRuby bug in the configuration manager, and fixes a bug related to `Bundler.rubygems.installed_specs`.
+Version <dev> adds Apache Kafka instrumentation for the rdkafka and ruby-kafka gems, introduces a configuration-based, automatic way to add custom instrumentation method tracers, correctly captures MIME type for AcionDispatch 7.0+ requests, fixes a JRuby bug in the configuration manager, and fixes a bug related to `Bundler.rubygems.installed_specs`.
 
 - **Feature: Add Apache Kafka instrumentation for the rdkafka and ruby-kafka gems**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,10 @@ Version <dev> adds Apache Kafka instrumentation for the rdkafka and ruby-kafka g
 
 [PR#2851](https://github.com/newrelic/newrelic-ruby-agent/pull/2851)
 
+- **Feature: Collect just MIME type from AcionDispatch requests**
+  
+  Rails 7.0 [introduced changes](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#actiondispatch-request-content-type-now-returns-content-type-header-as-it-is) to the behavior of `ActionDispatch::Request#content_type`, adding extra request-related details the agent wasn't expecting to collect. Additionally, the agent's use of `content_type ` was triggering deprecation warnings. The agent now uses `ActionDispatch::Request#media_type` to capture the MIME type. Thanks to [@internethostage](https://github.com/internethostage) for letting us know about this change. [Issue#2500](https://github.com/newrelic/newrelic-ruby-agent/issues/2500) [PR#2855](https://github.com/newrelic/newrelic-ruby-agent/pull/2855)
+
 - **Bugfix: Corrected Boolean coercion for `newrelic.yml` configuration**
 
   Previously, any String assigned to New Relic configurations expecting a Boolean value were evaluated as `true`. This could lead to unexpected behavior. For example, setting `application_logging.enabled: 'false'` in `newrelic.yml` would incorrectly evaluate to `application_logging.enabled: true` due to the truthy nature of Strings. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ Version <dev> adds Apache Kafka instrumentation for the rdkafka and ruby-kafka g
 
 [PR#2851](https://github.com/newrelic/newrelic-ruby-agent/pull/2851)
 
-- **Feature: Collect just MIME type from AcionDispatch requests**
+- **Feature: Collect just MIME type for AcionDispatch 7.0+ requests**
   
   Rails 7.0 [introduced changes](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#actiondispatch-request-content-type-now-returns-content-type-header-as-it-is) to the behavior of `ActionDispatch::Request#content_type`, adding extra request-related details the agent wasn't expecting to collect. Additionally, the agent's use of `content_type ` was triggering deprecation warnings. The agent now uses `ActionDispatch::Request#media_type` to capture the MIME type. Thanks to [@internethostage](https://github.com/internethostage) for letting us know about this change. [Issue#2500](https://github.com/newrelic/newrelic-ruby-agent/issues/2500) [PR#2855](https://github.com/newrelic/newrelic-ruby-agent/pull/2855)
 

--- a/lib/new_relic/agent/transaction/request_attributes.rb
+++ b/lib/new_relic/agent/transaction/request_attributes.rb
@@ -135,7 +135,6 @@ module NewRelic
           elsif request.respond_to?(:content_type)
             :content_type
           end
-          # binding.irb if !content_type.nil?
 
           request.send(content_type) if content_type
         end

--- a/lib/new_relic/agent/transaction/request_attributes.rb
+++ b/lib/new_relic/agent/transaction/request_attributes.rb
@@ -131,10 +131,11 @@ module NewRelic
           # Rails 7.0 changed the behavior of `content_type`. We want just the MIME type, so use `media_type` if available.
           # https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#actiondispatch-request-content-type-now-returns-content-type-header-as-it-is
           content_type = if request.respond_to?(:media_type)
-            request.media_type
+            :media_type
           elsif request.respond_to?(:content_type)
-            request.content_type
+            :content_type
           end
+          # binding.irb if !content_type.nil?
 
           request.send(content_type) if content_type
         end

--- a/lib/new_relic/agent/transaction/request_attributes.rb
+++ b/lib/new_relic/agent/transaction/request_attributes.rb
@@ -24,7 +24,7 @@ module NewRelic
           @referer = referer_from_request(request)
           @accept = attribute_from_env(request, HTTP_ACCEPT_HEADER_KEY)
           @content_length = content_length_from_request(request)
-          @content_type = attribute_from_request(request, :content_type)
+          @content_type = content_type_attribute_from_request(request)
           @host = attribute_from_request(request, :host)
           @port = port_from_request(request)
           @user_agent = attribute_from_request(request, :user_agent)
@@ -125,6 +125,18 @@ module NewRelic
           if request.respond_to?(attribute_method)
             request.send(attribute_method)
           end
+        end
+
+        def content_type_attribute_from_request(request)
+          # Rails 7.0 changed the behavior of `content_type`. We want just the MIME type, so use `media_type` if available.
+          # https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#actiondispatch-request-content-type-now-returns-content-type-header-as-it-is
+          content_type = if request.respond_to?(:media_type)
+            request.media_type
+          elsif request.respond_to?(:content_type)
+            request.content_type
+          end
+
+          request.send(content_type) if content_type
         end
 
         def attribute_from_env(request, key)

--- a/test/new_relic/agent/transaction/request_attributes_test.rb
+++ b/test/new_relic/agent/transaction/request_attributes_test.rb
@@ -127,11 +127,40 @@ module NewRelic
           assert_equal 111, attrs.content_length
         end
 
-        def test_sets_content_type_from_request
+        def test_sets_content_type_from_request_content_type_attribute
           request = stub('request', :content_type => 'application/json')
           attrs = RequestAttributes.new(request)
 
           assert_equal 'application/json', attrs.content_type
+        end
+
+        def test_sets_content_type_from_request_media_type_attribute
+          media_type = 'pool-party/alligator'
+          request = stub('request', media_type: media_type)
+          attrs = RequestAttributes.new(request)
+
+          assert_equal media_type, attrs.content_type
+        end
+
+        def test_sets_content_type_to_nil_if_media_type_is_available_with_a_nil_value
+          request = stub('request', media_type: nil)
+          attrs = RequestAttributes.new(request)
+
+          assert_nil attrs.content_type
+        end
+
+        def test_sets_content_type_to_nil_if_content_type_is_available_with_a_nil_value
+          request = stub('request', content_type: nil)
+          attrs = RequestAttributes.new(request)
+
+          assert_nil attrs.content_type
+        end
+
+        def test_sets_content_type_to_nil_if_neither_media_type_or_content_type_are_available
+          request = stub('request')
+          attrs = RequestAttributes.new(request)
+
+          assert_nil attrs.content_type
         end
 
         def test_sets_host_from_request


### PR DESCRIPTION
Rails 7.0 [changed](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#actiondispatch-request-content-type-now-returns-content-type-header-as-it-is) the behavior of `ActionDispatch::Request#content_type`, adding extra request-related details the agent wasn't expecting to collect, such as charset. Additionally, the agent's use of `content_type ` was triggering deprecation warnings. This PR updated the agent to use `ActionDispatch::Request#media_type` to capture the MIME type when available.

Closes #2506 