### PR TITLE
Rails edge now requires sqlite3 2.1+

### DIFF
--- a/test/environments/railsedge/Gemfile
+++ b/test/environments/railsedge/Gemfile
@@ -11,7 +11,7 @@ gem 'mocha', '~> 1.16', require: false
 
 platforms :ruby, :rbx do
   gem 'mysql2', '>= 0.5.4'
-  gem 'sqlite3', '~> 2.0.4'
+  gem 'sqlite3', '>= 2.1'
 end
 
 gem 'newrelic_rpm', path: '../../..'


### PR DESCRIPTION
Updated 9 hours ago: https://github.com/rails/rails/commit/490004e35ef1dafb12e30affd7618366938c113d 

Full CI run: https://github.com/newrelic/newrelic-ruby-agent/actions/runs/11038047610 