### PR TITLE
Safety guard when the self.class is not responding to method identifier

### DIFF
--- a/lib/new_relic/agent/instrumentation/view_component/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/view_component/instrumentation.rb
@@ -11,7 +11,10 @@ module NewRelic::Agent::Instrumentation
 
       begin
         segment = NewRelic::Agent::Tracer.start_segment(
-          name: metric_name(self.class.identifier, self.class.name)
+          name: metric_name(
+            self.class.respond_to?(:identifier) ? self.class.identifier : nil,
+            self.class.name
+          )
         )
         yield
       rescue => e


### PR DESCRIPTION
# Overview

Issue: https://github.com/newrelic/newrelic-ruby-agent/issues/2869

Due to a recent change in the gem view_component 
https://github.com/ViewComponent/view_component/commit/451543a53f3c7c04036eb6109ac716511f3dcfc3#diff-b69c75ffd85596e0b5fca1327059ecf3b2930f3f77004c78a268fa85e8ec8d9eL601

We were getting:
`ActionView::Template::Error: undefined method `identifier'`

The method identifier on their base class has been removed.
This pull request make sure it returns nil if it is not found.