### PR TITLE
Remove railsedge testing from Ruby 3.1

### DIFF
--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Install Ruby ${{ matrix.ruby-version }}
         uses: ruby/setup-ruby@52753b7da854d5c07df37391a986c76ab4615999 # tag v1.191.0
         with:
-          ruby-version: ${{ matrix.ruby-version }}                                                                                                               
+          ruby-version: ${{ matrix.ruby-version }}
 
       - name: Set up mini-envs for ruby version
         uses: ./.github/actions/variable-mapper
@@ -76,7 +76,7 @@ jobs:
                 "rails": "norails,rails61,rails60,rails70,rails71"
               },
               "3.1.6": {
-                "rails": "norails,rails61,rails70,rails71,rails72,railsedge"
+                "rails": "norails,rails61,rails70,rails71,rails72"
               },
               "3.2.5": {
                 "rails": "norails,rails61,rails70,rails71,rails72,railsedge"

--- a/test/multiverse/lib/multiverse/envfile.rb
+++ b/test/multiverse/lib/multiverse/envfile.rb
@@ -169,7 +169,7 @@ module Multiverse
       # NOTE: The Rails Edge version is not tested unless the Ruby version in
       #       play is greater than or equal to (>=) the version number at the
       #       end of the unshifted inner array
-      gem_version_array.unshift(["github: 'rails'", 3.1])
+      gem_version_array.unshift(["github: 'rails'", 3.2])
     end
 
     # are we running in a CI context intended for PR approvals?

--- a/test/multiverse/suites/active_record_pg/Envfile
+++ b/test/multiverse/suites/active_record_pg/Envfile
@@ -12,7 +12,8 @@ end
 serialize!
 
 ACTIVERECORD_VERSIONS = [
-  [nil, 3.1],
+  [nil, 3.2],
+  ['7.2.0', 3.1],
   ['7.1.0', 2.7],
   ['7.0.0', 2.7],
   ['6.1.0', 2.5],
@@ -28,7 +29,7 @@ def gem_list(activerecord_version = nil)
   <<~RB
     gem 'activerecord'#{activerecord_version}
     gem 'pg'
-    
+
     gem 'rack'
     gem 'minitest', '~> 5.2.3'
   RB

--- a/test/multiverse/suites/active_support_broadcast_logger/Envfile
+++ b/test/multiverse/suites/active_support_broadcast_logger/Envfile
@@ -7,7 +7,8 @@ instrumentation_methods :chain, :prepend
 # ActiveSupport::BroadcastLogger introduced in Rails 7.1.
 # Rails 7.1 is the latest version at the time of writing.
 ACTIVE_SUPPORT_VERSIONS = [
-  [nil, 3.1],
+  [nil, 3.2],
+  ['7.2.0', 3.1],
   ['7.1.0', 2.7]
 ]
 

--- a/test/multiverse/suites/rails/Envfile
+++ b/test/multiverse/suites/rails/Envfile
@@ -3,7 +3,7 @@
 # frozen_string_literal: true
 
 RAILS_VERSIONS = [
-  [nil, 3.1],
+  [nil, 3.2],
   ['7.2.0', 3.1],
   ['7.1.0', 2.7],
   ['7.0.4', 2.7],

--- a/test/multiverse/suites/rails_prepend/Envfile
+++ b/test/multiverse/suites/rails_prepend/Envfile
@@ -3,7 +3,8 @@
 # frozen_string_literal: true
 
 RAILS_VERSIONS = [
-  [nil, 3.1],
+  [nil, 3.2],
+  ['7.2.0', 3.1],
   ['7.1.0', 2.7],
   ['7.0.0', 2.7],
   ['6.1.0', 2.5],


### PR DESCRIPTION
Rails 8.0 requires Ruby 3.2+.

~~Full CI run: https://github.com/newrelic/newrelic-ruby-agent/actions/runs/11110880352~~
~~Full CI run: https://github.com/newrelic/newrelic-ruby-agent/actions/runs/11111262251~~
Full CI run: https://github.com/newrelic/newrelic-ruby-agent/actions/runs/11111576874 