### PR TITLE
Remove opensearch service from depends_on

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,7 +101,7 @@ services:
     depends_on:
       - elasticsearch7
       - elasticsearch8
-      - opensearch
+      # - opensearch
       - mysql
       - memcached
       - mongodb


### PR DESCRIPTION
OpenSearch does not have a service, it's commented out. This was an oversight. The Docker compose file should start working again once this is merged.