### PR TITLE
type coercion for configuration parameters

### DIFF
--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -307,7 +307,7 @@ module NewRelic
           :public => true,
           :type => String,
           :allowed_from_server => false,
-          :transform => proc { |str| str.split(';') },
+          :transform => proc { |v| v.is_a?(String) ? v.split(';') : v },
           :description => 'Specify the [application name](/docs/apm/new-relic-apm/installation-configuration/name-your-application) used to aggregate data in the New Relic UI. To report data to [multiple apps at the same time](/docs/apm/new-relic-apm/installation-configuration/using-multiple-names-app), specify a list of names separated by a semicolon `;`. For example, `MyApp` or `MyStagingApp;Instance1`.'
         },
         :license_key => {

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -35,15 +35,6 @@ module NewRelic
       end
 
       class DefaultSource
-        BOOLEAN_MAP = {
-          'true' => true,
-          'yes' => true,
-          'on' => true,
-          'false' => false,
-          'no' => false,
-          'off' => false
-        }.freeze
-
         attr_reader :defaults
 
         extend Forwardable
@@ -71,12 +62,6 @@ module NewRelic
 
         def self.allowlist_for(key)
           value_from_defaults(key, :allowlist)
-        end
-
-        def self.boolean_for(key, value)
-          string_value = (value.respond_to?(:call) ? value.call : value).to_s
-
-          BOOLEAN_MAP.fetch(string_value, nil)
         end
 
         def self.default_for(key)
@@ -227,53 +212,14 @@ module NewRelic
           end
         end
 
-        def self.convert_to_regexp_list(raw_value)
-          value_list = convert_to_list(raw_value)
-          value_list.map do |value|
-            /#{value}/
-          end
+        def self.convert_to_regexp_list(string_array)
+          string_array.map { |value| /#{value}/ }
         end
 
-        def self.convert_to_list(value)
-          case value
-          when String
-            value.split(/\s*,\s*/)
-          when Array
-            value
-          else
-            raise ArgumentError.new("Config value '#{value}' couldn't be turned into a list.")
-          end
-        end
+        def self.convert_to_constant_list(string_array)
+          return string_array if string_array.empty?
 
-        def self.convert_to_hash(value)
-          return value if value.is_a?(Hash)
-
-          if value.is_a?(String)
-            return value.split(',').each_with_object({}) do |item, hash|
-              key, value = item.split('=')
-              hash[key] = value
-            end
-          end
-
-          raise ArgumentError.new(
-            "Config value '#{value}' of " \
-            "class #{value.class} couldn't be turned into a Hash."
-          )
-        end
-
-        SEMICOLON = ';'.freeze
-        def self.convert_to_list_on_semicolon(value)
-          case value
-          when Array then value
-          when String then value.split(SEMICOLON)
-          else NewRelic::EMPTY_ARRAY
-          end
-        end
-
-        def self.convert_to_constant_list(raw_value)
-          return NewRelic::EMPTY_ARRAY if raw_value.nil? || raw_value.empty?
-
-          constants = convert_to_list(raw_value).map! do |class_name|
+          constants = string_array.map! do |class_name|
             const = ::NewRelic::LanguageSupport.constantize(class_name)
             NewRelic::Agent.logger.warn("Ignoring invalid constant '#{class_name}' in #{raw_value}") unless const
             const
@@ -361,7 +307,7 @@ module NewRelic
           :public => true,
           :type => String,
           :allowed_from_server => false,
-          :transform => DefaultSource.method(:convert_to_list_on_semicolon),
+          :transform => proc { |str| str.split(';') },
           :description => 'Specify the [application name](/docs/apm/new-relic-apm/installation-configuration/name-your-application) used to aggregate data in the New Relic UI. To report data to [multiple apps at the same time](/docs/apm/new-relic-apm/installation-configuration/using-multiple-names-app), specify a list of names separated by a semicolon `;`. For example, `MyApp` or `MyStagingApp;Instance1`.'
         },
         :license_key => {
@@ -868,7 +814,6 @@ module NewRelic
           :default => {},
           :public => true,
           :type => Hash,
-          :transform => DefaultSource.method(:convert_to_hash),
           :allowed_from_server => false,
           :description => 'A hash with key/value pairs to add as custom attributes to all log events forwarded to New Relic. If sending using an environment variable, the value must be formatted like: "key1=value1,key2=value2"'
         },
@@ -914,7 +859,6 @@ module NewRelic
           :public => true,
           :type => Array,
           :allowed_from_server => false,
-          :transform => DefaultSource.method(:convert_to_list),
           :description => 'Prefix of attributes to exclude from all destinations. Allows `*` as wildcard at end.'
         },
         :'attributes.include' => {
@@ -922,7 +866,6 @@ module NewRelic
           :public => true,
           :type => Array,
           :allowed_from_server => false,
-          :transform => DefaultSource.method(:convert_to_list),
           :description => 'Prefix of attributes to include in all destinations. Allows `*` as wildcard at end.'
         },
         :'browser_monitoring.attributes.enabled' => {
@@ -937,7 +880,6 @@ module NewRelic
           :public => true,
           :type => Array,
           :allowed_from_server => false,
-          :transform => DefaultSource.method(:convert_to_list),
           :description => 'Prefix of attributes to exclude from browser monitoring. Allows `*` as wildcard at end.'
         },
         :'browser_monitoring.attributes.include' => {
@@ -945,7 +887,6 @@ module NewRelic
           :public => true,
           :type => Array,
           :allowed_from_server => false,
-          :transform => DefaultSource.method(:convert_to_list),
           :description => 'Prefix of attributes to include in browser monitoring. Allows `*` as wildcard at end.'
         },
         :'error_collector.attributes.enabled' => {
@@ -960,7 +901,6 @@ module NewRelic
           :public => true,
           :type => Array,
           :allowed_from_server => false,
-          :transform => DefaultSource.method(:convert_to_list),
           :description => 'Prefix of attributes to exclude from error collection. Allows `*` as wildcard at end.'
         },
         :'error_collector.attributes.include' => {
@@ -968,7 +908,6 @@ module NewRelic
           :public => true,
           :type => Array,
           :allowed_from_server => false,
-          :transform => DefaultSource.method(:convert_to_list),
           :description => 'Prefix of attributes to include in error collection. Allows `*` as wildcard at end.'
         },
         :'span_events.attributes.enabled' => {
@@ -983,7 +922,6 @@ module NewRelic
           :public => true,
           :type => Array,
           :allowed_from_server => false,
-          :transform => DefaultSource.method(:convert_to_list),
           :description => 'Prefix of attributes to exclude from span events. Allows `*` as wildcard at end.'
         },
         :'span_events.attributes.include' => {
@@ -991,7 +929,6 @@ module NewRelic
           :public => true,
           :type => Array,
           :allowed_from_server => false,
-          :transform => DefaultSource.method(:convert_to_list),
           :description => 'Prefix of attributes to include on span events. Allows `*` as wildcard at end.'
         },
         :'transaction_events.attributes.enabled' => {
@@ -1006,7 +943,6 @@ module NewRelic
           :public => true,
           :type => Array,
           :allowed_from_server => false,
-          :transform => DefaultSource.method(:convert_to_list),
           :description => 'Prefix of attributes to exclude from transaction events. Allows `*` as wildcard at end.'
         },
         :'transaction_events.attributes.include' => {
@@ -1014,7 +950,6 @@ module NewRelic
           :public => true,
           :type => Array,
           :allowed_from_server => false,
-          :transform => DefaultSource.method(:convert_to_list),
           :description => 'Prefix of attributes to include in transaction events. Allows `*` as wildcard at end.'
         },
         :'transaction_segments.attributes.enabled' => {
@@ -1029,7 +964,6 @@ module NewRelic
           :public => true,
           :type => Array,
           :allowed_from_server => false,
-          :transform => DefaultSource.method(:convert_to_list),
           :description => 'Prefix of attributes to exclude from transaction segments. Allows `*` as wildcard at end.'
         },
         :'transaction_segments.attributes.include' => {
@@ -1037,7 +971,6 @@ module NewRelic
           :public => true,
           :type => Array,
           :allowed_from_server => false,
-          :transform => DefaultSource.method(:convert_to_list),
           :description => 'Prefix of attributes to include on transaction segments. Allows `*` as wildcard at end.'
         },
         :'transaction_tracer.attributes.enabled' => {
@@ -1052,7 +985,6 @@ module NewRelic
           :public => true,
           :type => Array,
           :allowed_from_server => false,
-          :transform => DefaultSource.method(:convert_to_list),
           :description => 'Prefix of attributes to exclude from transaction traces. Allows `*` as wildcard at end.'
         },
         :'transaction_tracer.attributes.include' => {
@@ -1060,7 +992,6 @@ module NewRelic
           :public => true,
           :type => Array,
           :allowed_from_server => false,
-          :transform => DefaultSource.method(:convert_to_list),
           :description => 'Prefix of attributes to include in transaction traces. Allows `*` as wildcard at end.'
         },
         # Audit log
@@ -1468,7 +1399,6 @@ module NewRelic
           :public => true,
           :type => Array,
           :allowed_from_server => false,
-          :transform => DefaultSource.method(:convert_to_list),
           :description => 'Ordinarily the agent reports dyno names with a trailing dot and process ID (for example, `worker.3`). You can remove this trailing data by specifying the prefixes you want to report without trailing data (for example, `worker`).'
         },
         # Infinite tracing
@@ -1874,7 +1804,6 @@ module NewRelic
           type: Array,
           dynamic_name: true,
           allowed_from_server: false,
-          :transform => DefaultSource.method(:convert_to_list),
           :description => <<~DESCRIPTION
             An array of strings to specify which keys inside a Stripe event's `user_data` hash should be reported
             to New Relic. Each string in this array will be turned into a regular expression via `Regexp.new` to
@@ -1887,7 +1816,6 @@ module NewRelic
           type: Array,
           dynamic_name: true,
           allowed_from_server: false,
-          :transform => DefaultSource.method(:convert_to_list),
           :description => <<~DESCRIPTION
             An array of strings to specify which keys and/or values inside a Stripe event's `user_data` hash should
             not be reported to New Relic. Each string in this array will be turned into a regular expression via
@@ -2147,9 +2075,9 @@ module NewRelic
           :description => 'If true, the agent strips messages from all exceptions except those in the [allowlist](#strip_exception_messages-allowlist). Enabled automatically in [high security mode](/docs/accounts-partnerships/accounts/security/high-security).'
         },
         :'strip_exception_messages.allowed_classes' => {
-          :default => '',
+          :default => NewRelic::EMPTY_ARRAY,
           :public => true,
-          :type => String,
+          :type => Array,
           :allowed_from_server => false,
           :transform => DefaultSource.method(:convert_to_constant_list),
           :description => 'Specify a list of exceptions you do not want the agent to strip when [strip_exception_messages](#strip_exception_messages-enabled) is `true`. Separate exceptions with a comma. For example, `"ImportantException,PreserveMessageException"`.'

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -221,7 +221,7 @@ module NewRelic
 
           constants = string_array.map! do |class_name|
             const = ::NewRelic::LanguageSupport.constantize(class_name)
-            NewRelic::Agent.logger.warn("Ignoring invalid constant '#{class_name}' in #{raw_value}") unless const
+            NewRelic::Agent.logger.warn("Ignoring invalid constant '#{class_name}' in #{string_array}") unless const
             const
           end
           constants.compact!

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -308,6 +308,7 @@ module NewRelic
           :type => String,
           :allowed_from_server => false,
           :transform => proc { |v| v.is_a?(String) ? v.split(';') : v },
+          :transformed_type => Array,
           :description => 'Specify the [application name](/docs/apm/new-relic-apm/installation-configuration/name-your-application) used to aggregate data in the New Relic UI. To report data to [multiple apps at the same time](/docs/apm/new-relic-apm/installation-configuration/using-multiple-names-app), specify a list of names separated by a semicolon `;`. For example, `MyApp` or `MyStagingApp;Instance1`.'
         },
         :license_key => {
@@ -463,6 +464,7 @@ module NewRelic
           :public => true,
           :type => String,
           :allowed_from_server => false,
+          :transformed_type => Hash, # NOTE: :labels is a special case and transformed in manager.rb without a :transform key
           :description => 'A dictionary of [label names](/docs/data-analysis/user-interface-functions/labels-categories-organize-your-apps-servers) and values that will be applied to the data sent from this agent. May also be expressed as a semicolon-delimited `;` string of colon-separated `:` pairs. For example, `Server:One;Data Center:Primary`.'
         },
         :log_file_name => {
@@ -1008,6 +1010,7 @@ module NewRelic
           :type => Array,
           :allowed_from_server => false,
           :transform => DefaultSource.method(:convert_to_regexp_list),
+          :transformed_type => Array,
           :description => 'List of allowed endpoints to include in audit log.'
         },
         :'audit_log.path' => {
@@ -1089,6 +1092,7 @@ module NewRelic
           :type => Array,
           :allowed_from_server => false,
           :transform => proc { |arr| NewRelic::Agent.add_automatic_method_tracers(arr) },
+          :transformed_type => Array,
           :description => <<~DESCRIPTION
             An array of `CLASS#METHOD` (for instance methods) and/or `CLASS.METHOD` (for class methods) strings representing Ruby methods that the agent can automatically add custom instrumentation to. This doesn't require any modifications of the source code that defines the methods.
 
@@ -1587,6 +1591,7 @@ module NewRelic
           :type => Array,
           :allowed_from_server => false,
           :transform => DefaultSource.method(:convert_to_regexp_list),
+          :transformed_type => Array,
           :description => %Q(Specifies a list of hostname patterns separated by commas that will match gRPC hostnames that traffic is to be ignored by New Relic for. New Relic's gRPC client instrumentation will ignore traffic streamed to a host matching any of these patterns, and New Relic's gRPC server instrumentation will ignore traffic for a server running on a host whose hostname matches any of these patterns. By default, no traffic is ignored when gRPC instrumentation is itself enabled. For example, `"private.com$,exception.*"`)
         },
         :'instrumentation.grpc_server' => {
@@ -1933,6 +1938,7 @@ module NewRelic
           :type => Array,
           :allowed_from_server => false,
           :transform => DefaultSource.method(:convert_to_regexp_list),
+          :transformed_type => Array,
           :description => 'Specify an Array of Rake tasks to automatically instrument. ' \
           'This configuration option converts the Array to a RegEx list. If you\'d like ' \
           'to allow all tasks by default, use `rake.tasks: [.+]`. No rake tasks will be ' \
@@ -1953,6 +1959,7 @@ module NewRelic
           :type => Array,
           :allowed_from_server => true,
           :transform => DefaultSource.method(:convert_to_regexp_list),
+          :transformed_type => Array,
           :description => 'Define transactions you want the agent to ignore, by specifying a list of patterns matching the URI you want to ignore. For more detail, see [the docs on ignoring specific transactions](/docs/agents/ruby-agent/api-guides/ignoring-specific-transactions/#config-ignoring).'
         },
         # Serverless
@@ -1962,6 +1969,7 @@ module NewRelic
           :type => Boolean,
           :allowed_from_server => false,
           :transform => proc { |bool| NewRelic::Agent::ServerlessHandler.env_var_set? || bool },
+          :transformed_type => Boolean,
           :description => 'If `true`, the agent will operate in a streamlined mode suitable for use with short-lived ' \
                           'serverless functions. NOTE: Only AWS Lambda functions are supported currently and this ' \
                           "option is not intended for use without [New Relic's Ruby Lambda layer](https://docs.newrelic.com/docs/serverless-function-monitoring/aws-lambda-monitoring/get-started/monitoring-aws-lambda-serverless-monitoring/) offering."
@@ -2080,6 +2088,7 @@ module NewRelic
           :type => Array,
           :allowed_from_server => false,
           :transform => DefaultSource.method(:convert_to_constant_list),
+          :transformed_type => Array,
           :description => 'Specify a list of exceptions you do not want the agent to strip when [strip_exception_messages](#strip_exception_messages-enabled) is `true`. Separate exceptions with a comma. For example, `"ImportantException,PreserveMessageException"`.'
         },
         # Thread profiler

--- a/lib/new_relic/agent/configuration/environment_source.rb
+++ b/lib/new_relic/agent/configuration/environment_source.rb
@@ -13,20 +13,15 @@ module NewRelic
           /^NEW_RELIC_METADATA_/ # read by NewRelic::Agent::Connect::RequestBuilder
         ]
 
-        # TODO: remove type_map
-        attr_accessor :alias_map, :type_map
+        attr_accessor :alias_map
 
         def initialize
           set_log_file
           set_config_file
 
           @alias_map = {}
-          # TODO: remove type_map
-          @type_map = {}
 
           DEFAULTS.each do |config_setting, value|
-            # TODO: remove type_map
-            self.type_map[config_setting] = value[:type]
             set_aliases(config_setting, value)
           end
 

--- a/lib/new_relic/agent/configuration/manager.rb
+++ b/lib/new_relic/agent/configuration/manager.rb
@@ -208,6 +208,8 @@ module NewRelic
           return numeric_conversion(value) if NUMERIC_TYPES.include?(type) && NUMERIC_TYPES.include?(value.class)
           return string_conversion(value) if STRINGLIKE_TYPES.include?(type) && STRINGLIKE_TYPES.include?(value.class)
 
+          # convert bool to string for regex usage and bool hash lookup
+          value = value.to_s if type == Boolean
           if value.class != String
             return value if category == :test
 

--- a/lib/new_relic/agent/configuration/manager.rb
+++ b/lib/new_relic/agent/configuration/manager.rb
@@ -178,7 +178,7 @@ module NewRelic
         end
 
         def type_coerce(key, value, nr_supplied)
-          return validate_nil(key, nr_supplied) unless value
+          return validate_nil(key, nr_supplied) if value.nil?
 
           type = DEFAULTS.dig(key, :type)
           return value if value.is_a?(type) || boolean?(type, value) || instrumentation?(type, value)
@@ -208,7 +208,8 @@ module NewRelic
         end
 
         def default_without_warning(key)
-          DEFAULTS[key][:default]
+          default = DEFAULTS[key][:default]
+          default.respond_to?(:call) ? default.call : default
         end
 
         def validate_nil(key, nr_supplied = false)

--- a/lib/new_relic/agent/configuration/manager.rb
+++ b/lib/new_relic/agent/configuration/manager.rb
@@ -215,7 +215,7 @@ module NewRelic
           # convert bool to string for regex usage and bool hash lookup
           value = value.to_s if type == Boolean
           if value.class != String
-            return value if category == :test
+            return value if category == :test || likely_transformed_already?(key, value)
 
             return default_with_warning(key, value, "Expected to receive a value of type #{type} but " \
                                         "received #{value.class}.")
@@ -231,6 +231,10 @@ module NewRelic
           return value unless procedure
 
           procedure.call(value)
+        end
+
+        def likely_transformed_already?(key, value)
+          DEFAULTS.dig(key, :transformed_type) == value.class
         end
 
         def default_with_warning(key, value, msg)

--- a/lib/new_relic/agent/configuration/manager.rb
+++ b/lib/new_relic/agent/configuration/manager.rb
@@ -101,8 +101,6 @@ module NewRelic
         end
 
         def replace_or_add_config(source)
-          return if source.respond_to?(:empty?) && source.empty?
-
           source.freeze
           was_finished = finished_configuring?
 

--- a/lib/new_relic/agent/configuration/manager.rb
+++ b/lib/new_relic/agent/configuration/manager.rb
@@ -209,6 +209,8 @@ module NewRelic
           return string_conversion(value) if STRINGLIKE_TYPES.include?(type) && STRINGLIKE_TYPES.include?(value.class)
 
           if value.class != String
+            return value if category == :test
+
             return default_with_warning(key, value, "Expected to receive a value of type #{type} but " \
                                         "received #{value.class}.")
           end

--- a/lib/new_relic/agent/configuration/manager.rb
+++ b/lib/new_relic/agent/configuration/manager.rb
@@ -101,6 +101,8 @@ module NewRelic
         end
 
         def replace_or_add_config(source)
+          return if source.respond_to?(:empty?) && source.empty?
+
           source.freeze
           was_finished = finished_configuring?
 
@@ -185,7 +187,12 @@ module NewRelic
         def handle_nil_type(key, value, category)
           return value if %i[manual test].include?(category)
 
-          default_without_warning(key)
+          # TODO: identify all config params such as :web_transactions_apdex
+          #       that can exist in the @config hash without having an entry
+          #       in the DEFAULTS hash. then warn here when a key is in play
+          #       that is not on that allowlist. for now, just permit any key
+          #       and return the value.
+          default_without_warning(key) || value
         end
 
         # permit an int to be supplied for a float based param and vice versa
@@ -335,8 +342,8 @@ module NewRelic
         end
 
         def apply_mask(hash)
-          MASK_DEFAULTS \
-            .select { |_, proc| proc.call } \
+          MASK_DEFAULTS
+            .select { |_, proc| proc.call }
             .each { |key, _| hash.delete(key) }
           hash
         end

--- a/lib/new_relic/agent/configuration/manager.rb
+++ b/lib/new_relic/agent/configuration/manager.rb
@@ -27,6 +27,8 @@ module NewRelic
         }.freeze
 
         INSTRUMENTATION_VALUES = %w[chain prepend unsatisfied]
+        NUMERIC_TYPES = [Integer, Float]
+        STRINGLIKE_TYPES = [String, Symbol]
 
         TYPE_COERCIONS = {Integer => {pattern: /^\d+$/, proc: proc { |s| s.to_i }},
                           Float => {pattern: /^\d+\.\d+$/, proc: proc { |s| s.to_f }},
@@ -140,7 +142,7 @@ module NewRelic
             next unless config.has_key?(accessor)
 
             begin
-              return evaluate_and_apply_transformations(accessor, config[accessor], nr_supplied?(config.class))
+              return evaluate_and_apply_transformations(accessor, config[accessor], config_category(config.class))
             rescue
               next
             end
@@ -149,13 +151,17 @@ module NewRelic
           nil
         end
 
-        def nr_supplied?(klass)
-          !USER_CONFIG_CLASSES.include?(klass)
+        def config_category(klass)
+          return :user if USER_CONFIG_CLASSES.include?(klass)
+          return :test if [DottedHash, Hash].include?(klass)
+          return :manual if klass == ManualSource
+
+          return :nr
         end
 
-        def evaluate_and_apply_transformations(key, value, nr_supplied)
+        def evaluate_and_apply_transformations(key, value, category)
           evaluated = value.respond_to?(:call) ? value.call : value
-          evaluated = type_coerce(key, evaluated, nr_supplied)
+          evaluated = type_coerce(key, evaluated, category)
           evaluated = enforce_allowlist(key, evaluated)
 
           apply_transformations(key, evaluated)
@@ -177,11 +183,30 @@ module NewRelic
           false
         end
 
-        def type_coerce(key, value, nr_supplied)
-          return validate_nil(key, nr_supplied) if value.nil?
+        def handle_nil_type(key, value, category)
+          return value if %i[manual test].include?(category)
+
+          default_without_warning(key)
+        end
+
+        # permit an int to be supplied for a float based param and vice versa
+        def numeric_conversion(value)
+          value.is_a?(Integer) ? value.to_f : value.round
+        end
+
+        # permit a symbol to be supplied for a string based param and vice versa
+        def string_conversion(value)
+          value.is_a?(Symbol) ? value.to_s : value.to_sym
+        end
+
+        def type_coerce(key, value, category)
+          return validate_nil(key, category) if value.nil?
 
           type = DEFAULTS.dig(key, :type)
+          return handle_nil_type(key, value, category) unless type
           return value if value.is_a?(type) || boolean?(type, value) || instrumentation?(type, value)
+          return numeric_conversion(value) if NUMERIC_TYPES.include?(type) && NUMERIC_TYPES.include?(value.class)
+          return string_conversion(value) if STRINGLIKE_TYPES.include?(type) && STRINGLIKE_TYPES.include?(value.class)
 
           if value.class != String
             return default_with_warning(key, value, "Expected to receive a value of type #{type} but " \
@@ -208,13 +233,13 @@ module NewRelic
         end
 
         def default_without_warning(key)
-          default = DEFAULTS[key][:default]
+          default = DEFAULTS.dig(key, :default)
           default.respond_to?(:call) ? default.call : default
         end
 
-        def validate_nil(key, nr_supplied = false)
-          return if DEFAULTS.dig(key, :allow_nil)
-          return default_without_warning(key) if nr_supplied
+        def validate_nil(key, category)
+          return if DEFAULTS.dig(key, :allow_nil) || category == :test # tests are free to specify nil
+          return default_without_warning(key) unless category == :user # only user supplied config raises a warning
 
           default_with_warning(key, nil, 'Nil values are not permitted for the parameter.')
         end
@@ -250,13 +275,14 @@ module NewRelic
 
         def invoke_callbacks(direction, source)
           return unless source
+          return if source.respond_to?(:empty?) && source.empty?
 
           source.keys.each do |key|
             begin
               # we need to evaluate and apply transformations for the value to deal with procs as values
               # this is usually done by the fetch method when accessing config, however the callbacks bypass that
-              evaluated_cache = evaluate_and_apply_transformations(key, @cache[key])
-              evaluated_source = evaluate_and_apply_transformations(key, source[key])
+              evaluated_cache = evaluate_and_apply_transformations(key, @cache[key], :nr)
+              evaluated_source = evaluate_and_apply_transformations(key, source[key], config_category(source.class))
             rescue
               next
             end

--- a/lib/new_relic/agent/configuration/manager.rb
+++ b/lib/new_relic/agent/configuration/manager.rb
@@ -32,7 +32,6 @@ module NewRelic
 
         TYPE_COERCIONS = {Integer => {pattern: /^\d+$/, proc: proc { |s| s.to_i }},
                           Float => {pattern: /^\d+\.\d+$/, proc: proc { |s| s.to_f }},
-                          Symbol => {proc: proc { |s| s.to_sym }},
                           Array => {proc: proc { |s| s.split(/\s*,\s*/) }},
                           Hash => {proc: proc { |s| s.split(/\s*,\s*/).each_with_object({}) { |i, h| k, v = i.split(/\s*=\s*/); h[k] = v } }},
                           NewRelic::Agent::Configuration::Boolean => {pattern: /^(?:#{BOOLEAN_MAP.keys.join('|')})$/,

--- a/lib/new_relic/agent/configuration/manager.rb
+++ b/lib/new_relic/agent/configuration/manager.rb
@@ -293,7 +293,7 @@ module NewRelic
               next
             end
 
-            evaluated_cache = @cache.fetch(key, nil)
+            evaluated_cache = @cache[key]
             if evaluated_cache != evaluated_source
               @callbacks[key].each do |proc|
                 if direction == :add

--- a/lib/new_relic/agent/configuration/manager.rb
+++ b/lib/new_relic/agent/configuration/manager.rb
@@ -277,14 +277,16 @@ module NewRelic
           return if source.respond_to?(:empty?) && source.empty?
 
           source.keys.each do |key|
+            next unless @callbacks.key?(key)
+
             begin
-              evaluated_cache = evaluate_and_apply_transformations(key, @cache[key], :manual)
               evaluated_source = evaluate_and_apply_transformations(key, source[key], config_category(source.class))
             rescue => e
               NewRelic::Agent.logger.warn("Error evaluating callback for direction '#{direction}' with key '#{key}': #{e}")
               next
             end
 
+            evaluated_cache = @cache.fetch(key, nil)
             if evaluated_cache != evaluated_source
               @callbacks[key].each do |proc|
                 if direction == :add

--- a/lib/new_relic/control/instance_methods.rb
+++ b/lib/new_relic/control/instance_methods.rb
@@ -98,10 +98,8 @@ module NewRelic
         manual = Agent::Configuration::ManualSource.new(options)
         Agent.config.replace_or_add_config(manual)
 
-        # if manual config sees serverless mode enabled, then the proc
-        # must have returned 'true'. don't bother with YAML and high security
-        # in a serverless context
-        return if Agent.config[:'serverless_mode.enabled']
+        # don't bother with YAML and high security in a serverless context
+        return if Agent.config[:'serverless_mode.enabled'] || env == 'serverless'
 
         yaml_source = Agent::Configuration::YamlSource.new(config_file_path, env)
         log_yaml_source_failures(yaml_source) if yaml_source.failed?

--- a/lib/new_relic/control/instance_methods.rb
+++ b/lib/new_relic/control/instance_methods.rb
@@ -95,8 +95,10 @@ module NewRelic
       end
 
       def configure_agent(env, options)
-        manual = Agent::Configuration::ManualSource.new(options)
-        Agent.config.replace_or_add_config(manual)
+        unless options.empty?
+          manual = Agent::Configuration::ManualSource.new(options)
+          Agent.config.replace_or_add_config(manual)
+        end
 
         # don't bother with YAML and high security in a serverless context
         return if Agent.config[:'serverless_mode.enabled'] || env == 'serverless'

--- a/lib/new_relic/control/instance_methods.rb
+++ b/lib/new_relic/control/instance_methods.rb
@@ -95,10 +95,8 @@ module NewRelic
       end
 
       def configure_agent(env, options)
-        unless options.empty?
-          manual = Agent::Configuration::ManualSource.new(options)
-          Agent.config.replace_or_add_config(manual)
-        end
+        manual = Agent::Configuration::ManualSource.new(options)
+        Agent.config.replace_or_add_config(manual)
 
         # don't bother with YAML and high security in a serverless context
         return if Agent.config[:'serverless_mode.enabled'] || env == 'serverless'

--- a/test/multiverse/suites/agent_only/logging_test.rb
+++ b/test/multiverse/suites/agent_only/logging_test.rb
@@ -31,7 +31,7 @@ class LoggingTest < Minitest::Test
   def test_logs_error_with_bad_app_name
     running_agent_writes_to_log(
       {:app_name => false},
-      'No application name configured.'
+      'Using the default value'
     )
   end
 

--- a/test/multiverse/suites/rake/instrumentation_test.rb
+++ b/test/multiverse/suites/rake/instrumentation_test.rb
@@ -10,7 +10,7 @@ class RakeInstrumentationTest < Minitest::Test
     include NewRelic::Agent::Instrumentation::Rake::Tracer
 
     def name; 'Snake'; end
-    def timeout; 140.85; end
+    def timeout; 140; end
   end
 
   class ErrorClass < StandardError; end

--- a/test/new_relic/agent/configuration/default_source_test.rb
+++ b/test/new_relic/agent/configuration/default_source_test.rb
@@ -327,6 +327,7 @@ module NewRelic::Agent::Configuration
       with_config(key => 'yikes!') do
         NewRelic::Agent::Configuration::Manager.stub_const(:USER_CONFIG_CLASSES, [DottedHash]) do
           expects_logging(:warn, includes('Expected to receive a value of type NewRelic::Agent::Configuration::Boolean matching pattern '))
+          NewRelic::Agent.config[key]
         end
       end
     end

--- a/test/new_relic/agent/configuration/manager_test.rb
+++ b/test/new_relic/agent/configuration/manager_test.rb
@@ -414,21 +414,6 @@ module NewRelic::Agent::Configuration
       end
     end
 
-    def test_fetch_skips_the_config_layer_if_transformation_raises_error
-      bomb = proc do |value|
-        if value == 'boom'
-          raise StandardError.new
-        else
-          value
-        end
-      end
-      @manager.stubs(:transform_from_default).returns(bomb)
-
-      with_config(:'rules.ignore_url_regexes' => 'boom') do
-        assert_empty(@manager.fetch(:'rules.ignore_url_regexes'))
-      end
-    end
-
     def test_prepend_key_absent_to_instrumentation_value_of
       with_config({}) do
         result = @manager.fetch(:'instrumentation.net_http')
@@ -461,34 +446,15 @@ module NewRelic::Agent::Configuration
       end
     end
 
-    def test_evaluate_procs_returns_evaluated_value_if_it_responds_to_call
-      callable = proc { 'test' }
-
-      assert_equal 'test', @manager.evaluate_procs(callable)
-    end
-
-    def test_evaluate_procs_returns_original_value_if_it_does_not_respond_to_call
-      assert_equal 'test', @manager.evaluate_procs('test')
-    end
-
-    def test_apply_transformations_logs_error_if_transformation_fails
-      bomb = proc { raise StandardError.new }
-      @manager.stubs(:transform_from_default).returns(bomb)
-
-      expects_logging(:error, includes('Error applying transformation'), any_parameters)
-
-      assert_raises StandardError do
-        @manager.apply_transformations(:test_key, 'test_value')
-      end
-    end
-
-    def test_apply_transformations_reraises_errors
-      bomb = proc { raise StandardError.new }
-      @manager.stubs(:transform_from_default).returns(bomb)
-
-      assert_raises StandardError do
-        @manager.apply_transformations(:test_key, 'test_value')
-      end
+    def test_apply_transformations_logs_warning_if_transformation_fails
+      key = :test_key
+      bomb = proc { raise 'kaboom' }
+      ds = Minitest::Mock.new
+      ds.expect :transform_for, bomb, [key]
+      @manager.stubs(:default_source).returns(ds)
+      expects_logging(:warn, includes('Error encountered while applying transformation'), any_parameters)
+      @manager.apply_transformations(key, 'test_value')
+      ds.verify
     end
 
     def test_auto_determined_values_stay_cached

--- a/test/new_relic/agent/configuration/manager_test.rb
+++ b/test/new_relic/agent/configuration/manager_test.rb
@@ -516,6 +516,222 @@ module NewRelic::Agent::Configuration
       @manager.new_cache
     end
 
+    def test_type_coercion_of_an_integer_from_a_string
+      key = :max_chocolate_chips
+      defaults = {key => {default: 0, type: Integer}}
+      NewRelic::Agent::Configuration::Manager.stub_const(:DEFAULTS, defaults) do
+        value = @manager.type_coerce(key, '1138', :manual)
+
+        assert_equal 1138, value
+      end
+    end
+
+    def test_type_coercion_of_a_float_from_a_string
+      key = :slice_dice_ratio
+      defaults = {key => {default: 0.0, type: Float}}
+      NewRelic::Agent::Configuration::Manager.stub_const(:DEFAULTS, defaults) do
+        value = @manager.type_coerce(key, '867.5309', :manual)
+
+        assert_equal 867.5309, value # rubocop:disable Minitest/AssertInDelta
+      end
+    end
+
+    def test_type_coercion_of_a_string_from_a_symbol
+      key = :alert_highlight_color
+      defaults = {key => {default: 'beige', type: String}}
+      NewRelic::Agent::Configuration::Manager.stub_const(:DEFAULTS, defaults) do
+        value = @manager.type_coerce(key, :'forest green', :manual)
+
+        assert_equal 'forest green', value
+      end
+    end
+
+    def test_type_coercion_of_a_symbol_from_a_string
+      key = :sampling_direction
+      defaults = {key => {default: :forwards, type: Symbol}}
+      NewRelic::Agent::Configuration::Manager.stub_const(:DEFAULTS, defaults) do
+        value = @manager.type_coerce(key, 'backwards', :manual)
+
+        assert_equal :backwards, value
+      end
+    end
+
+    def test_type_coercion_of_an_array_from_a_string
+      key = :allowlisted_job_params
+      defaults = {key => {default: [], type: Array}}
+      NewRelic::Agent::Configuration::Manager.stub_const(:DEFAULTS, defaults) do
+        value = @manager.type_coerce(key, 'beans, rice, cheese', :manual)
+
+        assert_equal %w[beans rice cheese], value
+      end
+    end
+
+    def test_type_coercion_of_a_hash_from_a_string
+      key = :id_map
+      defaults = {key => {default: {}, type: Hash}}
+      NewRelic::Agent::Configuration::Manager.stub_const(:DEFAULTS, defaults) do
+        value = @manager.type_coerce(key, '19 = 81, Blind = Chance', :manual)
+
+        assert_equal({'19' => '81', 'Blind' => 'Chance'}, value)
+      end
+    end
+
+    def test_type_coercion_of_a_boolean_from_a_string
+      key = :vm_performance_analysis
+      defaults = {key => {default: false, type: NewRelic::Agent::Configuration::Boolean}}
+      NewRelic::Agent::Configuration::Manager.stub_const(:DEFAULTS, defaults) do
+        value = @manager.type_coerce(key, 'on', :manual)
+
+        assert_equal true, value # rubocop:disable Minitest/AssertTruthy
+      end
+    end
+
+    def test_type_coercion_of_an_integer_from_a_float
+      key = :applied_jigawatts
+      defaults = {key => {default: 0, type: Integer}}
+      NewRelic::Agent::Configuration::Manager.stub_const(:DEFAULTS, defaults) do
+        value = @manager.type_coerce(key, 1.21, :manual)
+
+        assert_equal 1, value
+      end
+    end
+
+    def test_type_coercion_of_a_float_from_an_int
+      key = :refresh_sampling_ratio
+      defaults = {key => {default: 12.5, type: Float}}
+      NewRelic::Agent::Configuration::Manager.stub_const(:DEFAULTS, defaults) do
+        value = @manager.type_coerce(key, 25, :manual)
+
+        assert_equal 25.0, value # rubocop:disable Minitest/AssertInDelta
+      end
+    end
+
+    def test_type_coercion_rejects_invalid_input_and_falls_back_to_the_default
+      key = :error_rate_threshold
+      default = 50
+      defaults = {key => {default: default, type: Integer}}
+      NewRelic::Agent::Configuration::Manager.stub_const(:DEFAULTS, defaults) do
+        expects_logging(:warn, includes('Expected to receive a value of type Integer matching pattern '))
+
+        value = @manager.type_coerce(key, 'seventy-five', :manual)
+
+        assert_equal default, value
+      end
+    end
+
+    def test_type_coercion_anticipates_an_invalid_type_without_a_proc_defined
+      key = :unexpected
+      input = 'original'
+      defaults = {key => {default: nil, type: Class}}
+      NewRelic::Agent::Configuration::Manager.stub_const(:DEFAULTS, defaults) do
+        value = @manager.type_coerce(key, input, :manual)
+
+        assert_equal input, value
+      end
+    end
+
+    def test_add_config_for_testing_enforces_an_input_class_allowlist
+      error = assert_raises RuntimeError do
+        @manager.add_config_for_testing(nil)
+      end
+
+      assert_equal 'Invalid config type for testing', error.message
+    end
+
+    def test_validate_nil_expects_nils_from_tests
+      expects_no_logging(:warn)
+
+      refute @manager.validate_nil(:a_key, :test)
+    end
+
+    def test_validates_nil_allows_nil_if_the_config_param_has_allow_nil_set
+      key = :optional_tolerance
+      defaults = {key => {default: '', type: String, allow_nil: true}}
+      NewRelic::Agent::Configuration::Manager.stub_const(:DEFAULTS, defaults) do
+        expects_no_logging(:warn)
+
+        refute @manager.validate_nil(key, :nr)
+      end
+    end
+
+    def test_validate_nil_warns_users
+      key = :required_tolerance
+      default = 1138
+      defaults = {key => {default: default, type: String}}
+      NewRelic::Agent::Configuration::Manager.stub_const(:DEFAULTS, defaults) do
+        expects_logging(:warn, includes('Nil values are not permitted'))
+
+        value = @manager.validate_nil(key, :user)
+
+        assert_equal default, value
+      end
+    end
+
+    def test_validate_nil_does_not_warn_for_nr_internal_category
+      key = :required_tolerance
+      default = 1138
+      defaults = {key => {default: default, type: String}}
+      NewRelic::Agent::Configuration::Manager.stub_const(:DEFAULTS, defaults) do
+        expects_no_logging(:warn)
+
+        value = @manager.validate_nil(key, :nr)
+
+        assert_equal default, value
+      end
+    end
+
+    def test_enforce_allowlist_only_operates_on_params_with_allowlists
+      key = :unguarded
+
+      default_source = Object.new
+      default_source.stubs(:allowlist_for).returns(nil)
+      @manager.stubs(:default_source).returns(default_source)
+
+      expects_no_logging(:warn)
+
+      value = @manager.enforce_allowlist(key, 9)
+
+      assert_equal 9, value
+    end
+
+    def test_enforce_allowlist_does_not_warn_if_the_input_value_is_on_the_allowlist
+      key = :guarded
+      default = 1138
+      allowlist = [default, 11, 38]
+      defaults = {key => {default: default, allowlist: allowlist}}
+
+      default_source = Object.new
+      default_source.stubs(:allowlist_for).returns(allowlist)
+      @manager.stubs(:default_source).returns(default_source)
+
+      NewRelic::Agent::Configuration::Manager.stub_const(:DEFAULTS, defaults) do
+        expects_no_logging(:warn)
+
+        value = @manager.enforce_allowlist(key, 11)
+
+        assert_equal 11, value
+      end
+    end
+
+    def test_enforce_allowlist_warns_if_the_input_value_is_not_on_the_allowlist
+      key = :guarded
+      default = 1138
+      allowlist = [default, 11, 38]
+      defaults = {key => {default: default, allowlist: allowlist}}
+
+      default_source = Object.new
+      default_source.stubs(:allowlist_for).returns(allowlist)
+      @manager.stubs(:default_source).returns(default_source)
+
+      NewRelic::Agent::Configuration::Manager.stub_const(:DEFAULTS, defaults) do
+        expects_logging(:warn, includes('Expected to receive a value found on the following list'))
+
+        value = @manager.enforce_allowlist(key, 9)
+
+        assert_equal default, value
+      end
+    end
+
     private
 
     def assert_parsed_labels(expected)

--- a/test/new_relic/agent/hostname_test.rb
+++ b/test/new_relic/agent/hostname_test.rb
@@ -80,14 +80,6 @@ module NewRelic
         end
       end
 
-      def test_shortens_to_prefixes_with_unsupported_object
-        with_dyno_name('Imladris.1', :'heroku.use_dyno_names' => true, :'heroku.dyno_name_prefixes_to_shorten' => Object.new) do
-          expects_logging(:error, includes('heroku.dyno_name_prefixes_to_shorten'), instance_of(ArgumentError))
-
-          assert_equal 'Imladris.1', NewRelic::Agent::Hostname.get
-        end
-      end
-
       def test_local_predicate_true_when_host_local
         hosts = %w[localhost 0.0.0.0 127.0.0.1 0:0:0:0:0:0:0:1
           0:0:0:0:0:0:0:0 ::1 ::]

--- a/test/new_relic/agent/local_log_decorator_test.rb
+++ b/test/new_relic/agent/local_log_decorator_test.rb
@@ -94,7 +94,7 @@ module NewRelic::Agent
       end
 
       def test_safe_without_entity_name
-        with_config(app_name: nil) do
+        with_config(app_name: []) do
           decorated_message = LocalLogDecorator.decorate(MESSAGE)
 
           assert_includes decorated_message, '||'


### PR DESCRIPTION
Rework the processing of configuration parameters to address #2852.

- nils to produce errors when user-supplied for params that don't support them
- introduce a common shared type coercion layer for all config values so that things like environment variable and YAML values are both consistently coerced
- allow type coercion to Array/Hash to replace all of the equivalent default source  based`:transform` entries
- lay the foundation for increased server side and env var based support for certain params that are currently marked as YAML source only (functionally ready now, updating tests and docs for each affected param to be handled later)
- permit Integer values for Float params (using `#to_f`) and Float values for Integer params (using `#round`)
- prevent fatal interruptions and log warnings when a default value can be found to replace a given bogus input value
- leverage default source's `:allow_nil` setting to enforce non-nil values for params that don't support nil

resolves #2852