### PR TITLE
Karafka rdkafka bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Version <dev> resolves a bug in rdkafka instrumentation when using the karafka-r
 
 - **Bugfix: Instrumentation errors when using the karafka-rdkafka gem**
 
-  Due to version differences between the rdkafka gem and karafka-rdkafka gem, the agent was installing instrumentation on some versions of karafka-rdkafka that encountered errors. This has now been resolved. Thank you to @krisdigital for bringing this issue to our attention. [PR#2880](https://github.com/newrelic/newrelic-ruby-agent/pull/2880)
+  Due to version differences between the rdkafka gem and karafka-rdkafka gem, the agent could encounter an error when it tried to install rdkafka instrumentation. This has now been resolved. Thank you to @krisdigital for bringing this issue to our attention. [PR#2880](https://github.com/newrelic/newrelic-ruby-agent/pull/2880)
 
 
 ## v9.14.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # New Relic Ruby Agent Release Notes
 
+## dev
+
+Version <dev> resolves a bug in rdkafka instrumentation when using the karafka-rdkafka gem.
+
+- **Bugfix: Instrumentation errors when using the karafka-rdkafka gem**
+
+  Due to version differences between the rdkafka gem and karafka-rdkafka gem, the agent was installing instrumentation on some versions of karafka-rdkafka that encountered errors. This has now been resolved. Thank you to @krisdigital for bringing this issue to our attention. [PR#2880](https://github.com/newrelic/newrelic-ruby-agent/pull/2880)
+
+
 ## v9.14.0
 
 Version 9.14.0 adds Apache Kafka instrumentation for the rdkafka and ruby-kafka gems, introduces a configuration-based, automatic way to add custom instrumentation method tracers, correctly captures MIME type for ActionDispatch 7.0+ requests, properly handles Boolean coercion for `newrelic.yml` configuration, fixes a JRuby bug in the configuration manager, fixes a bug related to `Bundler.rubygems.installed_specs`, and fixes a bug to make the agent compatible with ViewComponent v3.15.0+.

--- a/lib/new_relic/agent/instrumentation/rdkafka/chain.rb
+++ b/lib/new_relic/agent/instrumentation/rdkafka/chain.rb
@@ -40,7 +40,8 @@ module NewRelic::Agent::Instrumentation
         alias_method(:producer_without_new_relic, :producer)
         alias_method(:consumer_without_new_relic, :consumer)
 
-        if Gem::Version.new(::Rdkafka::VERSION) >= Gem::Version.new('0.16.0')
+        if Gem::Version.new(::Rdkafka::VERSION) >= Gem::Version.new('0.16.0') ||
+            (Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.7.0'))
           def producer(**kwargs)
             producer_without_new_relic(**kwargs).tap do |producer|
               set_nr_config(producer)

--- a/lib/new_relic/agent/instrumentation/rdkafka/prepend.rb
+++ b/lib/new_relic/agent/instrumentation/rdkafka/prepend.rb
@@ -36,7 +36,8 @@ module NewRelic::Agent::Instrumentation
     module Prepend
       include NewRelic::Agent::Instrumentation::RdkafkaConfig
 
-      if defined?(::Rdkafka) && Gem::Version.new(::Rdkafka::VERSION) >= Gem::Version.new('0.16.0')
+      if (defined?(::Rdkafka) && Gem::Version.new(::Rdkafka::VERSION) >= Gem::Version.new('0.16.0')) ||
+          (Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.7.0'))
         def producer(**kwargs)
           super.tap do |producer|
             set_nr_config(producer)


### PR DESCRIPTION
The rdkafka instrumentation gets installed on both the rdkafka gem and the karafka-rdkafka gem because it is a forked versions or rdkafka. However, they introduced a change in different versions that requires instrumentation to be installed different. 
resolves https://github.com/newrelic/newrelic-ruby-agent/issues/2879