### PR TITLE
Remove excess info-level instrumentation logs

### DIFF
--- a/lib/new_relic/agent/instrumentation/active_support_broadcast_logger.rb
+++ b/lib/new_relic/agent/instrumentation/active_support_broadcast_logger.rb
@@ -12,8 +12,6 @@ DependencyDetection.defer do
   depends_on { defined?(ActiveSupport::BroadcastLogger) }
 
   executes do
-    NewRelic::Agent.logger.info('Installing ActiveSupport::BroadcastLogger instrumentation')
-
     if use_prepend?
       prepend_instrument ActiveSupport::BroadcastLogger, NewRelic::Agent::Instrumentation::ActiveSupportBroadcastLogger::Prepend
     else

--- a/lib/new_relic/agent/instrumentation/active_support_logger.rb
+++ b/lib/new_relic/agent/instrumentation/active_support_logger.rb
@@ -14,8 +14,6 @@ DependencyDetection.defer do
   end
 
   executes do
-    NewRelic::Agent.logger.info('Installing ActiveSupport::Logger instrumentation')
-
     if use_prepend?
       # the only method currently instrumented is a class method
       prepend_instrument ActiveSupport::Logger.singleton_class, NewRelic::Agent::Instrumentation::ActiveSupportLogger::Prepend

--- a/lib/new_relic/agent/instrumentation/async_http.rb
+++ b/lib/new_relic/agent/instrumentation/async_http.rb
@@ -16,9 +16,8 @@ DependencyDetection.defer do
   end
 
   executes do
-    NewRelic::Agent.logger.info('Installing async_http instrumentation')
-
     require 'async/http/internet'
+
     if use_prepend?
       prepend_instrument Async::HTTP::Internet, NewRelic::Agent::Instrumentation::AsyncHttp::Prepend
     else

--- a/lib/new_relic/agent/instrumentation/aws_sqs.rb
+++ b/lib/new_relic/agent/instrumentation/aws_sqs.rb
@@ -14,8 +14,6 @@ DependencyDetection.defer do
   end
 
   executes do
-    NewRelic::Agent.logger.info('Installing aws-sdk-sqs instrumentation')
-
     if use_prepend?
       prepend_instrument Aws::SQS::Client, NewRelic::Agent::Instrumentation::AwsSqs::Prepend
     else

--- a/lib/new_relic/agent/instrumentation/bunny.rb
+++ b/lib/new_relic/agent/instrumentation/bunny.rb
@@ -21,9 +21,9 @@ DependencyDetection.defer do
 
   executes do
     if use_prepend?
-      prepend_instrument Bunny::Exchange, NewRelic::Agent::Instrumentation::Bunny::Prepend::Exchange
-      prepend_instrument Bunny::Queue, NewRelic::Agent::Instrumentation::Bunny::Prepend::Queue
-      prepend_instrument Bunny::Consumer, NewRelic::Agent::Instrumentation::Bunny::Prepend::Consumer
+      prepend_instrument Bunny::Exchange, NewRelic::Agent::Instrumentation::Bunny::Prepend::Exchange, 'Bunny::Exchange'
+      prepend_instrument Bunny::Queue, NewRelic::Agent::Instrumentation::Bunny::Prepend::Queue, 'Bunny::Queue'
+      prepend_instrument Bunny::Consumer, NewRelic::Agent::Instrumentation::Bunny::Prepend::Consumer, 'Bunny::Consumer'
     else
       chain_instrument NewRelic::Agent::Instrumentation::Bunny::Chain
     end

--- a/lib/new_relic/agent/instrumentation/bunny.rb
+++ b/lib/new_relic/agent/instrumentation/bunny.rb
@@ -14,7 +14,6 @@ DependencyDetection.defer do
   end
 
   executes do
-    NewRelic::Agent.logger.info('Installing Bunny instrumentation')
     require 'new_relic/agent/distributed_tracing/cross_app_tracing'
     require 'new_relic/agent/messaging'
     require 'new_relic/agent/transaction/message_broker_segment'

--- a/lib/new_relic/agent/instrumentation/concurrent_ruby.rb
+++ b/lib/new_relic/agent/instrumentation/concurrent_ruby.rb
@@ -16,8 +16,6 @@ DependencyDetection.defer do
   end
 
   executes do
-    NewRelic::Agent.logger.info('Installing concurrent-ruby instrumentation')
-
     if use_prepend?
       prepend_instrument(Concurrent::ThreadPoolExecutor, NewRelic::Agent::Instrumentation::ConcurrentRuby::Prepend)
 

--- a/lib/new_relic/agent/instrumentation/curb.rb
+++ b/lib/new_relic/agent/instrumentation/curb.rb
@@ -25,7 +25,7 @@ DependencyDetection.defer do
       prepend_instrument Curl::Easy, NewRelic::Agent::Instrumentation::Curb::Easy::Prepend, "Curb::Easy"
       prepend_instrument Curl::Multi, NewRelic::Agent::Instrumentation::Curb::Multi::Prepend, "Curb::Multi"
     else
-      chain_instrument NewRelic::Agent::Instrumentation::Curb::Chain, supportability_name = NewRelic::Agent::Instrumentation::Curb::Multi::INSTRUMENTATION_NAME
+      chain_instrument NewRelic::Agent::Instrumentation::Curb::Chain, NewRelic::Agent::Instrumentation::Curb::Multi::INSTRUMENTATION_NAME
     end 
   end
 end

--- a/lib/new_relic/agent/instrumentation/curb.rb
+++ b/lib/new_relic/agent/instrumentation/curb.rb
@@ -22,10 +22,10 @@ DependencyDetection.defer do
 
   executes do
     if use_prepend?
-      prepend_instrument Curl::Easy, NewRelic::Agent::Instrumentation::Curb::Easy::Prepend
-      prepend_instrument Curl::Multi, NewRelic::Agent::Instrumentation::Curb::Multi::Prepend
+      prepend_instrument Curl::Easy, NewRelic::Agent::Instrumentation::Curb::Easy::Prepend, "Curb::Easy"
+      prepend_instrument Curl::Multi, NewRelic::Agent::Instrumentation::Curb::Multi::Prepend, "Curb::Multi"
     else
-      chain_instrument NewRelic::Agent::Instrumentation::Curb::Chain
-    end
+      chain_instrument NewRelic::Agent::Instrumentation::Curb::Chain, supportability_name = NewRelic::Agent::Instrumentation::Curb::Multi::INSTRUMENTATION_NAME
+    end 
   end
 end

--- a/lib/new_relic/agent/instrumentation/curb.rb
+++ b/lib/new_relic/agent/instrumentation/curb.rb
@@ -16,7 +16,6 @@ DependencyDetection.defer do
   end
 
   executes do
-    NewRelic::Agent.logger.info('Installing Curb instrumentation')
     require 'new_relic/agent/distributed_tracing/cross_app_tracing'
     require 'new_relic/agent/http_clients/curb_wrappers'
   end

--- a/lib/new_relic/agent/instrumentation/curb.rb
+++ b/lib/new_relic/agent/instrumentation/curb.rb
@@ -22,10 +22,10 @@ DependencyDetection.defer do
 
   executes do
     if use_prepend?
-      prepend_instrument Curl::Easy, NewRelic::Agent::Instrumentation::Curb::Easy::Prepend, "Curb::Easy"
-      prepend_instrument Curl::Multi, NewRelic::Agent::Instrumentation::Curb::Multi::Prepend, "Curb::Multi"
+      prepend_instrument Curl::Easy, NewRelic::Agent::Instrumentation::Curb::Easy::Prepend, 'Curb::Easy'
+      prepend_instrument Curl::Multi, NewRelic::Agent::Instrumentation::Curb::Multi::Prepend, 'Curb::Multi'
     else
       chain_instrument NewRelic::Agent::Instrumentation::Curb::Chain, NewRelic::Agent::Instrumentation::Curb::Multi::INSTRUMENTATION_NAME
-    end 
+    end
   end
 end

--- a/lib/new_relic/agent/instrumentation/delayed_job_instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/delayed_job_instrumentation.rb
@@ -83,10 +83,6 @@ DependencyDetection.defer do
   end
 
   executes do
-    NewRelic::Agent.logger.info('Installing DelayedJob instrumentation [part 1/2]')
-  end
-
-  executes do
     if use_prepend?
       prepend_instrument Delayed::Worker, NewRelic::Agent::Instrumentation::DelayedJob::Prepend
     else

--- a/lib/new_relic/agent/instrumentation/dynamodb.rb
+++ b/lib/new_relic/agent/instrumentation/dynamodb.rb
@@ -14,8 +14,6 @@ DependencyDetection.defer do
   end
 
   executes do
-    NewRelic::Agent.logger.info('Installing DynamoDB instrumentation')
-
     if use_prepend?
       prepend_instrument Aws::DynamoDB::Client, NewRelic::Agent::Instrumentation::DynamoDB::Prepend
     else

--- a/lib/new_relic/agent/instrumentation/elasticsearch.rb
+++ b/lib/new_relic/agent/instrumentation/elasticsearch.rb
@@ -14,8 +14,6 @@ DependencyDetection.defer do
   end
 
   executes do
-    NewRelic::Agent.logger.info('Installing Elasticsearch instrumentation')
-
     to_instrument = if Gem::Version.create(Elasticsearch::VERSION) < Gem::Version.create('8.0.0')
       Elasticsearch::Transport::Client
     else

--- a/lib/new_relic/agent/instrumentation/ethon.rb
+++ b/lib/new_relic/agent/instrumentation/ethon.rb
@@ -22,10 +22,6 @@ DependencyDetection.defer do
   end
 
   executes do
-    NewRelic::Agent.logger.info('Installing ethon instrumentation')
-  end
-
-  executes do
     if use_prepend?
       # NOTE: by default prepend_instrument will go with the module name that
       #       precedes 'Prepend' (so 'Easy' and 'Multi'), but we want to use

--- a/lib/new_relic/agent/instrumentation/fiber.rb
+++ b/lib/new_relic/agent/instrumentation/fiber.rb
@@ -14,8 +14,6 @@ DependencyDetection.defer do
   end
 
   executes do
-    NewRelic::Agent.logger.info('Installing Fiber instrumentation')
-
     if use_prepend?
       prepend_instrument Fiber, NewRelic::Agent::Instrumentation::MonitoredFiber::Prepend
     else

--- a/lib/new_relic/agent/instrumentation/httpclient.rb
+++ b/lib/new_relic/agent/instrumentation/httpclient.rb
@@ -23,7 +23,6 @@ DependencyDetection.defer do
   end
 
   executes do
-    NewRelic::Agent.logger.info('Installing HTTPClient instrumentation')
     require 'new_relic/agent/distributed_tracing/cross_app_tracing'
     require 'new_relic/agent/http_clients/httpclient_wrappers'
   end

--- a/lib/new_relic/agent/instrumentation/httprb.rb
+++ b/lib/new_relic/agent/instrumentation/httprb.rb
@@ -14,7 +14,6 @@ DependencyDetection.defer do
   end
 
   executes do
-    NewRelic::Agent.logger.info('Installing http.rb Wrappers')
     require 'new_relic/agent/distributed_tracing/cross_app_tracing'
     require 'new_relic/agent/http_clients/http_rb_wrappers'
   end

--- a/lib/new_relic/agent/instrumentation/httpx.rb
+++ b/lib/new_relic/agent/instrumentation/httpx.rb
@@ -14,10 +14,6 @@ DependencyDetection.defer do
   end
 
   executes do
-    NewRelic::Agent.logger.info('Installing httpx instrumentation')
-  end
-
-  executes do
     if use_prepend?
       prepend_instrument HTTPX::Session, NewRelic::Agent::Instrumentation::HTTPX::Prepend
     else

--- a/lib/new_relic/agent/instrumentation/logger.rb
+++ b/lib/new_relic/agent/instrumentation/logger.rb
@@ -18,7 +18,7 @@ DependencyDetection.defer do
     if use_prepend?
       prepend_instrument Logger, NewRelic::Agent::Instrumentation::Logger::Prepend
     else
-      chain_instrument NewRelic::Agent::Instrumentation::Logger
+      chain_instrument NewRelic::Agent::Instrumentation::Logger, NewRelic::Agent::Instrumentation::Logger::INSTRUMENTATION_NAME
     end
   end
 end

--- a/lib/new_relic/agent/instrumentation/logger.rb
+++ b/lib/new_relic/agent/instrumentation/logger.rb
@@ -15,8 +15,6 @@ DependencyDetection.defer do
   end
 
   executes do
-    NewRelic::Agent.logger.info('Installing Logger instrumentation')
-
     if use_prepend?
       prepend_instrument Logger, NewRelic::Agent::Instrumentation::Logger::Prepend
     else

--- a/lib/new_relic/agent/instrumentation/logstasher.rb
+++ b/lib/new_relic/agent/instrumentation/logstasher.rb
@@ -16,11 +16,10 @@ DependencyDetection.defer do
   end
 
   executes do
-    supportability_name = NewRelic::Agent::Instrumentation::LogStasher::INSTRUMENTATION_NAME
     if use_prepend?
-      prepend_instrument LogStasher.singleton_class, NewRelic::Agent::Instrumentation::LogStasher::Prepend, supportability_name
+      prepend_instrument LogStasher.singleton_class, NewRelic::Agent::Instrumentation::LogStasher::Prepend
     else
-      chain_instrument NewRelic::Agent::Instrumentation::LogStasher::Chain, supportability_name
+      chain_instrument NewRelic::Agent::Instrumentation::LogStasher::Chain
     end
   end
 end

--- a/lib/new_relic/agent/instrumentation/logstasher.rb
+++ b/lib/new_relic/agent/instrumentation/logstasher.rb
@@ -16,10 +16,11 @@ DependencyDetection.defer do
   end
 
   executes do
+    supportability_name = NewRelic::Agent::Instrumentation::LogStasher::INSTRUMENTATION_NAME
     if use_prepend?
-      prepend_instrument LogStasher.singleton_class, NewRelic::Agent::Instrumentation::LogStasher::Prepend
+      prepend_instrument LogStasher.singleton_class, NewRelic::Agent::Instrumentation::LogStasher::Prepend, supportability_name
     else
-      chain_instrument NewRelic::Agent::Instrumentation::LogStasher::Chain
+      chain_instrument NewRelic::Agent::Instrumentation::LogStasher::Chain, supportability_name
     end
   end
 end

--- a/lib/new_relic/agent/instrumentation/logstasher.rb
+++ b/lib/new_relic/agent/instrumentation/logstasher.rb
@@ -16,8 +16,6 @@ DependencyDetection.defer do
   end
 
   executes do
-    NewRelic::Agent.logger.info('Installing LogStasher instrumentation')
-
     if use_prepend?
       prepend_instrument LogStasher.singleton_class, NewRelic::Agent::Instrumentation::LogStasher::Prepend
     else

--- a/lib/new_relic/agent/instrumentation/memcache.rb
+++ b/lib/new_relic/agent/instrumentation/memcache.rb
@@ -74,7 +74,6 @@ DependencyDetection.defer do
   depends_on { NewRelic::Agent::Instrumentation::Memcache::DalliCAS.should_instrument? }
 
   executes do
-    NewRelic::Agent.logger.info('Installing Dalli CAS Client Memcache instrumentation')
     if use_prepend?
       prepend_module = NewRelic::Agent::Instrumentation::Memcache::Prepend
       prepend_module.dalli_cas_prependers do |client_class, instrumenting_module|

--- a/lib/new_relic/agent/instrumentation/opensearch.rb
+++ b/lib/new_relic/agent/instrumentation/opensearch.rb
@@ -14,8 +14,6 @@ DependencyDetection.defer do
   end
 
   executes do
-    NewRelic::Agent.logger.info('Installing opensearch-ruby instrumentation')
-
     if use_prepend?
       prepend_instrument OpenSearch::Transport::Client, NewRelic::Agent::Instrumentation::OpenSearch::Prepend
     else

--- a/lib/new_relic/agent/instrumentation/padrino.rb
+++ b/lib/new_relic/agent/instrumentation/padrino.rb
@@ -22,10 +22,11 @@ DependencyDetection.defer do
   depends_on { defined?(Padrino) && defined?(Padrino::Routing::InstanceMethods) }
 
   executes do
+    supportability_name = NewRelic::Agent::Instrumentation::Padrino::INSTRUMENTATION_NAME
     if use_prepend?
-      prepend_instrument Padrino::Application, NewRelic::Agent::Instrumentation::PadrinoTracer::Prepend
+      prepend_instrument Padrino::Application, NewRelic::Agent::Instrumentation::PadrinoTracer::Prepend, supportability_name
     else
-      chain_instrument NewRelic::Agent::Instrumentation::PadrinoTracer::Chain
+      chain_instrument NewRelic::Agent::Instrumentation::PadrinoTracer::Chain, supportability_name
     end
   end
 end

--- a/lib/new_relic/agent/instrumentation/padrino.rb
+++ b/lib/new_relic/agent/instrumentation/padrino.rb
@@ -22,7 +22,6 @@ DependencyDetection.defer do
   depends_on { defined?(Padrino) && defined?(Padrino::Routing::InstanceMethods) }
 
   executes do
-    NewRelic::Agent.logger.info('Installing Padrino instrumentation')
     if use_prepend?
       prepend_instrument Padrino::Application, NewRelic::Agent::Instrumentation::PadrinoTracer::Prepend
     else

--- a/lib/new_relic/agent/instrumentation/rake.rb
+++ b/lib/new_relic/agent/instrumentation/rake.rb
@@ -17,7 +17,6 @@ DependencyDetection.defer do
   depends_on { NewRelic::Agent::Instrumentation::Rake.safe_from_third_party_gem? }
 
   executes do
-    NewRelic::Agent.logger.info('Installing Rake instrumentation')
     NewRelic::Agent.logger.debug("Instrumenting Rake tasks: #{NewRelic::Agent.config[:'rake.tasks']}")
   end
 

--- a/lib/new_relic/agent/instrumentation/rdkafka.rb
+++ b/lib/new_relic/agent/instrumentation/rdkafka.rb
@@ -10,8 +10,6 @@ DependencyDetection.defer do
   end
 
   executes do
-    NewRelic::Agent.logger.info('Installing rdkafka instrumentation')
-
     require_relative 'rdkafka/instrumentation'
     require_relative 'rdkafka/chain'
     require_relative 'rdkafka/prepend'

--- a/lib/new_relic/agent/instrumentation/redis.rb
+++ b/lib/new_relic/agent/instrumentation/redis.rb
@@ -14,7 +14,7 @@ require_relative 'redis/cluster_middleware'
 
 DependencyDetection.defer do
   # Why not :redis? newrelic-redis used that name, so avoid conflicting
-  named :redis_instrumentation
+  @name = :redis_instrumentation
   configure_with :redis
 
   depends_on do

--- a/lib/new_relic/agent/instrumentation/redis.rb
+++ b/lib/new_relic/agent/instrumentation/redis.rb
@@ -31,7 +31,6 @@ DependencyDetection.defer do
   end
 
   executes do
-    NewRelic::Agent.logger.info('Installing Redis Instrumentation')
     if NewRelic::Agent::Instrumentation::Redis::Constants::HAS_REDIS_CLIENT
       RedisClient.register(NewRelic::Agent::Instrumentation::RedisClient::Middleware)
 

--- a/lib/new_relic/agent/instrumentation/redis.rb
+++ b/lib/new_relic/agent/instrumentation/redis.rb
@@ -14,7 +14,7 @@ require_relative 'redis/cluster_middleware'
 
 DependencyDetection.defer do
   # Why not :redis? newrelic-redis used that name, so avoid conflicting
-  @name = :redis_instrumentation
+  named :redis_instrumentation
   configure_with :redis
 
   depends_on do

--- a/lib/new_relic/agent/instrumentation/resque.rb
+++ b/lib/new_relic/agent/instrumentation/resque.rb
@@ -7,7 +7,7 @@ require_relative 'resque/chain'
 require_relative 'resque/prepend'
 
 DependencyDetection.defer do
-  @name = :resque
+  named :resque
 
   depends_on do
     defined?(Resque::Job)

--- a/lib/new_relic/agent/instrumentation/resque.rb
+++ b/lib/new_relic/agent/instrumentation/resque.rb
@@ -19,10 +19,6 @@ DependencyDetection.defer do
   end
 
   executes do
-    NewRelic::Agent.logger.info('Installing Resque instrumentation')
-  end
-
-  executes do
     if NewRelic::Agent.config[:'resque.use_ruby_dns'] && NewRelic::Agent.config[:dispatcher] == :resque
       NewRelic::Agent.logger.info('Requiring resolv-replace')
       require 'resolv'

--- a/lib/new_relic/agent/instrumentation/resque.rb
+++ b/lib/new_relic/agent/instrumentation/resque.rb
@@ -7,7 +7,7 @@ require_relative 'resque/chain'
 require_relative 'resque/prepend'
 
 DependencyDetection.defer do
-  named :resque
+  @name = :resque
 
   depends_on do
     defined?(Resque::Job)

--- a/lib/new_relic/agent/instrumentation/roda.rb
+++ b/lib/new_relic/agent/instrumentation/roda.rb
@@ -20,8 +20,6 @@ DependencyDetection.defer do
     require_relative '../../rack/agent_hooks'
     require_relative '../../rack/browser_monitoring'
 
-    NewRelic::Agent.logger.info('Installing Roda instrumentation')
-
     if use_prepend?
       require_relative 'roda/prepend'
       prepend_instrument Roda.singleton_class, NewRelic::Agent::Instrumentation::Roda::Build::Prepend

--- a/lib/new_relic/agent/instrumentation/roda.rb
+++ b/lib/new_relic/agent/instrumentation/roda.rb
@@ -22,11 +22,13 @@ DependencyDetection.defer do
 
     if use_prepend?
       require_relative 'roda/prepend'
-      prepend_instrument Roda.singleton_class, NewRelic::Agent::Instrumentation::Roda::Build::Prepend
+
+      supportability_name = NewRelic::Agent::Instrumentation::Roda::Tracer::INSTRUMENTATION_NAME
+      prepend_instrument Roda.singleton_class, NewRelic::Agent::Instrumentation::Roda::Build::Prepend, supportability_name
       prepend_instrument Roda, NewRelic::Agent::Instrumentation::Roda::Prepend
     else
       require_relative 'roda/chain'
-      chain_instrument NewRelic::Agent::Instrumentation::Roda::Build::Chain
+      chain_instrument NewRelic::Agent::Instrumentation::Roda::Build::Chain, supportability_name
       chain_instrument NewRelic::Agent::Instrumentation::Roda::Chain
     end
     Roda.class_eval { extend NewRelic::Agent::Instrumentation::Roda::Ignorer }

--- a/lib/new_relic/agent/instrumentation/ruby_kafka.rb
+++ b/lib/new_relic/agent/instrumentation/ruby_kafka.rb
@@ -14,8 +14,6 @@ DependencyDetection.defer do
   end
 
   executes do
-    NewRelic::Agent.logger.info('Installing ruby-kafka instrumentation')
-
     if use_prepend?
       prepend_instrument Kafka::Producer, NewRelic::Agent::Instrumentation::RubyKafkaProducer::Prepend
       prepend_instrument Kafka::Consumer, NewRelic::Agent::Instrumentation::RubyKafkaConsumer::Prepend

--- a/lib/new_relic/agent/instrumentation/sequel.rb
+++ b/lib/new_relic/agent/instrumentation/sequel.rb
@@ -4,7 +4,7 @@
 # frozen_string_literal: true
 
 DependencyDetection.defer do
-  named :sequel
+  @name = :sequel
 
   depends_on do
     defined?(Sequel)

--- a/lib/new_relic/agent/instrumentation/sequel.rb
+++ b/lib/new_relic/agent/instrumentation/sequel.rb
@@ -4,7 +4,7 @@
 # frozen_string_literal: true
 
 DependencyDetection.defer do
-  @name = :sequel
+  named :sequel
 
   depends_on do
     defined?(Sequel)

--- a/lib/new_relic/agent/instrumentation/sidekiq.rb
+++ b/lib/new_relic/agent/instrumentation/sidekiq.rb
@@ -7,7 +7,7 @@ require_relative 'sidekiq/server'
 require_relative 'sidekiq/extensions/delayed_class'
 
 DependencyDetection.defer do
-  @name = :sidekiq
+  named :sidekiq
 
   depends_on do
     defined?(Sidekiq) && !NewRelic::Agent.config[:disable_sidekiq]

--- a/lib/new_relic/agent/instrumentation/sidekiq.rb
+++ b/lib/new_relic/agent/instrumentation/sidekiq.rb
@@ -7,7 +7,7 @@ require_relative 'sidekiq/server'
 require_relative 'sidekiq/extensions/delayed_class'
 
 DependencyDetection.defer do
-  named :sidekiq
+  @name = :sidekiq
 
   depends_on do
     defined?(Sidekiq) && !NewRelic::Agent.config[:disable_sidekiq]

--- a/lib/new_relic/agent/instrumentation/sinatra.rb
+++ b/lib/new_relic/agent/instrumentation/sinatra.rb
@@ -17,10 +17,6 @@ DependencyDetection.defer do
   depends_on { Sinatra::Base.private_method_defined?(:route_eval) }
 
   executes do
-    NewRelic::Agent.logger.info('Installing Sinatra instrumentation')
-  end
-
-  executes do
     if use_prepend?
       prepend_instrument Sinatra::Base, NewRelic::Agent::Instrumentation::Sinatra::Prepend
     else

--- a/lib/new_relic/agent/instrumentation/sinatra.rb
+++ b/lib/new_relic/agent/instrumentation/sinatra.rb
@@ -28,14 +28,15 @@ DependencyDetection.defer do
   end
 
   executes do
+    supportability_name = NewRelic::Agent::Instrumentation::Sinatra::Tracer::INSTRUMENTATION_NAME
     # These requires are inside an executes block because they require rack, and
     # we can't be sure that rack is available when this file is first required.
     require 'new_relic/rack/agent_hooks'
     require 'new_relic/rack/browser_monitoring'
     if use_prepend?
-      prepend_instrument Sinatra::Base.singleton_class, NewRelic::Agent::Instrumentation::Sinatra::Build::Prepend
+      prepend_instrument Sinatra::Base.singleton_class, NewRelic::Agent::Instrumentation::Sinatra::Build::Prepend, supportability_name
     else
-      chain_instrument NewRelic::Agent::Instrumentation::Sinatra::Build::Chain
+      chain_instrument NewRelic::Agent::Instrumentation::Sinatra::Build::Chain, supportability_name
     end
   end
 end

--- a/lib/new_relic/agent/instrumentation/thread.rb
+++ b/lib/new_relic/agent/instrumentation/thread.rb
@@ -9,8 +9,6 @@ DependencyDetection.defer do
   named :thread
 
   executes do
-    NewRelic::Agent.logger.info('Installing Thread Instrumentation')
-
     if use_prepend?
       prepend_instrument Thread, NewRelic::Agent::Instrumentation::MonitoredThread::Prepend
     else

--- a/lib/new_relic/agent/instrumentation/tilt.rb
+++ b/lib/new_relic/agent/instrumentation/tilt.rb
@@ -12,10 +12,6 @@ DependencyDetection.defer do
   depends_on { defined?(Tilt) }
 
   executes do
-    NewRelic::Agent.logger.info('Installing Tilt instrumentation')
-  end
-
-  executes do
     if use_prepend?
       prepend_instrument Tilt::Template, NewRelic::Agent::Instrumentation::Tilt::Prepend
     else

--- a/lib/new_relic/agent/instrumentation/typhoeus.rb
+++ b/lib/new_relic/agent/instrumentation/typhoeus.rb
@@ -18,7 +18,6 @@ DependencyDetection.defer do
   end
 
   executes do
-    NewRelic::Agent.logger.info('Installing Typhoeus instrumentation')
     require 'new_relic/agent/distributed_tracing/cross_app_tracing'
     require 'new_relic/agent/http_clients/typhoeus_wrappers'
   end

--- a/lib/new_relic/agent/instrumentation/view_component.rb
+++ b/lib/new_relic/agent/instrumentation/view_component.rb
@@ -15,8 +15,6 @@ DependencyDetection.defer do
   end
 
   executes do
-    NewRelic::Agent.logger.info('Installing ViewComponent instrumentation')
-
     if use_prepend?
       prepend_instrument ViewComponent::Base, NewRelic::Agent::Instrumentation::ViewComponent::Prepend
     else

--- a/lib/tasks/instrumentation_generator/templates/dependency_detection.tt
+++ b/lib/tasks/instrumentation_generator/templates/dependency_detection.tt
@@ -18,8 +18,6 @@ DependencyDetection.defer do
   end
 
   executes do
-    NewRelic::Agent.logger.info('Installing <%= @name.downcase %> instrumentation')
-
     if use_prepend?
       prepend_instrument <%= @class_name %>, NewRelic::Agent::Instrumentation::<%= @class_name %>::Prepend
     else

--- a/lib/tasks/instrumentation_generator/templates/dependency_detection.tt
+++ b/lib/tasks/instrumentation_generator/templates/dependency_detection.tt
@@ -18,7 +18,7 @@ DependencyDetection.defer do
   end
 
   executes do
-    # prepend_instrument and chain_instrument call extract_supportability_name to get the library name for supportability and info-level logging. 
+    # prepend_instrument and chain_instrument call extract_supportability_name to get the library name for supportability metrics and info-level logging. 
     # This is done by spliting on the 2nd to last spot of the instrumented module. If this isn't how we want the name to appear, pass in the desired
     # name as a third arugment. 
     if use_prepend?

--- a/lib/tasks/instrumentation_generator/templates/dependency_detection.tt
+++ b/lib/tasks/instrumentation_generator/templates/dependency_detection.tt
@@ -18,9 +18,11 @@ DependencyDetection.defer do
   end
 
   executes do
-    # prepend_instrument and chain_instrument call extract_supportability_name to get the library name for supportability metrics and info-level logging. 
-    # This is done by spliting on the 2nd to last spot of the instrumented module. If this isn't how we want the name to appear, pass in the desired
-    # name as a third argument. 
+    # prepend_instrument and chain_instrument call extract_supportability_name
+    # to get the library name for supportability metrics and info-level logging. 
+    # This is done by spliting on the 2nd to last spot of the instrumented
+    # module. If this isn't how we want the name to appear, pass in the desired
+    # name as a third argument.
     if use_prepend?
       prepend_instrument <%= @class_name %>, NewRelic::Agent::Instrumentation::<%= @class_name %>::Prepend
     else

--- a/lib/tasks/instrumentation_generator/templates/dependency_detection.tt
+++ b/lib/tasks/instrumentation_generator/templates/dependency_detection.tt
@@ -18,6 +18,9 @@ DependencyDetection.defer do
   end
 
   executes do
+    # prepend_instrument and chain_instrument call extract_supportability_name to get the library name for supportability and info-level logging. 
+    # This is done by spliting on the 2nd to last spot of the instrumented module. If this isn't how we want the name to appear, pass in the desired
+    # name as a third arugment. 
     if use_prepend?
       prepend_instrument <%= @class_name %>, NewRelic::Agent::Instrumentation::<%= @class_name %>::Prepend
     else

--- a/lib/tasks/instrumentation_generator/templates/dependency_detection.tt
+++ b/lib/tasks/instrumentation_generator/templates/dependency_detection.tt
@@ -20,7 +20,7 @@ DependencyDetection.defer do
   executes do
     # prepend_instrument and chain_instrument call extract_supportability_name to get the library name for supportability metrics and info-level logging. 
     # This is done by spliting on the 2nd to last spot of the instrumented module. If this isn't how we want the name to appear, pass in the desired
-    # name as a third arugment. 
+    # name as a third argument. 
     if use_prepend?
       prepend_instrument <%= @class_name %>, NewRelic::Agent::Instrumentation::<%= @class_name %>::Prepend
     else


### PR DESCRIPTION
Removes info-level log statements for instrumentations. These statements are already produces in the `prepend_instrument` and `chain_instrument` methods, which call `log_and_instrument`. Each instrumentation file edited in this PR uses these methods.

The library name used for a supportability metric and logging statement is either extracted via `extract_supportability_name`, which splits on the 2nd to last spot of the instrumented module, or can be passed in as a third argument to `prepend_instrument` or `chain_instrument`. For libraries that have a weird 2nd to last name, a third argument was added with the desired name.

closes #2434