### PR TITLE
Stripe: restrict CI tests to Stripe <= v12

### DIFF
--- a/test/multiverse/suites/stripe/Envfile
+++ b/test/multiverse/suites/stripe/Envfile
@@ -7,7 +7,9 @@
 instrumentation_methods :chain
 
 STRIPE_VERSIONS = [
-  [nil, 2.4],
+  # TODO: support Stripe v13+ https://github.com/newrelic/newrelic-ruby-agent/issues/2884
+  # [nil, 2.4],
+  ['12.6.0', 2.4],
   ['5.38.0', 2.4]
 ]
 


### PR DESCRIPTION
For now, limit Stripe testing to < v13