### PR TITLE
Sequel: relax Ruby requirement for Timed pool

### DIFF
--- a/lib/sequel/extensions/new_relic_instrumentation.rb
+++ b/lib/sequel/extensions/new_relic_instrumentation.rb
@@ -79,7 +79,7 @@ module Sequel
 
     THREAD_SAFE_CONNECTION_POOL_CLASSES = [
       (defined?(::Sequel::ThreadedConnectionPool) && ::Sequel::ThreadedConnectionPool),
-      (defined?(::Sequel::TimedQueueConnectionPool) && RUBY_VERSION >= '3.4' && ::Sequel::TimedQueueConnectionPool)
+      (defined?(::Sequel::TimedQueueConnectionPool) && RUBY_VERSION >= '3.2' && ::Sequel::TimedQueueConnectionPool)
     ].compact.freeze
 
     def explainer_for(sql)


### PR DESCRIPTION
Accommodate Sequel v5.85.0, which has made the timed connection pool the default for Ruby 3.2+ by always  permitting the use of a timed connection pool for explain plan generation in a Ruby 3.2+ context (previously only a Ruby 3.4+ context would work).

https://sequel.jeremyevans.net/rdoc/files/doc/release_notes/5_85_0_txt.html#label-Other+Improvements

resolves https://github.com/newrelic/newrelic-ruby-agent/pull/2888