### PR TITLE
Stripe testing update

### DIFF
--- a/test/multiverse/suites/stripe/Envfile
+++ b/test/multiverse/suites/stripe/Envfile
@@ -7,8 +7,7 @@
 instrumentation_methods :chain
 
 STRIPE_VERSIONS = [
-  # TODO: support Stripe v13+ https://github.com/newrelic/newrelic-ruby-agent/issues/2884
-  # [nil, 2.4],
+  [nil, 2.4],
   ['12.6.0', 2.4],
   ['5.38.0', 2.4]
 ]

--- a/test/multiverse/suites/stripe/stripe_instrumentation_test.rb
+++ b/test/multiverse/suites/stripe/stripe_instrumentation_test.rb
@@ -199,7 +199,7 @@ class StripeInstrumentation < Minitest::Test
   end
 
   def with_stubbed_connection_manager(&block)
-    # Striped moved StripeClient and requestor logic to APIRequestor in v13.0.0
+    # Stripe moved StripeClient and requestor logic to APIRequestor in v13.0.0
     # https://github.com/stripe/stripe-ruby/pull/1458
     if Gem::Version.new(Stripe::VERSION) >= Gem::Version.new('13.0.0')
       Stripe::APIRequestor.stub(:default_connection_manager, @connection) do

--- a/test/multiverse/suites/stripe/stripe_instrumentation_test.rb
+++ b/test/multiverse/suites/stripe/stripe_instrumentation_test.rb
@@ -199,9 +199,19 @@ class StripeInstrumentation < Minitest::Test
   end
 
   def with_stubbed_connection_manager(&block)
-    Stripe::StripeClient.stub(:default_connection_manager, @connection) do
-      @connection.stub(:execute_request, @response) do
-        yield
+    # Striped moved StripeClient and requestor logic to APIRequestor in v13.0.0
+    # https://github.com/stripe/stripe-ruby/pull/1458
+    if Gem::Version.new(Stripe::VERSION) >= Gem::Version.new('13.0.0')
+      Stripe::APIRequestor.stub(:default_connection_manager, @connection) do
+        @connection.stub(:execute_request, @response) do
+          yield
+        end
+      end
+    else
+      Stripe::StripeClient.stub(:default_connection_manager, @connection) do
+        @connection.stub(:execute_request, @response) do
+          yield
+        end
       end
     end
   end


### PR DESCRIPTION
Striped [moved](https://github.com/stripe/stripe-ruby/pull/1458) StripeClient and requestor logic to APIRequestor in v13.0.0. This PR updates the test that makes use of this class and reinstates Stripe testing for newer versions.

closes [#2884](https://github.com/newrelic/newrelic-ruby-agent/issues/2884)