### PR TITLE
increase db.statement threshold to 4096

### DIFF
--- a/lib/new_relic/agent/span_event_primitive.rb
+++ b/lib/new_relic/agent/span_event_primitive.rb
@@ -52,6 +52,8 @@ module NewRelic
       DATASTORE_CATEGORY = 'datastore'
       CLIENT = 'client'
 
+      DB_STATEMENT_MAX_BYTES = 4096
+
       # Builds a Hash of error attributes as well as the Span ID when
       # an error is present.  Otherwise, returns nil when no error present.
       def error_attributes(segment)
@@ -114,9 +116,9 @@ module NewRelic
         agent_attributes[DB_SYSTEM_KEY] = segment.product if allowed?(DB_SYSTEM_KEY)
 
         if segment.sql_statement && allowed?(DB_STATEMENT_KEY)
-          agent_attributes[DB_STATEMENT_KEY] = truncate(segment.sql_statement.safe_sql, 2000)
+          agent_attributes[DB_STATEMENT_KEY] = truncate(segment.sql_statement.safe_sql, DB_STATEMENT_MAX_BYTES)
         elsif segment.nosql_statement && allowed?(DB_STATEMENT_KEY)
-          agent_attributes[DB_STATEMENT_KEY] = truncate(segment.nosql_statement, 2000)
+          agent_attributes[DB_STATEMENT_KEY] = truncate(segment.nosql_statement, DB_STATEMENT_MAX_BYTES)
         end
 
         [intrinsics, custom_attributes(segment), agent_attributes.merge(agent_attributes(segment))]

--- a/test/new_relic/agent/transaction/datastore_segment_test.rb
+++ b/test/new_relic/agent/transaction/datastore_segment_test.rb
@@ -383,6 +383,7 @@ module NewRelic
         end
 
         def test_span_event_truncates_long_sql_statement
+          select = 'select * from '
           with_config(:'transaction_tracer.record_sql' => 'raw') do
             in_transaction('wat') do |txn|
               txn.stubs(:sampled?).returns(true)
@@ -392,7 +393,7 @@ module NewRelic
                 operation: 'select'
               )
 
-              sql_statement = "select * from #{'a' * 2500}"
+              sql_statement = "#{select}#{'a' * (SpanEventPrimitive::DB_STATEMENT_MAX_BYTES + 500)}"
 
               segment.notice_sql(sql_statement)
               segment.finish
@@ -401,12 +402,15 @@ module NewRelic
 
           last_span_events = NewRelic::Agent.agent.span_event_aggregator.harvest![1]
           _, _, agent_attributes = last_span_events[0]
+          ellipsis = '...'
 
-          assert_equal 2000, agent_attributes['db.statement'].bytesize
-          assert_equal "select * from #{'a' * 1983}...", agent_attributes['db.statement']
+          assert_equal SpanEventPrimitive::DB_STATEMENT_MAX_BYTES, agent_attributes['db.statement'].bytesize
+          assert_equal "#{select}#{'a' * (SpanEventPrimitive::DB_STATEMENT_MAX_BYTES - select.size - ellipsis.size)}#{ellipsis}",
+            agent_attributes['db.statement']
         end
 
         def test_span_event_truncates_long_nosql_statement
+          set_mykey = 'set mykey '
           in_transaction('wat') do |txn|
             txn.stubs(:sampled?).returns(true)
 
@@ -414,7 +418,7 @@ module NewRelic
               product: 'Redis',
               operation: 'set'
             )
-            statement = "set mykey #{'a' * 2500}"
+            statement = "#{set_mykey}#{'a' * (SpanEventPrimitive::DB_STATEMENT_MAX_BYTES + 500)}"
 
             segment.notice_nosql_statement(statement)
             segment.finish
@@ -422,9 +426,11 @@ module NewRelic
 
           last_span_events = NewRelic::Agent.agent.span_event_aggregator.harvest![1]
           _, _, agent_attributes = last_span_events[0]
+          ellipsis = '...'
 
-          assert_equal 2000, agent_attributes['db.statement'].bytesize
-          assert_equal "set mykey #{'a' * 1987}...", agent_attributes['db.statement']
+          assert_equal SpanEventPrimitive::DB_STATEMENT_MAX_BYTES, agent_attributes['db.statement'].bytesize
+          assert_equal "#{set_mykey}#{'a' * (SpanEventPrimitive::DB_STATEMENT_MAX_BYTES - set_mykey.size - ellipsis.size)}#{ellipsis}",
+            agent_attributes['db.statement']
         end
 
         def test_span_event_truncates_long_attributes


### PR DESCRIPTION
increase the db.statement max from 2000 to 4096 as per the updated cross agent spec
