### PR TITLE
berm/bermq: only clean once

### DIFF
--- a/test/script/run_tests
+++ b/test/script/run_tests
@@ -96,8 +96,6 @@ run_multiverse() {
 
 # calls multiverse but only env 0 or specified and method prepend
 run_multiverse_quick() {
-  clean
-
   if [[ "$2" =~ [0-9]+ && ! "$2" =~ ^test ]]; then
     run_multiverse "$1",env="$2",method=prepend "$3" "$4"
   else


### PR DESCRIPTION
given than `berm` and `bermq` both follow the same path, prevent duplicate cleaning operations