### PR TITLE
Create helper to access Bundler.rubygems specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,15 @@
 
 ## dev
 
-Version <dev> resolves a bug in rdkafka instrumentation when using the karafka-rdkafka gem.
+Version <dev> resolves a bug in rdkafka instrumentation when using the karafka-rdkafka gem and fixes a bug with Grape instrumentation.
 
 - **Bugfix: Instrumentation errors when using the karafka-rdkafka gem**
 
   Due to version differences between the rdkafka gem and karafka-rdkafka gem, the agent could encounter an error when it tried to install rdkafka instrumentation. This has now been resolved. Thank you to @krisdigital for bringing this issue to our attention. [PR#2880](https://github.com/newrelic/newrelic-ruby-agent/pull/2880)
+
+- **Bugfix: Stop calling deprecated all_specs method to check for the presence of newrelic-grape**
+
+  In 9.14.0, we released a fix for calls to the deprecated `Bundler.rubygems.all_specs`, but the fix fell short for the agent's Grape instrumentation and deprecation warnings could still be raised. The condition has been simplified and deprecation warnings should no longer be raised. Thank you, [@excelsior](https://github.com/excelsior) for bringing this to our attention. [Issue#](https://github.com/newrelic/newrelic-ruby-agent/issues/2885) [PR#2906](https://github.com/newrelic/newrelic-ruby-agent/pull/2906)
 
 
 ## v9.14.0

--- a/lib/new_relic/agent/instrumentation/grape.rb
+++ b/lib/new_relic/agent/instrumentation/grape.rb
@@ -19,9 +19,13 @@ DependencyDetection.defer do
 
   depends_on do
     begin
-      if defined?(Bundler) &&
-          ((Bundler.rubygems.respond_to?(:installed_specs) && Bundler.rubygems.installed_specs.map(&:name).include?('newrelic-grape')) ||
-            Bundler.rubygems.all_specs.map(&:name).include?('newrelic-grape'))
+      specs = if Bundler.rubygems.respond_to?(:installed_specs)
+        Bundler.rubygems.installed_specs
+      else
+        Bundler.rubygems.all_specs
+      end
+
+      if specs.map(&:name).include?('newrelic-grape')
         NewRelic::Agent.logger.info('Not installing New Relic supported Grape instrumentation because the third party newrelic-grape gem is present')
         false
       else

--- a/lib/new_relic/agent/instrumentation/grape.rb
+++ b/lib/new_relic/agent/instrumentation/grape.rb
@@ -19,13 +19,7 @@ DependencyDetection.defer do
 
   depends_on do
     begin
-      specs = if Bundler.rubygems.respond_to?(:installed_specs)
-        Bundler.rubygems.installed_specs
-      else
-        Bundler.rubygems.all_specs
-      end
-
-      if specs.map(&:name).include?('newrelic-grape')
+      if NewRelic::Helper.rubygems_specs.map(&:name).include?('newrelic-grape')
         NewRelic::Agent.logger.info('Not installing New Relic supported Grape instrumentation because the third party newrelic-grape gem is present')
         false
       else

--- a/lib/new_relic/control/frameworks/rails4.rb
+++ b/lib/new_relic/control/frameworks/rails4.rb
@@ -9,11 +9,7 @@ module NewRelic
     module Frameworks
       class Rails4 < NewRelic::Control::Frameworks::Rails3
         def rails_gem_list
-          if Bundler.rubygems.respond_to?(:installed_specs)
-            Bundler.rubygems.installed_specs.map { |gem| "#{gem.name} (#{gem.version})" }
-          else
-            Bundler.rubygems.all_specs.map { |gem| "#{gem.name} (#{gem.version})" }
-          end
+          NewRelic::Helper.rubygems_specs.map { |gem| "#{gem.name} (#{gem.version})" }
         end
 
         def append_plugin_list

--- a/lib/new_relic/environment_report.rb
+++ b/lib/new_relic/environment_report.rb
@@ -44,11 +44,7 @@ module NewRelic
     ####################################
     report_on('Gems') do
       begin
-        if Bundler.rubygems.respond_to?(:installed_specs)
-          Bundler.rubygems.installed_specs.map { |gem| "#{gem.name}(#{gem.version})" }
-        else
-          Bundler.rubygems.all_specs.map { |gem| "#{gem.name}(#{gem.version})" }
-        end
+        NewRelic::Helper.rubygems_specs.map { |gem| "#{gem.name}(#{gem.version})" }
       rescue
         # There are certain rubygem, bundler, rails combinations (e.g. gem
         # 1.6.2, rails 2.3, bundler 1.2.3) where the code above throws an error

--- a/lib/new_relic/helper.rb
+++ b/lib/new_relic/helper.rb
@@ -82,5 +82,20 @@ module NewRelic
         File.exist?(executable_path) && File.file?(executable_path) && File.executable?(executable_path)
       end
     end
+
+    # Bundler version 2.5.12 deprecated all_specs and added installed_specs.
+    # To support newer Bundler versions, try to use installed_specs first,
+    # then fall back to all_specs.
+    # All callers expect this to be an array, so return an array if Bundler isn't defined
+    # @api private
+    def rubygems_specs
+      return [] unless defined?(Bundler)
+
+      if Bundler.rubygems.respond_to?(:installed_specs)
+        Bundler.rubygems.installed_specs
+      else
+        Bundler.rubygems.all_specs
+      end
+    end
   end
 end

--- a/lib/new_relic/language_support.rb
+++ b/lib/new_relic/language_support.rb
@@ -90,11 +90,7 @@ module NewRelic
     def bundled_gem?(gem_name)
       return false unless defined?(Bundler)
 
-      if Bundler.rubygems.respond_to?(:installed_specs)
-        Bundler.rubygems.installed_specs.map(&:name).include?(gem_name)
-      else
-        Bundler.rubygems.all_specs.map(&:name).include?(gem_name)
-      end
+      NewRelic::Helper.rubygems_specs.map(&:name).include?(gem_name)
     rescue => e
       ::NewRelic::Agent.logger.info("Could not determine if third party #{gem_name} gem is installed", e)
       false

--- a/test/new_relic/helper_test.rb
+++ b/test/new_relic/helper_test.rb
@@ -78,7 +78,9 @@ class HelperTest < Minitest::Test
     end
   end
 
-  ## rubygems_specs
+  #
+  # rubygems_specs
+  # 
   def test_rubygems_specs_returns_empty_array_without_bundler
     stub(:defined?, nil, ['Bundler']) do
       result = NewRelic::Helper.rubygems_specs
@@ -89,7 +91,7 @@ class HelperTest < Minitest::Test
   end
 
   def test_rubygems_specs_works_with_all_specs_when_installed_specs_is_absent
-    Bundler.rubygems.stub(:respond_to?, nil, [':installed_specs']) do
+    Bundler.rubygems.stub(:respond_to?, nil) do
       assert_equal Bundler.rubygems.all_specs, NewRelic::Helper.rubygems_specs
     end
   end

--- a/test/new_relic/helper_test.rb
+++ b/test/new_relic/helper_test.rb
@@ -77,4 +77,26 @@ class HelperTest < Minitest::Test
       NewRelic::Helper.run_command('executable that existed at detection time but is not there now')
     end
   end
+
+  ## rubygems_specs
+  def test_rubygems_specs_returns_empty_array_without_bundler
+    stub(:defined?, nil, ['Bundler']) do
+      result = NewRelic::Helper.rubygems_specs
+
+      assert_instance_of Array, result
+      assert_empty Array, result
+    end
+  end
+
+  def test_rubygems_specs_works_with_all_specs_when_installed_specs_is_absent
+    Bundler.rubygems.stub(:respond_to?, nil, [':installed_specs']) do
+      assert_equal Bundler.rubygems.all_specs, NewRelic::Helper.rubygems_specs
+    end
+  end
+
+  def test_rubygems_specs_works_with_installed_specs
+    skip 'running a version of Bundler that has not defined installed_specs' unless Bundler.rubygems.respond_to?(:installed_specs)
+
+    assert_equal Bundler.rubygems.installed_specs, NewRelic::Helper.rubygems_specs
+  end
 end

--- a/test/new_relic/helper_test.rb
+++ b/test/new_relic/helper_test.rb
@@ -80,7 +80,7 @@ class HelperTest < Minitest::Test
 
   #
   # rubygems_specs
-  # 
+  #
   def test_rubygems_specs_returns_empty_array_without_bundler
     stub(:defined?, nil, ['Bundler']) do
       result = NewRelic::Helper.rubygems_specs


### PR DESCRIPTION
This PR resolves a bug reported in #2885 to protect against scenarios where the version of Bundler used does not support `Bundler.rubygems.installed_specs` and needs to use `Bundler.rubygems.all_specs` to determine whether the third-party gem, `newrelic-grape` is installed in the environment.

Resolves #2885 
