### PR TITLE
Update View Component metric building

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # New Relic Ruby Agent Release Notes
 
+## dev
+
+Version <dev> updates View Componment instrumentation to use a default metric name when one is unavaliable.  
+
+- **Feature: Use default `View/component` metric name for unidentified View Components**
+  Previously, when a View Component metric name could not be identified, the agent would set the name as `nil`. Now, the agent defaults to using `View/component` as the metric name when one can not be identified. [PR#2907](https://github.com/newrelic/newrelic-ruby-agent/pull/2907)
+
+
 ## v9.14.0
 
 Version 9.14.0 adds Apache Kafka instrumentation for the rdkafka and ruby-kafka gems, introduces a configuration-based, automatic way to add custom instrumentation method tracers, correctly captures MIME type for ActionDispatch 7.0+ requests, properly handles Boolean coercion for `newrelic.yml` configuration, fixes a JRuby bug in the configuration manager, fixes a bug related to `Bundler.rubygems.installed_specs`, and fixes a bug to make the agent compatible with ViewComponent v3.15.0+.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 Version <dev> updates View Componment instrumentation to use a default metric name when one is unavaliable.  
 
 - **Feature: Use default `View/component` metric name for unidentified View Components**
+
   Previously, when a View Component metric name could not be identified, the agent would set the name as `nil`. Now, the agent defaults to using `View/component` as the metric name when one can not be identified. [PR#2907](https://github.com/newrelic/newrelic-ruby-agent/pull/2907)
 
 

--- a/lib/new_relic/agent/instrumentation/view_component/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/view_component/instrumentation.rb
@@ -10,12 +10,7 @@ module NewRelic::Agent::Instrumentation
       NewRelic::Agent.record_instrumentation_invocation(INSTRUMENTATION_NAME)
 
       begin
-        segment = NewRelic::Agent::Tracer.start_segment(
-          name: metric_name(
-            self.class.respond_to?(:identifier) ? self.class.identifier : nil,
-            self.class.name
-          )
-        )
+        segment = NewRelic::Agent::Tracer.start_segment(name: metric_name)
         yield
       rescue => e
         NewRelic::Agent.notice_error(e)
@@ -25,8 +20,12 @@ module NewRelic::Agent::Instrumentation
       end
     end
 
-    def metric_name(identifier, component)
-      "View/#{metric_path(identifier)}/#{component}"
+    def metric_name
+      "View/#{metric_path(self.class.source_location)}/#{self.class.name}"
+    rescue => e
+      NewRelic::Agent.logger.error('Error identifying View Component metric name', e)
+
+      'View/component'
     end
 
     def metric_path(identifier)

--- a/test/multiverse/suites/view_component/view_component_instrumentation_test.rb
+++ b/test/multiverse/suites/view_component/view_component_instrumentation_test.rb
@@ -58,8 +58,6 @@ class ViewComponentInstrumentationTest < ActionDispatch::IntegrationTest
     end
   end
 
-  # Test metric name being built when the controller class doesn't respond to :identifier
-  # https://github.com/newrelic/newrelic-ruby-agent/pull/2870
   def test_the_metric_name_records_default_name_on_error
     in_transaction do |txn|
       FAKE_CLASS.render_in_with_tracing { 11 * 38 }

--- a/test/multiverse/suites/view_component/view_component_instrumentation_test.rb
+++ b/test/multiverse/suites/view_component/view_component_instrumentation_test.rb
@@ -60,12 +60,12 @@ class ViewComponentInstrumentationTest < ActionDispatch::IntegrationTest
 
   # Test metric name being built when the controller class doesn't respond to :identifier
   # https://github.com/newrelic/newrelic-ruby-agent/pull/2870
-  def test_the_metric_name_omits_the_identifier_when_absent
+  def test_the_metric_name_records_default_name_on_error
     in_transaction do |txn|
       FAKE_CLASS.render_in_with_tracing { 11 * 38 }
       actual_name = txn.segments.last.name
 
-      assert_equal 'View/component/DummyViewComponentInstrumentationClass', actual_name
+      assert_equal 'View/component', actual_name
     end
   end
 end


### PR DESCRIPTION
View Component removed private method `.identifier` in v3.16.0, which is how the library used to identify components for instrumentation, and is what our was based off of as well. View Component now uses `source_location`. This PR updates our instrumentation to do the same and adds error handling in the case that the methods we rely on to build metric names are changed. `source_location` is a confirmed compatible call with the earliest version of View Component available on RubyGems, v1.16.0.

closes #2874