### PR TITLE
Rdkafka runs in its own multiverse group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,7 +216,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        multiverse: [agent, ai, background, background_2, database, frameworks, httpclients, httpclients_2, rails, rest]
+        multiverse: [agent, ai, background, background_2, kafka, database, frameworks, httpclients, httpclients_2, rails, rest]
         ruby-version: [2.4.10, 3.3.5]
 
     steps:

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -229,7 +229,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        multiverse: [agent, ai, background, background_2, database, frameworks, httpclients, httpclients_2, rails, rest]
+        multiverse: [agent, ai, background, background_2, database, kafka, frameworks, httpclients, httpclients_2, rails, rest]
         ruby-version: [2.4.10, 2.5.9, 2.6.10, 2.7.8, 3.0.7, 3.1.6, 3.2.5, 3.3.5, 3.4.0-preview2]
     steps:
       - name: Configure git

--- a/test/multiverse/lib/multiverse/runner.rb
+++ b/test/multiverse/lib/multiverse/runner.rb
@@ -102,6 +102,7 @@ module Multiverse
       'ai' => %w[ruby_openai],
       'background' => %w[delayed_job sidekiq resque],
       'background_2' => %w[rake],
+      'kafka' => %w[rdkafka],
       'database' => %w[elasticsearch mongo redis sequel],
       'rails' => %w[active_record active_record_pg active_support_broadcast_logger active_support_logger rails rails_prepend activemerchant],
       'frameworks' => %w[grape padrino roda sinatra],

--- a/test/multiverse/lib/multiverse/suite.rb
+++ b/test/multiverse/lib/multiverse/suite.rb
@@ -553,7 +553,7 @@ module Multiverse
 
     def check_for_failure(env)
       if $? != 0
-        OutputCollector.write(suite, env, red("#{suite.inspect} for Envfile entry #{env} failed!"))
+        OutputCollector.write(suite, env, red("#{suite.inspect} for Envfile entry #{env} failed! (exit: #{$?})"))
         OutputCollector.failed(suite, env)
       end
       Multiverse::Runner.notice_exit_status($?)


### PR DESCRIPTION
So this will make rdkafka run in it's own group for now. I named the group just kafka because i'd like to later include both kafka gems in it, but for now, for debugging our weird problems, I want it to only be rdkafka.

I also added the exit code to another string. We do already output the exit code in a different spot, but I wasn't seeing that message actually show up when we see our problem for some reason, so I've added it to a message that I do actually see, so maybe we'll get a little more info out of that.

```
Before:
"rdkafka" for Envfile entry 0 failed! 
Now
"rdkafka" for Envfile entry 0 failed! (exit: pid 9066 exit 1)
```