### PR TITLE
Fix for Jruby test failure that needs config enabled

### DIFF
--- a/test/new_relic/agent/configuration/manager_test.rb
+++ b/test/new_relic/agent/configuration/manager_test.rb
@@ -492,20 +492,22 @@ module NewRelic::Agent::Configuration
     end
 
     def test_auto_determined_values_stay_cached
-      name = :knockbreck_manse
+      with_config(:'security.agent.enabled' => true) do
+        name = :knockbreck_manse
 
-      DependencyDetection.defer do
-        named(name)
-        executes { use_prepend? }
-      end
+        DependencyDetection.defer do
+          named(name)
+          executes { use_prepend? }
+        end
 
-      key = :"instrumentation.#{name}"
-      with_config(key => 'auto') do
-        DependencyDetection.detect!
+        key = :"instrumentation.#{name}"
+        with_config(key => 'auto') do
+          DependencyDetection.detect!
 
-        @manager.replace_or_add_config(ServerSource.new({}))
+          @manager.replace_or_add_config(ServerSource.new({}))
 
-        assert_equal :prepend, @manager.instance_variable_get(:@cache)[key]
+          assert_equal :prepend, @manager.instance_variable_get(:@cache)[key]
+        end
       end
     end
 


### PR DESCRIPTION
Add the config that will allow the agent to do the behavior being tested in JRuby, since we will not do the extra config work in jruby unless the security agent is being used. 