### PR TITLE
Use double splat for Ruby >= 3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Version <dev> updates View Componment instrumentation to use a default metric na
 
   In 9.14.0, we released a fix for calls to the deprecated `Bundler.rubygems.all_specs`, but the fix fell short for the agent's Grape instrumentation and deprecation warnings could still be raised. The condition has been simplified and deprecation warnings should no longer be raised. Thank you, [@excelsior](https://github.com/excelsior) for bringing this to our attention. [Issue#](https://github.com/newrelic/newrelic-ruby-agent/issues/2885) [PR#2906](https://github.com/newrelic/newrelic-ruby-agent/pull/2906)
 
+- **Bufix: Instrumentation errors when using the ruby-kafka gem**
+
+  Kafka::Consumer#each_message takes keyword arguments, while the prepended method is defined with a single splat positional argument. In Ruby >= 3.0, this signature mismatch raises an ArgumentError. [PR#2915](https://github.com/newrelic/newrelic-ruby-agent/pull/2915)
+
 ## v9.14.0
 
 Version 9.14.0 adds Apache Kafka instrumentation for the rdkafka and ruby-kafka gems, introduces a configuration-based, automatic way to add custom instrumentation method tracers, correctly captures MIME type for ActionDispatch 7.0+ requests, properly handles Boolean coercion for `newrelic.yml` configuration, fixes a JRuby bug in the configuration manager, fixes a bug related to `Bundler.rubygems.installed_specs`, and fixes a bug to make the agent compatible with ViewComponent v3.15.0+.

--- a/lib/new_relic/agent/instrumentation/ruby_kafka/prepend.rb
+++ b/lib/new_relic/agent/instrumentation/ruby_kafka/prepend.rb
@@ -20,10 +20,20 @@ module NewRelic::Agent::Instrumentation
     module Prepend
       include NewRelic::Agent::Instrumentation::RubyKafka
 
-      def each_message(*args)
-        super do |message|
-          each_message_with_new_relic(message) do
-            yield(message)
+      if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3')
+        def each_message(**args)
+          super do |message|
+            each_message_with_new_relic(message) do
+              yield(message)
+            end
+          end
+        end
+      else
+        def each_message(*args)
+          super do |message|
+            each_message_with_new_relic(message) do
+              yield(message)
+            end
           end
         end
       end


### PR DESCRIPTION
# Overview
`Kafka::Consumer#each_message` takes keyword arguments. In Ruby >= 3.0, prepending it with a method that takes only positional arguments causes an ArgumentError when calling `super`.

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
