### PR TITLE
DD: update the rendering of the 'named' line

### DIFF
--- a/lib/tasks/instrumentation_generator/templates/dependency_detection.tt
+++ b/lib/tasks/instrumentation_generator/templates/dependency_detection.tt
@@ -3,7 +3,7 @@
 # frozen_string_literal: true
 
 DependencyDetection.defer do
-  named :<%= @name.match?(/\-|\_/) ? "'#{@snake_name}'" : @name.downcase %>
+  named :<%= @snake_name %>
 
   depends_on do
     # The class that needs to be defined to prepend/chain onto. This can be used


### PR DESCRIPTION
the template's rendering of a `named` line was previously attempting to
wrap symbol values with single quotes when necessary.

but given that everything is routed through the `snake_name` method,
nothing will ever need the quotes if we simply use the output of that
method, held in `@snake_name`.