### PR TITLE
bugfix: always apply transformations on booleans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## dev
 
-Version <dev> updates View Componment instrumentation to use a default metric name when one is unavailable, adds a configuration option to associate the AWS account ID with the DynamoDB calls from the AWS SDK, resolves a bug in rdkafka instrumentation when using the karafka-rdkafka gem, resolves a bug in the ruby-kafka instrumentation, and fixes a bug with Grape instrumentation.
+Version <dev> updates View Componment instrumentation to use a default metric name when one is unavailable, adds a configuration option to associate the AWS account ID with the DynamoDB calls from the AWS SDK, resolves a bug in rdkafka instrumentation when using the karafka-rdkafka gem, resolves a bug in the ruby-kafka instrumentation, fixes a bug with Grape instrumentation, and addresses a bug preventing Ruby based AWS Lambda layer contexts from working properly.
   
   
 - **Feature: New configuration option cloud.aws.account_id**
@@ -19,12 +19,15 @@ Version <dev> updates View Componment instrumentation to use a default metric na
 
 - **Bugfix: Stop calling deprecated all_specs method to check for the presence of newrelic-grape**
 
-  In 9.14.0, we released a fix for calls to the deprecated `Bundler.rubygems.all_specs`, but the fix fell short for the agent's Grape instrumentation and deprecation warnings could still be raised. The condition has been simplified and deprecation warnings should no longer be raised. Thank you, [@excelsior](https://github.com/excelsior) for bringing this to our attention. [Issue#](https://github.com/newrelic/newrelic-ruby-agent/issues/2885) [PR#2906](https://github.com/newrelic/newrelic-ruby-agent/pull/2906)
+  In 9.14.0, we released a fix for calls to the deprecated `Bundler.rubygems.all_specs`, but the fix fell short for the agent's Grape instrumentation and deprecation warnings could still be raised. The condition has been simplified and deprecation warnings should no longer be raised. Thank you, [@excelsior](https://github.com/excelsior) for bringing this to our attention. [Issue#2885](https://github.com/newrelic/newrelic-ruby-agent/issues/2885) [PR#2906](https://github.com/newrelic/newrelic-ruby-agent/pull/2906)
 
 - **Bugfix: Instrumentation errors when using the ruby-kafka gem**
 
   Kafka::Consumer#each_message takes keyword arguments, while the prepended method is defined with a single splat positional argument. In Ruby >= 3.0, this signature mismatch raises an ArgumentError. Thank you [@patrickarnett](https://github.com/patrickarnett) for providing this bugfix. [PR#2915](https://github.com/newrelic/newrelic-ruby-agent/pull/2915)
 
+- **Bugfix: Restore AWS Lambda layer based operational functionality**
+
+  Version 9.14.0 of the agent introduced an optimization related to how the agent handles boolean based configuration parameters which inadvertently caused the agent to stop operating properly in an AWS Lambda layer context. [Issue#2919](https://github.com/newrelic/newrelic-ruby-agent/issues/2919)
 
 ## v9.14.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ Version <dev> updates View Componment instrumentation to use a default metric na
 
   Kafka::Consumer#each_message takes keyword arguments, while the prepended method is defined with a single splat positional argument. In Ruby >= 3.0, this signature mismatch raises an ArgumentError. Thank you [@patrickarnett](https://github.com/patrickarnett) for providing this bugfix. [PR#2915](https://github.com/newrelic/newrelic-ruby-agent/pull/2915)
 
-- **Bugfix: Restore AWS Lambda layer based operational functionality**
+- **Bugfix: Restore AWS Lambda layer operational functionality**
 
   Version 9.14.0 of the agent introduced an optimization related to how the agent handles boolean based configuration parameters which inadvertently caused the agent to stop operating properly in an AWS Lambda layer context. [Issue#2919](https://github.com/newrelic/newrelic-ruby-agent/issues/2919)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ Version <dev> updates View Componment instrumentation to use a default metric na
 
 - **Bugfix: Restore AWS Lambda layer operational functionality**
 
-  Version 9.14.0 of the agent introduced an optimization related to how the agent handles boolean based configuration parameters which inadvertently caused the agent to stop operating properly in an AWS Lambda layer context. [Issue#2919](https://github.com/newrelic/newrelic-ruby-agent/issues/2919)
+  Version 9.14.0 of the agent introduced an optimization related to how the agent handles boolean configuration parameters which inadvertently caused the agent to stop operating properly in an AWS Lambda layer context. [Issue#2919](https://github.com/newrelic/newrelic-ruby-agent/issues/2919)[PR#2920](https://github.com/newrelic/newrelic-ruby-agent/pull/2920)
 
 ## v9.14.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 ## dev
 
-Version <dev> updates View Componment instrumentation to use a default metric name when one is unavailable, adds a configuration option to associate the AWS account ID with the DynamoDB calls from the AWS SDK, resolves a bug in rdkafka instrumentation when using the karafka-rdkafka gem, resolves a bug in the ruby-kafka instrumentation, fixes a bug with Grape instrumentation, and addresses a bug preventing Ruby based AWS Lambda layer contexts from working properly.
-  
+Version <dev> updates View Componment instrumentation to use a default metric name when one is unavailable, adds a configuration option to associate the AWS account ID with the DynamoDB calls from the AWS SDK, resolves a bug in rdkafka instrumentation when using the karafka-rdkafka gem, resolves a bug in the ruby-kafka instrumentation, fixes a bug with Grape instrumentation, and addresses a bug preventing the agent from running in serverless mode in an AWS Lambda layer.
   
 - **Feature: New configuration option cloud.aws.account_id**
 

--- a/lib/new_relic/agent/configuration/manager.rb
+++ b/lib/new_relic/agent/configuration/manager.rb
@@ -143,7 +143,7 @@ module NewRelic
           return default if default
 
           boolean = enforce_boolean(key, value)
-          return boolean if [true, false].include?(boolean)
+          evaluated = boolean if [true, false].include?(boolean)
 
           apply_transformations(key, evaluated)
         end

--- a/test/new_relic/agent/configuration/manager_test.rb
+++ b/test/new_relic/agent/configuration/manager_test.rb
@@ -552,6 +552,23 @@ module NewRelic::Agent::Configuration
       @manager.new_cache
     end
 
+    # https://github.com/newrelic/newrelic-ruby-agent/issues/2919
+    def test_that_boolean_based_params_always_go_through_any_defined_transform_sequence
+      key = :soundwave
+      defaults = {key => {default: false,
+                          public: true,
+                          type: Boolean,
+                          allowed_from_server: false,
+                          transform: proc { |bool| bool.to_s.reverse },
+                          description: 'Param what transforms'}}
+      NewRelic::Agent::Configuration.stub_const(:DEFAULTS, defaults) do
+        mgr = NewRelic::Agent::Configuration::Manager.new
+        value = mgr[key]
+
+        assert_equal 'eslaf', value, 'Expected `false` boolean value to be transformed!'
+      end
+    end
+
     private
 
     def assert_parsed_labels(expected)

--- a/test/new_relic/agent/serverless_handler_test.rb
+++ b/test/new_relic/agent/serverless_handler_test.rb
@@ -467,6 +467,18 @@ module NewRelic::Agent
         logger_mock.verify
       end
 
+      # https://github.com/newrelic/newrelic-ruby-agent/issues/2919
+      def test_env_var_will_properly_enable_serverless_mode
+        NewRelic::Agent.config.remove_config(@test_config)
+
+        ENV.stub(:key?, NewRelic::Agent::ServerlessHandler::LAMBDA_ENVIRONMENT_VARIABLE, true) do
+          NewRelic::Agent.config.send(:reset_cache)
+
+          assert NewRelic::Agent.config[:'serverless_mode.enabled'],
+            'Expected the presence of an env var to enable serverless mode!'
+        end
+      end
+
       private
 
       def handler


### PR DESCRIPTION
v9.14.0 introduced improved handling of boolean based configuration parameters and inadvertently broke AWS Lambda layer based functionality due to a bypassing of config transformations for booleans.

Boolean based values will now again be routed through their transformations if defined.

resolves #2919