### PR TITLE
add .vscode/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ lib/new_relic/build.rb
 .tm_properties
 .bundle
 .yardoc
+.vscode/
 artifacts/
 test/performance/log/
 test/performance/script/log/


### PR DESCRIPTION
My spellcheck stores saved words in a .vscode/ directory, and apparently thats not something we've had happen in our repo before, so I added it to the gitignore.