### PR TITLE
Add security scan

### DIFF
--- a/.github/versions.yml
+++ b/.github/versions.yml
@@ -36,3 +36,9 @@ adriangl/check-new-commits-action:
 softprops/action-gh-release:
   :tag: v2.0.8
   :sha: c062e08bd532815e2082a85e87e3ef29c3e6d191
+aquasecurity/trivy-action:
+  :tag: v0.28.0
+  :sha: 915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2
+github/codeql-action/upload-sarif:
+  :tag: v3.27.0
+  :sha: 662472033e021d55d94146f66f6058822b0b39fd

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,59 @@
+name: Security scan
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  schedule:
+    - cron: '0 9 * * *' # Same time as CI Cron
+
+jobs:
+  build:
+    name: Build and scan image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # tag v4.1.7
+      - name: Run Trivy in table mode
+        # Table output is only useful when running on a pull request or push.
+        if: contains(fromJSON('["push", "pull_request"]'), github.event_name)
+        uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2 # tag v.0.28.0
+        with:
+          format: table
+          exit-code: 1
+          ignore-unfixed: true
+          severity: 'CRITICAL,HIGH,MEDIUM,LOW'
+
+      - name: Run Trivy in report mode
+        # Only generate sarif when running nightly on the main branch.
+        if: ${{ github.event_name == 'schedule' }}
+        uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2 # tag v.0.28.0
+        with:
+          format: 'template'
+          template: '@/contrib/sarif.tpl'
+          output: 'trivy-results.sarif'
+          ignore-unfixed: true
+          severity: 'CRITICAL,HIGH,MEDIUM,LOW'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        # Only upload sarif when running nightly on the main branch.
+        if: ${{ github.event_name == 'schedule' }}
+        uses: github/codeql-action/upload-sarif@662472033e021d55d94146f66f6058822b0b39fd # tag v3.27.0
+        with:
+          sarif_file: 'trivy-results.sarif'
+
+  notify_slack_fail:
+    name: Notify slack fail
+    needs: [build]
+    runs-on: ubuntu-22.04
+    if: ${{ github.event_name == 'schedule' && failure() }}
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # tag v4.1.7
+      - uses: ./.github/actions/workflow-conclusion
+      - uses: voxmedia/github-action-slack-notify-build@3665186a8c1a022b28a1dbe0954e73aa9081ea9e # tag v1.6.0
+        if: ${{ env.WORKFLOW_CONCLUSION == 'failure' }}
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.RUBY_GITHUB_ACTIONS_BOT_WEBHOOK }}
+        with:
+          channel: ruby-agent-notifications
+          status: FAILED
+          color: danger

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - main
-  pull_request:
+      - dev
   schedule:
     - cron: '0 9 * * *' # Same time as CI Cron
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    name: Build and scan
+    name: Trivy Scan
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # tag v4.1.7

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -17,8 +17,11 @@ jobs:
         uses: ruby/setup-ruby@f26937343756480a8cb3ae1f623b9c8d89ed6984 # tag v1.196.0
         with:
           ruby-version: 3.3
-      - run: bundle
+
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # tag v4.1.7
+
+      - run: bundle # Generate a Gemfile.lock to scan
+
       - name: Run Trivy in table mode
         # Table output is only useful when running on a pull request or push.
         if: contains(fromJSON('["push", "pull_request"]'), github.event_name)
@@ -31,19 +34,18 @@ jobs:
           severity: CRITICAL,HIGH,MEDIUM,LOW
 
       - name: Run Trivy in report mode
-        # Only generate sarif when running nightly on the main branch.
+        # Only generate sarif when running nightly on the dev branch.
         if: ${{ github.event_name == 'schedule' }}
         uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2 # tag v.0.28.0
         with:
           scan-type: fs
-          format: template
-          template: '@/contrib/sarif.tpl'
+          format: sarif
           output: trivy-results.sarif
           ignore-unfixed: true
           severity: 'CRITICAL,HIGH,MEDIUM,LOW'
 
       - name: Upload Trivy scan results to GitHub Security tab
-        # Only upload sarif when running nightly on the main branch.
+        # Only upload sarif when running nightly on the dev branch.
         if: ${{ github.event_name == 'schedule' }}
         uses: github/codeql-action/upload-sarif@662472033e021d55d94146f66f6058822b0b39fd # tag v3.27.0
         with:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - main
       - dev
+  pull_request:
   schedule:
     - cron: '0 9 * * *' # Same time as CI Cron
 
@@ -12,6 +13,11 @@ jobs:
     name: Trivy Scan
     runs-on: ubuntu-latest
     steps:
+      - name: Install Ruby 3.3
+        uses: ruby/setup-ruby@f26937343756480a8cb3ae1f623b9c8d89ed6984 # tag v1.196.0
+        with:
+          ruby-version: 3.3
+      - run: bundle
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # tag v4.1.7
       - name: Run Trivy in table mode
         # Table output is only useful when running on a pull request or push.

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    name: Build and scan image
+    name: Build and scan
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # tag v4.1.7
@@ -18,19 +18,21 @@ jobs:
         if: contains(fromJSON('["push", "pull_request"]'), github.event_name)
         uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2 # tag v.0.28.0
         with:
+          scan-type: fs
           format: table
           exit-code: 1
           ignore-unfixed: true
-          severity: 'CRITICAL,HIGH,MEDIUM,LOW'
+          severity: CRITICAL,HIGH,MEDIUM,LOW
 
       - name: Run Trivy in report mode
         # Only generate sarif when running nightly on the main branch.
         if: ${{ github.event_name == 'schedule' }}
         uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2 # tag v.0.28.0
         with:
-          format: 'template'
+          scan-type: fs
+          format: template
           template: '@/contrib/sarif.tpl'
-          output: 'trivy-results.sarif'
+          output: trivy-results.sarif
           ignore-unfixed: true
           severity: 'CRITICAL,HIGH,MEDIUM,LOW'
 
@@ -39,7 +41,7 @@ jobs:
         if: ${{ github.event_name == 'schedule' }}
         uses: github/codeql-action/upload-sarif@662472033e021d55d94146f66f6058822b0b39fd # tag v3.27.0
         with:
-          sarif_file: 'trivy-results.sarif'
+          sarif_file: trivy-results.sarif
 
   notify_slack_fail:
     name: Notify slack fail


### PR DESCRIPTION
Resolves #2843 

Example scan: https://github.com/newrelic/newrelic-ruby-agent/actions/runs/11580092166 

Slack notifications only on scheduled runs that fail. Untested, but copied from our nightly cron.