### PR TITLE
Add configuration options to apply labels to log events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,15 @@
 
 ## dev
 
-Version <dev> introduces instrumentation for the aws-sdk-lambda gem.
+Version <dev> introduces instrumentation for the aws-sdk-lambda gem and allows users to opt-in to adding labels to logs.
 
 - **Feature: Instrumentation for aws-sdk-lambda**
 
-  If the aws-sdk-lambda gem is present and used to invoke remote AWS Lambda functions, timing and error details for the invocations will be reported to New Relic. [PR#2926](https://github.com/newrelic/newrelic-ruby-agent/pull/2926)
+  If the aws-sdk-lambda gem is present and used to invoke remote AWS Lambda functions, timing and error details for the invocations will be reported to New Relic. [PR#2926](https://github.com/newrelic/newrelic-ruby-agent/pull/2926).
+
+- **Feature: Add new configuration options to attach custom tags (labels) to logs**
+
+  The Ruby agent now allows you to opt-in to adding your custom tags (labels) to agent-forwarded logs. With custom tags on logs, platform engineers can easily filter, search, and correlate log data for faster and more efficient troubleshooting, improved performance, and optimized resource utilization. To learn more about this feature see the documentation: </docs/logs/logs-context/Custom-tags-agent-forwarder-logs>. [PR#2925](https://github.com/newrelic/newrelic-ruby-agent/pull/2925)
 
 ## v9.15.0
 

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -873,6 +873,21 @@ module NewRelic
           :allowed_from_server => false,
           :description => 'A hash with key/value pairs to add as custom attributes to all log events forwarded to New Relic. If sending using an environment variable, the value must be formatted like: "key1=value1,key2=value2"'
         },
+        :'application_logging.forwarding.labels.enabled' => {
+          :default => false,
+          :public => true,
+          :type => Boolean,
+          :allowed_from_server => false,
+          :description => 'If `true`, the agent attaches [labels](https://docs.newrelic.com/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration/#labels) to log records.'
+        },
+        :'application_logging.forwarding.labels.exclude' => {
+          :default => [],
+          :public => true,
+          :type => Array,
+          :transform => DefaultSource.method(:convert_to_list),
+          :allowed_from_server => false,
+          :description => 'A case-insensitive array or comma-delimited string containing the labels to exclude from log records.'
+        },
         :'application_logging.forwarding.max_samples_stored' => {
           :default => 10000,
           :public => true,

--- a/lib/new_relic/agent/log_event_aggregator.rb
+++ b/lib/new_relic/agent/log_event_aggregator.rb
@@ -25,6 +25,7 @@ module NewRelic
       METRICS_SUPPORTABILITY_FORMAT = 'Supportability/Logging/Metrics/Ruby/%s'.freeze
       FORWARDING_SUPPORTABILITY_FORMAT = 'Supportability/Logging/Forwarding/Ruby/%s'.freeze
       DECORATING_SUPPORTABILITY_FORMAT = 'Supportability/Logging/LocalDecorating/Ruby/%s'.freeze
+      LABELS_SUPPORTABILITY_FORMAT = 'Supportability/Logging/Labels/Ruby/%s'.freeze
       MAX_BYTES = 32768 # 32 * 1024 bytes (32 kibibytes)
 
       named :LogEventAggregator
@@ -38,6 +39,7 @@ module NewRelic
       METRICS_ENABLED_KEY = :'application_logging.metrics.enabled'
       FORWARDING_ENABLED_KEY = :'application_logging.forwarding.enabled'
       DECORATING_ENABLED_KEY = :'application_logging.local_decorating.enabled'
+      LABELS_ENABLED_KEY = :'application_logging.forwarding.labels.enabled'
       LOG_LEVEL_KEY = :'application_logging.forwarding.log_level'
       CUSTOM_ATTRIBUTES_KEY = :'application_logging.forwarding.custom_attributes'
 
@@ -253,6 +255,7 @@ module NewRelic
           record_configuration_metric(METRICS_SUPPORTABILITY_FORMAT, METRICS_ENABLED_KEY)
           record_configuration_metric(FORWARDING_SUPPORTABILITY_FORMAT, FORWARDING_ENABLED_KEY)
           record_configuration_metric(DECORATING_SUPPORTABILITY_FORMAT, DECORATING_ENABLED_KEY)
+          record_configuration_metric(LABELS_SUPPORTABILITY_FORMAT, LABELS_ENABLED_KEY)
 
           add_custom_attributes(NewRelic::Agent.config[CUSTOM_ATTRIBUTES_KEY])
         end

--- a/lib/new_relic/agent/log_event_aggregator.rb
+++ b/lib/new_relic/agent/log_event_aggregator.rb
@@ -230,6 +230,7 @@ module NewRelic
         @counter_lock.synchronize do
           @seen = 0
           @seen_by_severity.clear
+          remove_instance_variable(:@labels) if instance_variable_defined?(:@labels)
         end
 
         super
@@ -338,7 +339,7 @@ module NewRelic
       end
 
       def create_labels
-        return NewRelic::EMPTY_HASH unless NewRelic::Agent.config[:'application_logging.forwarding.labels.enabled']
+        return NewRelic::EMPTY_HASH unless NewRelic::Agent.config[LABELS_ENABLED_KEY]
 
         downcased_exclusions = NewRelic::Agent.config[:'application_logging.forwarding.labels.exclude'].map(&:downcase)
         log_labels = {}

--- a/lib/new_relic/agent/log_event_aggregator.rb
+++ b/lib/new_relic/agent/log_event_aggregator.rb
@@ -342,6 +342,7 @@ module NewRelic
 
         NewRelic::Agent.config.parsed_labels.each do |parsed_label|
           next if downcased_exclusions.include?(parsed_label['label_type'].downcase)
+
           # labels are referred to as tags in the UI, so prefix the
           # label-related attributes with 'tags.*'
           log_labels["tags.#{parsed_label['label_type']}"] = parsed_label['label_value']

--- a/lib/new_relic/agent/log_event_aggregator.rb
+++ b/lib/new_relic/agent/log_event_aggregator.rb
@@ -230,7 +230,6 @@ module NewRelic
         @counter_lock.synchronize do
           @seen = 0
           @seen_by_severity.clear
-          remove_instance_variable(:@labels) if instance_variable_defined?(:@labels)
         end
 
         super

--- a/test/new_relic/agent/log_event_aggregator_test.rb
+++ b/test/new_relic/agent/log_event_aggregator_test.rb
@@ -737,7 +737,7 @@ module NewRelic::Agent
       aggregator.remove_instance_variable(:@labels) if aggregator.instance_variable_defined?(:@labels)
 
       with_config(config) do
-        LinkingMetadata.stub('append_service_linking_metadata', { 'entity.guid' => 'GUID', 'entity.name' => 'Hola'}) do
+        LinkingMetadata.stub('append_service_linking_metadata', {'entity.guid' => 'GUID', 'entity.name' => 'Hola'}) do
           log_data = [
             {
               events_seen: 0,

--- a/test/new_relic/agent/log_event_aggregator_test.rb
+++ b/test/new_relic/agent/log_event_aggregator_test.rb
@@ -52,7 +52,8 @@ module NewRelic::Agent
         LogEventAggregator::OVERALL_ENABLED_KEY => true,
         LogEventAggregator::METRICS_ENABLED_KEY => true,
         LogEventAggregator::FORWARDING_ENABLED_KEY => true,
-        LogEventAggregator::DECORATING_ENABLED_KEY => true
+        LogEventAggregator::DECORATING_ENABLED_KEY => true,
+        LogEventAggregator::LABELS_ENABLED_KEY => true
       ) do
         NewRelic::Agent.config.notify_server_source_added
 
@@ -61,7 +62,8 @@ module NewRelic::Agent
           'Supportability/Logging/Ruby/LogStasher/enabled' => {:call_count => 1},
           'Supportability/Logging/Metrics/Ruby/enabled' => {:call_count => 1},
           'Supportability/Logging/Forwarding/Ruby/enabled' => {:call_count => 1},
-          'Supportability/Logging/LocalDecorating/Ruby/enabled' => {:call_count => 1}
+          'Supportability/Logging/LocalDecorating/Ruby/enabled' => {:call_count => 1},
+          'Supportability/Logging/Labels/Ruby/enabled' => {:call_count => 1}
         },
           :ignore_filter => %r{^Supportability/API/})
       end
@@ -72,7 +74,8 @@ module NewRelic::Agent
         LogEventAggregator::OVERALL_ENABLED_KEY => false,
         LogEventAggregator::METRICS_ENABLED_KEY => false,
         LogEventAggregator::FORWARDING_ENABLED_KEY => false,
-        LogEventAggregator::DECORATING_ENABLED_KEY => false
+        LogEventAggregator::DECORATING_ENABLED_KEY => false,
+        LogEventAggregator::LABELS_ENABLED_KEY => false
       ) do
         NewRelic::Agent.config.notify_server_source_added
 
@@ -81,7 +84,8 @@ module NewRelic::Agent
           'Supportability/Logging/Ruby/LogStasher/disabled' => {:call_count => 1},
           'Supportability/Logging/Metrics/Ruby/disabled' => {:call_count => 1},
           'Supportability/Logging/Forwarding/Ruby/disabled' => {:call_count => 1},
-          'Supportability/Logging/LocalDecorating/Ruby/disabled' => {:call_count => 1}
+          'Supportability/Logging/LocalDecorating/Ruby/disabled' => {:call_count => 1},
+          'Supportability/Logging/Labels/Ruby/disabled' => {:call_count => 1}
         },
           :ignore_filter => %r{^Supportability/API/})
       end
@@ -343,7 +347,8 @@ module NewRelic::Agent
           'Supportability/Logging/Ruby/LogStasher/enabled' => {:call_count => 1},
           'Supportability/Logging/Metrics/Ruby/enabled' => {:call_count => 1},
           'Supportability/Logging/Forwarding/Ruby/enabled' => {:call_count => 1},
-          'Supportability/Logging/LocalDecorating/Ruby/disabled' => {:call_count => 1}
+          'Supportability/Logging/LocalDecorating/Ruby/disabled' => {:call_count => 1},
+          'Supportability/Logging/Labels/Ruby/disabled' => {:call_count => 1}
         },
           :ignore_filter => %r{^Supportability/API/})
       end
@@ -366,7 +371,8 @@ module NewRelic::Agent
           'Supportability/Logging/Ruby/LogStasher/disabled' => {:call_count => 1},
           'Supportability/Logging/Metrics/Ruby/disabled' => {:call_count => 1},
           'Supportability/Logging/Forwarding/Ruby/disabled' => {:call_count => 1},
-          'Supportability/Logging/LocalDecorating/Ruby/disabled' => {:call_count => 1}
+          'Supportability/Logging/LocalDecorating/Ruby/disabled' => {:call_count => 1},
+          'Supportability/Logging/Labels/Ruby/disabled' => {:call_count => 1}
         },
           :ignore_filter => %r{^Supportability/API/})
       end
@@ -392,7 +398,8 @@ module NewRelic::Agent
           'Supportability/Logging/Ruby/LogStasher/disabled' => {:call_count => 1},
           'Supportability/Logging/Metrics/Ruby/disabled' => {:call_count => 1},
           'Supportability/Logging/Forwarding/Ruby/disabled' => {:call_count => 1},
-          'Supportability/Logging/LocalDecorating/Ruby/disabled' => {:call_count => 1}
+          'Supportability/Logging/LocalDecorating/Ruby/disabled' => {:call_count => 1},
+          'Supportability/Logging/Labels/Ruby/disabled' => {:call_count => 1}
         },
           :ignore_filter => %r{^Supportability/API/})
       end

--- a/test/new_relic/agent/log_event_aggregator_test.rb
+++ b/test/new_relic/agent/log_event_aggregator_test.rb
@@ -348,9 +348,9 @@ module NewRelic::Agent
 
         assert_metrics_recorded_exclusive({
           'Logging/lines' => {:call_count => 3},
-          'Logging/lines/DEBUG' => {:call_count => 3}, # ?
+          'Logging/lines/DEBUG' => {:call_count => 3},
           'Logging/Forwarding/Dropped' => {:call_count => 0},
-          'Supportability/Logging/Forwarding/Seen' => {:call_count => 3}, # ?
+          'Supportability/Logging/Forwarding/Seen' => {:call_count => 3},
           'Supportability/Logging/Forwarding/Sent' => {:call_count => 3}
         },
           :ignore_filter => %r{^Supportability/API/})

--- a/test/new_relic/agent/log_event_aggregator_test.rb
+++ b/test/new_relic/agent/log_event_aggregator_test.rb
@@ -731,6 +731,11 @@ module NewRelic::Agent
     end
 
     def assert_labels(config, expected_attributes = {})
+      # we should only have one log event aggregator per agent instance
+      # simulate that by resetting @labels between tests
+      aggregator = NewRelic::Agent.agent.log_event_aggregator
+      aggregator.remove_instance_variable(:@labels) if aggregator.instance_variable_defined?(:@labels)
+
       with_config(config) do
         LinkingMetadata.stub('append_service_linking_metadata', { 'entity.guid' => 'GUID', 'entity.name' => 'Hola'}) do
           log_data = [


### PR DESCRIPTION
Add your New Relic labels/tags to your log events

Now, logs forwarded by the Ruby agent can have your New Relic labels (referred to as tags in the UI), as set using the `:labels` config option in `newrelic.yml` or the `NEW_RELIC_LABELS` environment variable, applied as attributes to your log events. This can help you cross-reference information you're used to seeing on your entities and transactions on your log events as well.

All labels attached to log events as attributes will be prefixed with `tags.`

This feature is off by default. To enable it, you will need to update your configuration:
newrelic.yml:
`application_logging.forwarding.labels.enabled: true` 

environment variable:
`NEW_RELIC_APPLICATION_LOGGING_FORWARDING_LABELS_ENABLED=true`

In addition, we have a configuration option that allows you to specify labels you do not want to attach to your log events. `application_logging.forwarding.labels.exclude` is a case-insensitive list of label names you'd like excluded from the log events.

For example, the following configuration:
```yaml
# newrelic.yml

labels: 'Server:One;Data Center:Primary;environment:staging;cell:grapes'
application_logging.forwarding.enabled: true
application_logging.forwarding.labels.enabled: true
application_logging.forwarding.labels.exclude:
  - server
```

would add these attributes to your log event: 
```
tags.Data Center = 'Primary'
tags.environment = 'staging'
tags.cell = 'grapes'
```

Resolves #2857 