### PR TITLE
instrumentation for aws-sdk-lambda

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # New Relic Ruby Agent Release Notes
 
+## dev
+
+Version <dev> introduces instrumentation for the aws-sdk-lambda gem.
+
+- **Feature: Instrumentation for aws-sdk-lambda**
+
+  If the aws-sdk-lambda gem is present and used to invoke remote AWS Lambda functions, timing and error details for the invocations will be reported to New Relic. [PR#2926](https://github.com/newrelic/newrelic-ruby-agent/pull/2926)
+
 ## v9.15.0
 
 Version 9.15.0 updates View Componment instrumentation to use a default metric name when one is unavailable, adds a configuration option to associate the AWS account ID with the DynamoDB calls from the AWS SDK, resolves a bug in rdkafka instrumentation when using the karafka-rdkafka gem, resolves a bug in the ruby-kafka instrumentation, fixes a bug with Grape instrumentation, and addresses a bug preventing the agent from running in serverless mode in an AWS Lambda layer.

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -1529,6 +1529,15 @@ module NewRelic
           :allowed_from_server => false,
           :description => 'Controls auto-instrumentation of bunny at start-up. May be one of: `auto`, `prepend`, `chain`, `disabled`.'
         },
+        :'instrumentation.aws_sdk_lambda' => {
+          :default => 'auto',
+          :documentation_default => 'auto',
+          :public => true,
+          :type => String,
+          :dynamic_name => true,
+          :allowed_from_server => false,
+          :description => 'Controls auto-instrumentation of the aws_sdk_lambda library at start-up. May be one of `auto`, `prepend`, `chain`, `disabled`.'
+        },
         :'instrumentation.ruby_kafka' => {
           :default => 'auto',
           :public => true,

--- a/lib/new_relic/agent/instrumentation/aws_sdk_lambda.rb
+++ b/lib/new_relic/agent/instrumentation/aws_sdk_lambda.rb
@@ -1,0 +1,28 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+DependencyDetection.defer do
+  named :aws_sdk_lambda
+
+  depends_on do
+    defined?(Aws::Lambda::Client)
+  end
+
+  executes do
+    require_relative 'aws_sdk_lambda/instrumentation'
+
+    # prepend_instrument and chain_instrument call extract_supportability_name
+    # to get the library name for supportability metrics and info-level logging.
+    # This is done by spliting on the 2nd to last spot of the instrumented
+    # module. If this isn't how we want the name to appear, pass in the desired
+    # name as a third argument.
+    if use_prepend?
+      require_relative 'aws_sdk_lambda/prepend'
+      prepend_instrument Aws::Lambda::Client, NewRelic::Agent::Instrumentation::AwsSdkLambda::Prepend
+    else
+      require_relative 'aws_sdk_lambda/chain'
+      chain_instrument NewRelic::Agent::Instrumentation::AwsSdkLambda::Chain
+    end
+  end
+end

--- a/lib/new_relic/agent/instrumentation/aws_sdk_lambda.rb
+++ b/lib/new_relic/agent/instrumentation/aws_sdk_lambda.rb
@@ -12,11 +12,6 @@ DependencyDetection.defer do
   executes do
     require_relative 'aws_sdk_lambda/instrumentation'
 
-    # prepend_instrument and chain_instrument call extract_supportability_name
-    # to get the library name for supportability metrics and info-level logging.
-    # This is done by spliting on the 2nd to last spot of the instrumented
-    # module. If this isn't how we want the name to appear, pass in the desired
-    # name as a third argument.
     if use_prepend?
       require_relative 'aws_sdk_lambda/prepend'
       prepend_instrument Aws::Lambda::Client, NewRelic::Agent::Instrumentation::AwsSdkLambda::Prepend

--- a/lib/new_relic/agent/instrumentation/aws_sdk_lambda/chain.rb
+++ b/lib/new_relic/agent/instrumentation/aws_sdk_lambda/chain.rb
@@ -1,0 +1,31 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+module NewRelic::Agent::Instrumentation
+  module AwsSdkLambda::Chain
+    def self.instrument!
+      ::Aws::Lambda::Client.class_eval do
+        include NewRelic::Agent::Instrumentation::AwsSdkLambda
+
+        alias_method(:invoke_without_new_relic, :invoke)
+
+        def invoke(*args)
+          invoke_with_new_relic(*args) { invoke_without_new_relic(*args) }
+        end
+
+        alias_method(:invoke_async_without_new_relic, :invoke_async)
+
+        def invoke_async(*args)
+          invoke_async_with_new_relic(*args) { invoke_async_without_new_relic(*args) }
+        end
+
+        alias_method(:invoke_with_response_stream_without_new_relic, :invoke_with_response_stream)
+
+        def invoke_with_response_stream(*args)
+          invoke_with_response_stream_with_new_relic(*args) { invoke_with_response_stream_without_new_relic(*args) }
+        end
+      end
+    end
+  end
+end

--- a/lib/new_relic/agent/instrumentation/aws_sdk_lambda/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/aws_sdk_lambda/instrumentation.rb
@@ -1,0 +1,117 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+module NewRelic::Agent::Instrumentation
+  module AwsSdkLambda
+    INSTRUMENTATION_NAME = 'aws_sdk_lambda'
+    AWS_SERVICE = 'lambda'
+    CLOUD_PLATFORM = 'aws_lambda'
+    ERROR_STATUS_REGEX = /^(?:4|5)/
+    WRAPPED_RESPONSE = Struct.new(:status_code, :has_status_code?)
+
+    def invoke_with_new_relic(*args)
+      with_tracing(:invoke, *args) { yield }
+    end
+
+    def invoke_async_with_new_relic(*args)
+      with_tracing(:invoke_async, *args) { yield }
+    end
+
+    def invoke_with_response_stream_with_new_relic(*args)
+      with_tracing(:invoke_with_response_stream, *args) { yield }
+    end
+
+    private
+
+    def with_tracing(action, *args)
+      segment = generate_segment(action, *args)
+
+      # prevent additional instrumentation for things like Net::HTTP from
+      # creating any segments that may appear as redundant / confusing
+      NewRelic::Agent.disable_all_tracing do
+        begin
+          response = yield
+          process_response(response, segment)
+          response
+        rescue => e
+          # notice error that was unhandled by the AWS SDK Lambda client
+          NewRelic::Agent.notice_error(e)
+          raise
+        end
+      end
+    ensure
+      segment&.finish
+    end
+
+    def process_response(response, segment)
+      process_status_code(response, segment) if response.respond_to?(:status_code)
+      process_function_error(response.function_error, segment) if response.respond_to?(:function_error)
+    end
+
+    def process_status_code(response, segment)
+      status_code = response.status_code
+      return unless status_code
+
+      segment.process_response_headers(WRAPPED_RESPONSE.new(status_code, true))
+
+      # notice error that was handled by the function
+      if status_code.to_s.match?(ERROR_STATUS_REGEX)
+        payload = response.respond_to?(:payload) ? response.payload : '(empty response payload)'
+        wrap_and_notice_error("Lambda function error handled with status #{status_code}: #{payload}")
+      end
+    end
+
+    # notice error that was raised by the function
+    def process_function_error(function_error, segment)
+      return unless function_error
+
+      wrap_and_notice_error(function_error)
+    end
+
+    def wrap_and_notice_error(msg)
+      NewRelic::Agent.notice_error(StandardError.new(msg))
+    end
+
+    def generate_segment(action, options = {})
+      function = function_name(options)
+      region = aws_region
+      account_id = aws_account_id
+      arn = aws_arn(function, account_id, region)
+
+      segment = NewRelic::Agent::Tracer.start_external_request_segment(
+        library: INSTRUMENTATION_NAME,
+        uri: "https://lambda.#{aws_region || 'unknown-region'}.amazonaws.com",
+        procedure: action
+      )
+      segment.name = "External/Lambda/#{action}/#{function}"
+      segment.add_agent_attribute('cloud.account.id', account_id)
+      segment.add_agent_attribute('cloud.platform', CLOUD_PLATFORM)
+      segment.add_agent_attribute('cloud.region', region)
+      segment.add_agent_attribute('cloud.resource_id', arn) if arn
+
+      segment
+    end
+
+    def function_name(options = {})
+      (options.fetch(:function_name, nil) if options.respond_to?(:fetch)) || NewRelic::UNKNOWN
+    end
+
+    def aws_account_id
+      return unless self.respond_to?(:config)
+
+      configured_id = config&.account_id
+      return configured_id if configured_id
+
+      NewRelic::Agent::Aws.get_account_id(self.config)
+    end
+
+    def aws_region
+      config&.region if self.respond_to?(:config)
+    end
+
+    def aws_arn(function, account_id, region)
+      NewRelic::Agent::Aws.create_arn(AWS_SERVICE, "function:#{function}", region, account_id)
+    end
+  end
+end

--- a/lib/new_relic/agent/instrumentation/aws_sdk_lambda/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/aws_sdk_lambda/instrumentation.rb
@@ -31,13 +31,13 @@ module NewRelic::Agent::Instrumentation
       # prevent additional instrumentation for things like Net::HTTP from
       # creating any segments that may appear as redundant / confusing
       NewRelic::Agent.disable_all_tracing do
+        response = NewRelic::Agent::Tracer.capture_segment_error(segment) { yield }
         begin
-          response = yield
           process_response(response, segment)
-          response
         rescue => e
-          NewRelic::Agent.notice_error(e)
-          raise
+          NewRelic::Agent.logger.error("Error processing aws-sdk-lambda invocation response (action = #{action}): #{e}")
+        ensure
+          response
         end
       end
     ensure

--- a/lib/new_relic/agent/instrumentation/aws_sdk_lambda/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/aws_sdk_lambda/instrumentation.rb
@@ -79,7 +79,7 @@ module NewRelic::Agent::Instrumentation
 
       segment = NewRelic::Agent::Tracer.start_external_request_segment(
         library: INSTRUMENTATION_NAME,
-        uri: "https://lambda.#{aws_region || 'unknown-region'}.amazonaws.com",
+        uri: "https://lambda.#{region || 'unknown-region'}.amazonaws.com",
         procedure: action
       )
       segment.name = "External/Lambda/#{action}/#{function}"

--- a/lib/new_relic/agent/instrumentation/aws_sdk_lambda/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/aws_sdk_lambda/instrumentation.rb
@@ -75,7 +75,7 @@ module NewRelic::Agent::Instrumentation
       function = function_name(options)
       region = aws_region
       account_id = aws_account_id
-      arn = aws_arn(function, account_id, region)
+      arn = aws_arn(function, region)
 
       segment = NewRelic::Agent::Tracer.start_external_request_segment(
         library: INSTRUMENTATION_NAME,
@@ -98,18 +98,15 @@ module NewRelic::Agent::Instrumentation
     def aws_account_id
       return unless self.respond_to?(:config)
 
-      configured_id = config&.account_id
-      return configured_id if configured_id
-
-      NewRelic::Agent::Aws.get_account_id(self.config)
+      config&.account_id || NewRelic::Agent.config[:'cloud.aws.account_id']
     end
 
     def aws_region
       config&.region if self.respond_to?(:config)
     end
 
-    def aws_arn(function, account_id, region)
-      NewRelic::Agent::Aws.create_arn(AWS_SERVICE, "function:#{function}", region, account_id)
+    def aws_arn(function, region)
+      NewRelic::Agent::Aws.create_arn(AWS_SERVICE, "function:#{function}", region)
     end
   end
 end

--- a/lib/new_relic/agent/instrumentation/aws_sdk_lambda/prepend.rb
+++ b/lib/new_relic/agent/instrumentation/aws_sdk_lambda/prepend.rb
@@ -1,0 +1,21 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+module NewRelic::Agent::Instrumentation
+  module AwsSdkLambda::Prepend
+    include NewRelic::Agent::Instrumentation::AwsSdkLambda
+
+    def invoke(*args)
+      invoke_with_new_relic(*args) { super }
+    end
+
+    def invoke_async(*args)
+      invoke_async_with_new_relic(*args) { super }
+    end
+
+    def invoke_with_response_stream(*args)
+      invoke_with_response_stream_with_new_relic(*args) { super }
+    end
+  end
+end

--- a/test/multiverse/suites/aws_sdk_lambda/Envfile
+++ b/test/multiverse/suites/aws_sdk_lambda/Envfile
@@ -1,0 +1,9 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+instrumentation_methods :chain, :prepend
+
+gemfile <<~RB
+  gem 'aws-sdk-lambda'
+RB

--- a/test/multiverse/suites/aws_sdk_lambda/Envfile
+++ b/test/multiverse/suites/aws_sdk_lambda/Envfile
@@ -2,6 +2,8 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
+suite_condition('Requires Ruby v2.5+') { RUBY_VERSION.split('.')[0..1].join('.').to_f >= 2.5 }
+
 instrumentation_methods :chain, :prepend
 
 gemfile <<~RB

--- a/test/multiverse/suites/aws_sdk_lambda/aws_sdk_lambda_instrumentation_test.rb
+++ b/test/multiverse/suites/aws_sdk_lambda/aws_sdk_lambda_instrumentation_test.rb
@@ -1,0 +1,115 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+require_relative 'aws_sdk_monkeypatch'
+
+class AwsSdkLambdaInstrumentationTest < Minitest::Test
+  REGION = 'us-east-2'
+  AWS_ACCOUNT_ID = '8675309'
+
+  def setup
+    Aws.config.update(stub_responses: true)
+    @client = Aws::Lambda::Client.new(region: REGION)
+    @client.config.account_id = AWS_ACCOUNT_ID
+  end
+
+  def test_invoke
+    perform_invocation(:invoke)
+  end
+
+  def test_invoke_async
+    perform_invocation(:invoke_async, invoke_args: StringIO.new('null'))
+  end
+
+  def test_invoke_with_response_stream
+    perform_invocation(:invoke_with_response_stream, event_stream_handler: proc { |_stream| 'hi' })
+  end
+
+  # TODO
+  def test_client_call_raises_an_exception
+  end
+
+  # TODO
+  def test_client_response_indicates_an_unhandled_function_error
+  end
+
+  # TODO
+  def test_client_response_indicates_a_handled_function_error
+  end
+
+  private
+
+  def perform_invocation(method, extra_args = {})
+    function_name = 'Half-Life'
+
+    in_transaction do |txn|
+      @client.send(method, {function_name: function_name}.merge(extra_args))
+
+      segment = lambda_segment(txn)
+
+      assert_equal("External/Lambda/#{method}/#{function_name}", segment.name)
+      assert_equal("lambda.#{REGION}.amazonaws.com", segment.host)
+
+      # TODO: `yield` returns `nil` under AWS SDK response stubbing, so the
+      #        response status code, function error, and body won't work
+      # assert_equal(200, segment.http_status_code) unless method == :invoke_async
+
+      assert_equal('aws_sdk_lambda', segment.library)
+      assert_equal({'cloud.platform' => 'aws_lambda',
+                    'cloud.region' => REGION,
+                    'cloud.account.id' => AWS_ACCOUNT_ID,
+                    'cloud.resource_id' => "arn:aws:lambda:#{REGION}:#{AWS_ACCOUNT_ID}:function:#{function_name}"},
+        agent_attributes(segment))
+    end
+  end
+
+  def agent_attributes(segment)
+    segment.attributes.instance_variable_get(:@agent_attributes)
+  end
+
+  def lambda_segment(txn)
+    segments = txn.segments.select { |s| s.name != 'dummy' }
+
+    assert_equal 1, segments.size, "Expected to find exactly 1 Lambda client segment, found #{segments.size}"
+
+    segments.first
+  end
+end
+
+
+
+__END__
+
+
+require 'json'
+
+# 1.
+client = Aws::Lambda::Client.new(region: 'us-east-2')
+response = client.invoke(function_name: 'Half-Life')
+JSON.parse(response.payload.string)
+
+# 2.
+response = client.invoke_async({function_name: 'Half-Life', invoke_args: "{}"})
+response.status # => 202
+
+# 3.
+response = client.invoke_with_response_stream({function_name: 'Half-Life'}) { |str| }
+
+
+resp = client.invoke({
+  function_name: "NamespacedFunctionName", # required
+  invocation_type: "Event", # accepts Event, RequestResponse, DryRun
+  log_type: "None", # accepts None, Tail
+  client_context: "String",
+  payload: "data",
+  qualifier: "Qualifier",
+})
+
+# Response structure
+
+resp.status_code #=> Integer
+resp.function_error #=> String
+resp.log_result #=> String
+resp.payload #=> String
+resp.executed_version #=> String

--- a/test/multiverse/suites/aws_sdk_lambda/aws_sdk_monkeypatch.rb
+++ b/test/multiverse/suites/aws_sdk_lambda/aws_sdk_monkeypatch.rb
@@ -1,0 +1,14 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+module NRMonkeyPatch
+  def encode_eventstream_response(rules, data, builder)
+    # the original method calls `#inject` on the `data` argument, which will
+    # fail if `data` is `nil`, so `||` in an empty hash when `nil`
+
+    super(rules, data || {}, builder)
+  end
+end
+
+Aws::Stubbing::Protocols::RestJson.prepend(NRMonkeyPatch)

--- a/test/multiverse/suites/aws_sdk_lambda/config/newrelic.yml
+++ b/test/multiverse/suites/aws_sdk_lambda/config/newrelic.yml
@@ -1,0 +1,19 @@
+---
+development:
+  error_collector:
+    enabled: true
+  apdex_t: 0.5
+  monitor_mode: true
+  license_key: bootstrap_newrelic_admin_license_key_000
+  instrumentation:
+    aws_sdk_lambda: <%= $instrumentation_method %>
+  app_name: test
+  log_level: debug
+  host: 127.0.0.1
+  api_host: 127.0.0.1
+  transaction_trace:
+    record_sql: obfuscated
+    enabled: true
+    stack_trace_threshold: 0.5
+    transaction_threshold: 1.0
+  capture_params: false


### PR DESCRIPTION
Instrument the aws-sdk-lambda gem and upon function invocations performed by the client, create external request segments that include AWS resource information.