### PR TITLE
IAST scan skip, scan schedule, scan controllers & iast_test_identifier config

### DIFF
--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2855,6 +2855,7 @@ module NewRelic
           :default => 0,
           :public => true,
           :type => Integer,
+          :external => true,
           :allowed_from_server => true,
           :description => 'The duration field specifies the duration of the IAST scan in minutes. This determines how long the scan will run'
         },

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2833,7 +2833,7 @@ module NewRelic
           :public => true,
           :type => Boolean,
           :allowed_from_server => false,
-          :description => 'If `true`, disables SSRF(Server side reuqest forgery) detection'
+          :description => 'If `true`, disables Sever-Side Request Forgery (SSRF) detection in IAST scans.'
         },
         :'security.exclude_from_iast_scan.iast_detection_category.rxss' => {
           :default => false,

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2659,7 +2659,7 @@ module NewRelic
           :public => true,
           :type => Array,
           :allowed_from_server => true,
-          :transform => DefaultSource.method(:convert_to_regexp_list),
+          :transform => DefaultSource.method(:convert_to_list),
           :description => 'Defines api paths you want the security agent to ignore in IAST scan, by specifying a list of patterns matching the URI you want to ignore.'
         },
         :'security.exclude_from_iast_scan.http_request_parameters.header' => {

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2754,7 +2754,7 @@ module NewRelic
           :public => true,
           :type => Boolean,
           :allowed_from_server => false,
-          :description => 'If `true`, disables detection of low-severity insecure settings (e.g., hash, crypto, cookie, random generators, trust boundary).'
+          :description => 'If `true`, disables the detection of low-severity insecure settings (e.g., hash, crypto, cookie, random generators, trust boundary).'
         },
         :'security.exclude_from_iast_scan.iast_detection_category.invalid_file_access' => {
           :default => false,

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2825,7 +2825,7 @@ module NewRelic
           :public => true,
           :type => Boolean,
           :allowed_from_server => false,
-          :description => 'If `true`, disables XPATH injection detection'
+          :description => 'If `true`, disables XPATH injection detection in IAST scans.'
         },
         :'security.exclude_from_iast_scan.iast_detection_category.ssrf' => {
           :default => false,

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2746,7 +2746,7 @@ module NewRelic
           :external => true,
           :allowed_from_server => true,
           :transform => DefaultSource.method(:convert_to_list),
-          :description => 'Defines key values in http request body you want the security agent to ignore in IAST scan, by specifying a list of keys in the http request body you want to ignore.'
+          :description => 'An array of HTTP request body keys the security agent should ignore in IAST scans.'
         },
         :'security.exclude_from_iast_scan.iast_detection_category.insecure_settings' => {
           :default => false,

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2737,7 +2737,7 @@ module NewRelic
           :external => true,
           :allowed_from_server => true,
           :transform => DefaultSource.method(:convert_to_list),
-          :description => 'Defines http request query parameters you want the security agent to ignore in IAST scan, by specifying a list of patterns matching the http request query parameters you want to ignore.'
+          :description => 'An array of HTTP request query parameters the security agent should ignore in IAST scans. The array should specify a list of patterns matching the HTTP request query parameters to ignore.'
         },
         :'security.exclude_from_iast_scan.http_request_parameters.body' => {
           :default => [],

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2857,7 +2857,7 @@ module NewRelic
           :type => Integer,
           :external => true,
           :allowed_from_server => true,
-          :description => 'The duration field specifies the duration of the IAST scan in minutes. This determines how long the scan will run'
+          :description => 'Specifies the length of time (in minutes) that the IAST scan will run.'
         },
         :'security.scan_schedule.schedule' => {
           :default => '',

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2719,7 +2719,7 @@ module NewRelic
           :external => true,
           :allowed_from_server => true,
           :transform => DefaultSource.method(:convert_to_list),
-          :description => 'Defines API paths the security agent should ignore in IAST scans. Accepts an array of regex patterns matching the URI to ignore. The regex pattern should provide a complete match for the URL without the endpoint. For example, `[".*account.*], [".*/\api\/v1\/.*?\/login"]'`
+          :description => 'Defines API paths the security agent should ignore in IAST scans. Accepts an array of regex patterns matching the URI to ignore. The regex pattern should provide a complete match for the URL without the endpoint. For example, `[".*account.*"], [".*/\api\/v1\/.*?\/login"]`'
         },
         :'security.exclude_from_iast_scan.http_request_parameters.header' => {
           :default => [],

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2743,7 +2743,7 @@ module NewRelic
           :external => true,
           :allowed_from_server => true,
           :transform => DefaultSource.method(:convert_to_list),
-          :description => 'Defines api paths you want the security agent to ignore in IAST scan, by specifying a list of patterns matching the URI you want to ignore.'
+          :description => 'Defines api paths you want the security agent to ignore in IAST scan, by specifying a list of regex patterns matching the URI you want to ignore. The regex pattern should provide a complete match for the URL without the endpoint. e.g., [".*account.*], [".*/\api\/v1\/.*?\/login"]'
         },
         :'security.exclude_from_iast_scan.http_request_parameters.header' => {
           :default => [],

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2794,7 +2794,7 @@ module NewRelic
           :public => true,
           :type => Boolean,
           :allowed_from_server => false,
-          :description => 'If `true`, disables javascript injection detection in IAST scans.'
+          :description => 'If `true`, disables Javascript injection detection in IAST scans.'
         },
         :'security.exclude_from_iast_scan.iast_detection_category.command_injection' => {
           :default => false,

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2841,7 +2841,7 @@ module NewRelic
           :public => true,
           :type => Boolean,
           :allowed_from_server => false,
-          :description => 'If `true`, disables RXSS (reflected cross-site scripting) detection'
+          :description => 'If `true`, disables Reflected Cross-Site Scripting (RXSS) detection in IAST scans.'
         },
         :'security.scan_schedule.delay' => {
           :default => 0,

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2703,30 +2703,6 @@ module NewRelic
           :description => 'Defines the endpoint URL for posting security-related data',
           :dynamic_name => true
         },
-        :'security.detection.rci.enabled' => {
-          :default => true,
-          :external => true,
-          :public => true,
-          :type => Boolean,
-          :allowed_from_server => false,
-          :description => 'If `true`, enables RCI (remote code injection) detection'
-        },
-        :'security.detection.rxss.enabled' => {
-          :default => true,
-          :external => true,
-          :public => true,
-          :type => Boolean,
-          :allowed_from_server => false,
-          :description => 'If `true`, enables RXSS (reflected cross-site scripting) detection'
-        },
-        :'security.detection.deserialization.enabled' => {
-          :default => true,
-          :external => true,
-          :public => true,
-          :type => Boolean,
-          :allowed_from_server => false,
-          :description => 'If `true`, enables deserialization detection'
-        },
         :'security.application_info.port' => {
           :default => nil,
           :allow_nil => true,

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2645,6 +2645,118 @@ module NewRelic
           :external => true,
           :allowed_from_server => false,
           :description => 'Defines the request body limit to process in security events (in KB). The default value is 300, for 300KB.'
+        },
+        :'security.skip_iast_scan.api' => {
+          :default => [],
+          :public => true,
+          :type => Array,
+          :allowed_from_server => true,
+          :transform => DefaultSource.method(:convert_to_regexp_list),
+          :description => 'Defines api paths you want the security agent to ignore in IAST scan, by specifying a list of patterns matching the URI you want to ignore.'
+        },
+        :'security.skip_iast_scan.parameters.header' => {
+          :default => [],
+          :public => true,
+          :type => Array,
+          :allowed_from_server => true,
+          :transform => DefaultSource.method(:convert_to_list),
+          :description => 'Define http request headers you want the security agent to ignore in IAST scan, by specifying a list of patterns matching the header you want to ignore.'
+        },
+        :'security.skip_iast_scan.parameters.query' => {
+          :default => [],
+          :public => true,
+          :type => Array,
+          :allowed_from_server => true,
+          :transform => DefaultSource.method(:convert_to_list),
+          :description => 'Defines http request query parameters you want the security agent to ignore in IAST scan, by specifying a list of patterns matching the http request query parameters you want to ignore.'
+        },
+        :'security.skip_iast_scan.parameters.body' => {
+          :default => [],
+          :public => true,
+          :type => Array,
+          :allowed_from_server => true,
+          :transform => DefaultSource.method(:convert_to_regexp_list),
+          :description => 'Defines key values in http request body you want the security agent to ignore in IAST scan, by specifying a list of keys in the http request body you want to ignore.'
+        },
+        :'security.skip_iast_scan.iast_detection_category.insecure_settings' => {
+          :default => false,
+          :external => true,
+          :public => true,
+          :type => Boolean,
+          :allowed_from_server => false,
+          :description => 'If `true`, disables Low severity insecure settings(Hash, crypto, cookie, Ranndom) detection'
+        },
+        :'security.skip_iast_scan.iast_detection_category.invalid_file_access' => {
+          :default => false,
+          :external => true,
+          :public => true,
+          :type => Boolean,
+          :allowed_from_server => false,
+          :description => 'If `true`, disables file access related IAST detections'
+        },
+        :'security.skip_iast_scan.iast_detection_category.sql_injection' => {
+          :default => false,
+          :external => true,
+          :public => true,
+          :type => Boolean,
+          :allowed_from_server => false,
+          :description => 'If `true`, disables SQL injection detection'
+        },
+        :'security.skip_iast_scan.iast_detection_category.nosql_injection' => {
+          :default => false,
+          :external => true,
+          :public => true,
+          :type => Boolean,
+          :allowed_from_server => false,
+          :description => 'If `true`, disables NOSQL injection detection'
+        },
+        :'security.skip_iast_scan.iast_detection_category.ldap_injection' => {
+          :default => false,
+          :external => true,
+          :public => true,
+          :type => Boolean,
+          :allowed_from_server => false,
+          :description => 'If `true`, disables LDAP injection detection'
+        },
+        :'security.skip_iast_scan.iast_detection_category.javascript_injection' => {
+          :default => false,
+          :external => true,
+          :public => true,
+          :type => Boolean,
+          :allowed_from_server => false,
+          :description => 'If `true`, disables javascript injection detection'
+        },
+        :'security.skip_iast_scan.iast_detection_category.command_injection' => {
+          :default => false,
+          :external => true,
+          :public => true,
+          :type => Boolean,
+          :allowed_from_server => false,
+          :description => 'If `true`, disables system command injection detection'
+        },
+        :'security.skip_iast_scan.iast_detection_category.xpath_injection' => {
+          :default => false,
+          :external => true,
+          :public => true,
+          :type => Boolean,
+          :allowed_from_server => false,
+          :description => 'If `true`, disables XPATH injection detection'
+        },
+        :'security.skip_iast_scan.iast_detection_category.ssrf' => {
+          :default => false,
+          :external => true,
+          :public => true,
+          :type => Boolean,
+          :allowed_from_server => false,
+          :description => 'If `true`, disables SSRF(Server side reuqest forgery) detection'
+        },
+        :'security.skip_iast_scan.iast_detection_category.rxss' => {
+          :default => false,
+          :external => true,
+          :public => true,
+          :type => Boolean,
+          :allowed_from_server => false,
+          :description => 'If `true`, disables RXSS (reflected cross-site scripting) detection'
         }
       }.freeze
       # rubocop:enable Metrics/CollectionLiteralLength

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2847,6 +2847,7 @@ module NewRelic
           :default => 0,
           :public => true,
           :type => Integer,
+          :external => true,
           :allowed_from_server => true,
           :description => 'The delay field indicated time in minutes before the IAST scan starts after the application starts'
         },

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2762,7 +2762,7 @@ module NewRelic
           :public => true,
           :type => Boolean,
           :allowed_from_server => false,
-          :description => 'If `true`, disables file operation related IAST detections(File Access & Application integrity violation)'
+          :description => 'If `true`, disables file operation-related IAST detections (File Access & Application integrity violation)'
         },
         :'security.exclude_from_iast_scan.iast_detection_category.sql_injection' => {
           :default => false,

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2778,7 +2778,7 @@ module NewRelic
           :public => true,
           :type => Boolean,
           :allowed_from_server => false,
-          :description => 'If `true`, disables Low severity insecure settings(Hash, crypto, cookie, Ranndom) detection'
+          :description => 'If `true`, disables detection of low-severity insecure settings (e.g., hash, crypto, cookie, random generators, trust boundary).'
         },
         :'security.exclude_from_iast_scan.iast_detection_category.invalid_file_access' => {
           :default => false,

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2646,7 +2646,7 @@ module NewRelic
           :allowed_from_server => false,
           :description => 'Defines the request body limit to process in security events (in KB). The default value is 300, for 300KB.'
         },
-        :'security.skip_iast_scan.api' => {
+        :'security.exclude_from_iast_scan.api' => {
           :default => [],
           :public => true,
           :type => Array,
@@ -2654,7 +2654,7 @@ module NewRelic
           :transform => DefaultSource.method(:convert_to_regexp_list),
           :description => 'Defines api paths you want the security agent to ignore in IAST scan, by specifying a list of patterns matching the URI you want to ignore.'
         },
-        :'security.skip_iast_scan.parameters.header' => {
+        :'security.exclude_from_iast_scan.http_request_parameters.header' => {
           :default => [],
           :public => true,
           :type => Array,
@@ -2662,7 +2662,7 @@ module NewRelic
           :transform => DefaultSource.method(:convert_to_list),
           :description => 'Define http request headers you want the security agent to ignore in IAST scan, by specifying a list of patterns matching the header you want to ignore.'
         },
-        :'security.skip_iast_scan.parameters.query' => {
+        :'security.exclude_from_iast_scan.http_request_parameters.query' => {
           :default => [],
           :public => true,
           :type => Array,
@@ -2670,7 +2670,7 @@ module NewRelic
           :transform => DefaultSource.method(:convert_to_list),
           :description => 'Defines http request query parameters you want the security agent to ignore in IAST scan, by specifying a list of patterns matching the http request query parameters you want to ignore.'
         },
-        :'security.skip_iast_scan.parameters.body' => {
+        :'security.exclude_from_iast_scan.http_request_parameters.body' => {
           :default => [],
           :public => true,
           :type => Array,
@@ -2678,7 +2678,7 @@ module NewRelic
           :transform => DefaultSource.method(:convert_to_regexp_list),
           :description => 'Defines key values in http request body you want the security agent to ignore in IAST scan, by specifying a list of keys in the http request body you want to ignore.'
         },
-        :'security.skip_iast_scan.iast_detection_category.insecure_settings' => {
+        :'security.exclude_from_iast_scan.iast_detection_category.insecure_settings' => {
           :default => false,
           :external => true,
           :public => true,
@@ -2686,7 +2686,7 @@ module NewRelic
           :allowed_from_server => false,
           :description => 'If `true`, disables Low severity insecure settings(Hash, crypto, cookie, Ranndom) detection'
         },
-        :'security.skip_iast_scan.iast_detection_category.invalid_file_access' => {
+        :'security.exclude_from_iast_scan.iast_detection_category.invalid_file_access' => {
           :default => false,
           :external => true,
           :public => true,
@@ -2694,7 +2694,7 @@ module NewRelic
           :allowed_from_server => false,
           :description => 'If `true`, disables file access related IAST detections'
         },
-        :'security.skip_iast_scan.iast_detection_category.sql_injection' => {
+        :'security.exclude_from_iast_scan.iast_detection_category.sql_injection' => {
           :default => false,
           :external => true,
           :public => true,
@@ -2702,7 +2702,7 @@ module NewRelic
           :allowed_from_server => false,
           :description => 'If `true`, disables SQL injection detection'
         },
-        :'security.skip_iast_scan.iast_detection_category.nosql_injection' => {
+        :'security.exclude_from_iast_scan.iast_detection_category.nosql_injection' => {
           :default => false,
           :external => true,
           :public => true,
@@ -2710,7 +2710,7 @@ module NewRelic
           :allowed_from_server => false,
           :description => 'If `true`, disables NOSQL injection detection'
         },
-        :'security.skip_iast_scan.iast_detection_category.ldap_injection' => {
+        :'security.exclude_from_iast_scan.iast_detection_category.ldap_injection' => {
           :default => false,
           :external => true,
           :public => true,
@@ -2718,7 +2718,7 @@ module NewRelic
           :allowed_from_server => false,
           :description => 'If `true`, disables LDAP injection detection'
         },
-        :'security.skip_iast_scan.iast_detection_category.javascript_injection' => {
+        :'security.exclude_from_iast_scan.iast_detection_category.javascript_injection' => {
           :default => false,
           :external => true,
           :public => true,
@@ -2726,7 +2726,7 @@ module NewRelic
           :allowed_from_server => false,
           :description => 'If `true`, disables javascript injection detection'
         },
-        :'security.skip_iast_scan.iast_detection_category.command_injection' => {
+        :'security.exclude_from_iast_scan.iast_detection_category.command_injection' => {
           :default => false,
           :external => true,
           :public => true,
@@ -2734,7 +2734,7 @@ module NewRelic
           :allowed_from_server => false,
           :description => 'If `true`, disables system command injection detection'
         },
-        :'security.skip_iast_scan.iast_detection_category.xpath_injection' => {
+        :'security.exclude_from_iast_scan.iast_detection_category.xpath_injection' => {
           :default => false,
           :external => true,
           :public => true,
@@ -2742,7 +2742,7 @@ module NewRelic
           :allowed_from_server => false,
           :description => 'If `true`, disables XPATH injection detection'
         },
-        :'security.skip_iast_scan.iast_detection_category.ssrf' => {
+        :'security.exclude_from_iast_scan.iast_detection_category.ssrf' => {
           :default => false,
           :external => true,
           :public => true,
@@ -2750,7 +2750,7 @@ module NewRelic
           :allowed_from_server => false,
           :description => 'If `true`, disables SSRF(Server side reuqest forgery) detection'
         },
-        :'security.skip_iast_scan.iast_detection_category.rxss' => {
+        :'security.exclude_from_iast_scan.iast_detection_category.rxss' => {
           :default => false,
           :external => true,
           :public => true,

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2883,6 +2883,13 @@ module NewRelic
           :allowed_from_server => true,
           :description => 'Scan instance count controls the number of application instances for a specific entity where IAST analysis is performed'
         },
+        :'security.scan_controllers.report_http_response_body' => {
+          :default => true,
+          :public => true,
+          :type => Boolean,
+          :allowed_from_server => true,
+          :description => 'report_http_response_body allows user to enable/disable sending of HTTP responses body, Disabling this would also disable RXSS vulnerability detection'
+        },
         :'security.iast_test_identifier' => {
           :default => nil,
           :public => true,

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2728,7 +2728,7 @@ module NewRelic
           :external => true,
           :allowed_from_server => true,
           :transform => DefaultSource.method(:convert_to_list),
-          :description => 'Define http request headers you want the security agent to ignore in IAST scan, by specifying a list of patterns matching the header you want to ignore.'
+          :description => 'An array of HTTP request headers the security agent should ignore in IAST scans. The array should specify a list of patterns matching the headers to ignore.'
         },
         :'security.exclude_from_iast_scan.http_request_parameters.query' => {
           :default => [],

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2765,6 +2765,14 @@ module NewRelic
           :type => Boolean,
           :allowed_from_server => false,
           :description => 'If `true`, disables RXSS (reflected cross-site scripting) detection'
+        },
+        :'security.scan_controllers.iast_scan_request_rate_limit' => {
+          :default => 3600,
+          :public => true,
+          :type => Integer,
+          :dynamic_name => true,
+          :allowed_from_server => true,
+          :description => 'Number of http request limit for ISAT scan per minute. Default is 3600. Minimum is 12 and maximum is 3600'
         }
       }.freeze
       # rubocop:enable Metrics/CollectionLiteralLength

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2888,6 +2888,7 @@ module NewRelic
           :default => 0,
           :public => true,
           :type => Integer,
+          :external => true,
           :allowed_from_server => true,
           :description => 'Scan instance count controls the number of application instances for a specific entity where IAST analysis is performed'
         },

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2749,6 +2749,7 @@ module NewRelic
           :default => [],
           :public => true,
           :type => Array,
+          :external => true,
           :allowed_from_server => true,
           :transform => DefaultSource.method(:convert_to_list),
           :description => 'Defines http request query parameters you want the security agent to ignore in IAST scan, by specifying a list of patterns matching the http request query parameters you want to ignore.'

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2817,7 +2817,7 @@ module NewRelic
           :public => true,
           :type => Boolean,
           :allowed_from_server => false,
-          :description => 'If `true`, disables system command injection detection'
+          :description => 'If `true`, disables system command injection detection in IAST scans.'
         },
         :'security.exclude_from_iast_scan.iast_detection_category.xpath_injection' => {
           :default => false,

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2904,6 +2904,7 @@ module NewRelic
           :default => nil,
           :public => true,
           :type => String,
+          :external => true,
           :allowed_from_server => true,
           :description => 'This will allow users to run IAST for CI/CD'
         }

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2874,7 +2874,7 @@ module NewRelic
           :public => true,
           :type => Boolean,
           :allowed_from_server => false,
-          :description => 'always_sample_traces permits IAST to actively gather trace data in the background, and the collected data will be used by Security Agent to perform an IAST Scan at the scheduled time'
+          :description => 'If `true`, allows IAST to continuously gather trace data in the background. Collected data will be used by Security Agent to perform an IAST Scan at the scheduled time.'
         },
         :'security.scan_controllers.iast_scan_request_rate_limit' => {
           :default => 3600,

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2863,6 +2863,7 @@ module NewRelic
           :default => '',
           :public => true,
           :type => String,
+          :external => true,
           :allowed_from_server => true,
           :description => 'The schedule field specifies a cron expression that defines when the IAST scan should run',
           :dynamic_name => true

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2793,7 +2793,7 @@ module NewRelic
           :public => true,
           :type => Boolean,
           :allowed_from_server => false,
-          :description => 'If `true`, disables NOSQL injection detection'
+          :description => 'If `true`, disables NOSQL injection detection in IAST scans.'
         },
         :'security.exclude_from_iast_scan.iast_detection_category.ldap_injection' => {
           :default => false,

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2865,7 +2865,7 @@ module NewRelic
           :type => String,
           :external => true,
           :allowed_from_server => true,
-          :description => 'The schedule field specifies a cron expression that defines when the IAST scan should run',
+          :description => 'Specifies a cron expression that sets when the IAST scan should run.',
           :dynamic_name => true
         },
         :'security.scan_schedule.always_sample_traces' => {

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2710,7 +2710,7 @@ module NewRelic
           :type => Integer,
           :external => true,
           :allowed_from_server => false,
-          :description => 'The port the application is listening on. This setting is mandatory for Passenger servers. Other servers should be detected by default.'
+          :description => 'The port the application is listening on. This setting is mandatory for Passenger servers. Other servers are detected by default.'
         },
         :'security.exclude_from_iast_scan.api' => {
           :default => [],

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2786,7 +2786,7 @@ module NewRelic
           :public => true,
           :type => Boolean,
           :allowed_from_server => false,
-          :description => 'If `true`, disables file access related IAST detections'
+          :description => 'If `true`, disables file operation related IAST detections(File Access & Application integrity violation)'
         },
         :'security.exclude_from_iast_scan.iast_detection_category.sql_injection' => {
           :default => false,

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2785,7 +2785,7 @@ module NewRelic
           :public => true,
           :type => Boolean,
           :allowed_from_server => false,
-          :description => 'If `true`, disables SQL injection detection'
+          :description => 'If `true`, disables SQL injection detection in IAST scans.'
         },
         :'security.exclude_from_iast_scan.iast_detection_category.nosql_injection' => {
           :default => false,

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2911,6 +2911,7 @@ module NewRelic
         },
         :'security.iast_test_identifier' => {
           :default => nil,
+          :allow_nil => true,
           :public => true,
           :type => String,
           :external => true,

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2731,6 +2731,7 @@ module NewRelic
           :default => [],
           :public => true,
           :type => Array,
+          :external => true,
           :allowed_from_server => true,
           :transform => DefaultSource.method(:convert_to_list),
           :description => 'Defines api paths you want the security agent to ignore in IAST scan, by specifying a list of patterns matching the URI you want to ignore.'

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2770,9 +2770,22 @@ module NewRelic
           :default => 3600,
           :public => true,
           :type => Integer,
-          :dynamic_name => true,
           :allowed_from_server => true,
           :description => 'Number of http request limit for ISAT scan per minute. Default is 3600. Minimum is 12 and maximum is 3600'
+        },
+        :'security.scan_controllers.scan_instance_count' => {
+          :default => 0,
+          :public => true,
+          :type => Integer,
+          :allowed_from_server => true,
+          :description => 'Scan instance count controls the number of application instances for a specific entity where IAST analysis is performed'
+        },
+        :'security.iast_test_identifier' => {
+          :default => nil,
+          :public => true,
+          :type => String,
+          :allowed_from_server => true,
+          :description => 'This will allow users to run IAST for CI/CD'
         }
       }.freeze
       # rubocop:enable Metrics/CollectionLiteralLength

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2880,6 +2880,7 @@ module NewRelic
           :default => 3600,
           :public => true,
           :type => Integer,
+          :external => true,
           :allowed_from_server => true,
           :description => 'Number of http request limit for ISAT scan per minute. Default is 3600. Minimum is 12 and maximum is 3600'
         },

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2882,7 +2882,7 @@ module NewRelic
           :type => Integer,
           :external => true,
           :allowed_from_server => true,
-          :description => 'Number of http request limit for ISAT scan per minute. Default is 3600. Minimum is 12 and maximum is 3600'
+          :description => 'Sets the maximum number of HTTP requests allowed for the IAST scan per minute. Any Integer between 12 and 3600 is valid. The default value is 3600.'
         },
         :'security.scan_controllers.scan_instance_count' => {
           :default => 0,

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2727,15 +2727,6 @@ module NewRelic
           :allowed_from_server => false,
           :description => 'The port the application is listening on. This setting is mandatory for Passenger servers. Other servers should be detected by default.'
         },
-        :'security.request.body_limit' => {
-          :default => 300,
-          :allow_nil => true,
-          :public => true,
-          :type => Integer,
-          :external => true,
-          :allowed_from_server => false,
-          :description => 'Defines the request body limit to process in security events (in KB). The default value is 300, for 300KB.'
-        },
         :'security.exclude_from_iast_scan.api' => {
           :default => [],
           :public => true,

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2809,7 +2809,7 @@ module NewRelic
           :public => true,
           :type => Boolean,
           :allowed_from_server => false,
-          :description => 'If `true`, disables javascript injection detection'
+          :description => 'If `true`, disables javascript injection detection in IAST scans.'
         },
         :'security.exclude_from_iast_scan.iast_detection_category.command_injection' => {
           :default => false,

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2766,6 +2766,36 @@ module NewRelic
           :allowed_from_server => false,
           :description => 'If `true`, disables RXSS (reflected cross-site scripting) detection'
         },
+        :'security.scan_schedule.delay' => {
+          :default => 0,
+          :public => true,
+          :type => Integer,
+          :allowed_from_server => true,
+          :description => 'The delay field indicated time in minutes before the IAST scan starts after the application starts'
+        },
+        :'security.scan_schedule.duration' => {
+          :default => 0,
+          :public => true,
+          :type => Integer,
+          :allowed_from_server => true,
+          :description => 'The duration field specifies the duration of the IAST scan in minutes. This determines how long the scan will run'
+        },
+        :'security.scan_schedule.schedule' => {
+          :default => '',
+          :public => true,
+          :type => String,
+          :allowed_from_server => true,
+          :description => 'The schedule field specifies a cron expression that defines when the IAST scan should run',
+          :dynamic_name => true
+        },
+        :'security.scan_schedule.always_sample_traces' => {
+          :default => false,
+          :external => true,
+          :public => true,
+          :type => Boolean,
+          :allowed_from_server => false,
+          :description => 'always_sample_traces permits IAST to actively gather trace data in the background, and the collected data will be used by Security Agent to perform an IAST Scan at the scheduled time'
+        },
         :'security.scan_controllers.iast_scan_request_rate_limit' => {
           :default => 3600,
           :public => true,

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2859,7 +2859,7 @@ module NewRelic
           :public => true,
           :type => Boolean,
           :allowed_from_server => false,
-          :description => 'If `true`, allows IAST to continuously gather trace data in the background. Collected data will be used by Security Agent to perform an IAST Scan at the scheduled time.'
+          :description => 'If `true`, allows IAST to continuously gather trace data in the background. Collected data will be used by the security agent to perform an IAST scan at the scheduled time.'
         },
         :'security.scan_controllers.iast_scan_request_rate_limit' => {
           :default => 3600,

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2801,7 +2801,7 @@ module NewRelic
           :public => true,
           :type => Boolean,
           :allowed_from_server => false,
-          :description => 'If `true`, disables LDAP injection detection'
+          :description => 'If `true`, disables LDAP injection detection in IAST scans.'
         },
         :'security.exclude_from_iast_scan.iast_detection_category.javascript_injection' => {
           :default => false,

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2898,7 +2898,7 @@ module NewRelic
           :type => Boolean,
           :external => true,
           :allowed_from_server => true,
-          :description => 'report_http_response_body allows user to enable/disable sending of HTTP responses body, Disabling this would also disable RXSS vulnerability detection'
+          :description => 'If `true`, enables the sending of HTTP responses bodies. Disabling this also disables Reflected Cross-Site Scripting (RXSS) vulnerability detection.'
         },
         :'security.iast_test_identifier' => {
           :default => nil,

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2740,6 +2740,7 @@ module NewRelic
           :default => [],
           :public => true,
           :type => Array,
+          :external => true,
           :allowed_from_server => true,
           :transform => DefaultSource.method(:convert_to_list),
           :description => 'Define http request headers you want the security agent to ignore in IAST scan, by specifying a list of patterns matching the header you want to ignore.'

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2915,7 +2915,7 @@ module NewRelic
           :type => String,
           :external => true,
           :allowed_from_server => true,
-          :description => 'This will allow users to run IAST for CI/CD'
+          :description => 'Unique test identifier when runnning IAST in CI/CD environment to differentiate between different test runs, e.g., a build number.'
         }
       }.freeze
       # rubocop:enable Metrics/CollectionLiteralLength

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2890,7 +2890,7 @@ module NewRelic
           :type => Integer,
           :external => true,
           :allowed_from_server => true,
-          :description => 'Scan instance count controls the number of application instances for a specific entity where IAST analysis is performed'
+          :description => 'The number of application instances for a specific entity on which IAST analysis is performed.'
         },
         :'security.scan_controllers.report_http_response_body' => {
           :default => true,

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2758,6 +2758,7 @@ module NewRelic
           :default => [],
           :public => true,
           :type => Array,
+          :external => true,
           :allowed_from_server => true,
           :transform => DefaultSource.method(:convert_to_list),
           :description => 'Defines key values in http request body you want the security agent to ignore in IAST scan, by specifying a list of keys in the http request body you want to ignore.'

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2849,7 +2849,7 @@ module NewRelic
           :type => Integer,
           :external => true,
           :allowed_from_server => true,
-          :description => 'The delay field indicated time in minutes before the IAST scan starts after the application starts'
+          :description => 'Specifies the delay time (in minutes) before the IAST scan begins after the application starts.'
         },
         :'security.scan_schedule.duration' => {
           :default => 0,

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2719,7 +2719,7 @@ module NewRelic
           :external => true,
           :allowed_from_server => true,
           :transform => DefaultSource.method(:convert_to_list),
-          :description => 'Defines api paths you want the security agent to ignore in IAST scan, by specifying a list of regex patterns matching the URI you want to ignore. The regex pattern should provide a complete match for the URL without the endpoint. e.g., [".*account.*], [".*/\api\/v1\/.*?\/login"]'
+          :description => 'Defines API paths the security agent should ignore in IAST scans. Accepts an array of regex patterns matching the URI to ignore. The regex pattern should provide a complete match for the URL without the endpoint. For example, `[".*account.*], [".*/\api\/v1\/.*?\/login"]'`
         },
         :'security.exclude_from_iast_scan.http_request_parameters.header' => {
           :default => [],

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2896,6 +2896,7 @@ module NewRelic
           :default => true,
           :public => true,
           :type => Boolean,
+          :external => true,
           :allowed_from_server => true,
           :description => 'report_http_response_body allows user to enable/disable sending of HTTP responses body, Disabling this would also disable RXSS vulnerability detection'
         },

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2675,7 +2675,7 @@ module NewRelic
           :public => true,
           :type => Array,
           :allowed_from_server => true,
-          :transform => DefaultSource.method(:convert_to_regexp_list),
+          :transform => DefaultSource.method(:convert_to_list),
           :description => 'Defines key values in http request body you want the security agent to ignore in IAST scan, by specifying a list of keys in the http request body you want to ignore.'
         },
         :'security.exclude_from_iast_scan.iast_detection_category.insecure_settings' => {

--- a/newrelic.yml
+++ b/newrelic.yml
@@ -958,15 +958,6 @@ common: &default_settings
   # Passenger servers. Other servers should be detected by default.
   # security.application_info.port: nil
 
-  # If true, enables deserialization detection
-  # security.detection.deserialization.enabled: true
-
-  # If true, enables RCI (remote code injection) detection
-  # security.detection.rci.enabled: true
-
-  # If true, enables RXSS (reflected cross-site scripting) detection
-  # security.detection.rxss.enabled: true
-
   # If true, the security agent is started (the agent runs in its event loop)
   # security.enabled: false
 

--- a/newrelic.yml
+++ b/newrelic.yml
@@ -971,10 +971,6 @@ common: &default_settings
   # supported
   # security.mode: IAST
 
-  # Defines the request body limit to process in security events (in KB). The
-  # default value is 300, for 300KB.
-  # security.request.body_limit: 300
-
   # Defines the endpoint URL for posting security-related data
   # security.validator_service_url: wss://csec.nr-data.net
 


### PR DESCRIPTION
Updates in Ruby Security Configs:
- Added new security configs
```
security:
  exclude_from_iast_scan:
    api:
    http_request_parameters:
      header:
      query:
      body:
    iast_detection_category:
      insecure_settings: false
      invalid_file_access: false
      sql_injection: false
      nosql_injection: false
      ldap_injection: false
      javascript_injection: false
      command_injection: false
      xpath_injection: false
      ssrf: false
      rxss: false
  scan_schedule:
    delay: 0
    duration: 0
    schedule: ""
    always_sample_traces: false
  scan_controllers:
    iast_scan_request_rate_limit: 3600
    scan_instance_count: 0
    report_http_response_body: true
  iast_test_identifier: nil
```
- Removed security config
```
security.request.body_limit
security.detection.deserialization.enabled
security.detection.rci.enabled
security.detection.rxss.enabled
```