### PR TITLE
healthy urls test: ignore lambda comment

### DIFF
--- a/test/new_relic/healthy_urls_test.rb
+++ b/test/new_relic/healthy_urls_test.rb
@@ -65,7 +65,7 @@ class HealthyUrlsTest < Minitest::Test
   FILE_PATTERN = /(?:^(?:#{FILENAMES.join('|')})$)|\.(?:#{EXTENSIONS.join('|')})$/.freeze
   IGNORED_FILE_PATTERN = %r{/(?:coverage|test)/}.freeze
   URL_PATTERN = %r{(https?://.*?)[^a-zA-Z0-9/\.\-_#]}.freeze
-  IGNORED_URL_PATTERN = %r{(?:\{|\(|\$|169\.254|\.\.\.|learn\.|metadata\.google|honeyryderchuck\.gitlab\.io/httpx|https?://#)}
+  IGNORED_URL_PATTERN = %r{(?:\{|\(|\$|169\.254|\.\.\.|learn\.|metadata\.google|honeyryderchuck\.gitlab\.io/httpx|https?://(?:lambda\.)?#)}
   TIMEOUT = 5
   DEBUG = false
 


### PR DESCRIPTION
ignore `https://lambda.#` urls
