### PR TITLE
aws-sdk-lambda: don't use external segments

### DIFF
--- a/lib/new_relic/agent/instrumentation/aws_sdk_lambda/chain.rb
+++ b/lib/new_relic/agent/instrumentation/aws_sdk_lambda/chain.rb
@@ -2,6 +2,8 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
+require_relative 'instrumentation'
+
 module NewRelic::Agent::Instrumentation
   module AwsSdkLambda::Chain
     def self.instrument!

--- a/lib/new_relic/agent/instrumentation/aws_sdk_lambda/prepend.rb
+++ b/lib/new_relic/agent/instrumentation/aws_sdk_lambda/prepend.rb
@@ -2,6 +2,8 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
+require_relative 'instrumentation'
+
 module NewRelic::Agent::Instrumentation
   module AwsSdkLambda::Prepend
     include NewRelic::Agent::Instrumentation::AwsSdkLambda


### PR DESCRIPTION
the use of external request segments can cause confusion for Lambda entity relationships. should we wish to expose the underlying net call to the AWS back-end API in future, we can do so by simply removing the `disable_all_tracing` wrapper and allow the underlying Net::HTTP call to be instrumented.