### PR TITLE
Add token to Trivy report mode

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -40,6 +40,7 @@ jobs:
         if: ${{ github.event_name == 'schedule' }}
         uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2 # tag v0.28.0
         with:
+          token-setup-trivy: ${{ secrets.GITHUB_TOKEN }}
           scan-type: fs
           format: sarif
           output: trivy-results.sarif


### PR DESCRIPTION
One potential solution for the TOOMANYREQUESTS error.

Sources:
* https://github.com/aquasecurity/trivy/discussions/7538
* https://aquasecurity.github.io/trivy/v0.55/docs/references/troubleshooting/#github-rate-limiting 
* https://github.com/aquasecurity/trivy-action?tab=readme-ov-file#use-non-default-token-to-install-trivy 