### PR TITLE
Skip test_thread_profiling_can_stop on Ruby 3.0+

### DIFF
--- a/test/multiverse/suites/agent_only/thread_profiling_test.rb
+++ b/test/multiverse/suites/agent_only/thread_profiling_test.rb
@@ -57,6 +57,8 @@ class ThreadProfilingTest < Minitest::Test
   # go only let a few cycles through, so we check less than 10
 
   def test_thread_profiling
+    skip 'Fails on Ruby 3.0+, see Issue #2947' if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.0')
+
     run_transaction_in_thread(:controller)
     run_transaction_in_thread(:task)
 

--- a/test/multiverse/suites/agent_only/thread_profiling_test.rb
+++ b/test/multiverse/suites/agent_only/thread_profiling_test.rb
@@ -57,8 +57,6 @@ class ThreadProfilingTest < Minitest::Test
   # go only let a few cycles through, so we check less than 10
 
   def test_thread_profiling
-    skip 'Fails on Ruby 3.0+, see Issue #2947' if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.0')
-
     run_transaction_in_thread(:controller)
     run_transaction_in_thread(:task)
 
@@ -78,6 +76,8 @@ class ThreadProfilingTest < Minitest::Test
   end
 
   def test_thread_profiling_can_stop
+    skip 'Fails on Ruby 3.0+, see Issue #2947' if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.0')
+
     issue_command(START_COMMAND)
     issue_command(STOP_COMMAND)
 


### PR DESCRIPTION
This is a temporary measure until we can work on #2947 