### PR TITLE
disable HostAuthorization middleware for Sinatra testing

### DIFF
--- a/test/multiverse/suites/deferred_instrumentation/sinatra_test.rb
+++ b/test/multiverse/suites/deferred_instrumentation/sinatra_test.rb
@@ -10,6 +10,7 @@ require_relative '../../../helpers/exceptions'
 class DeferredSinatraTestApp < Sinatra::Base
   include NewRelic::TestHelpers::Exceptions
 
+  set :host_authorization, {permitted_hosts: []}
   configure do
     # display exceptions so we see what's going on
     disable :show_exceptions

--- a/test/multiverse/suites/rails/rails3_app/my_app.rb
+++ b/test/multiverse/suites/rails/rails3_app/my_app.rb
@@ -49,6 +49,7 @@ if !defined?(MyApp)
     end
 
     class SinatraTestApp < Sinatra::Base
+      set :host_authorization, {permitted_hosts: []}
       get '/' do
         raise 'Intentional error' if params['raise']
 

--- a/test/multiverse/suites/sinatra/ignoring_test.rb
+++ b/test/multiverse/suites/sinatra/ignoring_test.rb
@@ -252,7 +252,7 @@ end
 class SinatraIgnoreApdexAndEndUserApp < Sinatra::Base
   newrelic_ignore_apdex
   newrelic_ignore_enduser
-  
+
   set :host_authorization, {permitted_hosts: []}
   get '/' do
     request.path_info

--- a/test/multiverse/suites/sinatra/ignoring_test.rb
+++ b/test/multiverse/suites/sinatra/ignoring_test.rb
@@ -3,6 +3,7 @@
 # frozen_string_literal: true
 
 class SinatraIgnoreTestApp < Sinatra::Base
+  set :host_authorization, {permitted_hosts: []}
   get '/record' do
     request.path_info
   end
@@ -224,6 +225,7 @@ end
 class SinatraIgnoreItAllApp < Sinatra::Base
   newrelic_ignore
 
+  set :host_authorization, {permitted_hosts: []}
   get '/' do
     request.path_info
   end
@@ -250,7 +252,8 @@ end
 class SinatraIgnoreApdexAndEndUserApp < Sinatra::Base
   newrelic_ignore_apdex
   newrelic_ignore_enduser
-
+  
+  set :host_authorization, {permitted_hosts: []}
   get '/' do
     request.path_info
   end

--- a/test/multiverse/suites/sinatra/nested_middleware_test.rb
+++ b/test/multiverse/suites/sinatra/nested_middleware_test.rb
@@ -3,6 +3,7 @@
 # frozen_string_literal: true
 
 class MiddlewareApp < Sinatra::Base
+  set :host_authorization, {permitted_hosts: []}
   get '/middle' do
     'From the middlewarez'
   end
@@ -11,6 +12,7 @@ end
 class MainApp < Sinatra::Base
   use MiddlewareApp
 
+  set :host_authorization, {permitted_hosts: []}
   get '/main' do
     'mainly done'
   end

--- a/test/multiverse/suites/sinatra/sinatra_classic_test.rb
+++ b/test/multiverse/suites/sinatra/sinatra_classic_test.rb
@@ -8,6 +8,7 @@ require_relative '../../../helpers/exceptions'
 
 include NewRelic::TestHelpers::Exceptions
 
+set :host_authorization, {permitted_hosts: []}
 configure do
   # display exceptions so we see what's going on
   disable :show_exceptions

--- a/test/multiverse/suites/sinatra/sinatra_error_tracing_test.rb
+++ b/test/multiverse/suites/sinatra/sinatra_error_tracing_test.rb
@@ -3,6 +3,7 @@
 # frozen_string_literal: true
 
 class SinatraErrorTracingTestApp < Sinatra::Base
+  set :host_authorization, {permitted_hosts: []}
   configure do
     set :show_exceptions, false
   end

--- a/test/multiverse/suites/sinatra/sinatra_metric_explosion_test.rb
+++ b/test/multiverse/suites/sinatra/sinatra_metric_explosion_test.rb
@@ -3,6 +3,7 @@
 # frozen_string_literal: true
 
 class SinatraTestApp < Sinatra::Base
+  set :host_authorization, {permitted_hosts: []}
   get '/hello/:name' do |name|
     name ||= 'world'
     "hello #{name}"

--- a/test/multiverse/suites/sinatra/sinatra_modular_test.rb
+++ b/test/multiverse/suites/sinatra/sinatra_modular_test.rb
@@ -8,6 +8,7 @@ require_relative '../../../helpers/exceptions'
 class SinatraModularTestApp < Sinatra::Base
   include NewRelic::TestHelpers::Exceptions
 
+  set :host_authorization, {permitted_hosts: []}
   configure do
     # display exceptions so we see what's going on
     disable :show_exceptions

--- a/test/multiverse/suites/sinatra/sinatra_parameter_capture_test.rb
+++ b/test/multiverse/suites/sinatra/sinatra_parameter_capture_test.rb
@@ -3,6 +3,7 @@
 # frozen_string_literal: true
 
 class SinatraParameterCaptureTestApp < Sinatra::Base
+  set :host_authorization, {permitted_hosts: []}
   post '/capture_test' do
     'capture test'
   end

--- a/test/multiverse/suites/sinatra/sinatra_routes_test.rb
+++ b/test/multiverse/suites/sinatra/sinatra_routes_test.rb
@@ -3,6 +3,7 @@
 # frozen_string_literal: true
 
 class SinatraRouteTestApp < Sinatra::Base
+  set :host_authorization, {permitted_hosts: []}
   configure do
     # create a condition (sintra's version of a before_filter) that returns the
     # value that was passed into it.

--- a/test/multiverse/suites/sinatra_agent_disabled/shim_test.rb
+++ b/test/multiverse/suites/sinatra_agent_disabled/shim_test.rb
@@ -5,6 +5,7 @@
 require 'sinatra'
 
 class MiddlewareApp < Sinatra::Base
+  set :host_authorization, {permitted_hosts: []}
   get '/middle' do
     'From the middlewarez'
   end


### PR DESCRIPTION
Sinatra 4.1.0 introduced a new `host_authorization` setting that requires app creators to determine if a header value can be trusted - https://github.com/sinatra/sinatra/pull/2053

This change requires an update to the Sinatra test apps we've built for testing.