### PR TITLE
Sync changelog with docs editor updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ## v9.16.0
 
-Version 9.16.0 introduces instrumentation for the aws-sdk-lambda gem, allows users to opt-in to adding labels to logs, updates View Component instrumentation, and fixes a bug with explain plans on Rails 7.2+.
+Version 9.16.0 introduces the following features and bug fixes:
 
 - **Feature: Instrumentation for aws-sdk-lambda**
 
-  If the aws-sdk-lambda gem is present and used to invoke remote AWS Lambda functions, timing and error details for the invocations will be reported to New Relic. [PR#2926](https://github.com/newrelic/newrelic-ruby-agent/pull/2926).
+  When the aws-sdk-lambda gem is available and used to invoke remote AWS Lambda functions, the timing and error details of the invocations will be reported to New Relic. [PR#2926](https://github.com/newrelic/newrelic-ruby-agent/pull/2926).
 
 - **Feature: Add new configuration options to attach custom tags (labels) to logs**
 


### PR DESCRIPTION
The biggest change here is the removal of the overview sentence. If I remember correctly, the overview sentence used to help us on the page that displayed all of the Release Notes on the docs website. 

Now that the Release Notes page does not feature snippets, but instead shows the entire release notes, I don't think we need it anymore. 

* 9.16.0 release notes: https://docs.newrelic.com/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-9-16-0/ 
* Release notes page: https://docs.newrelic.com/docs/release-notes/agent-release-notes/ruby-release-notes 
* Old release notes structure: https://web.archive.org/web/20230205165159/https://docs.newrelic.com/docs/release-notes/agent-release-notes/ruby-release-notes/ 