### PR TITLE
Change agent status to debug not warn

### DIFF
--- a/lib/new_relic/agent.rb
+++ b/lib/new_relic/agent.rb
@@ -132,8 +132,8 @@ module NewRelic
     def agent # :nodoc:
       return @agent if @agent
 
-      NewRelic::Agent.logger.warn("Agent unavailable as it hasn't been started.")
-      NewRelic::Agent.logger.warn(caller.join("\n"))
+      NewRelic::Agent.logger.debug("Agent unavailable as it hasn't been started.")
+      NewRelic::Agent.logger.debug(caller.join("\n"))
       nil
     end
 

--- a/test/new_relic/agent_test.rb
+++ b/test/new_relic/agent_test.rb
@@ -123,9 +123,9 @@ module NewRelic
       NewRelic::Agent.shutdown
     end
 
-    def test_agent_logs_warning_when_not_started
+    def test_agent_logs_debug_when_not_started
       with_unstarted_agent do
-        expects_logging(:warn, includes("hasn't been started"))
+        expects_logging(:debug, includes("hasn't been started"))
         NewRelic::Agent.agent
       end
     end


### PR DESCRIPTION
Previously, the agent would emit a`WARN` level log when it is unavailable, causing excess log noise. The agent now emits a `DEBUG` level log instead.

closes #2972 