### PR TITLE
Do not attempt to decorate nil logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # New Relic Ruby Agent Release Notes
 
+## dev
+
+- **Bugfix: Do not attempt to decorate `nil` logs**
+
+  The agent no longer attempts to decorate `nil` logs with New Relic linking metadata. Thank you, [@arlando](https://github.com/arlando) for bringing this to our attention! [Issue#2985](https://github.com/newrelic/newrelic-ruby-agent/issues/2985) [PR#2986](https://github.com/newrelic/newrelic-ruby-agent/pull/2986)
+
 ## v9.16.1
 
 - **Bugfix: Add support for Trilogy database adapter**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## dev
 
-- **Bugfix: Do not attempt to decorate `nil` logs**
+- **Bugfix: Do not attempt to decorate logs with `nil` messages**
 
-  The agent no longer attempts to decorate `nil` logs with New Relic linking metadata. Thank you, [@arlando](https://github.com/arlando) for bringing this to our attention! [Issue#2985](https://github.com/newrelic/newrelic-ruby-agent/issues/2985) [PR#2986](https://github.com/newrelic/newrelic-ruby-agent/pull/2986)
+  The agent no longer attempts to add New Relic linking metadata to logs with `nil` messages. Thank you, [@arlando](https://github.com/arlando) for bringing this to our attention! [Issue#2985](https://github.com/newrelic/newrelic-ruby-agent/issues/2985) [PR#2986](https://github.com/newrelic/newrelic-ruby-agent/pull/2986)
 
 ## v9.16.1
 

--- a/lib/new_relic/agent/local_log_decorator.rb
+++ b/lib/new_relic/agent/local_log_decorator.rb
@@ -9,7 +9,7 @@ module NewRelic
       extend self
 
       def decorate(message)
-        return message unless decorating_enabled?
+        return message if !decorating_enabled? || message.nil?
 
         metadata = NewRelic::Agent.linking_metadata
 

--- a/test/new_relic/agent/local_log_decorator_test.rb
+++ b/test/new_relic/agent/local_log_decorator_test.rb
@@ -77,6 +77,13 @@ module NewRelic::Agent
         assert_equal decorated_message, "#{MESSAGE} #{METADATA_STRING}"
       end
 
+      def test_does_not_decorate_if_message_is_nil
+        metadata_stubs
+        decorated_message = LocalLogDecorator.decorate(nil)
+
+        assert_nil(decorated_message)
+      end
+
       def test_decorate_puts_metadata_at_end_of_first_newline
         metadata_stubs
         message = "This is a test of the Emergency Alert System\n this is only a test...."


### PR DESCRIPTION
We should guard against attempting to decorate `nil` logs.

closes #2985