### PR TITLE
Add Rails 8.0 to accepted framework versions

### DIFF
--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -139,7 +139,7 @@ module NewRelic
               case Rails::VERSION::MAJOR
               when 3
                 :rails3
-              when 4..7
+              when 4..8
                 :rails_notifications
               else
                 ::NewRelic::Agent.logger.warn("Detected untested Rails version #{Rails::VERSION::STRING}")


### PR DESCRIPTION
Previously, a log message stating "Detected untested Rails version 8.*" would be emitted. This is incorrect, as we are now testing the agent against Rails 8.0