### PR TITLE
Add backtrace line 0 to 3.4 ERB failure logs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -384,4 +384,4 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           resultPath: lib/coverage_results/.last_run.json
           failedThreshold: 93.5
-          failedThresholdBranch: 50
+          failedThresholdBranch: 0

--- a/.simplecov
+++ b/.simplecov
@@ -9,7 +9,7 @@ if ENV['CI']
 end
 
 SimpleCov.start do
-  enable_coverage(:branch)
+  # enable_coverage(:branch)
   SimpleCov.root(File.join(File.dirname(__FILE__), '/lib'))
   track_files('**/*.rb')
   formatter(SimpleCov::Formatter::SimpleFormatter) if ENV['CI']

--- a/lib/new_relic/agent/configuration/yaml_source.rb
+++ b/lib/new_relic/agent/configuration/yaml_source.rb
@@ -99,7 +99,10 @@ module NewRelic
             file.gsub!(/^\s*#.*$/, '#')
             ERB.new(file).result(binding)
           rescue ScriptError, StandardError => e
-            log_failure('Failed ERB processing configuration file. This is typically caused by a Ruby error in <% %> templating blocks in your newrelic.yml file.', e)
+            message = 'Failed ERB processing configuration file. This is typically caused by a Ruby error in <% %> templating blocks in your newrelic.yml file.'
+            failure_array = [message, e]
+            failure_array << e.backtrace[0] if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.4.0')
+            log_failure(*failure_array)
             nil
           end
         end

--- a/test/multiverse/suites/config_file_loading/Envfile
+++ b/test/multiverse/suites/config_file_loading/Envfile
@@ -25,6 +25,7 @@ def gem_list(psych_version = nil)
     # various places.
     gem 'fakefs', :require => false
 
+    gem 'date', '3.4.1' if Gem::Version.new(#{psych_version}) >= Gem::Version.new('5.2.1')
     gem 'psych'#{psych_version}
     gem 'jar-dependencies', '0.4.1' if RUBY_PLATFORM == 'java'
 

--- a/test/multiverse/suites/config_file_loading/Envfile
+++ b/test/multiverse/suites/config_file_loading/Envfile
@@ -6,13 +6,13 @@ omit_collector!
 
 PSYCH_VERSIONS = [
   [nil],
-  ['4.0.0'],
-  ['3.3.0']
+  ['4.0.0', 2.4, 3.3],
+  ['3.3.0', 2.4, 3.3]
 ]
 
 def stringio_version
   if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.4')
-    "gem 'stringio', '3.1.2.dev'"
+    "gem 'stringio', '~> 3.1.2'"
   else
     "gem 'stringio'"
   end

--- a/test/multiverse/suites/config_file_loading/Envfile
+++ b/test/multiverse/suites/config_file_loading/Envfile
@@ -4,15 +4,10 @@
 
 omit_collector!
 
-# TODO: RUBY 3.4
-# The CI has a prism-related error when it tries to run this suite
-# The problem may be a bug fixed in future preview releases
-# Disable ths suite for now, and try again when the next version
-# is out.
 PSYCH_VERSIONS = [
-  [nil, 2.4, 3.3],
-  ['4.0.0', 2.4, 3.3],
-  ['3.3.0', 2.4, 3.3]
+  [nil],
+  ['4.0.0'],
+  ['3.3.0']
 ]
 
 def stringio_version

--- a/test/multiverse/suites/config_file_loading/Envfile
+++ b/test/multiverse/suites/config_file_loading/Envfile
@@ -18,7 +18,6 @@ def stringio_version
   end
 end
 
-
 def date_version
   if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.4')
     "gem 'date', '~> 3.3.4'"

--- a/test/multiverse/suites/config_file_loading/Envfile
+++ b/test/multiverse/suites/config_file_loading/Envfile
@@ -18,14 +18,23 @@ def stringio_version
   end
 end
 
+
+def date_version
+  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.4')
+    "gem 'date', '~> 3.3.4'"
+  else
+    "gem 'date'"
+  end
+end
+
 def gem_list(psych_version = nil)
   <<~RB
     #{stringio_version}
+    #{date_version}
     # stub file system so we can test that newrelic.yml can be loaded from
     # various places.
     gem 'fakefs', :require => false
 
-    gem 'date', '3.4.1' if Gem::Version.new(#{psych_version}) >= Gem::Version.new('5.2.1')
     gem 'psych'#{psych_version}
     gem 'jar-dependencies', '0.4.1' if RUBY_PLATFORM == 'java'
 

--- a/test/multiverse/suites/config_file_loading/config_file_loading_test.rb
+++ b/test/multiverse/suites/config_file_loading/config_file_loading_test.rb
@@ -158,10 +158,6 @@ class ConfigFileLoadingTest < Minitest::Test
     assert_log_contains(log, /ERROR.*Failed to read or parse configuration file at config\/newrelic\.yml/)
   end
 
-  # TODO: RUBY 3.4 SUPPORT
-  # Both error class and output have changes in Ruby 3.4
-  # See Issue: https://github.com/newrelic/newrelic-ruby-agent/issues/2902
-  unless Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.4.0')
     def test_warning_logged_when_config_file_erb_error
       path = File.join(@cwd, 'config', 'newrelic.yml')
       setup_config(path, {}, "\n\n\n<%= this is not ruby %>") # the error is on line 4
@@ -172,7 +168,6 @@ class ConfigFileLoadingTest < Minitest::Test
       assert_log_contains(log, /ERROR.*Failed ERB processing/)
       assert_log_contains(log, /\(erb\):4/)
     end
-  end
 
   def test_exclude_commented_out_erb_lines
     config_contents = <<~YAML

--- a/test/multiverse/suites/config_file_loading/config_file_loading_test.rb
+++ b/test/multiverse/suites/config_file_loading/config_file_loading_test.rb
@@ -158,16 +158,16 @@ class ConfigFileLoadingTest < Minitest::Test
     assert_log_contains(log, /ERROR.*Failed to read or parse configuration file at config\/newrelic\.yml/)
   end
 
-    def test_warning_logged_when_config_file_erb_error
-      path = File.join(@cwd, 'config', 'newrelic.yml')
-      setup_config(path, {}, "\n\n\n<%= this is not ruby %>") # the error is on line 4
-      setup_agent
+  def test_warning_logged_when_config_file_erb_error
+    path = File.join(@cwd, 'config', 'newrelic.yml')
+    setup_config(path, {}, "\n\n\n<%= this is not ruby %>") # the error is on line 4
+    setup_agent
 
-      log = with_array_logger { NewRelic::Agent.manual_start }
+    log = with_array_logger { NewRelic::Agent.manual_start }
 
-      assert_log_contains(log, /ERROR.*Failed ERB processing/)
-      assert_log_contains(log, /\(erb\):4/)
-    end
+    assert_log_contains(log, /ERROR.*Failed ERB processing/)
+    assert_log_contains(log, /\(erb\):4/)
+  end
 
   def test_exclude_commented_out_erb_lines
     config_contents = <<~YAML


### PR DESCRIPTION
Ruby 3.4 no longer provides the line number in the exception message for the error raised by a failure to parse ERB in the newrelic.yml file.

To help our customers with debugging, add the line number to the output by printing the first line of the backtrace for the exception to the agent logs

Resolves #2902

Full CI: https://github.com/newrelic/newrelic-ruby-agent/actions/runs/12285237901

Also, we removed branch coverage because there's a bug in Ruby 3.4's version of the prism parser that causes suites to silently fail when simplecov runs: https://bugs.ruby-lang.org/issues/20866 