### PR TITLE
Move init container release from lambda to GHA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,14 +62,14 @@ jobs:
       run: ruby ./.github/workflows/scripts/rubygems-publish.rb infinite_tracing/newrelic-infinite_tracing
 
     - name: Create release tags for Lambda and K8s Init Containers
-      uses: dev-hanz-ops/install-gh-cli-action@c78dbed4be2f8d6133a14a9a597ee12fd4ed5c93 # v3
-      with:
-        gh-cli-version: 2.63.2
-      run: |
-        gh auth login --with-token <<< $GH_RELEASE_TOKEN
-        echo "newrelic/newrelic-lambda-layers - Releasing New Relic Ruby Agent ${GITHUB_REF}.0 with tag ${GITHUB_REF}.0_ruby"
-        gh create release "${GITHUB_REF}.0_ruby" -t "New Relic Ruby Agent ${GITHUB_REF}.0" --repo=newrelic/newrelic-lambda-layers
-        echo "newrelic/newrelic-agent-init-container - Releasing New Relic Ruby Agent ${GITHUB_REF}.0 with tag ${GITHUB_REF}.0_ruby"
-        gh create release "${GITHUB_REF}.0_ruby" -t "New Relic Ruby Agent ${GITHUB_REF}.0" --repo=newrelic/newrelic-agent-init-container
-      env:
-        GH_RELEASE_TOKEN: ${{ secrets.GH_RELEASE_TOKEN }}
+        run: |
+          RELEASE_TITLE="New Relic Ruby Agent ${GITHUB_REF}.0"
+          RELEASE_TAG="${GITHUB_REF}.0_ruby"
+          RELEASE_NOTES="Automated release for [Ruby Agent ${GITHUB_REF}](https://github.com/newrelic/newrelic-ruby-agent/releases/tag/${GITHUB_REF})"
+          gh auth login --with-token <<< $GH_RELEASE_TOKEN
+          echo "newrelic/newrelic-lambda-layers - Releasing ${RELEASE_TITLE} with tag ${RELEASE_TAG}"
+          gh release create "${RELEASE_TAG}" --title=${RELEASE_TITLE} --repo=newrelic/newrelic-lambda-layers --notes=${RELEASE_NOTES}
+          echo "newrelic/newrelic-agent-init-container - Releasing ${RELEASE_TITLE} with tag ${RELEASE_TAG}"
+          gh release create "${RELEASE_TAG}" --title=${RELEASE_TITLE} --repo=newrelic/newrelic-agent-init-container --notes=${RELEASE_NOTES}
+        env:
+          GH_RELEASE_TOKEN: ${{ secrets.GH_RELEASE_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,3 +60,16 @@ jobs:
 
     - name: Publish newrelic-infinite_tracing to rubygems.org
       run: ruby ./.github/workflows/scripts/rubygems-publish.rb infinite_tracing/newrelic-infinite_tracing
+
+    - name: Create release tags for Lambda and K8s Init Containers
+      uses: dev-hanz-ops/install-gh-cli-action@c78dbed4be2f8d6133a14a9a597ee12fd4ed5c93 # v3
+      with:
+        gh-cli-version: 2.63.2
+      run: |
+        gh auth login --with-token <<< $GH_RELEASE_TOKEN
+        echo "newrelic/newrelic-lambda-layers - Releasing New Relic Ruby Agent ${GITHUB_REF}.0 with tag ${GITHUB_REF}.0_ruby"
+        gh create release "${GITHUB_REF}.0_ruby" -t "New Relic Ruby Agent ${GITHUB_REF}.0" --repo=newrelic/newrelic-lambda-layers
+        echo "newrelic/newrelic-agent-init-container - Releasing New Relic Ruby Agent ${GITHUB_REF}.0 with tag ${GITHUB_REF}.0_ruby"
+        gh create release "${GITHUB_REF}.0_ruby" -t "New Relic Ruby Agent ${GITHUB_REF}.0" --repo=newrelic/newrelic-agent-init-container
+      env:
+        GH_RELEASE_TOKEN: ${{ secrets.GH_RELEASE_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,14 +62,14 @@ jobs:
       run: ruby ./.github/workflows/scripts/rubygems-publish.rb infinite_tracing/newrelic-infinite_tracing
 
     - name: Create release tags for Lambda and K8s Init Containers
-        run: |
-          RELEASE_TITLE="New Relic Ruby Agent ${GITHUB_REF}.0"
-          RELEASE_TAG="${GITHUB_REF}.0_ruby"
-          RELEASE_NOTES="Automated release for [Ruby Agent ${GITHUB_REF}](https://github.com/newrelic/newrelic-ruby-agent/releases/tag/${GITHUB_REF})"
-          gh auth login --with-token <<< $GH_RELEASE_TOKEN
-          echo "newrelic/newrelic-lambda-layers - Releasing ${RELEASE_TITLE} with tag ${RELEASE_TAG}"
-          gh release create "${RELEASE_TAG}" --title=${RELEASE_TITLE} --repo=newrelic/newrelic-lambda-layers --notes=${RELEASE_NOTES}
-          echo "newrelic/newrelic-agent-init-container - Releasing ${RELEASE_TITLE} with tag ${RELEASE_TAG}"
-          gh release create "${RELEASE_TAG}" --title=${RELEASE_TITLE} --repo=newrelic/newrelic-agent-init-container --notes=${RELEASE_NOTES}
-        env:
-          GH_RELEASE_TOKEN: ${{ secrets.GH_RELEASE_TOKEN }}
+      run: |
+        RELEASE_TITLE="New Relic Ruby Agent ${GITHUB_REF}.0"
+        RELEASE_TAG="${GITHUB_REF}.0_ruby"
+        RELEASE_NOTES="Automated release for [Ruby Agent ${GITHUB_REF}](https://github.com/newrelic/newrelic-ruby-agent/releases/tag/${GITHUB_REF})"
+        gh auth login --with-token <<< $GH_RELEASE_TOKEN
+        echo "newrelic/newrelic-lambda-layers - Releasing ${RELEASE_TITLE} with tag ${RELEASE_TAG}"
+        gh release create "${RELEASE_TAG}" --title=${RELEASE_TITLE} --repo=newrelic/newrelic-lambda-layers --notes=${RELEASE_NOTES}
+        echo "newrelic/newrelic-agent-init-container - Releasing ${RELEASE_TITLE} with tag ${RELEASE_TAG}"
+        gh release create "${RELEASE_TAG}" --title=${RELEASE_TITLE} --repo=newrelic/newrelic-agent-init-container --notes=${RELEASE_NOTES}
+      env:
+        GH_RELEASE_TOKEN: ${{ secrets.GH_RELEASE_TOKEN }}


### PR DESCRIPTION
# Overview
We are getting rid of the internal [auto-layer-releases repo](https://source.datanerd.us/aws-lambda/auto-layer-releases/blob/master/app.py) and moving creating of the release tags into each agent's GHA deploy flow.