### PR TITLE
Add rails80 testing explicitly to the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
                 "rails": "norails,rails42,rails52"
               },
               "3.3.6": {
-                "rails": "norails,rails61,rails72"
+                "rails": "norails,rails61,rails72,rails80"
               }
             }
 

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -79,13 +79,13 @@ jobs:
                 "rails": "norails,rails61,rails70,rails71,rails72"
               },
               "3.2.6": {
-                "rails": "norails,rails61,rails70,rails71,rails72,railsedge"
+                "rails": "norails,rails61,rails70,rails71,rails72,rails80,railsedge"
               },
               "3.3.6": {
-                "rails": "norails,rails61,rails70,rails71,rails72,railsedge"
+                "rails": "norails,rails61,rails70,rails71,rails72,rails80,railsedge"
               },
               "3.4.0-rc1": {
-                "rails": "norails,rails61,rails70,rails71,rails72"
+                "rails": "norails,rails61,rails70,rails71,rails72,rails80,railsedge"
               }
             }
 


### PR DESCRIPTION
Though Rails 8.0 has been tested through Rails Edge, let's make our support official.