### PR TITLE
Remove version lock on haml in Rails multiverse

### DIFF
--- a/test/multiverse/suites/rails/Envfile
+++ b/test/multiverse/suites/rails/Envfile
@@ -23,10 +23,8 @@ def haml_rails(rails_version = nil)
     rails_version.include?('4.0.13') ||
     rails_version.include?('4.1.16') ||
     rails_version.include?('4.2.11') ||
-    rails_version.include?('5.0.7') ||
-    rails_version.include?('5.1.7') ||
-    rails_version.include?('5.2.8'))
-    "gem 'haml-rails', '~> 1.0.0'"
+    rails_version.include?('5.0.7'))
+    "gem 'haml-rails', '~> 1.0'\ngem 'haml', '~> 5.1'\ngem 'tilt', '~> 2.4.0'"
   else
     "gem 'haml-rails', '~> 2.0'"
   end
@@ -43,7 +41,6 @@ end
 def gem_list(rails_version = nil)
   <<-RB
     gem 'rails'#{rails_version}
-    gem 'haml', '5.1.2'
     #{haml_rails(rails_version)}
     gem 'minitest', '#{minitest_rails_version(rails_version)}'
     gem 'erubis' if RUBY_PLATFORM.eql?('java')

--- a/test/multiverse/suites/rails_prepend/Envfile
+++ b/test/multiverse/suites/rails_prepend/Envfile
@@ -24,7 +24,7 @@ def gem_list(rails_version = nil)
   minitest_version = rails_version && rails_version.include?('4.0') ? '4.2.0' : '5.2.3'
   <<~RB
     gem 'rails'#{rails_version}
-    gem 'haml'
+    gem 'haml', '~> 6.0'
     gem 'newrelic_prepender', path: File.expand_path('../newrelic_prepender', __FILE__)
     gem 'minitest', '~> #{minitest_version}'
     gem 'erubis', '~> 2.7.0' if RUBY_PLATFORM.eql?('java')


### PR DESCRIPTION
CI with the other Rails versions passing also: https://github.com/newrelic/newrelic-ruby-agent/actions/runs/12519740439 
(timeouts though for some of the `rest` suite)