### PR TITLE
🎁 Run tests on Ruby 3.4.1

### DIFF
--- a/.github/versions.yml
+++ b/.github/versions.yml
@@ -1,8 +1,8 @@
 ---
 # This file is consumed by lib/tasks/gha.rake
 ruby/setup-ruby:
-  :tag: v1.204.0
-  :sha: 401c19e14f474b54450cd3905bb8b86e2c8509cf
+  :tag: v1.207.0
+  :sha: 4a9ddd6f338a97768b8006bf671dfbad383215f4
 actions/checkout:
   :tag: v4.1.7
   :sha: 692973e3d937129bcbf40652eb9f2f61becf3332

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
       - name: Configure git
         run: 'git config --global init.defaultBranch main'
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # tag v4.1.7
-      - uses: ruby/setup-ruby@401c19e14f474b54450cd3905bb8b86e2c8509cf # tag v1.204.0
+      - uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4 # tag v1.207.0
         with:
-          ruby-version: '3.3'
+          ruby-version: 3.4
       - run: bundle
       - run: rubocop
 
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: [2.4.10, 3.3.6]
+        ruby-version: [2.4.10, 3.4.1]
     steps:
       - name: Configure git
         run: 'git config --global init.defaultBranch main'
@@ -49,7 +49,7 @@ jobs:
         run: sudo apt-get update; sudo apt-get install -y --no-install-recommends libcurl4-nss-dev libsasl2-dev libxslt1-dev
 
       - name: Install Ruby ${{ matrix.ruby-version }}
-        uses: ruby/setup-ruby@401c19e14f474b54450cd3905bb8b86e2c8509cf # tag v1.204.0
+        uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4 # tag v1.207.0
         with:
           ruby-version: ${{ matrix.ruby-version }}
 
@@ -62,7 +62,7 @@ jobs:
               "2.4.10": {
                 "rails": "norails,rails42,rails52"
               },
-              "3.3.6": {
+              "3.4.1": {
                 "rails": "norails,rails61,rails72,rails80"
               }
             }
@@ -217,7 +217,7 @@ jobs:
       fail-fast: false
       matrix:
         multiverse: [agent, ai, background, background_2, kafka, database, frameworks, httpclients, httpclients_2, rails, rest]
-        ruby-version: [2.4.10, 3.3.6]
+        ruby-version: [2.4.10, 3.4.1]
 
     steps:
       - name: Configure git
@@ -231,7 +231,7 @@ jobs:
         run: sudo apt-get update; sudo apt-get install -y --no-install-recommends libcurl4-nss-dev libsasl2-dev libxslt1-dev
 
       - name: Install Ruby ${{ matrix.ruby-version }}
-        uses: ruby/setup-ruby@401c19e14f474b54450cd3905bb8b86e2c8509cf # tag v1.204.0
+        uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4 # tag v1.207.0
         with:
           ruby-version: ${{ matrix.ruby-version }}
 
@@ -317,14 +317,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: [2.7.8, 3.3.6]
+        ruby-version: [2.7.8, 3.4.1]
     steps:
       - name: Configure git
         run: 'git config --global init.defaultBranch main'
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # tag v4.1.7
 
       - name: Install Ruby ${{ matrix.ruby-version }}
-        uses: ruby/setup-ruby@401c19e14f474b54450cd3905bb8b86e2c8509cf # tag v1.204.0
+        uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4 # tag v1.207.0
         with:
           ruby-version: ${{ matrix.ruby-version }}
 
@@ -364,9 +364,9 @@ jobs:
       - name: Configure git
         run: 'git config --global init.defaultBranch main'
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # tag v4.1.7
-      - uses: ruby/setup-ruby@401c19e14f474b54450cd3905bb8b86e2c8509cf # tag v1.204.0
+      - uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4 # tag v1.207.0
         with:
-          ruby-version: '3.3'
+          ruby-version: 3.4
       - run: bundle
       - name: Download all workflow run artifacts
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # tag v4.1.8

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -16,9 +16,9 @@ jobs:
       - name: Configure git
         run: 'git config --global init.defaultBranch main'
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # tag v4.1.7
-      - uses: ruby/setup-ruby@401c19e14f474b54450cd3905bb8b86e2c8509cf # tag v1.204.0
+      - uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4 # tag v1.207.0
         with:
-          ruby-version: '3.3'
+          ruby-version: 3.4
       - run: bundle
       - run: rubocop
 
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: [2.4.10, 2.5.9, 2.6.10, 2.7.8, 3.0.7, 3.1.6, 3.2.6, 3.3.6, 3.4.0-rc1]
+        ruby-version: [2.4.10, 2.5.9, 2.6.10, 2.7.8, 3.0.7, 3.1.6, 3.2.6, 3.3.6, 3.4.1]
 
     steps:
       - name: Configure git
@@ -50,7 +50,7 @@ jobs:
         run: sudo apt-get update; sudo apt-get install -y --no-install-recommends libcurl4-nss-dev libsasl2-dev libxslt1-dev
 
       - name: Install Ruby ${{ matrix.ruby-version }}
-        uses: ruby/setup-ruby@401c19e14f474b54450cd3905bb8b86e2c8509cf # tag v1.204.0
+        uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4 # tag v1.207.0
         with:
           ruby-version: ${{ matrix.ruby-version }}
 
@@ -84,7 +84,7 @@ jobs:
               "3.3.6": {
                 "rails": "norails,rails61,rails70,rails71,rails72,rails80,railsedge"
               },
-              "3.4.0-rc1": {
+              "3.4.1": {
                 "rails": "norails,rails61,rails70,rails71,rails72,rails80,railsedge"
               }
             }
@@ -230,7 +230,7 @@ jobs:
       fail-fast: false
       matrix:
         multiverse: [agent, ai, background, background_2, database, kafka, frameworks, httpclients, httpclients_2, rails, rest]
-        ruby-version: [2.4.10, 2.5.9, 2.6.10, 2.7.8, 3.0.7, 3.1.6, 3.2.6, 3.3.6, 3.4.0-rc1]
+        ruby-version: [2.4.10, 2.5.9, 2.6.10, 2.7.8, 3.0.7, 3.1.6, 3.2.6, 3.3.6, 3.4.1]
     steps:
       - name: Configure git
         run: 'git config --global init.defaultBranch main'
@@ -243,7 +243,7 @@ jobs:
         run: sudo apt-get update; sudo apt-get install -y --no-install-recommends libcurl4-nss-dev libsasl2-dev libxslt1-dev
 
       - name: Install Ruby ${{ matrix.ruby-version }}
-        uses: ruby/setup-ruby@401c19e14f474b54450cd3905bb8b86e2c8509cf # tag v1.204.0
+        uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4 # tag v1.207.0
         with:
           ruby-version: ${{ matrix.ruby-version }}
 
@@ -308,14 +308,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: [2.7.8, 3.0.7, 3.1.6, 3.2.6, 3.3.6, 3.4.0-rc1]
+        ruby-version: [2.7.8, 3.0.7, 3.1.6, 3.2.6, 3.3.6, 3.4.1]
     steps:
       - name: Configure git
         run: 'git config --global init.defaultBranch main'
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # tag v4.1.7
 
       - name: Install Ruby ${{ matrix.ruby-version }}
-        uses: ruby/setup-ruby@401c19e14f474b54450cd3905bb8b86e2c8509cf # tag v1.204.0
+        uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4 # tag v1.207.0
         with:
           ruby-version: ${{ matrix.ruby-version }}
 

--- a/.github/workflows/ci_jruby.yml
+++ b/.github/workflows/ci_jruby.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # tag v4.1.7
 
       - name: Install JRuby
-        uses: ruby/setup-ruby@401c19e14f474b54450cd3905bb8b86e2c8509cf # tag v1.204.0
+        uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4 # tag v1.207.0
         with:
           ruby-version: jruby-9.4.9.0
 
@@ -49,7 +49,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # tag v4.1.7
 
       - name: Install JRuby
-        uses: ruby/setup-ruby@401c19e14f474b54450cd3905bb8b86e2c8509cf # tag v1.204.0
+        uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4 # tag v1.207.0
         with:
           ruby-version: jruby-9.4.9.0
 

--- a/.github/workflows/ci_special.yml
+++ b/.github/workflows/ci_special.yml
@@ -20,15 +20,15 @@ jobs:
       - name: Install OS packages
         run: sudo apt-get update; sudo apt-get install -y --no-install-recommends libcurl4-nss-dev libsasl2-dev libxslt1-dev
 
-      - name: Install Ruby 3.4.0-rc1
-        uses: ruby/setup-ruby@401c19e14f474b54450cd3905bb8b86e2c8509cf # tag v1.204.0
+      - name: Install Ruby 3.4
+        uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4 # tag v1.207.0
         with:
-          ruby-version: 3.4.0-rc1
+          ruby-version: 3.4
 
       - name: Setup bundler
         run: ./.github/workflows/scripts/setup_bundler
         env:
-          RUBY_VERSION: 3.4.0-rc1
+          RUBY_VERSION: 3.4
 
       - name: Run Unit Tests
         uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # tag v3.0.0

--- a/.github/workflows/config_docs.yml
+++ b/.github/workflows/config_docs.yml
@@ -14,10 +14,10 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-    - name: Install Ruby 3.3
-      uses: ruby/setup-ruby@401c19e14f474b54450cd3905bb8b86e2c8509cf # tag v1.204.0
+    - name: Install Ruby 3.4
+      uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4 # tag v1.207.0
       with:
-        ruby-version: 3.3
+        ruby-version: 3.4
 
     - name: Checkout code
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # tag v4.1.7

--- a/.github/workflows/performance_tests.yml
+++ b/.github/workflows/performance_tests.yml
@@ -33,9 +33,9 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # tag v4.1.7
         with:
           ref: 'main'
-      - uses: ruby/setup-ruby@401c19e14f474b54450cd3905bb8b86e2c8509cf # tag v1.204.0
+      - uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4 # tag v1.207.0
         with:
-          ruby-version: '3.3'
+          ruby-version: 3.4
       - run: bundle
       - run: bundle exec script/runner -B
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # tag v4.1.7

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -10,10 +10,10 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-    - name: Install Ruby 3.3
-      uses: ruby/setup-ruby@401c19e14f474b54450cd3905bb8b86e2c8509cf # tag v1.204.0
+    - name: Install Ruby 3.4
+      uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4 # tag v1.207.0
       with:
-        ruby-version: 3.3
+        ruby-version: 3.4
 
     - name: Checkout code
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # tag v4.1.7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,9 +16,9 @@ jobs:
       with:
         fetch-depth: 0
 
-    - uses: ruby/setup-ruby@401c19e14f474b54450cd3905bb8b86e2c8509cf # tag v1.204.0
+    - uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4 # tag v1.207.0
       with:
-        ruby-version: 3.3
+        ruby-version: 3.4
 
     - name: Install onetimepass
       run: pip install onetimepass==1.0.1

--- a/.github/workflows/release_notes.yml
+++ b/.github/workflows/release_notes.yml
@@ -13,9 +13,9 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: ruby/setup-ruby@401c19e14f474b54450cd3905bb8b86e2c8509cf # tag v1.204.0
+      - uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4 # tag v1.207.0
         with:
-          ruby-version: 3.3
+          ruby-version: 3.4
       - name: Checkout code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # tag v4.1.7
 

--- a/.github/workflows/release_pr.yml
+++ b/.github/workflows/release_pr.yml
@@ -13,10 +13,10 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-    - name: Install Ruby 3.3
-      uses: ruby/setup-ruby@401c19e14f474b54450cd3905bb8b86e2c8509cf # tag v1.204.0
+    - name: Install Ruby 3.4
+      uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4 # tag v1.207.0
       with:
-        ruby-version: 3.3
+        ruby-version: 3.4
 
     - name: Checkout code
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # tag v4.1.7

--- a/.github/workflows/slack_notifications.yml
+++ b/.github/workflows/slack_notifications.yml
@@ -8,9 +8,9 @@ jobs:
   gem_notifications:
     runs-on: ubuntu-22.04
     steps:
-      - uses: ruby/setup-ruby@401c19e14f474b54450cd3905bb8b86e2c8509cf # tag v1.204.0
+      - uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4 # tag v1.207.0
         with:
-          ruby-version: 3.3
+          ruby-version: 3.4
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # tag v4.1.7
       - run: gem install httparty
       - name: Check for outdated gems
@@ -47,9 +47,9 @@ jobs:
   cve_notifications:
     runs-on: ubuntu-22.04
     steps:
-      - uses: ruby/setup-ruby@401c19e14f474b54450cd3905bb8b86e2c8509cf # tag v1.204.0
+      - uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4 # tag v1.207.0
         with:
-          ruby-version: 3.3
+          ruby-version: 3.4
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # tag v4.1.7
       - run: gem install httparty
       - run: gem install feedjira

--- a/test/multiverse/suites/grpc/Envfile
+++ b/test/multiverse/suites/grpc/Envfile
@@ -8,9 +8,9 @@ end
 
 instrumentation_methods(:chain, :prepend)
 
-# TODO: permit testing of the nil (latest) version against Ruby 3.3+
+# TODO: permit testing of the nil (latest) version against Ruby 3.4+
 GRPC_VERSIONS = [
-  [nil, 2.6, 3.2],
+  [nil, 2.6],
   ['1.48.0', 2.5, 3.1]
 ]
 

--- a/test/multiverse/suites/grpc/Envfile
+++ b/test/multiverse/suites/grpc/Envfile
@@ -8,9 +8,9 @@ end
 
 instrumentation_methods(:chain, :prepend)
 
-# TODO: permit testing of the nil (latest) version against Ruby 3.4+
+# TODO: permit testing of the nil (latest) version against Ruby 3.3+
 GRPC_VERSIONS = [
-  [nil, 2.6],
+  [nil, 2.6, 3.2],
   ['1.48.0', 2.5, 3.1]
 ]
 

--- a/test/performance/Gemfile
+++ b/test/performance/Gemfile
@@ -5,7 +5,7 @@ source 'https://rubygems.org'
 gem 'newrelic_rpm', path: File.expand_path('../../..', __FILE__)
 
 gem 'puma', '~> 5.0'
-gem 'rails', '~> 7.0.6'
+gem 'rails', '~> 8.0'
 gem 'sqlite3', '~> 1.4'
 
 gem 'mocha'

--- a/test/performance/Gemfile
+++ b/test/performance/Gemfile
@@ -4,9 +4,9 @@ source 'https://rubygems.org'
 
 gem 'newrelic_rpm', path: File.expand_path('../../..', __FILE__)
 
-gem 'puma', '~> 5.0'
 gem 'rails', '~> 8.0'
-gem 'sqlite3', '~> 1.4'
+gem 'puma'
+gem 'sqlite3'
 
 gem 'mocha'
 gem 'redis'

--- a/test/performance/rails_app/config/application.rb
+++ b/test/performance/rails_app/config/application.rb
@@ -23,7 +23,7 @@ Bundler.require(*Rails.groups)
 module RailsApp
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults(7.0)
+    config.load_defaults(8.0)
 
     # Configuration for the application, engines, and railties goes here.
     #


### PR DESCRIPTION
Ruby 3.4.1 is out! This PR updates the CI to test the newest version and replaces the areas where we used Ruby 3.3 as our default version to Ruby 3.4.

Workflow dispatches to check: 
* Perf tests: ~~https://github.com/newrelic/newrelic-ruby-agent/actions/runs/12590713430~~ 
  * ~~https://github.com/newrelic/newrelic-ruby-agent/actions/runs/12590853852~~ (failing with base64 error)
  * https://github.com/newrelic/newrelic-ruby-agent/actions/runs/12601064376 => failing with the same error, but this seems to be because it's trying to use 3.4 on `main`, which is still pointing to the old Rails version. Perf tests ran locally just fine on the current branch. I think we're safe to test.
* 🟢 URL test CI: https://github.com/newrelic/newrelic-ruby-agent/actions/runs/12590710130 (as an example of a generic workflow with an overall Ruby version update)

Though other workflows were also updated, I don't want to trigger them. We'll have to keep an eye out for funny business the next time they run.