### PR TITLE
Use permalink for Logger::Severity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -626,7 +626,7 @@ Version 9.3.0 of the agent adds log-level filtering, adds custom attributes for 
   | --------------------------- | ------- | ------------------------------------------------------ | ------ |
   | `application_logging.forwarding.log_level` | `debug` | Sets the minimum log level for events forwarded to New Relic | `debug`, `info`, `warn`, `error`, `fatal`, `unknown` |
 
-  This setting uses [Ruby's Logger::Severity constants integer values](https://github.com/ruby/ruby/blob/master/lib/logger/severity.rb#L6-L17) to determine precedence.
+  This setting uses [Ruby's Logger::Severity constants integer values](https://github.com/ruby/logger/blob/113b82a06b3076b93a71cd467e1605b23afb3088/lib/logger/severity.rb#L6-L17) to determine precedence.
 
 - **Feature: Custom attributes for logs**
 

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -858,7 +858,7 @@ module NewRelic
           :description => <<~DESCRIPTION
             Sets the minimum level a log event must have to be forwarded to New Relic.
 
-            This is based on the integer values of Ruby's `Logger::Severity` constants: https://github.com/ruby/ruby/blob/master/lib/logger/severity.rb
+            This is based on the integer values of [Ruby's `Logger::Severity` constants](https://github.com/ruby/logger/blob/113b82a06b3076b93a71cd467e1605b23afb3088/lib/logger/severity.rb).
 
             The intention is to forward logs with the level given to the configuration, as well as any logs with a higher level of severity.
 

--- a/newrelic.yml
+++ b/newrelic.yml
@@ -74,7 +74,7 @@ common: &default_settings
 
   # Sets the minimum level a log event must have to be forwarded to New Relic.
   # This is based on the integer values of Ruby's Logger::Severity constants:
-  # https://github.com/ruby/ruby/blob/master/lib/logger/severity.rb
+  # https://github.com/ruby/logger/blob/113b82a06b3076b93a71cd467e1605b23afb3088/lib/logger/severity.rb
   # The intention is to forward logs with the level given to the configuration, as
   # well as any logs with a higher level of severity.
   # For example, setting this value to "debug" will forward all log events to New
@@ -949,7 +949,7 @@ common: &default_settings
   #   NOTE: All "security.*" configuration parameters are related only to the
   #         security agent, and all other configuration parameters that may
   #         have "security" in the name somewhere are related to the APM agent.
-  
+
   # If true, the security agent loads (the agent performs a Ruby 'require')
   # security.agent.enabled: false
 


### PR DESCRIPTION
Ruby moved the logger code out of the ruby/ruby repository. This change uses the ruby/logger repository and also uses a permalink. 

I imagine the newrelic.yml changes will be updated again whenever we release, so I just added the permalink to the existing setup to get the URL CI to pass.

Passing URL CI: https://github.com/newrelic/newrelic-ruby-agent/actions/runs/12755313559 🟢 