### PR TITLE
Update multiverse jobs in CI to avoid resource issues in github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,17 +201,6 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 10
-      zookeeper:
-        image: bitnami/zookeeper
-        ports:
-          - 2181:2181
-        env:
-          ALLOW_ANONYMOUS_LOGIN: yes
-        options: >-
-          --health-cmd "echo mntr | nc -w 2 -q 2 localhost 2181"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
       mongodb:
         image: ${{ contains(fromJson('["2.4.10"]'), matrix.ruby-version) && 'mongo:5.0.11' || 'mongo:latest' }}
         ports:
@@ -403,6 +392,17 @@ jobs:
           KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INSIDE:PLAINTEXT,OUTSIDE:PLAINTEXT
           KAFKA_INTER_BROKER_LISTENER_NAME: INSIDE
           KAFKA_ADVERTISED_LISTENERS: INSIDE://kafka:9093,OUTSIDE://localhost:9092
+      zookeeper:
+        image: bitnami/zookeeper
+        ports:
+          - 2181:2181
+        env:
+          ALLOW_ANONYMOUS_LOGIN: yes
+        options: >-
+          --health-cmd "echo mntr | nc -w 2 -q 2 localhost 2181"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,14 +112,6 @@ jobs:
   multiverse:
     needs: run_rubocop
     runs-on: ubuntu-22.04
-        image: redis
-        ports:
-          - 6379:6379
-        options: >-
-          --health-cmd "redis-cli ping"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,13 +147,6 @@ jobs:
           command: bundle exec rake test:multiverse[group="${{ matrix.multiverse }}"]
         env:
           VERBOSE_TEST_OUTPUT: true
-          MYSQL_PASSWORD: root
-          DB_PASSWORD: root
-          DB_PORT: ${{ job.services.mysql.ports[3306] }}
-          MYSQL_PORT: ${{ job.services.mysql.ports[3306] }}
-          MYSQL_HOST: 127.0.0.1
-          POSTGRES_USERNAME: postgres
-          POSTGRES_PASSWORD: password
           SERIALIZE: 1
           COVERAGE: true
           CI_FOR_PR: true
@@ -266,13 +259,6 @@ jobs:
           command: bundle exec rake test:multiverse[group="services_1"]
         env:
           VERBOSE_TEST_OUTPUT: true
-          MYSQL_PASSWORD: root
-          DB_PASSWORD: root
-          DB_PORT: ${{ job.services.mysql.ports[3306] }}
-          MYSQL_PORT: ${{ job.services.mysql.ports[3306] }}
-          MYSQL_HOST: 127.0.0.1
-          POSTGRES_USERNAME: postgres
-          POSTGRES_PASSWORD: password
           SERIALIZE: 1
           COVERAGE: true
           CI_FOR_PR: true
@@ -371,13 +357,6 @@ jobs:
           command: bundle exec rake test:multiverse[group="services_2"]
         env:
           VERBOSE_TEST_OUTPUT: true
-          MYSQL_PASSWORD: root
-          DB_PASSWORD: root
-          DB_PORT: ${{ job.services.mysql.ports[3306] }}
-          MYSQL_PORT: ${{ job.services.mysql.ports[3306] }}
-          MYSQL_HOST: 127.0.0.1
-          POSTGRES_USERNAME: postgres
-          POSTGRES_PASSWORD: password
           SERIALIZE: 1
           COVERAGE: true
           CI_FOR_PR: true
@@ -458,13 +437,6 @@ jobs:
           command: bundle exec rake test:multiverse[group="services_kafka"]
         env:
           VERBOSE_TEST_OUTPUT: true
-          MYSQL_PASSWORD: root
-          DB_PASSWORD: root
-          DB_PORT: ${{ job.services.mysql.ports[3306] }}
-          MYSQL_PORT: ${{ job.services.mysql.ports[3306] }}
-          MYSQL_HOST: 127.0.0.1
-          POSTGRES_USERNAME: postgres
-          POSTGRES_PASSWORD: password
           SERIALIZE: 1
           COVERAGE: true
           CI_FOR_PR: true
@@ -489,7 +461,6 @@ jobs:
           name: gem_manifest_${{ matrix.ruby-version }}_services_kafka.json
           path: gem_manifest_${{ matrix.ruby-version }}_services_kafka.json
           retention-days: 2
-
 
 
   multiverse_services_mysql_pg:
@@ -608,7 +579,6 @@ jobs:
           name: gem_manifest_${{ matrix.ruby-version }}_service_mysql_pg.json
           path: gem_manifest_${{ matrix.ruby-version }}_service_mysql_pg.json
           retention-days: 2
-
 
 
   infinite_tracing:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,99 +112,6 @@ jobs:
   multiverse:
     needs: run_rubocop
     runs-on: ubuntu-22.04
-    services:
-      elasticsearch7:
-        image: elasticsearch:7.16.2
-        env:
-          discovery.type: single-node
-        ports:
-          - 9200:9200
-        options: >-
-          --health-cmd "curl http://localhost:9200/_cluster/health"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 10
-      elasticsearch8:
-        image: elasticsearch:8.13.0
-        env:
-          discovery.type: single-node
-          xpack.security.enabled: false
-        ports:
-          - 9250:9200
-        options: >-
-          --health-cmd "curl http://localhost:9200/_cluster/health"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 10
-      zookeeper:
-        image: bitnami/zookeeper
-        ports:
-          - 2181:2181
-        env:
-          ALLOW_ANONYMOUS_LOGIN: yes
-        options: >-
-          --health-cmd "echo mntr | nc -w 2 -q 2 localhost 2181"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-      kafka:
-        image: bitnami/kafka
-        ports:
-          - 9092:9092
-        options: >-
-          --health-cmd "kafka-broker-api-versions.sh --version"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        env:
-          KAFKA_CFG_ZOOKEEPER_CONNECT: zookeeper:2181
-          ALLOW_PLAINTEXT_LISTENER: yes
-          KAFKA_LISTENERS: INSIDE://0.0.0.0:9093,OUTSIDE://0.0.0.0:9092
-          KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INSIDE:PLAINTEXT,OUTSIDE:PLAINTEXT
-          KAFKA_INTER_BROKER_LISTENER_NAME: INSIDE
-          KAFKA_ADVERTISED_LISTENERS: INSIDE://kafka:9093,OUTSIDE://localhost:9092
-      memcached:
-        image: memcached:latest
-        ports:
-          - 11211:11211
-        options: >-
-          --health-cmd "timeout 5 bash -c 'cat < /dev/null > /dev/udp/127.0.0.1/11211'"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-      mongodb:
-        image: ${{ contains(fromJson('["2.4.10"]'), matrix.ruby-version) && 'mongo:5.0.11' || 'mongo:latest' }}
-        ports:
-          - 27017:27017
-      mysql:
-        image: mysql:5.7
-        env:
-          MYSQL_ROOT_PASSWORD: root
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
-        ports:
-          - 3306
-      postgres:
-        image: postgres:latest
-        env:
-          POSTGRES_USERNAME: postgres
-          POSTGRES_PASSWORD: password
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-      rabbitmq:
-        image: rabbitmq:latest
-        ports:
-          - 5672:5672
-        options: >-
-          --health-cmd "rabbitmq-diagnostics -q check_port_connectivity"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-      redis:
         image: redis
         ports:
           - 6379:6379
@@ -216,7 +123,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        multiverse: [agent, ai, background, background_2, kafka, database, frameworks, httpclients, httpclients_2, rails, rest]
+        multiverse: [agent, ai, background, background_2, frameworks, httpclients, httpclients_2, rails, rest]
         ruby-version: [2.4.10, 3.4.1]
 
     steps:
@@ -309,6 +216,309 @@ jobs:
           name: gem_manifest_${{ matrix.ruby-version }}_${{ matrix.multiverse }}.json
           path: gem_manifest_${{ matrix.ruby-version }}_${{ matrix.multiverse }}.json
           retention-days: 2
+
+
+
+  multiverse_services_other:
+    needs: run_rubocop
+    runs-on: ubuntu-22.04
+    services:
+      elasticsearch7:
+        image: elasticsearch:7.16.2
+        env:
+          discovery.type: single-node
+        ports:
+          - 9200:9200
+        options: >-
+          --health-cmd "curl http://localhost:9200/_cluster/health"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+      elasticsearch8:
+        image: elasticsearch:8.13.0
+        env:
+          discovery.type: single-node
+          xpack.security.enabled: false
+        ports:
+          - 9250:9200
+        options: >-
+          --health-cmd "curl http://localhost:9200/_cluster/health"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+      zookeeper:
+        image: bitnami/zookeeper
+        ports:
+          - 2181:2181
+        env:
+          ALLOW_ANONYMOUS_LOGIN: yes
+        options: >-
+          --health-cmd "echo mntr | nc -w 2 -q 2 localhost 2181"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      kafka:
+        image: bitnami/kafka
+        ports:
+          - 9092:9092
+        options: >-
+          --health-cmd "kafka-broker-api-versions.sh --version"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        env:
+          KAFKA_CFG_ZOOKEEPER_CONNECT: zookeeper:2181
+          ALLOW_PLAINTEXT_LISTENER: yes
+          KAFKA_LISTENERS: INSIDE://0.0.0.0:9093,OUTSIDE://0.0.0.0:9092
+          KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INSIDE:PLAINTEXT,OUTSIDE:PLAINTEXT
+          KAFKA_INTER_BROKER_LISTENER_NAME: INSIDE
+          KAFKA_ADVERTISED_LISTENERS: INSIDE://kafka:9093,OUTSIDE://localhost:9092
+      memcached:
+        image: memcached:latest
+        ports:
+          - 11211:11211
+        options: >-
+          --health-cmd "timeout 5 bash -c 'cat < /dev/null > /dev/udp/127.0.0.1/11211'"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      mongodb:
+        image: ${{ contains(fromJson('["2.4.10"]'), matrix.ruby-version) && 'mongo:5.0.11' || 'mongo:latest' }}
+        ports:
+          - 27017:27017
+      rabbitmq:
+        image: rabbitmq:latest
+        ports:
+          - 5672:5672
+        options: >-
+          --health-cmd "rabbitmq-diagnostics -q check_port_connectivity"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      redis:
+        image: redis
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby-version: [2.4.10, 3.4.1]
+
+    steps:
+      - name: Configure git
+        run: 'git config --global init.defaultBranch main'
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # tag v4.1.7
+
+        # - curl is needed for Curb
+        # - xslt is needed for older Nokogiris, RUBY_VERSION < 2.5
+        # - sasl is needed for memcached
+      - name: Install OS packages
+        run: sudo apt-get update; sudo apt-get install -y --no-install-recommends libcurl4-nss-dev libsasl2-dev libxslt1-dev
+
+      - name: Install Ruby ${{ matrix.ruby-version }}
+        uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4 # tag v1.207.0
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+
+        # This allows the cache in the following step to be able to write files to the directory needed for mysql
+      # - if: matrix.ruby-version == '2.4.10'
+      #   name: Prepare mysql directory
+      #   run: sudo chown -R $USER /usr/local
+
+      # - if: matrix.ruby-version == '2.4.10'
+      #   name: Cache mysql55
+      #   id: mysql55-cache
+      #   uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # tag v4.0.2
+      #   with:
+      #     path: /usr/local/mysql55
+      #     key: mysql55-install
+
+      # - if: steps.mysql55-cache.outputs.cache-hit != 'true' && matrix.ruby-version == '2.4.10'
+      #   name: Install mysql55
+      #   run: sudo ./test/script/install_mysql55
+
+      - name: Setup bundler
+        run: ./.github/workflows/scripts/setup_bundler
+        env:
+          RUBY_VERSION: ${{ matrix.ruby-version }}
+
+
+      # - name: Wait for/Check Mysql
+      #   uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # tag v3.0.0
+      #   with:
+      #     timeout_minutes: 1
+      #     max_attempts: 20
+      #     command: |
+      #       mysql --host 127.0.0.1 --port ${{ job.services.mysql.ports[3306] }} -uroot -proot -e "SHOW GRANTS FOR 'root'@'localhost'";
+      #       if [[ $? != 0 ]]; then
+      #         sleep 1;
+      #       fi
+
+
+      - name: Run Multiverse Tests
+        uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # tag v3.0.0
+        with:
+          timeout_minutes: 60
+          max_attempts: 2
+          command: bundle exec rake test:multiverse[group="services"]
+        env:
+          VERBOSE_TEST_OUTPUT: true
+          MYSQL_PASSWORD: root
+          DB_PASSWORD: root
+          DB_PORT: ${{ job.services.mysql.ports[3306] }}
+          MYSQL_PORT: ${{ job.services.mysql.ports[3306] }}
+          MYSQL_HOST: 127.0.0.1
+          POSTGRES_USERNAME: postgres
+          POSTGRES_PASSWORD: password
+          SERIALIZE: 1
+          COVERAGE: true
+          CI_FOR_PR: true
+
+      - name: Annotate errors
+        if: ${{ failure() }}
+        uses: ./.github/actions/annotate
+
+      - name: Save coverage results
+        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # tag v4.3.4
+        with:
+          name: coverage-report-multiverse-${{ matrix.ruby-version }}-${{ matrix.multiverse }}
+          path: lib/coverage_*/.resultset.json
+          retention-days: 2
+
+      - name: Generate gem manifest
+        run: rake test:multiverse:gem_manifest
+
+      - name: Save gem manifest
+        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # tag v4.3.4
+        with:
+          name: gem_manifest_${{ matrix.ruby-version }}_${{ matrix.multiverse }}.json
+          path: gem_manifest_${{ matrix.ruby-version }}_${{ matrix.multiverse }}.json
+          retention-days: 2
+
+  multiverse_services_mysql_pg:
+    needs: run_rubocop
+    runs-on: ubuntu-22.04
+    services:
+      mysql:
+        image: mysql:5.7
+        env:
+          MYSQL_ROOT_PASSWORD: root
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+        ports:
+          - 3306
+      postgres:
+        image: postgres:latest
+        env:
+          POSTGRES_USERNAME: postgres
+          POSTGRES_PASSWORD: password
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby-version: [2.4.10, 3.4.1]
+
+    steps:
+      - name: Configure git
+        run: 'git config --global init.defaultBranch main'
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # tag v4.1.7
+
+        # - curl is needed for Curb
+        # - xslt is needed for older Nokogiris, RUBY_VERSION < 2.5
+        # - sasl is needed for memcached
+      - name: Install OS packages
+        run: sudo apt-get update; sudo apt-get install -y --no-install-recommends libcurl4-nss-dev libsasl2-dev libxslt1-dev
+
+      - name: Install Ruby ${{ matrix.ruby-version }}
+        uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4 # tag v1.207.0
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+
+        # This allows the cache in the following step to be able to write files to the directory needed for mysql
+      - if: matrix.ruby-version == '2.4.10'
+        name: Prepare mysql directory
+        run: sudo chown -R $USER /usr/local
+
+      - if: matrix.ruby-version == '2.4.10'
+        name: Cache mysql55
+        id: mysql55-cache
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # tag v4.0.2
+        with:
+          path: /usr/local/mysql55
+          key: mysql55-install
+
+      - if: steps.mysql55-cache.outputs.cache-hit != 'true' && matrix.ruby-version == '2.4.10'
+        name: Install mysql55
+        run: sudo ./test/script/install_mysql55
+
+      - name: Setup bundler
+        run: ./.github/workflows/scripts/setup_bundler
+        env:
+          RUBY_VERSION: ${{ matrix.ruby-version }}
+
+
+      - name: Wait for/Check Mysql
+        uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # tag v3.0.0
+        with:
+          timeout_minutes: 1
+          max_attempts: 20
+          command: |
+            mysql --host 127.0.0.1 --port ${{ job.services.mysql.ports[3306] }} -uroot -proot -e "SHOW GRANTS FOR 'root'@'localhost'";
+            if [[ $? != 0 ]]; then
+              sleep 1;
+            fi
+
+
+      - name: Run Multiverse Tests
+        uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # tag v3.0.0
+        with:
+          timeout_minutes: 60
+          max_attempts: 2
+          command: bundle exec rake test:multiverse[group="services_2"]
+        env:
+          VERBOSE_TEST_OUTPUT: true
+          MYSQL_PASSWORD: root
+          DB_PASSWORD: root
+          DB_PORT: ${{ job.services.mysql.ports[3306] }}
+          MYSQL_PORT: ${{ job.services.mysql.ports[3306] }}
+          MYSQL_HOST: 127.0.0.1
+          POSTGRES_USERNAME: postgres
+          POSTGRES_PASSWORD: password
+          SERIALIZE: 1
+          COVERAGE: true
+          CI_FOR_PR: true
+
+      - name: Annotate errors
+        if: ${{ failure() }}
+        uses: ./.github/actions/annotate
+
+      - name: Save coverage results
+        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # tag v4.3.4
+        with:
+          name: coverage-report-multiverse-${{ matrix.ruby-version }}-${{ matrix.multiverse }}
+          path: lib/coverage_*/.resultset.json
+          retention-days: 2
+
+      - name: Generate gem manifest
+        run: rake test:multiverse:gem_manifest
+
+      - name: Save gem manifest
+        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # tag v4.3.4
+        with:
+          name: gem_manifest_${{ matrix.ruby-version }}_${{ matrix.multiverse }}.json
+          path: gem_manifest_${{ matrix.ruby-version }}_${{ matrix.multiverse }}.json
+          retention-days: 2
+
 
 
   infinite_tracing:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,40 +134,10 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby-version }}
 
-        # This allows the cache in the following step to be able to write files to the directory needed for mysql
-      - if: matrix.ruby-version == '2.4.10'
-        name: Prepare mysql directory
-        run: sudo chown -R $USER /usr/local
-
-      - if: matrix.ruby-version == '2.4.10'
-        name: Cache mysql55
-        id: mysql55-cache
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # tag v4.0.2
-        with:
-          path: /usr/local/mysql55
-          key: mysql55-install
-
-      - if: steps.mysql55-cache.outputs.cache-hit != 'true' && matrix.ruby-version == '2.4.10'
-        name: Install mysql55
-        run: sudo ./test/script/install_mysql55
-
       - name: Setup bundler
         run: ./.github/workflows/scripts/setup_bundler
         env:
           RUBY_VERSION: ${{ matrix.ruby-version }}
-
-
-      - name: Wait for/Check Mysql
-        uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # tag v3.0.0
-        with:
-          timeout_minutes: 1
-          max_attempts: 20
-          command: |
-            mysql --host 127.0.0.1 --port ${{ job.services.mysql.ports[3306] }} -uroot -proot -e "SHOW GRANTS FOR 'root'@'localhost'";
-            if [[ $? != 0 ]]; then
-              sleep 1;
-            fi
-
 
       - name: Run Multiverse Tests
         uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # tag v3.0.0
@@ -211,7 +181,7 @@ jobs:
 
 
 
-  multiverse_services_other:
+  multiverse_services_1:
     needs: run_rubocop
     runs-on: ubuntu-22.04
     services:
@@ -249,6 +219,90 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+      mongodb:
+        image: ${{ contains(fromJson('["2.4.10"]'), matrix.ruby-version) && 'mongo:5.0.11' || 'mongo:latest' }}
+        ports:
+          - 27017:27017
+      rabbitmq:
+        image: rabbitmq:latest
+        ports:
+          - 5672:5672
+        options: >-
+          --health-cmd "rabbitmq-diagnostics -q check_port_connectivity"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby-version: [2.4.10, 3.4.1]
+
+    steps:
+      - name: Configure git
+        run: 'git config --global init.defaultBranch main'
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # tag v4.1.7
+
+        # - curl is needed for Curb
+        # - xslt is needed for older Nokogiris, RUBY_VERSION < 2.5
+        # - sasl is needed for memcached
+      - name: Install OS packages
+        run: sudo apt-get update; sudo apt-get install -y --no-install-recommends libcurl4-nss-dev libsasl2-dev libxslt1-dev
+
+      - name: Install Ruby ${{ matrix.ruby-version }}
+        uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4 # tag v1.207.0
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+
+      - name: Setup bundler
+        run: ./.github/workflows/scripts/setup_bundler
+        env:
+          RUBY_VERSION: ${{ matrix.ruby-version }}
+
+      - name: Run Multiverse Tests
+        uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # tag v3.0.0
+        with:
+          timeout_minutes: 60
+          max_attempts: 2
+          command: bundle exec rake test:multiverse[group="services_1"]
+        env:
+          VERBOSE_TEST_OUTPUT: true
+          MYSQL_PASSWORD: root
+          DB_PASSWORD: root
+          DB_PORT: ${{ job.services.mysql.ports[3306] }}
+          MYSQL_PORT: ${{ job.services.mysql.ports[3306] }}
+          MYSQL_HOST: 127.0.0.1
+          POSTGRES_USERNAME: postgres
+          POSTGRES_PASSWORD: password
+          SERIALIZE: 1
+          COVERAGE: true
+          CI_FOR_PR: true
+
+      - name: Annotate errors
+        if: ${{ failure() }}
+        uses: ./.github/actions/annotate
+
+      - name: Save coverage results
+        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # tag v4.3.4
+        with:
+          name: coverage-report-multiverse-${{ matrix.ruby-version }}-services_1
+          path: lib/coverage_*/.resultset.json
+          retention-days: 2
+
+      - name: Generate gem manifest
+        run: rake test:multiverse:gem_manifest
+
+      - name: Save gem manifest
+        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # tag v4.3.4
+        with:
+          name: gem_manifest_${{ matrix.ruby-version }}_services_1.json
+          path: gem_manifest_${{ matrix.ruby-version }}_services_1.json
+          retention-days: 2
+
+
+  multiverse_services_2:
+    needs: run_rubocop
+    runs-on: ubuntu-22.04
+    services:
       kafka:
         image: bitnami/kafka
         ports:
@@ -271,19 +325,6 @@ jobs:
           - 11211:11211
         options: >-
           --health-cmd "timeout 5 bash -c 'cat < /dev/null > /dev/udp/127.0.0.1/11211'"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-      mongodb:
-        image: ${{ contains(fromJson('["2.4.10"]'), matrix.ruby-version) && 'mongo:5.0.11' || 'mongo:latest' }}
-        ports:
-          - 27017:27017
-      rabbitmq:
-        image: rabbitmq:latest
-        ports:
-          - 5672:5672
-        options: >-
-          --health-cmd "rabbitmq-diagnostics -q check_port_connectivity"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
@@ -317,47 +358,17 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby-version }}
 
-        # This allows the cache in the following step to be able to write files to the directory needed for mysql
-      # - if: matrix.ruby-version == '2.4.10'
-      #   name: Prepare mysql directory
-      #   run: sudo chown -R $USER /usr/local
-
-      # - if: matrix.ruby-version == '2.4.10'
-      #   name: Cache mysql55
-      #   id: mysql55-cache
-      #   uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # tag v4.0.2
-      #   with:
-      #     path: /usr/local/mysql55
-      #     key: mysql55-install
-
-      # - if: steps.mysql55-cache.outputs.cache-hit != 'true' && matrix.ruby-version == '2.4.10'
-      #   name: Install mysql55
-      #   run: sudo ./test/script/install_mysql55
-
       - name: Setup bundler
         run: ./.github/workflows/scripts/setup_bundler
         env:
           RUBY_VERSION: ${{ matrix.ruby-version }}
-
-
-      # - name: Wait for/Check Mysql
-      #   uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # tag v3.0.0
-      #   with:
-      #     timeout_minutes: 1
-      #     max_attempts: 20
-      #     command: |
-      #       mysql --host 127.0.0.1 --port ${{ job.services.mysql.ports[3306] }} -uroot -proot -e "SHOW GRANTS FOR 'root'@'localhost'";
-      #       if [[ $? != 0 ]]; then
-      #         sleep 1;
-      #       fi
-
 
       - name: Run Multiverse Tests
         uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # tag v3.0.0
         with:
           timeout_minutes: 60
           max_attempts: 2
-          command: bundle exec rake test:multiverse[group="services"]
+          command: bundle exec rake test:multiverse[group="services_2"]
         env:
           VERBOSE_TEST_OUTPUT: true
           MYSQL_PASSWORD: root
@@ -378,7 +389,7 @@ jobs:
       - name: Save coverage results
         uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # tag v4.3.4
         with:
-          name: coverage-report-multiverse-${{ matrix.ruby-version }}-${{ matrix.multiverse }}
+          name: coverage-report-multiverse-${{ matrix.ruby-version }}-services_2
           path: lib/coverage_*/.resultset.json
           retention-days: 2
 
@@ -388,9 +399,98 @@ jobs:
       - name: Save gem manifest
         uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # tag v4.3.4
         with:
-          name: gem_manifest_${{ matrix.ruby-version }}_${{ matrix.multiverse }}.json
-          path: gem_manifest_${{ matrix.ruby-version }}_${{ matrix.multiverse }}.json
+          name: gem_manifest_${{ matrix.ruby-version }}_services_2.json
+          path: gem_manifest_${{ matrix.ruby-version }}_services_2.json
           retention-days: 2
+
+
+  multiverse_services_kafka:
+    needs: run_rubocop
+    runs-on: ubuntu-22.04
+    services:
+      kafka:
+        image: bitnami/kafka
+        ports:
+          - 9092:9092
+        options: >-
+          --health-cmd "kafka-broker-api-versions.sh --version"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        env:
+          KAFKA_CFG_ZOOKEEPER_CONNECT: zookeeper:2181
+          ALLOW_PLAINTEXT_LISTENER: yes
+          KAFKA_LISTENERS: INSIDE://0.0.0.0:9093,OUTSIDE://0.0.0.0:9092
+          KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INSIDE:PLAINTEXT,OUTSIDE:PLAINTEXT
+          KAFKA_INTER_BROKER_LISTENER_NAME: INSIDE
+          KAFKA_ADVERTISED_LISTENERS: INSIDE://kafka:9093,OUTSIDE://localhost:9092
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby-version: [2.4.10, 3.4.1]
+
+    steps:
+      - name: Configure git
+        run: 'git config --global init.defaultBranch main'
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # tag v4.1.7
+
+        # - curl is needed for Curb
+        # - xslt is needed for older Nokogiris, RUBY_VERSION < 2.5
+        # - sasl is needed for memcached
+      - name: Install OS packages
+        run: sudo apt-get update; sudo apt-get install -y --no-install-recommends libcurl4-nss-dev libsasl2-dev libxslt1-dev
+
+      - name: Install Ruby ${{ matrix.ruby-version }}
+        uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4 # tag v1.207.0
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+
+      - name: Setup bundler
+        run: ./.github/workflows/scripts/setup_bundler
+        env:
+          RUBY_VERSION: ${{ matrix.ruby-version }}
+
+      - name: Run Multiverse Tests
+        uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # tag v3.0.0
+        with:
+          timeout_minutes: 60
+          max_attempts: 2
+          command: bundle exec rake test:multiverse[group="services_kafka"]
+        env:
+          VERBOSE_TEST_OUTPUT: true
+          MYSQL_PASSWORD: root
+          DB_PASSWORD: root
+          DB_PORT: ${{ job.services.mysql.ports[3306] }}
+          MYSQL_PORT: ${{ job.services.mysql.ports[3306] }}
+          MYSQL_HOST: 127.0.0.1
+          POSTGRES_USERNAME: postgres
+          POSTGRES_PASSWORD: password
+          SERIALIZE: 1
+          COVERAGE: true
+          CI_FOR_PR: true
+
+      - name: Annotate errors
+        if: ${{ failure() }}
+        uses: ./.github/actions/annotate
+
+      - name: Save coverage results
+        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # tag v4.3.4
+        with:
+          name: coverage-report-multiverse-${{ matrix.ruby-version }}-services_kafka
+          path: lib/coverage_*/.resultset.json
+          retention-days: 2
+
+      - name: Generate gem manifest
+        run: rake test:multiverse:gem_manifest
+
+      - name: Save gem manifest
+        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # tag v4.3.4
+        with:
+          name: gem_manifest_${{ matrix.ruby-version }}_services_kafka.json
+          path: gem_manifest_${{ matrix.ruby-version }}_services_kafka.json
+          retention-days: 2
+
+
 
   multiverse_services_mysql_pg:
     needs: run_rubocop
@@ -458,7 +558,6 @@ jobs:
         env:
           RUBY_VERSION: ${{ matrix.ruby-version }}
 
-
       - name: Wait for/Check Mysql
         uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # tag v3.0.0
         with:
@@ -470,13 +569,12 @@ jobs:
               sleep 1;
             fi
 
-
       - name: Run Multiverse Tests
         uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # tag v3.0.0
         with:
           timeout_minutes: 60
           max_attempts: 2
-          command: bundle exec rake test:multiverse[group="services_2"]
+          command: bundle exec rake test:multiverse[group="services_mysql_pg"]
         env:
           VERBOSE_TEST_OUTPUT: true
           MYSQL_PASSWORD: root
@@ -497,7 +595,7 @@ jobs:
       - name: Save coverage results
         uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # tag v4.3.4
         with:
-          name: coverage-report-multiverse-${{ matrix.ruby-version }}-${{ matrix.multiverse }}
+          name: coverage-report-multiverse-${{ matrix.ruby-version }}-service_mysql_pg
           path: lib/coverage_*/.resultset.json
           retention-days: 2
 
@@ -507,8 +605,8 @@ jobs:
       - name: Save gem manifest
         uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # tag v4.3.4
         with:
-          name: gem_manifest_${{ matrix.ruby-version }}_${{ matrix.multiverse }}.json
-          path: gem_manifest_${{ matrix.ruby-version }}_${{ matrix.multiverse }}.json
+          name: gem_manifest_${{ matrix.ruby-version }}_service_mysql_pg.json
+          path: gem_manifest_${{ matrix.ruby-version }}_service_mysql_pg.json
           retention-days: 2
 
 

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -146,39 +146,10 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby-version }}
 
-      # - if: matrix.ruby-version == '2.4.10'
-      #   name: Prepare mysql dirextory
-      #   run: sudo chown -R $USER /usr/local
-
-      # - if: matrix.ruby-version == '2.4.10'
-      #   name: Cache mysql55
-      #   id: mysql55-cache
-      #   uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # tag v4.0.2
-      #   with:
-      #     path: /usr/local/mysql55
-      #     key: mysql55-install
-
-      # - if: steps.mysql55-cache.outputs.cache-hit != 'true' && ( matrix.ruby-version == '2.4.10')
-      #   name: Install mysql55
-      #   run: sudo ./test/script/install_mysql55
-
       - name: Setup bundler
         run: ./.github/workflows/scripts/setup_bundler
         env:
           RUBY_VERSION: ${{ matrix.ruby-version }}
-
-
-      # - name: Wait for/Check Mysql
-      #   uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # tag v3.0.0
-      #   with:
-      #     timeout_minutes: 1
-      #     max_attempts: 20
-      #     command: |
-      #       mysql --host 127.0.0.1 --port ${{ job.services.mysql.ports[3306] }} -uroot -proot -e "SHOW GRANTS FOR 'root'@'localhost'";
-      #       if [[ $? != 0 ]]; then
-      #         sleep 1;
-      #       fi
-
 
       - name: Run Multiverse Tests
         uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # tag v3.0.0
@@ -201,7 +172,8 @@ jobs:
         if: ${{ failure() }}
         uses: ./.github/actions/annotate
 
-  multiverse_services_other:
+
+  multiverse_services_1:
     needs: run_rubocop
     runs-on: ubuntu-22.04
     services:
@@ -239,6 +211,90 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+      mongodb:
+        image: ${{ contains(fromJson('["2.4.10"]'), matrix.ruby-version) && 'mongo:5.0.11' || 'mongo:latest' }}
+        ports:
+          - 27017:27017
+      rabbitmq:
+        image: rabbitmq:latest
+        ports:
+          - 5672:5672
+        options: >-
+          --health-cmd "rabbitmq-diagnostics -q check_port_connectivity"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby-version: [2.4.10, 2.5.9, 2.6.10, 2.7.8, 3.0.7, 3.1.6, 3.2.6, 3.3.6, 3.4.1]
+
+    steps:
+      - name: Configure git
+        run: 'git config --global init.defaultBranch main'
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # tag v4.1.7
+
+        # - curl is needed for Curb
+        # - xslt is needed for older Nokogiris, RUBY_VERSION < 2.5
+        # - sasl is needed for memcached
+      - name: Install OS packages
+        run: sudo apt-get update; sudo apt-get install -y --no-install-recommends libcurl4-nss-dev libsasl2-dev libxslt1-dev
+
+      - name: Install Ruby ${{ matrix.ruby-version }}
+        uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4 # tag v1.207.0
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+
+      - name: Setup bundler
+        run: ./.github/workflows/scripts/setup_bundler
+        env:
+          RUBY_VERSION: ${{ matrix.ruby-version }}
+
+      - name: Run Multiverse Tests
+        uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # tag v3.0.0
+        with:
+          timeout_minutes: 60
+          max_attempts: 2
+          command: bundle exec rake test:multiverse[group="services_1"]
+        env:
+          VERBOSE_TEST_OUTPUT: true
+          MYSQL_PASSWORD: root
+          DB_PASSWORD: root
+          DB_PORT: ${{ job.services.mysql.ports[3306] }}
+          MYSQL_PORT: ${{ job.services.mysql.ports[3306] }}
+          MYSQL_HOST: 127.0.0.1
+          POSTGRES_USERNAME: postgres
+          POSTGRES_PASSWORD: password
+          SERIALIZE: 1
+          COVERAGE: true
+          CI_FOR_PR: true
+
+      - name: Annotate errors
+        if: ${{ failure() }}
+        uses: ./.github/actions/annotate
+
+      - name: Save coverage results
+        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # tag v4.3.4
+        with:
+          name: coverage-report-multiverse-${{ matrix.ruby-version }}-services_1
+          path: lib/coverage_*/.resultset.json
+          retention-days: 2
+
+      - name: Generate gem manifest
+        run: rake test:multiverse:gem_manifest
+
+      - name: Save gem manifest
+        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # tag v4.3.4
+        with:
+          name: gem_manifest_${{ matrix.ruby-version }}_services_1.json
+          path: gem_manifest_${{ matrix.ruby-version }}_services_1.json
+          retention-days: 2
+
+
+  multiverse_services_2:
+    needs: run_rubocop
+    runs-on: ubuntu-22.04
+    services:
       kafka:
         image: bitnami/kafka
         ports:
@@ -264,19 +320,6 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
-      mongodb:
-        image: ${{ contains(fromJson('["2.4.10"]'), matrix.ruby-version) && 'mongo:5.0.11' || 'mongo:latest' }}
-        ports:
-          - 27017:27017
-      rabbitmq:
-        image: rabbitmq:latest
-        ports:
-          - 5672:5672
-        options: >-
-          --health-cmd "rabbitmq-diagnostics -q check_port_connectivity"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
       redis:
         image: redis
         ports:
@@ -290,7 +333,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version: [2.4.10, 2.5.9, 2.6.10, 2.7.8, 3.0.7, 3.1.6, 3.2.6, 3.3.6, 3.4.1]
-        # ruby-version: [2.4.10, 3.4.1]
 
     steps:
       - name: Configure git
@@ -308,47 +350,86 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby-version }}
 
-        # This allows the cache in the following step to be able to write files to the directory needed for mysql
-      # - if: matrix.ruby-version == '2.4.10'
-      #   name: Prepare mysql directory
-      #   run: sudo chown -R $USER /usr/local
-
-      # - if: matrix.ruby-version == '2.4.10'
-      #   name: Cache mysql55
-      #   id: mysql55-cache
-      #   uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # tag v4.0.2
-      #   with:
-      #     path: /usr/local/mysql55
-      #     key: mysql55-install
-
-      # - if: steps.mysql55-cache.outputs.cache-hit != 'true' && matrix.ruby-version == '2.4.10'
-      #   name: Install mysql55
-      #   run: sudo ./test/script/install_mysql55
-
       - name: Setup bundler
         run: ./.github/workflows/scripts/setup_bundler
         env:
           RUBY_VERSION: ${{ matrix.ruby-version }}
-
-
-      # - name: Wait for/Check Mysql
-      #   uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # tag v3.0.0
-      #   with:
-      #     timeout_minutes: 1
-      #     max_attempts: 20
-      #     command: |
-      #       mysql --host 127.0.0.1 --port ${{ job.services.mysql.ports[3306] }} -uroot -proot -e "SHOW GRANTS FOR 'root'@'localhost'";
-      #       if [[ $? != 0 ]]; then
-      #         sleep 1;
-      #       fi
-
 
       - name: Run Multiverse Tests
         uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # tag v3.0.0
         with:
           timeout_minutes: 60
           max_attempts: 2
-          command: bundle exec rake test:multiverse[group="services"]
+          command: bundle exec rake test:multiverse[group="services_2"]
+        env:
+          VERBOSE_TEST_OUTPUT: true
+          DB_PASSWORD: root
+          MYSQL_PASSWORD: root
+          DB_PORT: ${{ job.services.mysql.ports[3306] }}
+          MYSQL_PORT: ${{ job.services.mysql.ports[3306] }}
+          MYSQL_HOST: 127.0.0.1
+          POSTGRES_USERNAME: postgres
+          POSTGRES_PASSWORD: password
+          SERIALIZE: 1
+
+      - name: Annotate errors
+        if: ${{ failure() }}
+        uses: ./.github/actions/annotate
+
+
+
+  multiverse_services_kafka:
+    needs: run_rubocop
+    runs-on: ubuntu-22.04
+    services:
+      kafka:
+        image: bitnami/kafka
+        ports:
+          - 9092:9092
+        options: >-
+          --health-cmd "kafka-broker-api-versions.sh --version"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        env:
+          KAFKA_CFG_ZOOKEEPER_CONNECT: zookeeper:2181
+          ALLOW_PLAINTEXT_LISTENER: yes
+          KAFKA_LISTENERS: INSIDE://0.0.0.0:9093,OUTSIDE://0.0.0.0:9092
+          KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INSIDE:PLAINTEXT,OUTSIDE:PLAINTEXT
+          KAFKA_INTER_BROKER_LISTENER_NAME: INSIDE
+          KAFKA_ADVERTISED_LISTENERS: INSIDE://kafka:9093,OUTSIDE://localhost:9092
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby-version: [2.4.10, 2.5.9, 2.6.10, 2.7.8, 3.0.7, 3.1.6, 3.2.6, 3.3.6, 3.4.1]
+
+    steps:
+      - name: Configure git
+        run: 'git config --global init.defaultBranch main'
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # tag v4.1.7
+
+        # - curl is needed for Curb
+        # - xslt is needed for older Nokogiris, RUBY_VERSION < 2.5
+        # - sasl is needed for memcached
+      - name: Install OS packages
+        run: sudo apt-get update; sudo apt-get install -y --no-install-recommends libcurl4-nss-dev libsasl2-dev libxslt1-dev
+
+      - name: Install Ruby ${{ matrix.ruby-version }}
+        uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4 # tag v1.207.0
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+
+      - name: Setup bundler
+        run: ./.github/workflows/scripts/setup_bundler
+        env:
+          RUBY_VERSION: ${{ matrix.ruby-version }}
+
+      - name: Run Multiverse Tests
+        uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # tag v3.0.0
+        with:
+          timeout_minutes: 60
+          max_attempts: 2
+          command: bundle exec rake test:multiverse[group="services_kafka"]
         env:
           VERBOSE_TEST_OUTPUT: true
           DB_PASSWORD: root
@@ -392,7 +473,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version: [2.4.10, 2.5.9, 2.6.10, 2.7.8, 3.0.7, 3.1.6, 3.2.6, 3.3.6, 3.4.1]
-        # ruby-version: [2.4.10, 3.4.1]
 
     steps:
       - name: Configure git
@@ -444,13 +524,12 @@ jobs:
               sleep 1;
             fi
 
-
       - name: Run Multiverse Tests
         uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # tag v3.0.0
         with:
           timeout_minutes: 60
           max_attempts: 2
-          command: bundle exec rake test:multiverse[group="services_2"]
+          command: bundle exec rake test:multiverse[group="services_mysql_pg"]
         env:
           VERBOSE_TEST_OUTPUT: true
           DB_PASSWORD: root

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -193,17 +193,6 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 10
-      zookeeper:
-        image: bitnami/zookeeper
-        ports:
-          - 2181:2181
-        env:
-          ALLOW_ANONYMOUS_LOGIN: yes
-        options: >-
-          --health-cmd "echo mntr | nc -w 2 -q 2 localhost 2181"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
       mongodb:
         image: ${{ contains(fromJson('["2.4.10"]'), matrix.ruby-version) && 'mongo:5.0.11' || 'mongo:latest' }}
         ports:
@@ -358,6 +347,17 @@ jobs:
           KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INSIDE:PLAINTEXT,OUTSIDE:PLAINTEXT
           KAFKA_INTER_BROKER_LISTENER_NAME: INSIDE
           KAFKA_ADVERTISED_LISTENERS: INSIDE://kafka:9093,OUTSIDE://localhost:9092
+      zookeeper:
+        image: bitnami/zookeeper
+        ports:
+          - 2181:2181
+        env:
+          ALLOW_ANONYMOUS_LOGIN: yes
+        options: >-
+          --health-cmd "echo mntr | nc -w 2 -q 2 localhost 2181"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -364,22 +364,6 @@ jobs:
         if: ${{ failure() }}
         uses: ./.github/actions/annotate
 
-      - name: Save coverage results
-        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # tag v4.3.4
-        with:
-          name: coverage-report-multiverse-${{ matrix.ruby-version }}-${{ matrix.multiverse }}
-          path: lib/coverage_*/.resultset.json
-          retention-days: 2
-
-      - name: Generate gem manifest
-        run: rake test:multiverse:gem_manifest
-
-      - name: Save gem manifest
-        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # tag v4.3.4
-        with:
-          name: gem_manifest_${{ matrix.ruby-version }}_${{ matrix.multiverse }}.json
-          path: gem_manifest_${{ matrix.ruby-version }}_${{ matrix.multiverse }}.json
-          retention-days: 2
 
   multiverse_services_mysql_pg:
     needs: run_rubocop
@@ -482,22 +466,6 @@ jobs:
         if: ${{ failure() }}
         uses: ./.github/actions/annotate
 
-      - name: Save coverage results
-        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # tag v4.3.4
-        with:
-          name: coverage-report-multiverse-${{ matrix.ruby-version }}-${{ matrix.multiverse }}
-          path: lib/coverage_*/.resultset.json
-          retention-days: 2
-
-      - name: Generate gem manifest
-        run: rake test:multiverse:gem_manifest
-
-      - name: Save gem manifest
-        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # tag v4.3.4
-        with:
-          name: gem_manifest_${{ matrix.ruby-version }}_${{ matrix.multiverse }}.json
-          path: gem_manifest_${{ matrix.ruby-version }}_${{ matrix.multiverse }}.json
-          retention-days: 2
 
 
 

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -159,13 +159,6 @@ jobs:
           command:  bundle exec rake test:multiverse[group="${{ matrix.multiverse }}"]
         env:
           VERBOSE_TEST_OUTPUT: true
-          DB_PASSWORD: root
-          MYSQL_PASSWORD: root
-          DB_PORT: ${{ job.services.mysql.ports[3306] }}
-          MYSQL_PORT: ${{ job.services.mysql.ports[3306] }}
-          MYSQL_HOST: 127.0.0.1
-          POSTGRES_USERNAME: postgres
-          POSTGRES_PASSWORD: password
           SERIALIZE: 1
 
       - name: Annotate errors
@@ -258,37 +251,11 @@ jobs:
           command: bundle exec rake test:multiverse[group="services_1"]
         env:
           VERBOSE_TEST_OUTPUT: true
-          MYSQL_PASSWORD: root
-          DB_PASSWORD: root
-          DB_PORT: ${{ job.services.mysql.ports[3306] }}
-          MYSQL_PORT: ${{ job.services.mysql.ports[3306] }}
-          MYSQL_HOST: 127.0.0.1
-          POSTGRES_USERNAME: postgres
-          POSTGRES_PASSWORD: password
           SERIALIZE: 1
-          COVERAGE: true
-          CI_FOR_PR: true
 
       - name: Annotate errors
         if: ${{ failure() }}
         uses: ./.github/actions/annotate
-
-      - name: Save coverage results
-        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # tag v4.3.4
-        with:
-          name: coverage-report-multiverse-${{ matrix.ruby-version }}-services_1
-          path: lib/coverage_*/.resultset.json
-          retention-days: 2
-
-      - name: Generate gem manifest
-        run: rake test:multiverse:gem_manifest
-
-      - name: Save gem manifest
-        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # tag v4.3.4
-        with:
-          name: gem_manifest_${{ matrix.ruby-version }}_services_1.json
-          path: gem_manifest_${{ matrix.ruby-version }}_services_1.json
-          retention-days: 2
 
 
   multiverse_services_2:
@@ -363,13 +330,6 @@ jobs:
           command: bundle exec rake test:multiverse[group="services_2"]
         env:
           VERBOSE_TEST_OUTPUT: true
-          DB_PASSWORD: root
-          MYSQL_PASSWORD: root
-          DB_PORT: ${{ job.services.mysql.ports[3306] }}
-          MYSQL_PORT: ${{ job.services.mysql.ports[3306] }}
-          MYSQL_HOST: 127.0.0.1
-          POSTGRES_USERNAME: postgres
-          POSTGRES_PASSWORD: password
           SERIALIZE: 1
 
       - name: Annotate errors
@@ -432,13 +392,6 @@ jobs:
           command: bundle exec rake test:multiverse[group="services_kafka"]
         env:
           VERBOSE_TEST_OUTPUT: true
-          DB_PASSWORD: root
-          MYSQL_PASSWORD: root
-          DB_PORT: ${{ job.services.mysql.ports[3306] }}
-          MYSQL_PORT: ${{ job.services.mysql.ports[3306] }}
-          MYSQL_HOST: 127.0.0.1
-          POSTGRES_USERNAME: postgres
-          POSTGRES_PASSWORD: password
           SERIALIZE: 1
 
       - name: Annotate errors

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -125,6 +125,85 @@ jobs:
 
   multiverse:
     runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        multiverse: [agent, ai, background, background_2, frameworks, httpclients, httpclients_2, rails, rest]
+        ruby-version: [2.4.10, 2.5.9, 2.6.10, 2.7.8, 3.0.7, 3.1.6, 3.2.6, 3.3.6, 3.4.1]
+    steps:
+      - name: Configure git
+        run: 'git config --global init.defaultBranch main'
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # tag v4.1.7
+
+        # - curl is needed for Curb
+        # - xslt is needed for older Nokogiris, RUBY_VERSION < 2.5
+        # - sasl is needed for memcached
+      - name: Install OS packages
+        run: sudo apt-get update; sudo apt-get install -y --no-install-recommends libcurl4-nss-dev libsasl2-dev libxslt1-dev
+
+      - name: Install Ruby ${{ matrix.ruby-version }}
+        uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4 # tag v1.207.0
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+
+      # - if: matrix.ruby-version == '2.4.10'
+      #   name: Prepare mysql dirextory
+      #   run: sudo chown -R $USER /usr/local
+
+      # - if: matrix.ruby-version == '2.4.10'
+      #   name: Cache mysql55
+      #   id: mysql55-cache
+      #   uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # tag v4.0.2
+      #   with:
+      #     path: /usr/local/mysql55
+      #     key: mysql55-install
+
+      # - if: steps.mysql55-cache.outputs.cache-hit != 'true' && ( matrix.ruby-version == '2.4.10')
+      #   name: Install mysql55
+      #   run: sudo ./test/script/install_mysql55
+
+      - name: Setup bundler
+        run: ./.github/workflows/scripts/setup_bundler
+        env:
+          RUBY_VERSION: ${{ matrix.ruby-version }}
+
+
+      # - name: Wait for/Check Mysql
+      #   uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # tag v3.0.0
+      #   with:
+      #     timeout_minutes: 1
+      #     max_attempts: 20
+      #     command: |
+      #       mysql --host 127.0.0.1 --port ${{ job.services.mysql.ports[3306] }} -uroot -proot -e "SHOW GRANTS FOR 'root'@'localhost'";
+      #       if [[ $? != 0 ]]; then
+      #         sleep 1;
+      #       fi
+
+
+      - name: Run Multiverse Tests
+        uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # tag v3.0.0
+        with:
+          timeout_minutes: 60
+          max_attempts: 2
+          command:  bundle exec rake test:multiverse[group="${{ matrix.multiverse }}"]
+        env:
+          VERBOSE_TEST_OUTPUT: true
+          DB_PASSWORD: root
+          MYSQL_PASSWORD: root
+          DB_PORT: ${{ job.services.mysql.ports[3306] }}
+          MYSQL_PORT: ${{ job.services.mysql.ports[3306] }}
+          MYSQL_HOST: 127.0.0.1
+          POSTGRES_USERNAME: postgres
+          POSTGRES_PASSWORD: password
+          SERIALIZE: 1
+
+      - name: Annotate errors
+        if: ${{ failure() }}
+        uses: ./.github/actions/annotate
+
+  multiverse_services_other:
+    needs: run_rubocop
+    runs-on: ubuntu-22.04
     services:
       elasticsearch7:
         image: elasticsearch:7.16.2
@@ -138,7 +217,7 @@ jobs:
           --health-timeout 5s
           --health-retries 10
       elasticsearch8:
-        image: elasticsearch:8.4.2
+        image: elasticsearch:8.13.0
         env:
           discovery.type: single-node
           xpack.security.enabled: false
@@ -189,25 +268,6 @@ jobs:
         image: ${{ contains(fromJson('["2.4.10"]'), matrix.ruby-version) && 'mongo:5.0.11' || 'mongo:latest' }}
         ports:
           - 27017:27017
-      mysql:
-        image: mysql:5.7
-        env:
-          MYSQL_ROOT_PASSWORD: root
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
-        ports:
-          - 3306
-      postgres:
-        image: postgres:latest
-        env:
-          POSTGRES_USERNAME: postgres
-          POSTGRES_PASSWORD: password
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
       rabbitmq:
         image: rabbitmq:latest
         ports:
@@ -229,8 +289,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        multiverse: [agent, ai, background, background_2, database, kafka, frameworks, httpclients, httpclients_2, rails, rest]
         ruby-version: [2.4.10, 2.5.9, 2.6.10, 2.7.8, 3.0.7, 3.1.6, 3.2.6, 3.3.6, 3.4.1]
+        # ruby-version: [2.4.10, 3.4.1]
+
     steps:
       - name: Configure git
         run: 'git config --global init.defaultBranch main'
@@ -247,8 +308,127 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby-version }}
 
+        # This allows the cache in the following step to be able to write files to the directory needed for mysql
+      # - if: matrix.ruby-version == '2.4.10'
+      #   name: Prepare mysql directory
+      #   run: sudo chown -R $USER /usr/local
+
+      # - if: matrix.ruby-version == '2.4.10'
+      #   name: Cache mysql55
+      #   id: mysql55-cache
+      #   uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # tag v4.0.2
+      #   with:
+      #     path: /usr/local/mysql55
+      #     key: mysql55-install
+
+      # - if: steps.mysql55-cache.outputs.cache-hit != 'true' && matrix.ruby-version == '2.4.10'
+      #   name: Install mysql55
+      #   run: sudo ./test/script/install_mysql55
+
+      - name: Setup bundler
+        run: ./.github/workflows/scripts/setup_bundler
+        env:
+          RUBY_VERSION: ${{ matrix.ruby-version }}
+
+
+      # - name: Wait for/Check Mysql
+      #   uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # tag v3.0.0
+      #   with:
+      #     timeout_minutes: 1
+      #     max_attempts: 20
+      #     command: |
+      #       mysql --host 127.0.0.1 --port ${{ job.services.mysql.ports[3306] }} -uroot -proot -e "SHOW GRANTS FOR 'root'@'localhost'";
+      #       if [[ $? != 0 ]]; then
+      #         sleep 1;
+      #       fi
+
+
+      - name: Run Multiverse Tests
+        uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # tag v3.0.0
+        with:
+          timeout_minutes: 60
+          max_attempts: 2
+          command: bundle exec rake test:multiverse[group="services"]
+        env:
+          VERBOSE_TEST_OUTPUT: true
+          DB_PASSWORD: root
+          MYSQL_PASSWORD: root
+          DB_PORT: ${{ job.services.mysql.ports[3306] }}
+          MYSQL_PORT: ${{ job.services.mysql.ports[3306] }}
+          MYSQL_HOST: 127.0.0.1
+          POSTGRES_USERNAME: postgres
+          POSTGRES_PASSWORD: password
+          SERIALIZE: 1
+
+      - name: Annotate errors
+        if: ${{ failure() }}
+        uses: ./.github/actions/annotate
+
+      - name: Save coverage results
+        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # tag v4.3.4
+        with:
+          name: coverage-report-multiverse-${{ matrix.ruby-version }}-${{ matrix.multiverse }}
+          path: lib/coverage_*/.resultset.json
+          retention-days: 2
+
+      - name: Generate gem manifest
+        run: rake test:multiverse:gem_manifest
+
+      - name: Save gem manifest
+        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # tag v4.3.4
+        with:
+          name: gem_manifest_${{ matrix.ruby-version }}_${{ matrix.multiverse }}.json
+          path: gem_manifest_${{ matrix.ruby-version }}_${{ matrix.multiverse }}.json
+          retention-days: 2
+
+  multiverse_services_mysql_pg:
+    needs: run_rubocop
+    runs-on: ubuntu-22.04
+    services:
+      mysql:
+        image: mysql:5.7
+        env:
+          MYSQL_ROOT_PASSWORD: root
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+        ports:
+          - 3306
+      postgres:
+        image: postgres:latest
+        env:
+          POSTGRES_USERNAME: postgres
+          POSTGRES_PASSWORD: password
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby-version: [2.4.10, 2.5.9, 2.6.10, 2.7.8, 3.0.7, 3.1.6, 3.2.6, 3.3.6, 3.4.1]
+        # ruby-version: [2.4.10, 3.4.1]
+
+    steps:
+      - name: Configure git
+        run: 'git config --global init.defaultBranch main'
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # tag v4.1.7
+
+        # - curl is needed for Curb
+        # - xslt is needed for older Nokogiris, RUBY_VERSION < 2.5
+        # - sasl is needed for memcached
+      - name: Install OS packages
+        run: sudo apt-get update; sudo apt-get install -y --no-install-recommends libcurl4-nss-dev libsasl2-dev libxslt1-dev
+
+      - name: Install Ruby ${{ matrix.ruby-version }}
+        uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4 # tag v1.207.0
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+
+        # This allows the cache in the following step to be able to write files to the directory needed for mysql
       - if: matrix.ruby-version == '2.4.10'
-        name: Prepare mysql dirextory
+        name: Prepare mysql directory
         run: sudo chown -R $USER /usr/local
 
       - if: matrix.ruby-version == '2.4.10'
@@ -259,7 +439,7 @@ jobs:
           path: /usr/local/mysql55
           key: mysql55-install
 
-      - if: steps.mysql55-cache.outputs.cache-hit != 'true' && ( matrix.ruby-version == '2.4.10')
+      - if: steps.mysql55-cache.outputs.cache-hit != 'true' && matrix.ruby-version == '2.4.10'
         name: Install mysql55
         run: sudo ./test/script/install_mysql55
 
@@ -286,7 +466,7 @@ jobs:
         with:
           timeout_minutes: 60
           max_attempts: 2
-          command:  bundle exec rake test:multiverse[group="${{ matrix.multiverse }}"]
+          command: bundle exec rake test:multiverse[group="services_2"]
         env:
           VERBOSE_TEST_OUTPUT: true
           DB_PASSWORD: root
@@ -301,6 +481,24 @@ jobs:
       - name: Annotate errors
         if: ${{ failure() }}
         uses: ./.github/actions/annotate
+
+      - name: Save coverage results
+        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # tag v4.3.4
+        with:
+          name: coverage-report-multiverse-${{ matrix.ruby-version }}-${{ matrix.multiverse }}
+          path: lib/coverage_*/.resultset.json
+          retention-days: 2
+
+      - name: Generate gem manifest
+        run: rake test:multiverse:gem_manifest
+
+      - name: Save gem manifest
+        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # tag v4.3.4
+        with:
+          name: gem_manifest_${{ matrix.ruby-version }}_${{ matrix.multiverse }}.json
+          path: gem_manifest_${{ matrix.ruby-version }}_${{ matrix.multiverse }}.json
+          retention-days: 2
+
 
 
   infinite_tracing:

--- a/test/multiverse/lib/multiverse/runner.rb
+++ b/test/multiverse/lib/multiverse/runner.rb
@@ -108,7 +108,7 @@ module Multiverse
       'rails' => %w[active_support_broadcast_logger active_support_logger rails rails_prepend activemerchant],
 
       # these neede services running in github actions, so they are separated
-      'services_1' => %w[elasticsearch mongo sequel bunny],
+      'services_1' => %w[elasticsearch mongo bunny],
       'services_2' => %w[redis sidekiq memcache],
       'services_kafka' => %w[rdkafka ruby_kafka],
       'services_mysql_pg' => %w[active_record active_record_pg],

--- a/test/multiverse/lib/multiverse/runner.rb
+++ b/test/multiverse/lib/multiverse/runner.rb
@@ -102,9 +102,11 @@ module Multiverse
       'ai' => %w[ruby_openai],
       'background' => %w[delayed_job sidekiq resque],
       'background_2' => %w[rake],
-      'kafka' => %w[rdkafka],
-      'database' => %w[elasticsearch mongo redis sequel],
-      'rails' => %w[active_record active_record_pg active_support_broadcast_logger active_support_logger rails rails_prepend activemerchant],
+      # 'kafka' => %w[rdkafka ruby_kafka],
+      'services' => %w[elasticsearch mongo redis sequel bunny memcache rdkafka ruby_kafka], # needs github actions services, other than PG and mysql
+      'services_2' => %w[active_record active_record_pg], # needs github actions services for mysql and pg
+      # 'database' => %w[elasticsearch mongo redis sequel],
+      'rails' => %w[active_support_broadcast_logger active_support_logger rails rails_prepend activemerchant],
       'frameworks' => %w[grape padrino roda sinatra],
       'httpclients' => %w[async_http curb excon httpclient],
       'httpclients_2' => %w[typhoeus net_http httprb ethon httpx],

--- a/test/multiverse/lib/multiverse/runner.rb
+++ b/test/multiverse/lib/multiverse/runner.rb
@@ -100,10 +100,10 @@ module Multiverse
     GROUPS = {
       'agent' => %w[agent_only bare config_file_loading deferred_instrumentation high_security no_json json marshalling thread yajl],
       'ai' => %w[ruby_openai],
-      'background' => %w[delayed_job sidekiq resque],
+      'background' => %w[delayed_job resque],
       'background_2' => %w[rake],
       # 'kafka' => %w[rdkafka ruby_kafka],
-      'services' => %w[elasticsearch mongo redis sequel bunny memcache rdkafka ruby_kafka], # needs github actions services, other than PG and mysql
+      'services' => %w[elasticsearch mongo redis sidekiq sequel bunny memcache rdkafka ruby_kafka], # needs github actions services, other than PG and mysql
       'services_2' => %w[active_record active_record_pg], # needs github actions services for mysql and pg
       # 'database' => %w[elasticsearch mongo redis sequel],
       'rails' => %w[active_support_broadcast_logger active_support_logger rails rails_prepend activemerchant],

--- a/test/multiverse/lib/multiverse/runner.rb
+++ b/test/multiverse/lib/multiverse/runner.rb
@@ -102,14 +102,17 @@ module Multiverse
       'ai' => %w[ruby_openai],
       'background' => %w[delayed_job resque],
       'background_2' => %w[rake],
-      # 'kafka' => %w[rdkafka ruby_kafka],
-      'services' => %w[elasticsearch mongo redis sidekiq sequel bunny memcache rdkafka ruby_kafka], # needs github actions services, other than PG and mysql
-      'services_2' => %w[active_record active_record_pg], # needs github actions services for mysql and pg
-      # 'database' => %w[elasticsearch mongo redis sequel],
-      'rails' => %w[active_support_broadcast_logger active_support_logger rails rails_prepend activemerchant],
       'frameworks' => %w[grape padrino roda sinatra],
       'httpclients' => %w[async_http curb excon httpclient],
       'httpclients_2' => %w[typhoeus net_http httprb ethon httpx],
+      'rails' => %w[active_support_broadcast_logger active_support_logger rails rails_prepend activemerchant],
+
+      # these neede services running in github actions, so they are separated
+      'services_1' => %w[elasticsearch mongo sequel bunny],
+      'services_2' => %w[redis sidekiq memcache],
+      'services_kafka' => %w[rdkafka ruby_kafka],
+      'services_mysql_pg' => %w[active_record active_record_pg],
+
       'infinite_tracing' => %w[infinite_tracing],
 
       'rest' => [] # Specially handled below

--- a/test/multiverse/lib/multiverse/runner.rb
+++ b/test/multiverse/lib/multiverse/runner.rb
@@ -107,7 +107,7 @@ module Multiverse
       'httpclients_2' => %w[typhoeus net_http httprb ethon httpx],
       'rails' => %w[active_support_broadcast_logger active_support_logger rails rails_prepend activemerchant],
 
-      # these neede services running in github actions, so they are separated
+      # these need services running in github actions, so they are separated
       'services_1' => %w[elasticsearch mongo bunny],
       'services_2' => %w[redis sidekiq memcache],
       'services_kafka' => %w[rdkafka ruby_kafka],


### PR DESCRIPTION
So, this does seem to work to prevent the github communication errors/running out of resources thing from happening, yay!

scheduled CI run: https://github.com/newrelic/newrelic-ruby-agent/actions/runs/12772900369
I saw a couple of random actual intermittent test failures, like a timeout or openai complaining about not having a token, BUT I haven't seen ANY github communication errors come up on there and I tried rerunning it several times to give it as many chances to fail as I could. 

I don't love how much bigger the files are now and all the duplication I had to add. 
But it's better to have an annoying file than have github actions run out of resources all the time though, so ¯\\_(ツ)_/¯ oh well


Here is what changed for multiverse:

- multiverse: removed all services and runs most our multiverse like normal
- multiverse_services_1: elasticsearch, mongo, bunny
- multiverse_services_2: redis, sidekiq (bc sidekiq uses redis), memcache
- multiverse_services_kafka: rdkafka, ruby_kafka
- multiverse_services_mysql_pg: active_record, active_record_pg

I wanted mysql running with very few other things since that was mentioned in some of the comments we saw as being a problem. 
I also didn't want too many services running in the same one just because I wanted to minimize the number of services each group was running to avoid resource issues.
Also I wanted kafka on its own because we've seen some weird issues with rdkafka in the past so just wanted those alone in case those things continue happening.


resolves https://github.com/newrelic/newrelic-ruby-agent/issues/3004