### PR TITLE
Update k8s boot/strap priority agent version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
   The agent now supports Ruby 3.4.0. We've made incremental changes throughout the preview stage to reach compatibility. This release includes an update to the Thread Profiler for compatibility with Ruby 3.4.0's new backtrace format. [Issue#2992](https://github.com/newrelic/newrelic-ruby-agent/issues/2992) [PR#2997](https://github.com/newrelic/newrelic-ruby-agent/pull/2997)
 
-- **Feature: Use the agent version recieved from Kubernetes APM auto-attach**
+- **Feature: Use the agent deployment received from Kubernetes APM auto-attach**
 
   Previously, an existing deployment Ruby agent would continue be used if re-installing the agent via [Kubernetes APM auto-attach](https://docs.newrelic.com/docs/kubernetes-pixie/kubernetes-integration/installation/k8s-agent-operator/). Now, the agent version installed from Kubernetes APM auto-attach will be deployed and any existing deployment will be removed. [PR#3018](https://github.com/newrelic/newrelic-ruby-agent/pull/3018)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@
 
   The agent now supports Ruby 3.4.0. We've made incremental changes throughout the preview stage to reach compatibility. This release includes an update to the Thread Profiler for compatibility with Ruby 3.4.0's new backtrace format. [Issue#2992](https://github.com/newrelic/newrelic-ruby-agent/issues/2992) [PR#2997](https://github.com/newrelic/newrelic-ruby-agent/pull/2997)
 
-- **Feature: Use the agent deployment received from Kubernetes APM auto-attach**
+- **Feature: Kubernetes APM auto-attach - new agent version precedent**
 
-  Previously, an existing deployment Ruby agent would continue be used if re-installing the agent via [Kubernetes APM auto-attach](https://docs.newrelic.com/docs/kubernetes-pixie/kubernetes-integration/installation/k8s-agent-operator/). Now, the agent version installed from Kubernetes APM auto-attach will be deployed and any existing deployment will be removed. [PR#3018](https://github.com/newrelic/newrelic-ruby-agent/pull/3018)
+  Previously, when a customer installed the Ruby agent via [Kubernetes APM auto-attach](https://docs.newrelic.com/docs/kubernetes-pixie/kubernetes-integration/installation/k8s-agent-operator/) and also had the Ruby agent listed in their `Gemfile`, the agent version in `Gemfile` would take precedence. Now, the agent version installed by auto-attach takes priority. [PR#3018](https://github.com/newrelic/newrelic-ruby-agent/pull/3018)
 
 - **Bugfix: Stop emitting inaccurate debug-level log about deprecated configuration options**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
   The agent now supports Ruby 3.4.0. We've made incremental changes throughout the preview stage to reach compatibility. This release includes an update to the Thread Profiler for compatibility with Ruby 3.4.0's new backtrace format. [Issue#2992](https://github.com/newrelic/newrelic-ruby-agent/issues/2992) [PR#2997](https://github.com/newrelic/newrelic-ruby-agent/pull/2997)
 
+- **Feature: Use the agent version recieved from Kubernetes APM auto-attach**
+
+  Previously, an existing deployment Ruby agent would continue be used if re-installing the agent via [Kubernetes APM auto-attach](https://docs.newrelic.com/docs/kubernetes-pixie/kubernetes-integration/installation/k8s-agent-operator/). Now, the agent version installed from Kubernetes APM auto-attach will be deployed and any existing deployment will be removed. [PR#3018](https://github.com/newrelic/newrelic-ruby-agent/pull/3018)
+
 - **Bugfix: Stop emitting inaccurate debug-level log about deprecated configuration options**
 
   In the previous major release, we dropped support for `disable_<library_name>` configuration options in favor of `instrumentation.<library_name>`. Previously, a DEBUG level log warning appeared whenever `disable_*` options were set to `true`, even for libraries (e.g. Action Dispatch) without equivalent `instrumentation.*` options:

--- a/lib/boot/strap.rb
+++ b/lib/boot/strap.rb
@@ -47,9 +47,9 @@ module NRBundlerPatch
   NR_AGENT_GEM = 'newrelic_rpm'
 
   def require(*_groups)
-    super
-
     require_newrelic
+
+    super
   end
 
   def require_newrelic

--- a/lib/boot/strap.rb
+++ b/lib/boot/strap.rb
@@ -17,6 +17,9 @@
 #   - Ruby (tested v2.4+)
 #   - Bundler (included with Ruby, tested v1.17+)
 #
+# Note: The latest version of the New Relic Ruby agent will be used when
+# instrumenting your application using this method.
+#
 # Instructions:
 #   - First, make sure the New Relic Ruby agent exists on disk. For these
 #     instructions, we'll assume the agent exists at `/newrelic`.
@@ -44,13 +47,14 @@ module NRBundlerPatch
   NR_AGENT_GEM = 'newrelic_rpm'
 
   def require(*_groups)
-    super
-
     require_newrelic
+
+    super
   end
 
   def require_newrelic
     lib = File.expand_path('../..', __FILE__)
+    $LOAD_PATH.reject! { |path| path.include?('newrelic_rpm') }
     $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
     Kernel.require NR_AGENT_GEM
   end

--- a/lib/boot/strap.rb
+++ b/lib/boot/strap.rb
@@ -54,7 +54,7 @@ module NRBundlerPatch
 
   def require_newrelic
     lib = File.expand_path('../..', __FILE__)
-    $LOAD_PATH.reject! { |path| path.include?('newrelic_rpm') }
+    # $LOAD_PATH.reject! { |path| path.include?('newrelic_rpm') }
     $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
     Kernel.require NR_AGENT_GEM
   end

--- a/lib/boot/strap.rb
+++ b/lib/boot/strap.rb
@@ -47,9 +47,9 @@ module NRBundlerPatch
   NR_AGENT_GEM = 'newrelic_rpm'
 
   def require(*_groups)
-    require_newrelic
-
     super
+
+    require_newrelic
   end
 
   def require_newrelic

--- a/lib/boot/strap.rb
+++ b/lib/boot/strap.rb
@@ -55,7 +55,7 @@ module NRBundlerPatch
   def require_newrelic
     lib = File.expand_path('../..', __FILE__)
     $LOAD_PATH.reject! { |path| path.include?('newrelic_rpm') }
-    $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+    $LOAD_PATH.unshift(lib)
     Kernel.require NR_AGENT_GEM
   end
 end

--- a/lib/boot/strap.rb
+++ b/lib/boot/strap.rb
@@ -55,7 +55,7 @@ module NRBundlerPatch
   def require_newrelic
     lib = File.expand_path('../..', __FILE__)
     $LOAD_PATH.reject! { |path| path.include?('newrelic_rpm') }
-    $LOAD_PATH.push(lib)
+    $LOAD_PATH.unshift(lib)
     Kernel.require NR_AGENT_GEM
   end
 end

--- a/lib/boot/strap.rb
+++ b/lib/boot/strap.rb
@@ -47,14 +47,14 @@ module NRBundlerPatch
   NR_AGENT_GEM = 'newrelic_rpm'
 
   def require(*_groups)
-    super
-
     require_newrelic
+
+    super
   end
 
   def require_newrelic
     lib = File.expand_path('../..', __FILE__)
-    # $LOAD_PATH.reject! { |path| path.include?('newrelic_rpm') }
+    $LOAD_PATH.reject! { |path| path.include?('newrelic_rpm') }
     $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
     Kernel.require NR_AGENT_GEM
   end

--- a/lib/boot/strap.rb
+++ b/lib/boot/strap.rb
@@ -55,7 +55,7 @@ module NRBundlerPatch
   def require_newrelic
     lib = File.expand_path('../..', __FILE__)
     $LOAD_PATH.reject! { |path| path.include?('newrelic_rpm') }
-    $LOAD_PATH.unshift(lib)
+    $LOAD_PATH.push(lib)
     Kernel.require NR_AGENT_GEM
   end
 end

--- a/lib/boot/strap.rb
+++ b/lib/boot/strap.rb
@@ -17,9 +17,6 @@
 #   - Ruby (tested v2.4+)
 #   - Bundler (included with Ruby, tested v1.17+)
 #
-# Note: The latest version of the New Relic Ruby agent will be used when
-# instrumenting your application using this method.
-#
 # Instructions:
 #   - First, make sure the New Relic Ruby agent exists on disk. For these
 #     instructions, we'll assume the agent exists at `/newrelic`.

--- a/test/new_relic/boot/strap_test.rb
+++ b/test/new_relic/boot/strap_test.rb
@@ -26,7 +26,7 @@ class NewRelicBootstrapTest < Minitest::Test
     end
 
     assert_equal 2, required_gems.size, "Expected 2 gems to be required, saw #{required_gems.size}."
-    assert_equal [PhonyBundler::DEFAULT_GEM_NAME, 'newrelic_rpm'], required_gems,
+    assert_equal ['newrelic_rpm', PhonyBundler::DEFAULT_GEM_NAME], required_gems,
       "Expected to see 'newrelic_rpm' required. Only saw #{required_gems}"
   end
 


### PR DESCRIPTION
Previously, when the new relic ruby agent was installed via in a customer's `Gemfile` and attempted to be installed through the k8s operator, the agent version listed in `Gemfile` would take priority. Now, if the agent is installed via operator when both are present, the Gemfile version will be removed and the operator version will be used. 

Closes #2890 