### PR TITLE
only run special CI when on CI, not locally

### DIFF
--- a/test/helpers/misc.rb
+++ b/test/helpers/misc.rb
@@ -135,7 +135,7 @@ end
 # special CI context. When in a local dev context or in a special CI context,
 # permit the test(s) to run.
 def skip_unless_special_ci
-  return if ENV.fetch('CI', nil).nil? || ENV.fetch('SPECIAL_CI', nil)
+  return if ENV.fetch('SPECIAL_CI', nil)
 
   skip 'This test only runs as part of the special CI workflow'
 end

--- a/test/helpers/misc.rb
+++ b/test/helpers/misc.rb
@@ -131,9 +131,7 @@ def skip_unless_ci_cron
   skip 'This test only runs as part of the CI cron workflow'
 end
 
-# If in a CI (non local dev) context, skip unless operating within the
-# special CI context. When in a local dev context or in a special CI context,
-# permit the test(s) to run.
+# skip unless operating within the special CI context
 def skip_unless_special_ci
   return if ENV.fetch('SPECIAL_CI', nil)
 


### PR DESCRIPTION
stops the url checker test from running locally