### PR TITLE
Explicitly require logger in suite.rb

### DIFF
--- a/test/multiverse/README.md
+++ b/test/multiverse/README.md
@@ -109,7 +109,7 @@ Multiverse groups collect multiple suites together within a shared broad topic. 
 ```shell
 # database = group name
 rake 'test:multiverse[group=database]'
-``
+```
 
 You can pass these additional parameters to the test:multiverse rake task to control how tests are run:
 

--- a/test/multiverse/lib/multiverse/suite.rb
+++ b/test/multiverse/lib/multiverse/suite.rb
@@ -11,6 +11,7 @@ require_relative '../../../warning_test_helper'
 require_relative '../../../simplecov_test_helper'
 require_relative '../../../../lib/new_relic/base64'
 
+require 'logger'
 require 'rubygems'
 require 'fileutils'
 require 'digest'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -15,6 +15,12 @@ $: << File.expand_path('../../lib', __FILE__)
 $: << File.expand_path('../../test', __FILE__)
 $:.uniq!
 
+# TODO: OLD RAILS - 6.0, 6.1, 7.0
+# Suites related to these versions started failing because of an uninitialized
+# constant error related to Logger::Severity, regardless of Ruby version.
+# Explicitly requiring 'logger' seems to fix the problem
+# We can remove this workaround when we drop support for these Rails versions
+require 'logger'
 require 'rubygems'
 require 'rake'
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -15,12 +15,6 @@ $: << File.expand_path('../../lib', __FILE__)
 $: << File.expand_path('../../test', __FILE__)
 $:.uniq!
 
-# TODO: OLD RAILS - 6.0, 6.1, 7.0
-# Suites related to these versions started failing because of an uninitialized
-# constant error related to Logger::Severity, regardless of Ruby version.
-# Explicitly requiring 'logger' seems to fix the problem
-# We can remove this workaround when we drop support for these Rails versions
-require 'logger'
 require 'rubygems'
 require 'rake'
 
@@ -55,6 +49,7 @@ end
 
 # This is the public method recommended for plugin developers to share our
 # agent helpers. Use it so we don't accidentally break it.
+require 'logger'
 NewRelic::Agent.require_test_helper
 
 # If these are set, many tests fail. We delete them from this process.

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -49,7 +49,6 @@ end
 
 # This is the public method recommended for plugin developers to share our
 # agent helpers. Use it so we don't accidentally break it.
-require 'logger'
 NewRelic::Agent.require_test_helper
 
 # If these are set, many tests fail. We delete them from this process.


### PR DESCRIPTION
Suites related to Rails 6.0, 6.1 and 7.0 started to fail with an uninitialized constant error related to the Logger::Severity constant. This only fixes failures in the multiverse suite.