### PR TITLE
Update to "forum" links

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -16,7 +16,7 @@ TIP: Do NOT share sensitive information, whether personal, proprietary, or other
 ## Expected Behavior
 Tell us what you expected to happen.
 
-## [Troubleshooting](https://discuss.newrelic.com/t/troubleshooting-frameworks/108787) or [NR Diag](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics) results
+## [Troubleshooting](https://forum.newrelic.com/s/hubtopic/aAX8W0000008bSoWAI/troubleshooting-frameworks) or [NR Diag](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics) results
 Provide any other relevant log data.
 TIP:  Scrub logs and diagnostic information for sensitive information 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -184,9 +184,9 @@ New Relic hosts and moderates an online forum where customers can interact with
 New Relic employees as well as other customers to get help and share best
 practices. Like all official New Relic open source projects, there's a related
 Community topic in the New Relic Explorers Hub. You can find this project's
-topic/threads here:
+topic/threads under the "Ruby Agent" category here:
 
-[Explorer's Hub](https://discuss.newrelic.com/tags/rubyagent)
+[Explorer's Hub](https://forum.newrelic.com/s/)
 
 ## And Finally...
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -186,7 +186,7 @@ practices. Like all official New Relic open source projects, there's a related
 Community topic in the New Relic Explorers Hub. You can find this project's
 topic/threads under the "Ruby Agent" category here:
 
-[Explorer's Hub](https://forum.newrelic.com/s/)
+[Explorer's Hub](https://forum.newrelic.com/s/category/Category__c/Default)
 
 ## And Finally...
 


### PR DESCRIPTION
`discuss.newrelic.com` should be replaced by the new site, `forum.newrelic.com`. While old links redirect, we should update our docs to use the correct URLs.