### PR TITLE
Ruby openai intermittent failure fix

### DIFF
--- a/test/multiverse/suites/ruby_openai/openai_helpers.rb
+++ b/test/multiverse/suites/ruby_openai/openai_helpers.rb
@@ -53,6 +53,7 @@ module OpenAIHelpers
   end
 
   def connection_client
+    client # can cause failure if this has never been created before on older versions for the test that uses connection_client
     Gem::Version.new(::OpenAI::VERSION) <= Gem::Version.new('4.3.2') ? OpenAI::Client : client
   end
 


### PR DESCRIPTION
when client is created it gives it a face access token. the error we were seeing was when connection_client is used in the first test run instead of client, it was mad about not having any access token. so I made it create the client in connection_client and that made it work.
resolves https://github.com/newrelic/newrelic-ruby-agent/issues/3031