### PR TITLE
Add Redshift active record adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 
 - **Feature: Add Redshift as recognized ActiveRecord adapter**
 
-  When the agent does not recognize an activerecord adapter, host, port, and database name information is not added to the datastore span. Redshift will now be treated like PostgreSQL, and the agent will save the host, port, and database name on the span. [PR#3032](https://github.com/newrelic/newrelic-ruby-agent/pull/3032)
+  When the agent does not recognize an ActiveRecord adapter, the host, port, and database name information is not added to the datastore span. Redshift will now be treated like PostgreSQL, and the agent will save the host, port, and database name on the span. [PR#3032](https://github.com/newrelic/newrelic-ruby-agent/pull/3032)
 
 - **Feature: Add instrumentation for aws-sdk-kinesis**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 
   When the agent is started within an [Agent Control](https://docs-preview.newrelic.com/docs/new-relic-agent-control) environment, a health check file will be created at the configured file location for every agent process. By default, this location is: '/newrelic/apm/health'. The health check files will be updated at the configured frequency, which defaults to every five seconds. [PR#2995](https://github.com/newrelic/newrelic-ruby-agent/pull/2995)
 
+- **Feature: Add Redshift as recognized ActiveRecord adapter**
+
+  When the agent does not recognize an activerecord adapter, host, port, and database name information is not added to the datastore span. Redshift will now be treated like PostgreSQL, and the agent will save the host, port, and database name on the span. [PR#3032](https://github.com/newrelic/newrelic-ruby-agent/pull/3032)
+
 - **Bugfix: Stop emitting inaccurate debug-level log about deprecated configuration options**
 
   In the previous major release, we dropped support for `disable_<library_name>` configuration options in favor of `instrumentation.<library_name>`. Previously, a DEBUG level log warning appeared whenever `disable_*` options were set to `true`, even for libraries (e.g. Action Dispatch) without equivalent `instrumentation.*` options:

--- a/lib/new_relic/agent/database.rb
+++ b/lib/new_relic/agent/database.rb
@@ -278,9 +278,10 @@ module NewRelic
         MYSQL2_PREFIX = 'mysql2'.freeze
         SQLITE_PREFIX = 'sqlite'.freeze
         TRILOGY_PREFIX = 'trilogy'.freeze
+        REDSHIFT_PREFIX = 'redshift'.freeze
 
         def symbolized_adapter(adapter)
-          if adapter.start_with?(POSTGRES_PREFIX) || adapter == POSTGIS_PREFIX
+          if adapter.start_with?(POSTGRES_PREFIX) || adapter == POSTGIS_PREFIX || adapter == REDSHIFT_PREFIX
             :postgres
           elsif adapter == MYSQL_PREFIX
             :mysql

--- a/lib/new_relic/agent/instrumentation/active_record_helper.rb
+++ b/lib/new_relic/agent/instrumentation/active_record_helper.rb
@@ -225,7 +225,8 @@ module NewRelic
 
             'postgresql' => :postgres,
             'jdbcpostgresql' => :postgres,
-            'postgis' => :postgres
+            'postgis' => :postgres,
+            'redshift' => :postgres
           }.freeze
 
           DATASTORE_DEFAULT_PORTS = {

--- a/lib/new_relic/agent/instrumentation/active_record_subscriber.rb
+++ b/lib/new_relic/agent/instrumentation/active_record_subscriber.rb
@@ -123,7 +123,7 @@ module NewRelic
               database = config && config[:database]
             end
           rescue
-            NewRelic::Agent.logger.debug("Failed to retrieve ActiveRecord host port and database details for adapter: #{config && config[:adapter]}")
+            NewRelic::Agent.logger.debug("Failed to retrieve ActiveRecord host, port, and database details for adapter: #{config && config[:adapter]}")
           end
 
           segment = Tracer.start_datastore_segment(product: product,

--- a/lib/new_relic/agent/instrumentation/active_record_subscriber.rb
+++ b/lib/new_relic/agent/instrumentation/active_record_subscriber.rb
@@ -116,10 +116,14 @@ module NewRelic
           port_path_or_id = nil
           database = nil
 
-          if ActiveRecordHelper::InstanceIdentification.supported_adapter?(config)
-            host = ActiveRecordHelper::InstanceIdentification.host(config)
-            port_path_or_id = ActiveRecordHelper::InstanceIdentification.port_path_or_id(config)
-            database = config && config[:database]
+          begin
+            if ActiveRecordHelper::InstanceIdentification.supported_adapter?(config)
+              host = ActiveRecordHelper::InstanceIdentification.host(config)
+              port_path_or_id = ActiveRecordHelper::InstanceIdentification.port_path_or_id(config)
+              database = config && config[:database]
+            end
+          rescue
+            NewRelic::Agent.logger.debug("Failed to retrieve ActiveRecord host port and database details for adapter: #{config && config[:adapter]}")
           end
 
           segment = Tracer.start_datastore_segment(product: product,

--- a/test/new_relic/agent/database_test.rb
+++ b/test/new_relic/agent/database_test.rb
@@ -52,6 +52,13 @@ class NewRelic::Agent::DatabaseTest < Minitest::Test
     assert_equal(:postgres, statement.adapter)
   end
 
+  def test_adapter_from_config_string_redshift
+    config = {:adapter => 'redshift'}
+    statement = NewRelic::Agent::Database::Statement.new('some query', config)
+
+    assert_equal(:postgres, statement.adapter)
+  end
+
   def test_adapter_from_config_trilogy
     config = {:adapter => 'trilogy'}
     statement = NewRelic::Agent::Database::Statement.new('some query', config)


### PR DESCRIPTION
We won't record host, port or db name info unless we recognize the adapter. Also for redshift, regular activerecord doesnt work, so you need to use some other gem for a redshift adapter (it looks like there are quite a lot of these for each rails version). It seems pretty consistently to be named redshift on the adapter in those gems though it seems, on the ones i saw at least. 


This is the gem i used in my testing https://github.com/pennylane-hq/activerecord-adapter-redshift

closes https://github.com/newrelic/newrelic-ruby-agent/issues/2900