### PR TITLE
update link for sidekiq issue

### DIFF
--- a/lib/new_relic/agent/instrumentation/sidekiq/extensions/delayed_class.rb
+++ b/lib/new_relic/agent/instrumentation/sidekiq/extensions/delayed_class.rb
@@ -6,7 +6,7 @@
 #       Delayed extensions are disabled by default in Sidekiq 5 and 6 and
 #       were removed entirely in Sidekiq 7.
 #
-#       see https://github.com/mperham/sidekiq/issues/5076 for the discussion
+#       see https://github.com/sidekiq/sidekiq/issues/5076 for the discussion
 #       of the removal, which includes mentions of alternatives
 if defined?(Sidekiq::VERSION) && Sidekiq::VERSION < '7.0.0'
   class Sidekiq::Extensions::DelayedClass


### PR DESCRIPTION
the url test was failing with:

```
  1) Failure:
HealthyUrlsTest#test_all_urls [/opt/hostedtoolcache/Ruby/3.4.1/x64/lib/ruby/gems/3.4.0/gems/minitest-5.3.3/lib/minitest/assertions.rb:129]:
1 URLs were unreachable!

  https://github.com/mperham/sidekiq/issues/5076 - HTTP 404: Not Found
    files: /home/runner/work/newrelic-ruby-agent/newrelic-ruby-agent/lib/new_relic/agent/instrumentation/sidekiq/extensions/delayed_class.rb.
Expected {"https://github.com/mperham/sidekiq/issues/5076" => "HTTP 404: Not Found"} to be empty.
```

Looks like the link has changed, so i updated it here.
```
old: https://github.com/mperham/sidekiq/issues/5076
new: https://github.com/sidekiq/sidekiq/issues/5076
```

