### PR TITLE
Use GITHUB_REF_NAME instead of GITHUB_REF

### DIFF
--- a/.github/workflows/lambda_release.yml
+++ b/.github/workflows/lambda_release.yml
@@ -23,9 +23,9 @@ jobs:
 
     - name: Create release tags for Lambda and K8s Init Containers
       run: |
-        RELEASE_TITLE="New Relic Ruby Agent ${GITHUB_REF}.0"
-        RELEASE_TAG="${GITHUB_REF}.0_ruby"
-        RELEASE_NOTES="Automated release for [Ruby Agent ${GITHUB_REF}](https://github.com/newrelic/newrelic-ruby-agent/releases/tag/${GITHUB_REF})"
+        RELEASE_TITLE="New Relic Ruby Agent ${GITHUB_REF_NAME}.0"
+        RELEASE_TAG="${GITHUB_REF_NAME}.0_ruby"
+        RELEASE_NOTES="Automated release for [Ruby Agent ${GITHUB_REF_NAME}](https://github.com/newrelic/newrelic-ruby-agent/releases/tag/${GITHUB_REF_NAME})"
         gh auth login --with-token <<< $GH_RELEASE_TOKEN
         echo "newrelic/newrelic-lambda-layers - Releasing ${RELEASE_TITLE} with tag ${RELEASE_TAG}"
         gh release create "${RELEASE_TAG}" --title=${RELEASE_TITLE} --repo=newrelic/newrelic-lambda-layers --notes=${RELEASE_NOTES}


### PR DESCRIPTION

# Overview
Previously the workflow was using GITHUB_REF which is refs/heads/tag-name instead of tag-name. This has been fixed.

Submitter Checklist:
- [ ] Include a link to the related GitHub issue, if applicable
- [ ] Include a security review link, if applicable

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
GitHub Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
