### PR TITLE
Add safe navigation in case segment is nil in net http instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,9 @@
 
 ## dev
 
-
 - **Feature: Add elasticsearch.capture_cluster_name configuration option**
 
-    A new configuration option, `elasticsearch.capture_cluster_name`, has been added to control capturing Elasticsearch cluster names. Cluster names are captured by default, but can now be disabled as needed. [PR#3038](https://github.com/newrelic/newrelic-ruby-agent/pull/3038)
+  A new configuration option, `elasticsearch.capture_cluster_name`, has been added to control capturing Elasticsearch cluster names. Cluster names are captured by default, but can now be disabled as needed. [PR#3038](https://github.com/newrelic/newrelic-ruby-agent/pull/3038)
 
 - **Bugfix: Prevent a `nil` segment from causing errors in Net::HTTP instrumentation**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## dev
 
-- **Bugfix: Prevent a nil segment from causing errors in Net HTTP instrumentation**
+- **Bugfix: Prevent a `nil` segment from causing errors in Net::HTTP instrumentation**
 
   When using JRuby, a race condition can happen that causes the segment creation to fail and returns nil. This would cause an error to occur when methods were later called on the nil segment. These methods will not be called now if it is nil, preventing that error from occurring. [PR#3046](https://github.com/newrelic/newrelic-ruby-agent/pull/3046)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # New Relic Ruby Agent Release Notes
 
+## dev
+
+- **Bugfix: Prevent a nil segment from causing errors in Net HTTP instrumentation**
+
+  When using JRuby, a race condition can happen that causes the segment creation to fail and returns nil. This would cause an error to occur when methods were later called on the nil segment. These methods will not be called now if it is nil, preventing that error from occurring. [PR#3046](https://github.com/newrelic/newrelic-ruby-agent/pull/3046)
+
+
 ## v9.17.0
 
 - **Feature: Support Ruby 3.4.0**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - **Bugfix: Prevent a `nil` segment from causing errors in Net::HTTP instrumentation**
 
-  When using JRuby, a race condition can happen that causes the segment creation to fail and returns nil. This would cause an error to occur when methods were later called on the nil segment. These methods will not be called now if it is nil, preventing that error from occurring. [PR#3046](https://github.com/newrelic/newrelic-ruby-agent/pull/3046)
+  When using JRuby, a race condition can happen that causes the segment creation to fail and return `nil`. This would cause an error to occur when methods were later called on the `nil` segment. These methods will no longer be called if the segment is `nil`, preventing that error from occurring. [PR#3046](https://github.com/newrelic/newrelic-ruby-agent/pull/3046)
 
 
 ## v9.17.0

--- a/lib/new_relic/agent/instrumentation/net_http/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/net_http/instrumentation.rb
@@ -21,7 +21,7 @@ module NewRelic
 
           begin
             response = nil
-            segment.add_request_headers(wrapped_request)
+            segment&.add_request_headers(wrapped_request)
 
             # RUBY-1244 Disable further tracing in request to avoid double
             # counting if connection wasn't started (which calls request again).
@@ -34,10 +34,10 @@ module NewRelic
             wrapped_response = NewRelic::Agent::HTTPClients::NetHTTPResponse.new(response)
 
             if NewRelic::Agent::LLM.openai_parent?(segment)
-              NewRelic::Agent::LLM.populate_openai_response_headers(wrapped_response, segment.parent)
+              NewRelic::Agent::LLM.populate_openai_response_headers(wrapped_response, segment&.parent)
             end
 
-            segment.process_response_headers(wrapped_response)
+            segment&.process_response_headers(wrapped_response)
 
             response
           ensure


### PR DESCRIPTION

related to https://github.com/newrelic/newrelic-ruby-agent/issues/3021

This isn't addressing the root cause of the issue yet, as that's still being investigated, but this change should prevent the primary reported error from occurring. 