### PR TITLE
Prepend NR middleware to Sidekiq middleware chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@
   When using JRuby, a race condition can happen that causes the segment creation to fail and return `nil`. This would cause an error to occur when methods were later called on the `nil` segment. These methods will no longer be called if the segment is `nil`, preventing that error from occurring. [PR#3046](https://github.com/newrelic/newrelic-ruby-agent/pull/3046)
 
 - **Bugfix: Stop reporting rescued Sidekiq::OverLimit exceptions**
-  When Sidekiq's concurrent rate limiters encounter an `OverLimit` exception, Sidekiq typically handles this by re-enqueuing the job. Previously, all occurrences of `Sidekiq::OverLimit` were being logged as errors in New Relic, even when Sidekiq's middleware resolved the exception. New Relic will no longer report errors that are handled by Sidekiq's own middleware. Thanks to [@97jaz](https://github.com/97jaz) for reporting this issue. [Issue#3037](https://github.com/newrelic/newrelic-ruby-agent/issues/3037) [PR#3047](https://github.com/newrelic/newrelic-ruby-agent/pull/3047)
+
+  When Sidekiq's concurrent rate limiters encounter an `OverLimit` exception, Sidekiq typically handles this by re-enqueuing the job. Previously, all occurrences of `Sidekiq::OverLimit` were logged as errors in New Relic, even when Sidekiq's middleware resolved the exception. New Relic will no longer report errors that are handled by Sidekiq's own middleware. Thanks to [@97jaz](https://github.com/97jaz) for reporting this issue. [Issue#3037](https://github.com/newrelic/newrelic-ruby-agent/issues/3037) [PR#3047](https://github.com/newrelic/newrelic-ruby-agent/pull/3047)
 
 ## v9.17.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
   When using JRuby, a race condition can happen that causes the segment creation to fail and return `nil`. This would cause an error to occur when methods were later called on the `nil` segment. These methods will no longer be called if the segment is `nil`, preventing that error from occurring. [PR#3046](https://github.com/newrelic/newrelic-ruby-agent/pull/3046)
 
+- **Bugfix: Stop reporting rescued Sidekiq::OverLimit exceptions**
+  When Sidekiq's concurrent rate limiters encounter an `OverLimit` exception, Sidekiq typically handles this by re-enqueuing the job. Previously, all occurrences of `Sidekiq::OverLimit` were being logged as errors in New Relic, even when Sidekiq's middleware resolved the exception. New Relic will no longer report errors that are handled by Sidekiq's own middleware. Thanks to [@97jaz](https://github.com/97jaz) for reporting this issue. [Issue#3037](https://github.com/newrelic/newrelic-ruby-agent/issues/3037) [PR#3047](https://github.com/newrelic/newrelic-ruby-agent/pull/3047)
 
 ## v9.17.0
 


### PR DESCRIPTION
Prepend the agent to Sidekiq's middleware chain. This stops Sidekiq-resolved exceptions from being reported to New Relic. 

We have a playground app that reproduces this issue. The introduction of this code successfully stops the error from being reported.

Closes #3037 