### PR TITLE
chore: move ignore_classes in docs

### DIFF
--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -698,20 +698,6 @@ module NewRelic
           :description => 'Specify a threshold in seconds. Transactions with a duration longer than this threshold are eligible for transaction traces. Specify a float value or the string `apdex_f`.'
         },
         # Error collector
-        :'error_collector.ignore_classes' => {
-          :default => ['ActionController::RoutingError', 'Sinatra::NotFound'],
-          :public => true,
-          :type => Array,
-          :allowed_from_server => true,
-          :dynamic_name => true,
-          :description => <<~DESCRIPTION
-            A list of error classes that the agent should ignore.
-
-              <Callout variant="caution">
-                This option can't be set via environment variable.
-              </Callout>
-          DESCRIPTION
-        },
         :'error_collector.capture_events' => {
           :default => value_of(:'error_collector.enabled'),
           :documentation_default => true,
@@ -764,7 +750,20 @@ module NewRelic
           :dynamic_name => true,
           :description => 'A comma separated list of status codes, possibly including ranges. Errors associated with these status codes, where applicable, will be treated as expected.'
         },
+        :'error_collector.ignore_classes' => {
+          :default => ['ActionController::RoutingError', 'Sinatra::NotFound'],
+          :public => true,
+          :type => Array,
+          :allowed_from_server => true,
+          :dynamic_name => true,
+          :description => <<~DESCRIPTION
+            A list of error classes that the agent should ignore.
 
+              <Callout variant="caution">
+                This option can't be set via environment variable.
+              </Callout>
+          DESCRIPTION
+        },
         :'error_collector.ignore_messages' => {
           :default => {},
           :public => true,


### PR DESCRIPTION
# Overview

Moving the `error_collector.ignore_classes` config details so the `error_collector` section is alphabetized as this is the only section out of place. This also groups the `ignore_` section in a logical way for browsing [the config doc](https://docs.newrelic.com/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration/#error-collector).

<img width="449" alt="image" src="https://github.com/user-attachments/assets/f3b9006f-d644-4730-8ee2-ba2d56be627f" />

Submitter Checklist:
- [ ] Include a link to the related GitHub issue, if applicable
- [ ] Include a security review link, if applicable

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
GitHub Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
