### PR TITLE
Add nil safety for Jruby issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
   When using JRuby, a race condition can happen that causes the segment creation to fail and return `nil`. This would cause an error to occur when methods were later called on the `nil` segment. These methods will no longer be called if the segment is `nil`, preventing that error from occurring. [PR#3046](https://github.com/newrelic/newrelic-ruby-agent/pull/3046)
 
+- **Bugfix: JRuby multithreading improvements**
+  
+  Added some additional nil checks and mutexes to prevent issues when using the agent on JRuby with multiple threads. [PR#3053](https://github.com/newrelic/newrelic-ruby-agent/pull/3053)
+
 
 ## v9.17.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 - **Bugfix: JRuby multithreading improvements**
   
-  Added some additional nil checks and mutexes to prevent issues when using the agent on JRuby with multiple threads. [PR#3053](https://github.com/newrelic/newrelic-ruby-agent/pull/3053)
+  Added some additional nil checks and mutexes to prevent issues when using the agent on JRuby with multiple threads. Thanks to @NC-piercej for bringing this to our attention [Issue#3021](https://github.com/newrelic/newrelic-ruby-agent/issues/3021) [PR#3053](https://github.com/newrelic/newrelic-ruby-agent/pull/3053)
 
 - **Bugfix: Stop reporting rescued Sidekiq::OverLimit exceptions**
 

--- a/lib/new_relic/agent/transaction.rb
+++ b/lib/new_relic/agent/transaction.rb
@@ -215,6 +215,7 @@ module NewRelic
         @nesting_max_depth = 0
         @current_segment_by_thread = {}
         @current_segment_lock = Mutex.new
+        @segment_lock = Mutex.new
         @segments = []
 
         self.default_name = options[:transaction_name]
@@ -437,7 +438,7 @@ module NewRelic
       end
 
       def initial_segment
-        segments.first
+        segments&.first
       end
 
       def finished?

--- a/lib/new_relic/agent/transaction/tracing.rb
+++ b/lib/new_relic/agent/transaction/tracing.rb
@@ -25,7 +25,7 @@ module NewRelic
           segment.parent = parent || thread_starting_span || current_segment
           set_current_segment(segment)
           if @segments.length < segment_limit
-            @segments << segment
+            @segment_lock.synchronize { @segments << segment }
           else
             segment.record_on_finish = true
             ::NewRelic::Agent.logger.debug("Segment limit of #{segment_limit} reached, ceasing collection.")

--- a/lib/new_relic/agent/transaction/tracing.rb
+++ b/lib/new_relic/agent/transaction/tracing.rb
@@ -50,7 +50,7 @@ module NewRelic
 
         def segment_complete(segment)
           # if parent was in another thread, remove the current_segment entry for this thread
-          if segment&.parent&.starting_segment_key != NewRelic::Agent::Tracer.current_segment_key
+          if segment.parent&.starting_segment_key != NewRelic::Agent::Tracer.current_segment_key
             remove_current_segment_by_thread_id(NewRelic::Agent::Tracer.current_segment_key)
           else
             set_current_segment(segment.parent)

--- a/lib/new_relic/agent/transaction/tracing.rb
+++ b/lib/new_relic/agent/transaction/tracing.rb
@@ -64,7 +64,7 @@ module NewRelic
         private
 
         def finalize_segments
-          segments.each { |s| s.finalize }
+          segments.each { |s| s&.finalize }
         end
 
         WEB_TRANSACTION_TOTAL_TIME = 'WebTransactionTotalTime'.freeze

--- a/lib/new_relic/agent/transaction/tracing.rb
+++ b/lib/new_relic/agent/transaction/tracing.rb
@@ -64,7 +64,7 @@ module NewRelic
         private
 
         def finalize_segments
-          segments.each { |s| s&.finalize }
+          @segment_lock.synchronize { segments.each { |s| s&.finalize } }
         end
 
         WEB_TRANSACTION_TOTAL_TIME = 'WebTransactionTotalTime'.freeze

--- a/lib/new_relic/agent/transaction/tracing.rb
+++ b/lib/new_relic/agent/transaction/tracing.rb
@@ -42,8 +42,7 @@ module NewRelic
         def thread_starting_span
           # if the previous current segment was in another thread, use the thread local parent
           if ThreadLocalStorage[:newrelic_thread_span_parent] &&
-              current_segment &&
-              current_segment.starting_segment_key != NewRelic::Agent::Tracer.current_segment_key
+              current_segment&.starting_segment_key != NewRelic::Agent::Tracer.current_segment_key
 
             ThreadLocalStorage[:newrelic_thread_span_parent]
           end
@@ -51,7 +50,7 @@ module NewRelic
 
         def segment_complete(segment)
           # if parent was in another thread, remove the current_segment entry for this thread
-          if segment.parent && segment.parent.starting_segment_key != NewRelic::Agent::Tracer.current_segment_key
+          if segment&.parent&.starting_segment_key != NewRelic::Agent::Tracer.current_segment_key
             remove_current_segment_by_thread_id(NewRelic::Agent::Tracer.current_segment_key)
           else
             set_current_segment(segment.parent)


### PR DESCRIPTION
Adds some safe navigation operators in cases where things are nil, for increased safety. 
Also added a new mutex for modifying and finalizing segments.
These things were added due to issues when running in jruby. 
resolves https://github.com/newrelic/newrelic-ruby-agent/issues/3021