### PR TITLE
Add support to sidekiq-delay_extensions

### DIFF
--- a/lib/new_relic/agent/instrumentation/sidekiq.rb
+++ b/lib/new_relic/agent/instrumentation/sidekiq.rb
@@ -5,6 +5,7 @@
 require_relative 'sidekiq/client'
 require_relative 'sidekiq/server'
 require_relative 'sidekiq/extensions/delayed_class'
+require_relative 'sidekiq/extensions/delay_extensions'
 
 DependencyDetection.defer do
   @name = :sidekiq

--- a/lib/new_relic/agent/instrumentation/sidekiq/extensions/delay_extensions.rb
+++ b/lib/new_relic/agent/instrumentation/sidekiq/extensions/delay_extensions.rb
@@ -1,0 +1,24 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+if defined?(Sidekiq::DelayExtensions)
+  class Sidekiq::DelayExtensions::GenericJob
+    def newrelic_trace_args(msg, queue)
+      (target, method_name, *) = ::Sidekiq::DelayExtensions::YAML.unsafe_load(msg['args'][0])
+
+      if target.is_a?(String)
+        target = target.constantize
+      end
+
+      {
+        :name => method_name,
+        :class_name => target.name,
+        :category => 'OtherTransaction/SidekiqJob'
+      }
+    rescue => e
+      NewRelic::Agent.logger.error('Failure during deserializing YAML for Sidekiq::DelayExtensions::GenericJob', e)
+      NewRelic::Agent::Instrumentation::Sidekiq::Server.default_trace_args(msg)
+    end
+  end
+end


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
`Sidekiq::Extensions::DelayedClass` got removed on https://github.com/sidekiq/sidekiq/issues/5076 but a gem was created to support that feature: https://github.com/gemhome/sidekiq-delay_extensions

We are adding the instrumentation as we had for the native extensions.

Submitter Checklist:
- [ ] Include a link to the related GitHub issue, if applicable
- [ ] Include a security review link, if applicable

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
GitHub Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
