### PR TITLE
Move Slack notifications up 2 hours

### DIFF
--- a/.github/workflows/slack_notifications.yml
+++ b/.github/workflows/slack_notifications.yml
@@ -2,7 +2,7 @@ name: Slack Notifications
 
 on:
   schedule:
-    - cron:  '0 10 * * *'
+    - cron:  '0 8 * * *'
 
 jobs:
   gem_notifications:


### PR DESCRIPTION
Let's have slack notifications for new gem releases run an hour before our CI. These should now run at about midnight and the CI kicks off at 1am PST.