### PR TITLE
Add supportability metric for agent version

### DIFF
--- a/lib/new_relic/control/instance_methods.rb
+++ b/lib/new_relic/control/instance_methods.rb
@@ -74,6 +74,7 @@ module NewRelic
         NewRelic::Agent.agent = NewRelic::Agent::Agent.instance
         init_instrumentation
         init_security_agent
+        report_agent_version_metric
       end
 
       def determine_env(options)
@@ -170,6 +171,10 @@ module NewRelic
 
       def stdout
         STDOUT
+      end
+
+      def report_agent_version_metric
+        NewRelic::Agent.record_metric_once("Supportability/AgentVersion/newrelic_rpm/#{NewRelic::VERSION::STRING}")
       end
     end
     include InstanceMethods

--- a/test/new_relic/control_test.rb
+++ b/test/new_relic/control_test.rb
@@ -150,6 +150,23 @@ class NewRelic::ControlTest < Minitest::Test
     end
   end
 
+  def test_init_plugin_records_agent_version_metric
+    reset_agent
+
+    NewRelic::VERSION.stub_const(:STRING, '1.2.3') do
+      with_config(:disable_samplers => true,
+        :disable_harvest_thread => true,
+        :agent_enabled          => true,
+        :monitor_mode           => true,
+        :license_key            => 'a' * 40) do
+
+        NewRelic::Control.instance.init_plugin
+
+        assert_metrics_recorded('Supportability/AgentVersion/newrelic_rpm/1.2.3')
+      end
+    end
+  end
+
   def reset_agent
     NewRelic::Agent.shutdown
     NewRelic::Agent.instance.instance_variable_get(:@harvest_samplers).clear

--- a/test/new_relic/control_test.rb
+++ b/test/new_relic/control_test.rb
@@ -159,7 +159,6 @@ class NewRelic::ControlTest < Minitest::Test
         :agent_enabled          => true,
         :monitor_mode           => true,
         :license_key            => 'a' * 40) do
-
         NewRelic::Control.instance.init_plugin
 
         assert_metrics_recorded('Supportability/AgentVersion/newrelic_rpm/1.2.3')


### PR DESCRIPTION
Proposed new metric name: `Supportability/AgentVersion/newrelic_rpm/#{NewRelic::VERSION::STRING}`

Closes #2627
