### PR TITLE
Test 7.x of Sidekiq

### DIFF
--- a/test/multiverse/suites/sidekiq/Envfile
+++ b/test/multiverse/suites/sidekiq/Envfile
@@ -7,7 +7,8 @@ suite_condition("Sidekiq does not run on JRuby") do
 end
 
 SIDEKIQ_VERSIONS = [
-  [nil, 2.7],
+  [nil, 3.2],
+  ['7.3.9', 2.7],
   ['6.4.0', 2.5],
   ['5.0.3', 2.4, 2.5]
 ]


### PR DESCRIPTION
With the release of Sidekiq 8, we should update our multiverse test suite to test 7.x now that `nil` is grabbing 8.x

Note Sidekiq 8 requires Ruby >= 3.2, so we will use that Ruby version as the min.