### PR TITLE
Remove instrumentation generator from build

### DIFF
--- a/.build_ignore
+++ b/.build_ignore
@@ -21,6 +21,7 @@ README.md
 test/
 lib/tasks/bump_version.rb
 lib/tasks/coverage_report.rb
+lib/tasks/instrumentation_generator/
 lib/tasks/multiverse.rake
 lib/tasks/multiverse.rb
 lib/tasks/tests.rb


### PR DESCRIPTION
The template for newrelic.yml in the generator can cause conflicts with the NRDiag tool.

Closes #2441