### PR TITLE
Pin rack version on tests

### DIFF
--- a/test/multiverse/suites/rails/Envfile
+++ b/test/multiverse/suites/rails/Envfile
@@ -44,6 +44,7 @@ def gem_list(rails_version = nil)
     #{haml_rails(rails_version)}
     gem 'minitest', '#{minitest_rails_version(rails_version)}'
     gem 'erubis' if RUBY_PLATFORM.eql?('java')
+    gem 'rack', '3.1.11'
     gem 'loofah', '~> 2.20.0' if RUBY_VERSION >= '2.4.0' && RUBY_VERSION < '2.5.0'
     gem 'drb' if RUBY_VERSION >= '3.4.0'
   RB

--- a/test/multiverse/suites/view_component/Envfile
+++ b/test/multiverse/suites/view_component/Envfile
@@ -15,6 +15,7 @@ def gem_list(view_component_version = nil)
     gem 'rails'
     gem 'view_component'#{view_component_version}
     gem 'rack-test'
+    gem 'rack', '3.1.11'
     gem 'loofah', '~> 2.20.0' if RUBY_VERSION >= '2.4.0' && RUBY_VERSION < '2.5.0'
   RB
 end


### PR DESCRIPTION
view component and rails multiverse suites began timing out when rack released a new version on the 10th. For now, lets pin the version to the old one while we investigate what is causing issues with the fake server multiverse uses