### PR TITLE
fix the regex used for deciding to require rackup/handler

### DIFF
--- a/test/new_relic/fake_server.rb
+++ b/test/new_relic/fake_server.rb
@@ -5,7 +5,7 @@
 require 'webrick'
 require 'webrick/https'
 require 'rack'
-require 'rackup/handler' unless /^1|^2/.match?(::Rack.release)
+require 'rackup/handler' unless /^1|^2/.match?(Rack.release)
 require 'timeout'
 require 'json'
 

--- a/test/new_relic/fake_server.rb
+++ b/test/new_relic/fake_server.rb
@@ -5,7 +5,7 @@
 require 'webrick'
 require 'webrick/https'
 require 'rack'
-require 'rackup/handler' unless /^1|2/.match?(Rack.release)
+require 'rackup/handler' unless /^1|^2/.match?(::Rack.release)
 require 'timeout'
 require 'json'
 
@@ -85,6 +85,7 @@ module NewRelic
     end
 
     def webrick_handler
+      binding.irb
       handler = defined?(::Rackup) ? ::Rackup::Handler : ::Rack::Handler
       handler.get(:webrick)
     end

--- a/test/new_relic/fake_server.rb
+++ b/test/new_relic/fake_server.rb
@@ -85,7 +85,6 @@ module NewRelic
     end
 
     def webrick_handler
-      binding.irb
       handler = defined?(::Rackup) ? ::Rackup::Handler : ::Rack::Handler
       handler.get(:webrick)
     end


### PR DESCRIPTION
so the rack problem we had was because there was simply a 2 in the version number.
For deciding when to install rackup/handler, we were using the regex `/^1|2/` which checks to see if it starts with a 1 OR 2, BUT what it's actually checking is if (starts with a 1) OR 2. So just a 2 hanging out anywhere in the version will be like, yeah that's matching. 
So i changed it to `/^1|^2/` which is just starts with a 1 OR starts with a 2. which is what we actually intended originally. 