### PR TITLE
Add action to put new issues on the board

### DIFF
--- a/.github/versions.yml
+++ b/.github/versions.yml
@@ -42,3 +42,6 @@ aquasecurity/trivy-action:
 github/codeql-action/upload-sarif:
   :tag: v3.27.0
   :sha: 662472033e021d55d94146f66f6058822b0b39fd
+actions/add-to-project:
+  :tag: v1.0.2
+  :sha: 244f685bbc3b7adfa8466e08b698b5577571133e

--- a/.github/workflows/add_issues_to_project.yml
+++ b/.github/workflows/add_issues_to_project.yml
@@ -1,0 +1,16 @@
+name: Add new issues to Ruby Engineering Board project
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # tag 1.0.2
+        with:
+          project-url: https://github.com/orgs/newrelic/projects/84
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I think New Relic may have hit [its auto-add workflow limits](https://docs.github.com/en/issues/planning-and-tracking-with-projects/automating-your-project/adding-items-automatically#about-automatically-adding-items), which would prevent our items from getting auto-added to our engineering board. 

As a workaround, we can call the add-to-project action in a workflow whenever a new issue is created. Unfortunately, it doesn't have an option to set a column. I'm not exactly sure where the issues will go. 