### PR TITLE
Update add_issues_to_project workflow token

### DIFF
--- a/.github/workflows/add_issues_to_project.yml
+++ b/.github/workflows/add_issues_to_project.yml
@@ -1,4 +1,4 @@
-name: Add new issues to Ruby Engineering Board project
+name: Add new issues to project
 
 on:
   issues:
@@ -13,4 +13,4 @@ jobs:
       - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # tag 1.0.2
         with:
           project-url: https://github.com/orgs/newrelic/projects/84
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.NEW_RELIC_RUBY_AGENT_BOT_GITHUB_ADD_TO_PROJECT_ACTION }}


### PR DESCRIPTION
The token used needs to be a PAT. See the action's README for details. Also, make the name shorter.

https://github.com/actions/add-to-project?tab=readme-ov-file#creating-a-pat-and-adding-it-to-your-repository 