### PR TITLE
Parallelize vendor metadata requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
   Sidekiq delay extensions were removed from Sidekiq in 7.x and are now avaliable through the [sidekiq-delay_extensions](https://rubygems.org/gems/sidekiq-delay_extensions) gem. Thanks to [@sobrinho](https://github.com/sobrinho), the agent now has continued support for delay extensions.[PR#3056](https://github.com/newrelic/newrelic-ruby-agent/pull/3056)
 
+- **Feature: Parallelize calls for vendor metadata**
+
+  Previously, the agent would make calls for vendor metadata in a serial fashion. This could lead to a delay in starting the agent. Now, the agent will make these calls in parallel, reducing the time it takes to start the agent. [PR#3094](https://github.com/newrelic/newrelic-ruby-agent/pull/3094)
+
 - **Bugfix: Prevent a nil segment from causing errors in Net::HTTP instrumentation**
 
   When using JRuby, a race condition can happen that causes the segment creation to fail and return `nil`. This would cause an error to occur when methods were later called on the `nil` segment. These methods will no longer be called if the segment is `nil`, preventing that error from occurring. [PR#3046](https://github.com/newrelic/newrelic-ruby-agent/pull/3046)

--- a/lib/new_relic/agent/utilization_data.rb
+++ b/lib/new_relic/agent/utilization_data.rb
@@ -86,11 +86,10 @@ module NewRelic
 
       def append_vendor_info(collector_hash)
         threads = []
+        complete = false
 
         VENDORS.each_pair do |klass, config_option|
           next unless Agent.config[config_option]
-
-          # complete = false
 
           threads << Thread.new do
             vendor = klass.new
@@ -99,16 +98,14 @@ module NewRelic
               collector_hash[:vendors] ||= {}
               collector_hash[:vendors][vendor.vendor_name.to_sym] = vendor.metadata
 
-              # complete = true
+              complete = true
             end
           end
         end
 
-        threads.each(&:join)
-        # while complete == false && threads.any?(&:alive?)
-        #   threads.each
-        #   sleep 0.01
-        # end
+        while complete == false && threads.any?(&:alive?)
+          sleep 0.01
+        end
       end
 
       def append_docker_info(collector_hash)

--- a/lib/new_relic/agent/utilization_data.rb
+++ b/lib/new_relic/agent/utilization_data.rb
@@ -85,17 +85,30 @@ module NewRelic
       end
 
       def append_vendor_info(collector_hash)
+        threads = []
+
         VENDORS.each_pair do |klass, config_option|
           next unless Agent.config[config_option]
 
-          vendor = klass.new
+          # complete = false
 
-          if vendor.detect
-            collector_hash[:vendors] ||= {}
-            collector_hash[:vendors][vendor.vendor_name.to_sym] = vendor.metadata
-            break
+          threads << Thread.new do
+            vendor = klass.new
+
+            if vendor.detect
+              collector_hash[:vendors] ||= {}
+              collector_hash[:vendors][vendor.vendor_name.to_sym] = vendor.metadata
+
+              # complete = true
+            end
           end
         end
+
+        threads.each(&:join)
+        # while complete == false && threads.any?(&:alive?)
+        #   threads.each
+        #   sleep 0.01
+        # end
       end
 
       def append_docker_info(collector_hash)


### PR DESCRIPTION

This updated our checks for vendor metadata to be run in parallel to decrease how much time it takes to get this information.
It will wait until one successful request OR until all finish unsuccessfully 



closes #2845 (the other idea mentioned in the issue is something we are already doing)