### PR TITLE
Set hostname for logs using config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,16 @@
 
   Sidekiq delay extensions were removed from Sidekiq in 7.x and are now avaliable through the [sidekiq-delay_extensions](https://rubygems.org/gems/sidekiq-delay_extensions) gem. Thanks to [@sobrinho](https://github.com/sobrinho), the agent now has continued support for delay extensions.[PR#3056](https://github.com/newrelic/newrelic-ruby-agent/pull/3056)
 
+- **Feature: Use process_host.display_name configuration to set Hostname attribute on logs and other linking metadata**
+
+  Previously, the hostname was assigned by the `NewRelic::Agent::Hostname.get` API. This API is the default value of `process_host.display_name`. Now, user-configured values for the host name will be applied. Thank you [@flivni](https://github.com/flivni) for bringing this to our attention! [Issue#1696](https://github.com/newrelic/newrelic-ruby-agent/issues/1696) [PR#](https://github.com/newrelic/newrelic-ruby-agent/pulls)
+
 - **Bugfix: Prevent a nil segment from causing errors in Net::HTTP instrumentation**
 
   When using JRuby, a race condition can happen that causes the segment creation to fail and return `nil`. This would cause an error to occur when methods were later called on the `nil` segment. These methods will no longer be called if the segment is `nil`, preventing that error from occurring. [PR#3046](https://github.com/newrelic/newrelic-ruby-agent/pull/3046)
 
 - **Bugfix: JRuby multithreading improvements**
-  
+
   Added some additional nil checks and mutexes to prevent issues when using the agent on JRuby with multiple threads. Thanks to @NC-piercej for bringing this to our attention [Issue#3021](https://github.com/newrelic/newrelic-ruby-agent/issues/3021) [PR#3053](https://github.com/newrelic/newrelic-ruby-agent/pull/3053)
 
 - **Bugfix: Stop reporting rescued Sidekiq::OverLimit exceptions**

--- a/lib/new_relic/agent/linking_metadata.rb
+++ b/lib/new_relic/agent/linking_metadata.rb
@@ -17,7 +17,7 @@ module NewRelic
 
         metadata[ENTITY_NAME_KEY] = config[:app_name][0]
         metadata[ENTITY_TYPE_KEY] = ENTITY_TYPE
-        metadata[HOSTNAME_KEY] = Hostname.get
+        metadata[HOSTNAME_KEY] = NewRelic::Agent.config[:'process_host.display_name']
 
         if entity_guid = config[:entity_guid]
           metadata[ENTITY_GUID_KEY] = entity_guid

--- a/lib/new_relic/agent/logging.rb
+++ b/lib/new_relic/agent/logging.rb
@@ -81,7 +81,7 @@ module NewRelic
         end
 
         def add_hostname(message)
-          add_key_value(message, HOSTNAME_KEY, Hostname.get)
+          add_key_value(message, HOSTNAME_KEY, NewRelic::Agent.config[:'process_host.display_name'])
         end
 
         def add_entity_guid(message)

--- a/test/new_relic/agent/linking_metadata_test.rb
+++ b/test/new_relic/agent/linking_metadata_test.rb
@@ -90,6 +90,16 @@ module NewRelic::Agent
         assert_equal(expected, result)
       end
 
+      def test_uses_process_host_display_name_as_hostname
+        with_config(:'process_host.display_name' => 'crossword-oreo-panda') do
+          result = Hash.new
+          LinkingMetadata.append_service_linking_metadata(result)
+
+          refute_equal(('crossword-oreo-panda'), Hostname.get)
+          assert_equal('crossword-oreo-panda', result['hostname'])
+        end
+      end
+
       def apply_config(config)
         @config = config
         NewRelic::Agent.config.add_config_for_testing(@config)

--- a/test/new_relic/agent/logging_test.rb
+++ b/test/new_relic/agent/logging_test.rb
@@ -142,6 +142,17 @@ module NewRelic
 
           refute_equal formatter, logger.formatter
         end
+
+        def test_hostname_is_same_as_process_host_display_name_config
+          logger = DecoratingLogger.new(@output)
+
+          with_config(:'process_host.display_name' => 'soothing-caramel-bedtime') do
+            logger.info('one')
+
+            refute_equal 'soothing-caramel-bedtime', Hostname.get
+            assert_equal 'soothing-caramel-bedtime', last_message['hostname']
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
The default value of 'process_host.display_name' is the same as NewRelic::Agent::Hostname.get, so this change will only impact users who have set a unique value on the config.

Resolves #1696

**PENDING MERGE: Need to finish cross-agent discussion**