### PR TITLE
Refactor URI host handling to ensure downcasing is applied correctly on frozen strings

### DIFF
--- a/lib/new_relic/agent/http_clients/uri_util.rb
+++ b/lib/new_relic/agent/http_clients/uri_util.rb
@@ -36,7 +36,7 @@ module NewRelic
               uri = ::URI.parse(url)
             end
           end
-          uri.host&.downcase!
+          uri.host = uri.host&.downcase
           uri
         end
 


### PR DESCRIPTION
# Overview

When passing a frozen string as the host, the agent breaks with the following error:
```
FrozenError (can't modify frozen String)
```

I encountered this issue while using the [Pusher gem](https://github.com/pusher/pusher-http-ruby). The idea of this pull request is to replace the use of the downcase! method with a reassignment of the string, preventing errors when working with frozen strings.

I have applied thos changes on my project and it started to work fine.

Submitter Checklist:
- [x] Include a link to the related GitHub issue, if applicable. 
- [x] Include a security review link, if applicable

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
GitHub Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
