### PR TITLE
Adapt newrelic.yml generator to code fences

### DIFF
--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -387,9 +387,9 @@ module NewRelic
           :allowed_from_server => false,
           :description => <<~DESCRIPTION
             An array of ActiveSupport custom event names to subscribe to and instrument. For example,
-              - one.custom.event
-              - another.event
-              - a.third.event
+            - one.custom.event
+            - another.event
+            - a.third.event
           DESCRIPTION
         },
         :'ai_monitoring.enabled' => {
@@ -407,11 +407,11 @@ module NewRelic
           :description => <<~DESCRIPTION
             If `false`, LLM instrumentation (OpenAI only for now) will not capture input and output content on specific LLM events.
 
-              The excluded attributes include:
-                * `content` from LlmChatCompletionMessage events
-                * `input` from LlmEmbedding events
+            The excluded attributes include:
+              * `content` from LlmChatCompletionMessage events
+              * `input` from LlmEmbedding events
 
-              This is an optional security setting to prevent recording sensitive data sent to and received from your LLMs.
+            This is an optional security setting to prevent recording sensitive data sent to and received from your LLMs.
           DESCRIPTION
         },
         # this is only set via server side config
@@ -460,9 +460,9 @@ module NewRelic
           :description => <<~DESCRIPTION
             When `true`, the agent captures HTTP request parameters and attaches them to transaction traces, traced errors, and [`TransactionError` events](/attribute-dictionary?attribute_name=&events_tids%5B%5D=8241).
 
-                <Callout variant="caution">
-                  When using the `capture_params` setting, the Ruby agent will not attempt to filter secret information. `Recommendation:` To filter secret information from request parameters, use the [`attributes.include` setting](/docs/agents/ruby-agent/attributes/enable-disable-attributes-ruby) instead. For more information, see the <a href="/docs/agents/ruby-agent/attributes/ruby-attribute-examples#ex_req_params">Ruby attribute examples</a>.
-                </Callout>
+            <Callout variant="caution">
+              When using the `capture_params` setting, the Ruby agent will not attempt to filter secret information. `Recommendation:` To filter secret information from request parameters, use the [`attributes.include` setting](/docs/agents/ruby-agent/attributes/enable-disable-attributes-ruby) instead. For more information, see the <a href="/docs/agents/ruby-agent/attributes/ruby-attribute-examples#ex_req_params">Ruby attribute examples</a>.
+            </Callout>
           DESCRIPTION
         },
         :'clear_transaction_state_after_fork' => {
@@ -487,10 +487,10 @@ module NewRelic
           :allowed_from_server => false,
           :description => <<~DESC
             Path to `newrelic.yml`. If undefined, the agent checks the following directories (in order):
-                * `config/newrelic.yml`
-                * `newrelic.yml`
-                * `$HOME/.newrelic/newrelic.yml`
-                * `$HOME/newrelic.yml`
+              * `config/newrelic.yml`
+              * `newrelic.yml`
+              * `$HOME/.newrelic/newrelic.yml`
+              * `$HOME/newrelic.yml`
           DESC
         },
         :'exclude_newrelic_header' => {
@@ -674,13 +674,13 @@ module NewRelic
           :public => true,
           :type => String,
           :allowed_from_server => true,
-          :description => 'Obfuscation level for SQL queries reported in transaction trace nodes.
-
-  By default, this is set to `obfuscated`, which strips out the numeric and string literals.
-
-  - If you do not want the agent to capture query information, set this to `none`.
-  - If you want the agent to capture all query information in its original form, set this to `raw`.
-  - When you enable [high security mode](/docs/agents/manage-apm-agents/configuration/high-security-mode), this is automatically set to `obfuscated`.'
+          :description => <<~DESC
+            Obfuscation level for SQL queries reported in transaction trace nodes.
+            By default, this is set to `obfuscated`, which strips out the numeric and string literals.
+            - If you do not want the agent to capture query information, set this to `none`.
+            - If you want the agent to capture all query information in its original form, set this to `raw`.
+            - When you enable [high security mode](/docs/agents/manage-apm-agents/configuration/high-security-mode), this is automatically set to `obfuscated`.
+          DESC
         },
 
         :'transaction_tracer.stack_trace_threshold' => {
@@ -722,10 +722,9 @@ module NewRelic
           :dynamic_name => true,
           :description => <<~DESCRIPTION
             A list of error classes that the agent should treat as expected.
-
-              <Callout variant="caution">
-                This option can't be set via environment variable.
-              </Callout>
+            <Callout variant="caution">
+              This option can't be set via environment variable.
+            </Callout>
           DESCRIPTION
         },
         :'error_collector.expected_messages' => {
@@ -736,10 +735,9 @@ module NewRelic
           :dynamic_name => true,
           :description => <<~DESCRIPTION
             A map of error classes to a list of messages. When an error of one of the classes specified here occurs, if its error message contains one of the strings corresponding to it here, that error will be treated as expected.
-
-              <Callout variant="caution">
-                This option can't be set via environment variable.
-              </Callout>
+            <Callout variant="caution">
+              This option can't be set via environment variable.
+            </Callout>
           DESCRIPTION
         },
         :'error_collector.expected_status_codes' => {
@@ -758,10 +756,9 @@ module NewRelic
           :dynamic_name => true,
           :description => <<~DESCRIPTION
             A list of error classes that the agent should ignore.
-
-              <Callout variant="caution">
-                This option can't be set via environment variable.
-              </Callout>
+            <Callout variant="caution">
+              This option can't be set via environment variable.
+            </Callout>
           DESCRIPTION
         },
         :'error_collector.ignore_messages' => {
@@ -772,10 +769,9 @@ module NewRelic
           :dynamic_name => true,
           :description => <<~DESCRIPTION
             A map of error classes to a list of messages. When an error of one of the classes specified here occurs, if its error message contains one of the strings corresponding to it here, that error will be ignored.
-
-              <Callout variant="caution">
-                This option can't be set via environment variable.
-              </Callout>
+            <Callout variant="caution">
+              This option can't be set via environment variable.
+            </Callout>
           DESCRIPTION
         },
         :'error_collector.ignore_status_codes' => {
@@ -864,12 +860,12 @@ module NewRelic
             For example, setting this value to "debug" will forward all log events to New Relic. Setting this value to "error" will only forward log events with the levels "error", "fatal", and "unknown".
 
             Valid values (ordered lowest to highest):
-              * "debug"
-              * "info"
-              * "warn"
-              * "error"
-              * "fatal"
-              * "unknown"
+            * "debug"
+            * "info"
+            * "warn"
+            * "error"
+            * "fatal"
+            * "unknown"
           DESCRIPTION
         },
         :'application_logging.forwarding.custom_attributes' => {
@@ -1242,7 +1238,7 @@ module NewRelic
           # Keep the extra two-space indent before the second bullet to appease translation tool
           :description => <<~DESC
             * Specify a maximum number of custom events to buffer in memory at a time.
-              * When configuring the agent for [AI monitoring](/docs/ai-monitoring/intro-to-ai-monitoring), \
+            * When configuring the agent for [AI monitoring](/docs/ai-monitoring/intro-to-ai-monitoring), \
             set to max value `100000`. This ensures the agent captures the maximum amount of LLM events.
           DESC
         },
@@ -1384,9 +1380,9 @@ module NewRelic
           :description => <<~DESCRIPTION
             If `true`, the agent won't wrap third-party middlewares in instrumentation (regardless of whether they are installed via `Rack::Builder` or Rails).
 
-              <Callout variant="important">
-                When middleware instrumentation is disabled, if an application is using middleware that could alter the response code, the HTTP status code reported on the transaction may not reflect the altered value.
-              </Callout>
+            <Callout variant="important">
+              When middleware instrumentation is disabled, if an application is using middleware that could alter the response code, the HTTP status code reported on the transaction may not reflect the altered value.
+            </Callout>
           DESCRIPTION
         },
         :disable_samplers => {
@@ -1425,20 +1421,19 @@ module NewRelic
           :description => <<~DESCRIPTION
             If `true`, disables agent middleware for Sinatra. This middleware is responsible for advanced feature support such as [cross application tracing](/docs/apm/transactions/cross-application-traces/cross-application-tracing), [page load timing](/docs/browser/new-relic-browser/getting-started/new-relic-browser), and [error collection](/docs/apm/applications-menu/events/view-apm-error-analytics).
 
-                <Callout variant="important">
-                  Cross application tracing is deprecated in favor of [distributed tracing](/docs/apm/distributed-tracing/getting-started/introduction-distributed-tracing). Distributed tracing is on by default for Ruby agent versions 8.0.0 and above. Middlewares are not required to support distributed tracing.
+            <Callout variant="important">
+              Cross application tracing is deprecated in favor of [distributed tracing](/docs/apm/distributed-tracing/getting-started/introduction-distributed-tracing). Distributed tracing is on by default for Ruby agent versions 8.0.0 and above. Middlewares are not required to support distributed tracing.
 
-                  To continue using cross application tracing, update the following options in your `newrelic.yml` configuration file:
+              To continue using cross application tracing, update the following options in your `newrelic.yml` configuration file:
 
-                  ```yaml
-                  # newrelic.yml
-
-                    cross_application_tracer:
-                      enabled: true
-                    distributed_tracing:
-                      enabled: false
-                  ```
-                </Callout>
+              ```yaml
+              # newrelic.yml
+              cross_application_tracer:
+                enabled: true
+              distributed_tracing:
+                enabled: false
+              ```
+            </Callout>
           DESCRIPTION
         },
         :disable_view_instrumentation => {
@@ -2191,7 +2186,7 @@ module NewRelic
           # Keep the extra two-space indent before the second bullet to appease translation tool
           :description => <<~DESC
             * Defines the maximum number of span events reported from a single harvest. Any Integer between `1` and `10000` is valid.'
-              * When configuring the agent for [AI monitoring](/docs/ai-monitoring/intro-to-ai-monitoring), set to max value `10000`.\
+            * When configuring the agent for [AI monitoring](/docs/ai-monitoring/intro-to-ai-monitoring), set to max value `10000`.\
             This ensures the agent captures the maximum amount of distributed traces.
           DESC
         },
@@ -2534,11 +2529,9 @@ module NewRelic
           :allowlist => %i[none low medium high],
           :external => :infinite_tracing,
           :description => <<~DESC
-            Configure the compression level for data sent to the trace observer.
-
-              May be one of: `:none`, `:low`, `:medium`, `:high`.
-
-              Set the level to `:none` to disable compression.
+            Configure the compression level for data sent to the trace observer. \
+            May be one of: `:none`, `:low`, `:medium`, `:high`. \
+            Set the level to `:none` to disable compression.
           DESC
         },
         :js_agent_file => {

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -1427,7 +1427,6 @@ module NewRelic
             To continue using cross application tracing, update the following options in your `newrelic.yml` configuration file:
 
             ```yaml
-            # newrelic.yml
             cross_application_tracer:
               enabled: true
             distributed_tracing:

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2185,7 +2185,7 @@ module NewRelic
           # Keep the extra two-space indent before the second bullet to appease translation tool
           :description => <<~DESC
             - Defines the maximum number of span events reported from a single harvest. Any Integer between `1` and `10000` is valid.'
-            - When configuring the agent for [AI monitoring](/docs/ai-monitoring/intro-to-ai-monitoring), set to max value `10000`.\
+              - When configuring the agent for [AI monitoring](/docs/ai-monitoring/intro-to-ai-monitoring), set to max value `10000`.\
             This ensures the agent captures the maximum amount of distributed traces.
           DESC
         },

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -408,8 +408,8 @@ module NewRelic
             If `false`, LLM instrumentation (OpenAI only for now) will not capture input and output content on specific LLM events.
 
             The excluded attributes include:
-              * `content` from LlmChatCompletionMessage events
-              * `input` from LlmEmbedding events
+            - `content` from LlmChatCompletionMessage events
+            - `input` from LlmEmbedding events
 
             This is an optional security setting to prevent recording sensitive data sent to and received from your LLMs.
           DESCRIPTION
@@ -461,7 +461,7 @@ module NewRelic
             When `true`, the agent captures HTTP request parameters and attaches them to transaction traces, traced errors, and [`TransactionError` events](/attribute-dictionary?attribute_name=&events_tids%5B%5D=8241).
 
             <Callout variant="caution">
-              When using the `capture_params` setting, the Ruby agent will not attempt to filter secret information. `Recommendation:` To filter secret information from request parameters, use the [`attributes.include` setting](/docs/agents/ruby-agent/attributes/enable-disable-attributes-ruby) instead. For more information, see the <a href="/docs/agents/ruby-agent/attributes/ruby-attribute-examples#ex_req_params">Ruby attribute examples</a>.
+            When using the `capture_params` setting, the Ruby agent will not attempt to filter secret information. `Recommendation:` To filter secret information from request parameters, use the [`attributes.include` setting](/docs/agents/ruby-agent/attributes/enable-disable-attributes-ruby) instead. For more information, see the <a href="/docs/agents/ruby-agent/attributes/ruby-attribute-examples#ex_req_params">Ruby attribute examples</a>.
             </Callout>
           DESCRIPTION
         },
@@ -487,10 +487,10 @@ module NewRelic
           :allowed_from_server => false,
           :description => <<~DESC
             Path to `newrelic.yml`. If undefined, the agent checks the following directories (in order):
-              * `config/newrelic.yml`
-              * `newrelic.yml`
-              * `$HOME/.newrelic/newrelic.yml`
-              * `$HOME/newrelic.yml`
+            - `config/newrelic.yml`
+            - `newrelic.yml`
+            - `$HOME/.newrelic/newrelic.yml`
+            - `$HOME/newrelic.yml`
           DESC
         },
         :'exclude_newrelic_header' => {
@@ -723,7 +723,7 @@ module NewRelic
           :description => <<~DESCRIPTION
             A list of error classes that the agent should treat as expected.
             <Callout variant="caution">
-              This option can't be set via environment variable.
+            This option can't be set via environment variable.
             </Callout>
           DESCRIPTION
         },
@@ -736,7 +736,7 @@ module NewRelic
           :description => <<~DESCRIPTION
             A map of error classes to a list of messages. When an error of one of the classes specified here occurs, if its error message contains one of the strings corresponding to it here, that error will be treated as expected.
             <Callout variant="caution">
-              This option can't be set via environment variable.
+            This option can't be set via environment variable.
             </Callout>
           DESCRIPTION
         },
@@ -757,7 +757,7 @@ module NewRelic
           :description => <<~DESCRIPTION
             A list of error classes that the agent should ignore.
             <Callout variant="caution">
-              This option can't be set via environment variable.
+            This option can't be set via environment variable.
             </Callout>
           DESCRIPTION
         },
@@ -770,7 +770,7 @@ module NewRelic
           :description => <<~DESCRIPTION
             A map of error classes to a list of messages. When an error of one of the classes specified here occurs, if its error message contains one of the strings corresponding to it here, that error will be ignored.
             <Callout variant="caution">
-              This option can't be set via environment variable.
+            This option can't be set via environment variable.
             </Callout>
           DESCRIPTION
         },
@@ -860,12 +860,12 @@ module NewRelic
             For example, setting this value to "debug" will forward all log events to New Relic. Setting this value to "error" will only forward log events with the levels "error", "fatal", and "unknown".
 
             Valid values (ordered lowest to highest):
-            * "debug"
-            * "info"
-            * "warn"
-            * "error"
-            * "fatal"
-            * "unknown"
+            - "debug"
+            - "info"
+            - "warn"
+            - "error"
+            - "fatal"
+            - "unknown"
           DESCRIPTION
         },
         :'application_logging.forwarding.custom_attributes' => {
@@ -1237,8 +1237,8 @@ module NewRelic
           :dynamic_name => true,
           # Keep the extra two-space indent before the second bullet to appease translation tool
           :description => <<~DESC
-            * Specify a maximum number of custom events to buffer in memory at a time.
-            * When configuring the agent for [AI monitoring](/docs/ai-monitoring/intro-to-ai-monitoring), \
+            - Specify a maximum number of custom events to buffer in memory at a time.
+              - When configuring the agent for [AI monitoring](/docs/ai-monitoring/intro-to-ai-monitoring), \
             set to max value `100000`. This ensures the agent captures the maximum amount of LLM events.
           DESC
         },
@@ -1381,7 +1381,7 @@ module NewRelic
             If `true`, the agent won't wrap third-party middlewares in instrumentation (regardless of whether they are installed via `Rack::Builder` or Rails).
 
             <Callout variant="important">
-              When middleware instrumentation is disabled, if an application is using middleware that could alter the response code, the HTTP status code reported on the transaction may not reflect the altered value.
+            When middleware instrumentation is disabled, if an application is using middleware that could alter the response code, the HTTP status code reported on the transaction may not reflect the altered value.
             </Callout>
           DESCRIPTION
         },
@@ -1422,17 +1422,17 @@ module NewRelic
             If `true`, disables agent middleware for Sinatra. This middleware is responsible for advanced feature support such as [cross application tracing](/docs/apm/transactions/cross-application-traces/cross-application-tracing), [page load timing](/docs/browser/new-relic-browser/getting-started/new-relic-browser), and [error collection](/docs/apm/applications-menu/events/view-apm-error-analytics).
 
             <Callout variant="important">
-              Cross application tracing is deprecated in favor of [distributed tracing](/docs/apm/distributed-tracing/getting-started/introduction-distributed-tracing). Distributed tracing is on by default for Ruby agent versions 8.0.0 and above. Middlewares are not required to support distributed tracing.
+            Cross application tracing is deprecated in favor of [distributed tracing](/docs/apm/distributed-tracing/getting-started/introduction-distributed-tracing). Distributed tracing is on by default for Ruby agent versions 8.0.0 and above. Middlewares are not required to support distributed tracing.
 
-              To continue using cross application tracing, update the following options in your `newrelic.yml` configuration file:
+            To continue using cross application tracing, update the following options in your `newrelic.yml` configuration file:
 
-              ```yaml
-              # newrelic.yml
-              cross_application_tracer:
-                enabled: true
-              distributed_tracing:
-                enabled: false
-              ```
+            ```yaml
+            # newrelic.yml
+            cross_application_tracer:
+              enabled: true
+            distributed_tracing:
+              enabled: false
+            ```
             </Callout>
           DESCRIPTION
         },
@@ -2047,7 +2047,7 @@ module NewRelic
             If `true`, when the agent is in an application using Ruby on Rails, it will start after `config/initializers` run.
 
             <Callout variant="caution">
-              This option may only be set by environment variable.
+            This option may only be set by environment variable.
             </Callout>
           DESCRIPTION
         },
@@ -2185,8 +2185,8 @@ module NewRelic
           :allowed_from_server => true,
           # Keep the extra two-space indent before the second bullet to appease translation tool
           :description => <<~DESC
-            * Defines the maximum number of span events reported from a single harvest. Any Integer between `1` and `10000` is valid.'
-            * When configuring the agent for [AI monitoring](/docs/ai-monitoring/intro-to-ai-monitoring), set to max value `10000`.\
+            - Defines the maximum number of span events reported from a single harvest. Any Integer between `1` and `10000` is valid.'
+            - When configuring the agent for [AI monitoring](/docs/ai-monitoring/intro-to-ai-monitoring), set to max value `10000`.\
             This ensures the agent captures the maximum amount of distributed traces.
           DESC
         },

--- a/lib/tasks/helpers/newrelicyml.rb
+++ b/lib/tasks/helpers/newrelicyml.rb
@@ -135,12 +135,14 @@ module NewRelicYML
   end
 
   def self.sanitize_description(description)
-    # remove callouts
+    # remove callouts 
     description = description.split("\n").reject { |line| line.match?('</?Callout') }.join("\n")
     # remove InlinePopover, keep the text inside type
     description.gsub!(/<InlinePopover type="(.*)" \/>/, '\1')
     # remove hyperlinks
     description.gsub!(/\[([^\]]+)\]\([^\)]+\)/, '\1')
+    # delete lines with code fences including the language
+    description.gsub!(/```[a-zA-Z0-9_]*\n(.*?)```/m, '\1')
     # remove single pairs of backticks
     description.gsub!(/`([^`]+)`/, '\1')
     # removed href links
@@ -153,8 +155,8 @@ module NewRelicYML
     # remove leading and trailing whitespace
     description.strip!
     # wrap text after 80 characters, assuming we're at one tabstop's (two
-    # spaces') level of indentation already
-    description.gsub!(/(.{1,78})(\s+|\Z)/, "\\1\n")
+    # spaces') level of indentation already, keep leading whitespace
+    description.gsub!(/(.{1,78})(\s|\Z)/, "\\1\n")
     # add hashtags to lines
     description = description.split("\n").map { |line| "  # #{line}" }.join("\n")
 

--- a/lib/tasks/helpers/newrelicyml.rb
+++ b/lib/tasks/helpers/newrelicyml.rb
@@ -135,7 +135,7 @@ module NewRelicYML
   end
 
   def self.sanitize_description(description)
-    # remove callouts 
+    # remove callouts
     description = description.split("\n").reject { |line| line.match?('</?Callout') }.join("\n")
     # remove InlinePopover, keep the text inside type
     description.gsub!(/<InlinePopover type="(.*)" \/>/, '\1')

--- a/newrelic.yml
+++ b/newrelic.yml
@@ -42,8 +42,8 @@ common: &default_settings
   # output content on specific LLM events.
   # 
   # The excluded attributes include:
-  #   * content from LlmChatCompletionMessage events
-  #   * input from LlmEmbedding events
+  # - content from LlmChatCompletionMessage events
+  # - input from LlmEmbedding events
   # 
   # This is an optional security setting to prevent recording sensitive data sent
   # to and received from your LLMs.
@@ -86,12 +86,12 @@ common: &default_settings
   # levels "error", "fatal", and "unknown".
   # 
   # Valid values (ordered lowest to highest):
-  # * "debug"
-  # * "info"
-  # * "warn"
-  # * "error"
-  # * "fatal"
-  # * "unknown"
+  # - "debug"
+  # - "info"
+  # - "warn"
+  # - "error"
+  # - "fatal"
+  # - "unknown"
   # application_logging.forwarding.log_level: debug
 
   # Defines the maximum number of log records to buffer in memory at a time.
@@ -224,7 +224,7 @@ common: &default_settings
   # When true, the agent captures HTTP request parameters and attaches them to
   # transaction traces, traced errors, and TransactionError events.
   # 
-  #   When using the capture_params setting, the Ruby agent will not attempt to
+  # When using the capture_params setting, the Ruby agent will not attempt to
   # filter secret information. Recommendation: To filter secret information from
   # request parameters, use the attributes.include setting instead. For more
   # information, see the Ruby attribute examples.
@@ -243,10 +243,10 @@ common: &default_settings
 
   # Path to newrelic.yml. If undefined, the agent checks the following directories
   # (in order):
-  #   * config/newrelic.yml
-  #   * newrelic.yml
-  #   * $HOME/.newrelic/newrelic.yml
-  #   * $HOME/newrelic.yml
+  # - config/newrelic.yml
+  # - newrelic.yml
+  # - $HOME/.newrelic/newrelic.yml
+  # - $HOME/newrelic.yml
   # config_path: newrelic.yml
 
   # If false, custom attributes will not be sent on events.
@@ -255,9 +255,9 @@ common: &default_settings
   # If true, the agent captures custom events.
   # custom_insights_events.enabled: true
 
-  # * Specify a maximum number of custom events to buffer in memory at a time.
-  # * When configuring the agent for AI monitoring, set to max value 100000. This
-  # ensures the agent captures the maximum amount of LLM events.
+  # - Specify a maximum number of custom events to buffer in memory at a time.
+  #   - When configuring the agent for AI monitoring, set to max value 100000.
+  # This ensures the agent captures the maximum amount of LLM events.
   # custom_insights_events.max_samples_stored: 3000
 
   # If false, the agent will not add database_name parameter to transaction or
@@ -311,7 +311,7 @@ common: &default_settings
   # If true, the agent won't wrap third-party middlewares in instrumentation
   # (regardless of whether they are installed via Rack::Builder or Rails).
   # 
-  #   When middleware instrumentation is disabled, if an application is using
+  # When middleware instrumentation is disabled, if an application is using
   # middleware that could alter the response code, the HTTP status code reported
   # on the transaction may not reflect the altered value.
   # disable_middleware_instrumentation: false
@@ -334,18 +334,18 @@ common: &default_settings
   # for advanced feature support such as cross application tracing, page load
   # timing, and error collection.
   # 
-  #   Cross application tracing is deprecated in favor of distributed tracing.
+  # Cross application tracing is deprecated in favor of distributed tracing.
   # Distributed tracing is on by default for Ruby agent versions 8.0.0 and above.
   # Middlewares are not required to support distributed tracing.
   # 
-  #   To continue using cross application tracing, update the following options in
+  # To continue using cross application tracing, update the following options in
   # your newrelic.yml configuration file:
   # 
-  #     # newrelic.yml
-  #   cross_application_tracer:
-  #     enabled: true
-  #   distributed_tracing:
-  #     enabled: false
+  # # newrelic.yml
+  # cross_application_tracer:
+  #   enabled: true
+  # distributed_tracing:
+  #   enabled: false
   # disable_sinatra_auto_middleware: false
 
   # If true, disables view instrumentation.
@@ -388,13 +388,13 @@ common: &default_settings
   # error_collector.enabled: true
 
   # A list of error classes that the agent should treat as expected.
-  #   This option can't be set via environment variable.
+  # This option can't be set via environment variable.
   # error_collector.expected_classes: []
 
   # A map of error classes to a list of messages. When an error of one of the
   # classes specified here occurs, if its error message contains one of the
   # strings corresponding to it here, that error will be treated as expected.
-  #   This option can't be set via environment variable.
+  # This option can't be set via environment variable.
   # error_collector.expected_messages: {}
 
   # A comma separated list of status codes, possibly including ranges. Errors
@@ -403,13 +403,13 @@ common: &default_settings
   # error_collector.expected_status_codes: ""
 
   # A list of error classes that the agent should ignore.
-  #   This option can't be set via environment variable.
+  # This option can't be set via environment variable.
   # error_collector.ignore_classes: ["ActionController::RoutingError", "Sinatra::NotFound"]
 
   # A map of error classes to a list of messages. When an error of one of the
   # classes specified here occurs, if its error message contains one of the
   # strings corresponding to it here, that error will be ignored.
-  #   This option can't be set via environment variable.
+  # This option can't be set via environment variable.
   # error_collector.ignore_messages: {"ThreadError"=>["queue empty"]}
 
   # A comma separated list of status codes, possibly including ranges. Errors
@@ -813,9 +813,9 @@ common: &default_settings
   # If true, enables span event sampling.
   # span_events.enabled: true
 
-  # * Defines the maximum number of span events reported from a single harvest.
+  # - Defines the maximum number of span events reported from a single harvest.
   # Any Integer between 1 and 10000 is valid.'
-  # * When configuring the agent for AI monitoring, set to max value 10000.This
+  # - When configuring the agent for AI monitoring, set to max value 10000.This
   # ensures the agent captures the maximum amount of distributed traces.
   # span_events.max_samples_stored: 2000
 

--- a/newrelic.yml
+++ b/newrelic.yml
@@ -341,7 +341,6 @@ common: &default_settings
   # To continue using cross application tracing, update the following options in
   # your newrelic.yml configuration file:
   # 
-  # # newrelic.yml
   # cross_application_tracer:
   #   enabled: true
   # distributed_tracing:

--- a/newrelic.yml
+++ b/newrelic.yml
@@ -814,7 +814,7 @@ common: &default_settings
 
   # - Defines the maximum number of span events reported from a single harvest.
   # Any Integer between 1 and 10000 is valid.'
-  # - When configuring the agent for AI monitoring, set to max value 10000.This
+  #   - When configuring the agent for AI monitoring, set to max value 10000.This
   # ensures the agent captures the maximum amount of distributed traces.
   # span_events.max_samples_stored: 2000
 

--- a/newrelic.yml
+++ b/newrelic.yml
@@ -40,9 +40,11 @@ common: &default_settings
 
   # If false, LLM instrumentation (OpenAI only for now) will not capture input and
   # output content on specific LLM events.
+  # 
   # The excluded attributes include:
-  # * content from LlmChatCompletionMessage events
-  # * input from LlmEmbedding events
+  #   * content from LlmChatCompletionMessage events
+  #   * input from LlmEmbedding events
+  # 
   # This is an optional security setting to prevent recording sensitive data sent
   # to and received from your LLMs.
   # ai_monitoring.record_content.enabled: true
@@ -73,13 +75,16 @@ common: &default_settings
   # application_logging.forwarding.labels.exclude: []
 
   # Sets the minimum level a log event must have to be forwarded to New Relic.
-  # This is based on the integer values of Ruby's Logger::Severity constants:
-  # https://github.com/ruby/logger/blob/113b82a06b3076b93a71cd467e1605b23afb3088/lib/logger/severity.rb
+  # 
+  # This is based on the integer values of Ruby's Logger::Severity constants.
+  # 
   # The intention is to forward logs with the level given to the configuration, as
   # well as any logs with a higher level of severity.
+  # 
   # For example, setting this value to "debug" will forward all log events to New
   # Relic. Setting this value to "error" will only forward log events with the
   # levels "error", "fatal", and "unknown".
+  # 
   # Valid values (ordered lowest to highest):
   # * "debug"
   # * "info"
@@ -124,48 +129,52 @@ common: &default_settings
   # methods) strings representing Ruby methods that the agent can automatically
   # add custom instrumentation to. This doesn't require any modifications of the
   # source code that defines the methods.
+  # 
   # Use fully qualified class names (using the :: delimiter) that include any
   # module or class namespacing.
+  # 
   # Here is some Ruby source code that defines a render_png instance method for an
   # Image class and a notify class method for a User class, both within a
   # MyCompany module namespace:
-  #
+  # 
   # module MyCompany
   #   class Image
   #     def render_png
   #       # code to render a PNG
   #     end
   #   end
-  #
+  # 
   #   class User
   #     def self.notify
   #       # code to notify users
   #     end
   #   end
   # end
-  #
+  # 
+  # 
   # Given that source code, the newrelic.yml config file might request
   # instrumentation for both of these methods like so:
-  #
+  # 
   # automatic_custom_instrumentation_method_list:
-  # - MyCompany::Image#render_png
-  # - MyCompany::User.notify
-  #
+  #   - MyCompany::Image#render_png
+  #   - MyCompany::User.notify
+  # 
+  # 
   # That configuration example uses YAML array syntax to specify both methods.
   # Alternatively, you can use a comma-delimited string:
-  #
+  # 
   # automatic_custom_instrumentation_method_list: 'MyCompany::Image#render_png,
   # MyCompany::User.notify'
-  #
+  # 
+  # 
   # Whitespace around the comma(s) in the list is optional. When configuring the
   # agent with a list of methods via the
   # NEW_RELIC_AUTOMATIC_CUSTOM_INSTRUMENTATION_METHOD_LIST environment variable,
   # use this comma-delimited string format:
-  #
+  # 
   # export
   # NEW_RELIC_AUTOMATIC_CUSTOM_INSTRUMENTATION_METHOD_LIST='MyCompany::Image#render_png,
   # MyCompany::User.notify'
-  #
   # automatic_custom_instrumentation_method_list: []
 
   # Specify a list of constants that should prevent the agent from starting
@@ -214,7 +223,8 @@ common: &default_settings
 
   # When true, the agent captures HTTP request parameters and attaches them to
   # transaction traces, traced errors, and TransactionError events.
-  # When using the capture_params setting, the Ruby agent will not attempt to
+  # 
+  #   When using the capture_params setting, the Ruby agent will not attempt to
   # filter secret information. Recommendation: To filter secret information from
   # request parameters, use the attributes.include setting instead. For more
   # information, see the Ruby attribute examples.
@@ -233,10 +243,10 @@ common: &default_settings
 
   # Path to newrelic.yml. If undefined, the agent checks the following directories
   # (in order):
-  # * config/newrelic.yml
-  # * newrelic.yml
-  # * $HOME/.newrelic/newrelic.yml
-  # * $HOME/newrelic.yml
+  #   * config/newrelic.yml
+  #   * newrelic.yml
+  #   * $HOME/.newrelic/newrelic.yml
+  #   * $HOME/newrelic.yml
   # config_path: newrelic.yml
 
   # If false, custom attributes will not be sent on events.
@@ -300,7 +310,8 @@ common: &default_settings
 
   # If true, the agent won't wrap third-party middlewares in instrumentation
   # (regardless of whether they are installed via Rack::Builder or Rails).
-  # When middleware instrumentation is disabled, if an application is using
+  # 
+  #   When middleware instrumentation is disabled, if an application is using
   # middleware that could alter the response code, the HTTP status code reported
   # on the transaction may not reflect the altered value.
   # disable_middleware_instrumentation: false
@@ -322,6 +333,19 @@ common: &default_settings
   # If true, disables agent middleware for Sinatra. This middleware is responsible
   # for advanced feature support such as cross application tracing, page load
   # timing, and error collection.
+  # 
+  #   Cross application tracing is deprecated in favor of distributed tracing.
+  # Distributed tracing is on by default for Ruby agent versions 8.0.0 and above.
+  # Middlewares are not required to support distributed tracing.
+  # 
+  #   To continue using cross application tracing, update the following options in
+  # your newrelic.yml configuration file:
+  # 
+  #     # newrelic.yml
+  #   cross_application_tracer:
+  #     enabled: true
+  #   distributed_tracing:
+  #     enabled: false
   # disable_sinatra_auto_middleware: false
 
   # If true, disables view instrumentation.
@@ -335,6 +359,10 @@ common: &default_settings
   # New Relic features, so carefully consult the transition guide before you
   # enable this feature.
   # distributed_tracing.enabled: true
+
+  # If true, the agent captures the Elasticsearch cluster name in transaction
+  # traces.
+  # elasticsearch.capture_cluster_name: true
 
   # If true, the agent captures Elasticsearch queries in transaction traces.
   # elasticsearch.capture_queries: true
@@ -360,13 +388,13 @@ common: &default_settings
   # error_collector.enabled: true
 
   # A list of error classes that the agent should treat as expected.
-  # This option can't be set via environment variable.
+  #   This option can't be set via environment variable.
   # error_collector.expected_classes: []
 
   # A map of error classes to a list of messages. When an error of one of the
   # classes specified here occurs, if its error message contains one of the
   # strings corresponding to it here, that error will be treated as expected.
-  # This option can't be set via environment variable.
+  #   This option can't be set via environment variable.
   # error_collector.expected_messages: {}
 
   # A comma separated list of status codes, possibly including ranges. Errors
@@ -375,14 +403,14 @@ common: &default_settings
   # error_collector.expected_status_codes: ""
 
   # A list of error classes that the agent should ignore.
-  # This option can't be set via environment variable.
+  #   This option can't be set via environment variable.
   # error_collector.ignore_classes: ["ActionController::RoutingError", "Sinatra::NotFound"]
 
   # A map of error classes to a list of messages. When an error of one of the
   # classes specified here occurs, if its error message contains one of the
   # strings corresponding to it here, that error will be ignored.
-  # This option can't be set via environment variable.
-  # error_collector.ignore_messages: {}
+  #   This option can't be set via environment variable.
+  # error_collector.ignore_messages: {"ThreadError"=>["queue empty"]}
 
   # A comma separated list of status codes, possibly including ranges. Errors
   # associated with these status codes, where applicable, will be ignored.
@@ -428,9 +456,9 @@ common: &default_settings
   # sending each span individually.
   # infinite_tracing.batching: true
 
-  # Configure the compression level for data sent to the trace observer.
-  # May be one of: :none, :low, :medium, :high.
-  # Set the level to :none to disable compression.
+  # Configure the compression level for data sent to the trace observer. May be
+  # one of: :none, :low, :medium, :high. Set the level to :none to disable
+  # compression.
   # infinite_tracing.compression_level: high
 
   # Configures the hostname for the trace observer Host. When configured, enables
@@ -957,7 +985,7 @@ common: &default_settings
   #   NOTE: All "security.*" configuration parameters are related only to the
   #         security agent, and all other configuration parameters that may
   #         have "security" in the name somewhere are related to the APM agent.
-
+  
   # If true, the security agent is loaded (a Ruby 'require' is performed)
   # security.agent.enabled: false
 


### PR DESCRIPTION
Add support for code fences in the newrelicyml.rb generator. 

Closes [#2959](https://github.com/newrelic/newrelic-ruby-agent/issues/2959)