### PR TITLE
Fixes NoMethodError: undefined method `queue_name' for nil in ActiveJobSubscriber when using perform_all_later.

### DIFF
--- a/lib/new_relic/agent/instrumentation/active_job_subscriber.rb
+++ b/lib/new_relic/agent/instrumentation/active_job_subscriber.rb
@@ -8,7 +8,7 @@ module NewRelic
   module Agent
     module Instrumentation
       class ActiveJobSubscriber < NotificationsSubscriber
-        PAYLOAD_KEYS = %i[adapter db_runtime error job wait]
+        PAYLOAD_KEYS = %i[adapter db_runtime error job wait jobs]
 
         def add_segment_params(segment, payload)
           PAYLOAD_KEYS.each do |key|
@@ -16,8 +16,12 @@ module NewRelic
           end
         end
 
+        # NOTE: For `enqueue_all.active_job`, only the first job is used to determine the queue.
+        # Therefore, this assumes all jobs given as arguments for perform_all_later share the same queue.
         def metric_name(name, payload)
-          queue = payload[:job].queue_name
+          job = payload[:job] || payload[:jobs].first
+
+          queue = job.queue_name
           method = method_from_name(name)
           "Ruby/ActiveJob/#{queue}/#{method}"
         end

--- a/test/new_relic/agent/instrumentation/rails/active_job_subscriber.rb
+++ b/test/new_relic/agent/instrumentation/rails/active_job_subscriber.rb
@@ -35,6 +35,11 @@ module NewRelic::Agent::Instrumentation
         SUBSCRIBER.send(:metric_name, 'indecipherable', {job: TestJob.new})
     end
 
+    def test_segment_naming_multiple_jobs
+      assert_equal 'Ruby/ActiveJob/default/Unknown',
+        SUBSCRIBER.send(:metric_name, 'indecipherable', {jobs: [TestJob.new, TestJob.new]})
+    end
+
     # perform.active_job
     def test_perform_active_job
       job = TestJob.new


### PR DESCRIPTION


# Overview

Stacktrace: 
```
** [NewRelic][2025-04-01 13:44:17 +0000 run.* (4)] ERROR : Error during start callback for event 'enqueue_all.active_job':
** [NewRelic][2025-04-01 13:44:17 +0000 run.* (4)] ERROR : NoMethodError: undefined method `queue_name' for nil
** [NewRelic][2025-04-01 13:44:17 +0000 run.* (4)] ERROR : Debugging backtrace:
/app/vendor/bundle/ruby/3.3.0/gems/newrelic_rpm-9.17.0/lib/new_relic/agent/instrumentation/active_job_subscriber.rb:20:in `metric_name'
  /app/vendor/bundle/ruby/3.3.0/gems/newrelic_rpm-9.17.0/lib/new_relic/agent/instrumentation/notifications_subscriber.rb:71:in `start_segment'
  /app/vendor/bundle/ruby/3.3.0/gems/newrelic_rpm-9.17.0/lib/new_relic/agent/instrumentation/notifications_subscriber.rb:57:in `start'
  /app/vendor/bundle/ruby/3.3.0/gems/activesupport-7.1.3.2/lib/active_support/notifications/fanout.rb:159:in `block in start'
  /app/vendor/bundle/ruby/3.3.0/gems/activesupport-7.1.3.2/lib/active_support/notifications/fanout.rb:26:in `block in iterate_guarding_exceptions'
  /app/vendor/bundle/ruby/3.3.0/gems/activesupport-7.1.3.2/lib/active_support/notifications/fanout.rb:25:in `each'
  /app/vendor/bundle/ruby/3.3.0/gems/activesupport-7.1.3.2/lib/active_support/notifications/fanout.rb:25:in `iterate_guarding_exceptions'
  /app/vendor/bundle/ruby/3.3.0/gems/activesupport-7.1.3.2/lib/active_support/notifications/fanout.rb:125:in `each'
  /app/vendor/bundle/ruby/3.3.0/gems/activesupport-7.1.3.2/lib/active_support/notifications/fanout.rb:158:in `start'
  /app/vendor/bundle/ruby/3.3.0/gems/activesupport-7.1.3.2/lib/active_support/notifications/fanout.rb:249:in `block in start'
  /app/vendor/bundle/ruby/3.3.0/gems/activesupport-7.1.3.2/lib/active_support/notifications/fanout.rb:26:in `block in iterate_guarding_exceptions'
  /app/vendor/bundle/ruby/3.3.0/gems/activesupport-7.1.3.2/lib/active_support/notifications/fanout.rb:25:in `each'
  /app/vendor/bundle/ruby/3.3.0/gems/activesupport-7.1.3.2/lib/active_support/notifications/fanout.rb:25:in `iterate_guarding_exceptions'
  /app/vendor/bundle/ruby/3.3.0/gems/activesupport-7.1.3.2/lib/active_support/notifications/fanout.rb:248:in `start'
  /app/vendor/bundle/ruby/3.3.0/gems/activesupport-7.1.3.2/lib/active_support/notifications/instrumenter.rb:56:in `instrument'
  /app/vendor/bundle/ruby/3.3.0/gems/activesupport-7.1.3.2/lib/active_support/notifications.rb:206:in `instrument'
  /app/vendor/bundle/ruby/3.3.0/gems/activejob-7.1.3.2/lib/active_job/instrumentation.rb:8:in `instrument_enqueue_all'
  /app/vendor/bundle/ruby/3.3.0/gems/activejob-7.1.3.2/lib/active_job/enqueuing.rb:19:in `block in perform_all_later'
  /app/vendor/bundle/ruby/3.3.0/gems/activejob-7.1.3.2/lib/active_job/enqueuing.rb:18:in `each'
  /app/vendor/bundle/ruby/3.3.0/gems/activejob-7.1.3.2/lib/active_job/enqueuing.rb:18:in `perform_all_later'
  /app/lib/tasks/elasticsearch.rake:68:in `enqueue_elasticsearch_jobs'
  /app/lib/tasks/elasticsearch.rake:23:in `block (3 levels) in <main>'
  /app/lib/tasks/elasticsearch.rake:16:in `each'
  /app/lib/tasks/elasticsearch.rake:16:in `each_with_index'
  /app/lib/tasks/elasticsearch.rake:16:in `block (2 levels) in <main>'
  /app/vendor/bundle/ruby/3.3.0/gems/rake-13.2.1/lib/rake/task.rb:279:in `block in execute'
  /app/vendor/bundle/ruby/3.3.0/gems/rake-13.2.1/lib/rake/task.rb:279:in `each'
  /app/vendor/bundle/ruby/3.3.0/gems/rake-13.2.1/lib/rake/task.rb:279:in `execute'
  /app/vendor/bundle/ruby/3.3.0/gems/rake-13.2.1/lib/rake/task.rb:219:in `block in invoke_with_call_chain'
  /app/vendor/bundle/ruby/3.3.0/gems/rake-13.2.1/lib/rake/task.rb:199:in `synchronize'
  /app/vendor/bundle/ruby/3.3.0/gems/rake-13.2.1/lib/rake/task.rb:199:in `invoke_with_call_chain'
  /app/vendor/bundle/ruby/3.3.0/gems/rake-13.2.1/lib/rake/task.rb:188:in `invoke'
  /app/vendor/bundle/ruby/3.3.0/gems/rake-13.2.1/lib/rake/application.rb:188:in `invoke_task'
  /app/vendor/bundle/ruby/3.3.0/gems/rake-13.2.1/lib/rake/application.rb:138:in `block (2 levels) in top_level'
  /app/vendor/bundle/ruby/3.3.0/gems/rake-13.2.1/lib/rake/application.rb:138:in `each'
  /app/vendor/bundle/ruby/3.3.0/gems/rake-13.2.1/lib/rake/application.rb:138:in `block in top_level'
  /app/vendor/bundle/ruby/3.3.0/gems/rake-13.2.1/lib/rake/application.rb:147:in `run_with_threads'
  /app/vendor/bundle/ruby/3.3.0/gems/rake-13.2.1/lib/rake/application.rb:132:in `top_level'
  /app/vendor/bundle/ruby/3.3.0/gems/rake-13.2.1/lib/rake/application.rb:83:in `block in run'
  /app/vendor/bundle/ruby/3.3.0/gems/rake-13.2.1/lib/rake/application.rb:214:in `standard_exception_handling'
  /app/vendor/bundle/ruby/3.3.0/gems/rake-13.2.1/lib/rake/application.rb:80:in `run'
  /app/bin/rake:4:in `<main>'
```

1. perform_all_later([job1, job2]) is called
2. Rails emits enqueue_all.active_job with { jobs: [...] }
3. New Relic receives that notification. 
4. ActiveJobSubscriber#start is triggered 
5. metric_name(name, payload) is called inside start 
6. payload[:job] is nil 

Prove payload locally in rails console:

1. Subribe to "enqueue_all.active_job" Event
```
ActiveSupport::Notifications.subscribe("enqueue_all.active_job") do |*args|
  event = ActiveSupport::Notifications::Event.new(*args)
  puts "Event payload: #{event.payload.inspect}"
end
```

2.  Run perform_all_later
```ActiveJob.perform_all_later([SomeJob.new])
```
Output:

Event payload: `{:adapter=> SidekiqAdapter, :jobs=>[SomeJob.new]) `contains to no :job key


Submitter Checklist:
- [ ] Include a link to the related GitHub issue, if applicable
- [ ] Include a security review link, if applicable

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
GitHub Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Add performance label
- [ ] Perform appropriate level of performance testing
- [ ] Confirm all checks passed
- [ ] Add version label prior to acceptance
