### PR TITLE
Bump ci_cron Ruby versions to latest

### DIFF
--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: [2.4.10, 2.5.9, 2.6.10, 2.7.8, 3.0.7, 3.1.6, 3.2.6, 3.3.6, 3.4.2]
+        ruby-version: [2.4.10, 2.5.9, 2.6.10, 2.7.8, 3.0.7, 3.1.7, 3.2.8, 3.3.8, 3.4.2]
 
     steps:
       - name: Configure git
@@ -75,13 +75,13 @@ jobs:
               "3.0.7": {
                 "rails": "norails,rails61,rails60,rails70,rails71"
               },
-              "3.1.6": {
+              "3.1.7": {
                 "rails": "norails,rails61,rails70,rails71,rails72"
               },
-              "3.2.6": {
+              "3.2.8": {
                 "rails": "norails,rails61,rails70,rails71,rails72,rails80,railsedge"
               },
-              "3.3.6": {
+              "3.3.8": {
                 "rails": "norails,rails61,rails70,rails71,rails72,rails80,railsedge"
               },
               "3.4.2": {
@@ -129,7 +129,7 @@ jobs:
       fail-fast: false
       matrix:
         multiverse: [agent, ai, background, background_2, frameworks, httpclients, httpclients_2, rails, rest]
-        ruby-version: [2.4.10, 2.5.9, 2.6.10, 2.7.8, 3.0.7, 3.1.6, 3.2.6, 3.3.6, 3.4.2]
+        ruby-version: [2.4.10, 2.5.9, 2.6.10, 2.7.8, 3.0.7, 3.1.7, 3.2.8, 3.3.8, 3.4.2]
     steps:
       - name: Configure git
         run: 'git config --global init.defaultBranch main'
@@ -209,7 +209,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: [2.4.10, 2.5.9, 2.6.10, 2.7.8, 3.0.7, 3.1.6, 3.2.6, 3.3.6, 3.4.2]
+        ruby-version: [2.4.10, 2.5.9, 2.6.10, 2.7.8, 3.0.7, 3.1.7, 3.2.8, 3.3.8, 3.4.2]
 
     steps:
       - name: Configure git
@@ -300,7 +300,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: [2.4.10, 2.5.9, 2.6.10, 2.7.8, 3.0.7, 3.1.6, 3.2.6, 3.3.6, 3.4.2]
+        ruby-version: [2.4.10, 2.5.9, 2.6.10, 2.7.8, 3.0.7, 3.1.7, 3.2.8, 3.3.8, 3.4.2]
 
     steps:
       - name: Configure git
@@ -375,7 +375,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: [2.4.10, 2.5.9, 2.6.10, 2.7.8, 3.0.7, 3.1.6, 3.2.6, 3.3.6, 3.4.2]
+        ruby-version: [2.4.10, 2.5.9, 2.6.10, 2.7.8, 3.0.7, 3.1.7, 3.2.8, 3.3.8, 3.4.2]
 
     steps:
       - name: Configure git
@@ -439,7 +439,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: [2.4.10, 2.5.9, 2.6.10, 2.7.8, 3.0.7, 3.1.6, 3.2.6, 3.3.6, 3.4.2]
+        ruby-version: [2.4.10, 2.5.9, 2.6.10, 2.7.8, 3.0.7, 3.1.7, 3.2.8, 3.3.8, 3.4.2]
 
     steps:
       - name: Configure git
@@ -520,7 +520,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: [2.7.8, 3.0.7, 3.1.6, 3.2.6, 3.3.6, 3.4.2]
+        ruby-version: [2.7.8, 3.0.7, 3.1.7, 3.2.8, 3.3.8, 3.4.2]
     steps:
       - name: Configure git
         run: 'git config --global init.defaultBranch main'


### PR DESCRIPTION
Updates to 3.1.7, 3.2.8, 3.3.8
