### PR TITLE
W3C Sampling Flag Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 - **Feature: Add support for W3C TraceContext Trace Flag**
 
-  Previously, the agent would not use the Trace flag field of the traceparent header for sampling decisions. This could lead to fragmented traces in the UI. While the default behavior remains unchanged, 2 new configuration options, `distributed_tracing.sampler.remote_parent_sampled` and `distributed_tracing.sampler.remote_parent_not_sampled`, have been introduced that will allow more control over the way sampling decisions are made. [PR#3135](https://github.com/newrelic/newrelic-ruby-agent/pull/3135)
+  Previously, the agent would not use the trace flag field of the traceparent header for sampling decisions. This could lead to fragmented traces in the UI. While the default behavior remains unchanged, two new configuration options, `distributed_tracing.sampler.remote_parent_sampled` and `distributed_tracing.sampler.remote_parent_not_sampled`, have been introduced to allow more control over the way sampling decisions are made. [PR#3135](https://github.com/newrelic/newrelic-ruby-agent/pull/3135)
 
 - **Bugfix: Include request.uri in Transaction events by default**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
   The agent will now record the Thread ID as an attribute on each span. [PR#3122](https://github.com/newrelic/newrelic-ruby-agent/pull/3122)
 
+- **Feature: Add support for W3C TraceContext Trace Flag**
+
+  Previously, the agent would not use the Trace flag field of the traceparent header for sampling decisions. This could lead to fragmented traces in the UI. While the default behavior remains unchanged, 2 new configuration options, `distributed_tracing.sampler.remote_parent_sampled` and `distributed_tracing.sampler.remote_parent_not_sampled`, have been introduced that will allow more control over the way sampling decisions are made. [PR#3135](https://github.com/newrelic/newrelic-ruby-agent/pull/3135)
+
 - **Bugfix: Include request.uri in Transaction events by default**
 
   [The New Relic data dictionary expects Transaction events to have the `request.uri` attribute.](https://docs.newrelic.com/attribute-dictionary/?event=Transaction&attribute=request.uri) The Ruby agent now fulfills this expectation. If you would like to exclude `request.uri` from Transaction events, you can do so by setting `transaction_events.attributes.exclude` to `'request.uri'`. [PR#3103](https://github.com/newrelic/newrelic-ruby-agent/pull/3103)

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -1458,6 +1458,20 @@ module NewRelic
           :allowed_from_server => true,
           :description => 'Distributed tracing lets you see the path that a request takes through your distributed system. Enabling distributed tracing changes the behavior of some New Relic features, so carefully consult the [transition guide](/docs/transition-guide-distributed-tracing) before you enable this feature.'
         },
+        :'distributed_tracing.sampler.remote_parent_sampled' => {
+          :default => 'default',
+          :public => true,
+          :type => String,
+          :allowed_from_server => true,
+          :description => 'default, always_on, always_off'
+        },
+        :'distributed_tracing.sampler.remote_parent_not_sampled' => {
+          :default => 'default',
+          :public => true,
+          :type => String,
+          :allowed_from_server => true,
+          :description => 'default, always_on, always_of'
+        },
         # Elasticsearch
         :'elasticsearch.capture_cluster_name' => {
           :default => true,

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -1463,14 +1463,14 @@ module NewRelic
           :public => true,
           :type => String,
           :allowed_from_server => true,
-          :description => 'default, always_on, always_off'
+          :description => 'This setting controls the behavior of transaction sampling when a remote parent is sampled and the trace flag is set in the traceparent. Available values are `default`, `always_on`, and `always_off`.'
         },
         :'distributed_tracing.sampler.remote_parent_not_sampled' => {
           :default => 'default',
           :public => true,
           :type => String,
           :allowed_from_server => true,
-          :description => 'default, always_on, always_of'
+          :description => 'This setting controls the behavior of transaction sampling when a remote parent is not sampled and the trace flag is not set in the traceparent. Available values are `default`, `always_on`, and `always_off`.'
         },
         # Elasticsearch
         :'elasticsearch.capture_cluster_name' => {

--- a/lib/new_relic/agent/transaction/trace_context.rb
+++ b/lib/new_relic/agent/transaction/trace_context.rb
@@ -136,16 +136,21 @@ module NewRelic
 
           transaction.distributed_tracer.parent_transaction_id = payload.transaction_id
 
-          unless payload.sampled.nil?
-            transaction.sampled = payload.sampled
-            transaction.priority = payload.priority if payload.priority
-          end
+          trace_context_sampled_priority(payload)
+
           NewRelic::Agent.increment_metric(ACCEPT_SUCCESS_METRIC)
           true
         rescue => e
           NewRelic::Agent.increment_metric(ACCEPT_EXCEPTION_METRIC)
           NewRelic::Agent.logger.warn('Failed to accept trace context payload', e)
           false
+        end
+
+        def trace_context_sampled_priority(payload)
+          unless payload.sampled.nil?
+            transaction.sampled = payload.sampled
+            transaction.priority = payload.priority if payload.priority
+          end
         end
 
         def ignore_trace_context?

--- a/test/new_relic/agent/distributed_tracing/trace_context_test.rb
+++ b/test/new_relic/agent/distributed_tracing/trace_context_test.rb
@@ -404,6 +404,7 @@ module NewRelic::Agent::DistributedTracing
 
     def make_payload
       in_transaction('test_txn') do |txn|
+        txn.stubs(:sampled?).returns(true)
         return txn.distributed_tracer.create_trace_state_payload
       end
     end

--- a/test/new_relic/agent/distributed_tracing/trace_context_test.rb
+++ b/test/new_relic/agent/distributed_tracing/trace_context_test.rb
@@ -417,6 +417,25 @@ module NewRelic::Agent::DistributedTracing
       end
     end
 
+    def test_sampled_logic_if_invalid_traceparent
+      payload = make_payload
+
+      carrier = {
+        NewRelic::TRACEPARENT_KEY => '00-a8e67265afe2773a3c611b94306ee5c2-fb1010463ea28a38-02',
+        NewRelic::TRACESTATE_KEY => "other=asdf,190@nr=#{payload.to_s},otherother=asdfasdf"
+      }
+
+      with_config(:'distributed_tracing.sampler.remote_parent_sampled' => 'always_on') do
+        in_transaction('accepting_txn') do |txn|
+          txn.sampled = false
+          NewRelic::Agent::DistributedTracing.accept_distributed_trace_headers(carrier, 'other')
+
+          # should fall back to using nr state sampled flag
+          assert_predicate txn, :sampled?
+        end
+      end
+    end
+
     def make_inbound_carrier(options = {})
       {
         NewRelic::TRACEPARENT_KEY => '00-a8e67265afe2773a3c611b94306ee5c2-fb1010463ea28a38-01',

--- a/test/new_relic/agent/distributed_tracing/trace_context_test.rb
+++ b/test/new_relic/agent/distributed_tracing/trace_context_test.rb
@@ -311,7 +311,7 @@ module NewRelic::Agent::DistributedTracing
         NewRelic::TRACESTATE_KEY => "other=asdf,190@nr=#{payload.to_s},otherother=asdfasdf"
       }
 
-      with_config(:'distributed_tracing.sampled.remote_parent_sampled' => 'always_on') do
+      with_config(:'distributed_tracing.sampler.remote_parent_sampled' => 'always_on') do
         in_transaction('accepting_txn') do |txn|
           txn.sampled = false
           NewRelic::Agent::DistributedTracing.accept_distributed_trace_headers(carrier, 'other')
@@ -330,7 +330,7 @@ module NewRelic::Agent::DistributedTracing
         NewRelic::TRACESTATE_KEY => "other=asdf,190@nr=#{payload.to_s},otherother=asdfasdf"
       }
 
-      with_config(:'distributed_tracing.sampled.remote_parent_sampled' => 'always_off') do
+      with_config(:'distributed_tracing.sampler.remote_parent_sampled' => 'always_off') do
         in_transaction('accepting_txn') do |txn|
           txn.sampled = false
           NewRelic::Agent::DistributedTracing.accept_distributed_trace_headers(carrier, 'other')
@@ -366,7 +366,7 @@ module NewRelic::Agent::DistributedTracing
         NewRelic::TRACESTATE_KEY => "other=asdf,190@nr=#{payload.to_s},otherother=asdfasdf"
       }
 
-      with_config(:'distributed_tracing.sampled.remote_parent_sampled' => 'always_on') do
+      with_config(:'distributed_tracing.sampler.remote_parent_not_sampled' => 'always_on') do
         in_transaction('accepting_txn') do |txn|
           txn.sampled = false
           NewRelic::Agent::DistributedTracing.accept_distributed_trace_headers(carrier, 'other')
@@ -385,7 +385,7 @@ module NewRelic::Agent::DistributedTracing
         NewRelic::TRACESTATE_KEY => "other=asdf,190@nr=#{payload.to_s},otherother=asdfasdf"
       }
 
-      with_config(:'distributed_tracing.sampled.remote_parent_sampled' => 'always_off') do
+      with_config(:'distributed_tracing.sampler.remote_parent_not_sampled' => 'always_off') do
         in_transaction('accepting_txn') do |txn|
           txn.sampled = false
           NewRelic::Agent::DistributedTracing.accept_distributed_trace_headers(carrier, 'other')

--- a/test/new_relic/agent/distributed_tracing/trace_context_test.rb
+++ b/test/new_relic/agent/distributed_tracing/trace_context_test.rb
@@ -353,7 +353,6 @@ module NewRelic::Agent::DistributedTracing
         txn.sampled = false
         NewRelic::Agent::DistributedTracing.accept_distributed_trace_headers(carrier, 'other')
 
-        # make sure it uses trace state
         assert_predicate txn, :sampled?
       end
     end


### PR DESCRIPTION
Adds logic to support the new configuration options to modify how we decide sampling and priority based on incoming traceparent value. When in default mode, the existing logic of the agent remains unchanged. 

resolves https://github.com/newrelic/newrelic-ruby-agent/issues/3077

related agent specs
[Original PR](https://source.datanerd.us/agents/agent-specs/pull/726)
[Clarifying Configs](https://source.datanerd.us/agents/agent-specs/pull/729)
