### PR TITLE
Add host.displayName to agent-forwarded log events

### DIFF
--- a/lib/new_relic/agent/log_event_aggregator.rb
+++ b/lib/new_relic/agent/log_event_aggregator.rb
@@ -209,8 +209,15 @@ module NewRelic
         # sent by classic logs-in-context
         common_attributes.delete(ENTITY_TYPE_KEY)
         aggregator = NewRelic::Agent.agent.log_event_aggregator
+
+        # Add custom attributes and labels to the common attributes
+        # As they will be consistent across all log events
         common_attributes.merge!(aggregator.attributes.custom_attributes)
         common_attributes.merge!(aggregator.labels)
+
+        if common_attributes['hostname'] != NewRelic::Agent.config[:'process_host.display_name']
+          common_attributes['host.displayName'] = NewRelic::Agent.config[:'process_host.display_name']
+        end
 
         _, items = data
         payload = [{


### PR DESCRIPTION
When the display name is different from the hostname, add the display name as an attribute on the log event.

This cannot be added for locally decorated logs, as the local log decorator has specific columns designed for linking metadata. The display host is not a valid piece of linking metadata.

TODO: 
- [ ] Support the `NewRelic::Agent::Logging::DecoratingFormatter`

Closes #1696 