### PR TITLE
HA CAT - Do not create a segment without a transaction

### DIFF
--- a/lib/new_relic/agent/opentelemetry/trace/tracer.rb
+++ b/lib/new_relic/agent/opentelemetry/trace/tracer.rb
@@ -16,6 +16,8 @@ module NewRelic
             case kind
             when :internal
               begin
+                return yield unless NewRelic::Agent::Tracer.current_transaction
+
                 segment = NewRelic::Agent::Tracer.start_segment(name: name)
                 span = Span.new(segment: segment, transaction: segment.transaction)
 

--- a/test/multiverse/suites/hybrid_agent/hybrid_agent_test.rb
+++ b/test/multiverse/suites/hybrid_agent/hybrid_agent_test.rb
@@ -31,7 +31,10 @@ class HybridAgentTest < Minitest::Test
   # Now that we're starting to implement, use this to add tests individually
   # until the full suite can be run on the CI
   def focus_tests
-    %w[creates_opentelemetry_segment_in_a_transaction]
+    %w[
+      creates_opentelemetry_segment_in_a_transaction
+      does_not_create_segment_without_a_transaction
+    ]
   end
 
   test_cases = load_cross_agent_test('hybrid_agent')


### PR DESCRIPTION
For internal span kinds, yield immediately if there is not a current transaction

Resolves #3141 