### PR TITLE
stop testing elasticsearch 9 for now

### DIFF
--- a/test/multiverse/suites/elasticsearch/Envfile
+++ b/test/multiverse/suites/elasticsearch/Envfile
@@ -5,7 +5,7 @@
 instrumentation_methods :chain, :prepend
 
 ELASTICSEARCH_VERSIONS = [
-  [nil, 2.5],
+  # [nil, 2.5], # temporarily stop testing elasticsearch 9
   ['8.12.0', 2.5],
   ['7.17.1', 2.4]
 ]


### PR DESCRIPTION
We're failing on elasticsearch 9 after release. Once we resolve this issue, we need to reenable the tests.

related to: https://github.com/newrelic/newrelic-ruby-agent/issues/3153