### PR TITLE
Hybrid Agent: Create New Relic Span as child of OpenTelemetry Span

### DIFF
--- a/lib/new_relic/agent/opentelemetry/trace/tracer.rb
+++ b/lib/new_relic/agent/opentelemetry/trace/tracer.rb
@@ -19,11 +19,8 @@ module NewRelic
                 return yield unless NewRelic::Agent::Tracer.current_transaction
 
                 segment = NewRelic::Agent::Tracer.start_segment(name: name)
-                span = Span.new(segment: segment, transaction: segment.transaction)
 
-                ::OpenTelemetry::Trace.with_span(span) do
-                  yield
-                end
+                NewRelic::Agent::Tracer.capture_segment_error(segment) { yield }
               ensure
                 segment&.finish
               end

--- a/lib/new_relic/agent/opentelemetry/transaction_patch.rb
+++ b/lib/new_relic/agent/opentelemetry/transaction_patch.rb
@@ -1,0 +1,57 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+module NewRelic
+  module Agent
+    module OpenTelemetry
+      module TransactionPatch
+        attr_accessor :opentelemetry_context
+
+        def initialize(_category, _options)
+          @opentelemetry_context = {}
+          super
+        end
+
+        def otel_current_span_key
+          # CURRENT_SPAN_KEY is a private constant
+          ::OpenTelemetry::Trace.const_get(:CURRENT_SPAN_KEY)
+        end
+
+        def set_current_segment(new_segment)
+          @current_segment_lock.synchronize do
+            # detach the current token, if one is present
+            unless opentelemetry_context.empty?
+              ::OpenTelemetry::Context.detach(opentelemetry_context[otel_current_span_key])
+            end
+
+            # create an otel span for the new segment
+            span = Trace::Span.new(segment: new_segment, transaction: new_segment.transaction)
+
+            # set otel's current span to the newly created otel span
+            ctx = ::OpenTelemetry::Context.current.set_value(otel_current_span_key, span)
+
+            # attach the token generated from updating the current span
+            token = ::OpenTelemetry::Context.attach(ctx)
+
+            # update our context tracking hash to correlate the context token
+            # with the otel_current_span_key
+            opentelemetry_context[otel_current_span_key] = token
+          end
+
+          super
+        end
+
+        def remove_current_segment_by_thread_id(id)
+          # make sure the context is fully detached when the transaction ends
+          @current_segment_lock.synchronize do
+            ::OpenTelemetry::Context.detach(opentelemetry_context[otel_current_span_key])
+            opentelemetry_context.delete(id)
+          end
+
+          super
+        end
+      end
+    end
+  end
+end

--- a/lib/new_relic/agent/opentelemetry_bridge.rb
+++ b/lib/new_relic/agent/opentelemetry_bridge.rb
@@ -18,8 +18,10 @@ module NewRelic
       def self.install
         require 'opentelemetry' # requires the opentelemetry-api gem
         require_relative 'opentelemetry/trace'
+        require_relative 'opentelemetry/transaction_patch'
 
-        ::OpenTelemetry.tracer_provider = NewRelic::Agent::OpenTelemetry::Trace::TracerProvider.new
+        ::OpenTelemetry.tracer_provider = OpenTelemetry::Trace::TracerProvider.new
+        Transaction.prepend(OpenTelemetry::TransactionPatch)
       end
     end
   end

--- a/test/multiverse/suites/hybrid_agent/hybrid_agent_test.rb
+++ b/test/multiverse/suites/hybrid_agent/hybrid_agent_test.rb
@@ -32,8 +32,9 @@ class HybridAgentTest < Minitest::Test
   # until the full suite can be run on the CI
   def focus_tests
     %w[
-      creates_opentelemetry_segment_in_a_transaction
       does_not_create_segment_without_a_transaction
+      creates_opentelemetry_segment_in_a_transaction
+      creates_new_relic_span_as_child_of_opentelemetry_span
     ]
   end
 

--- a/test/multiverse/suites/hybrid_agent/span_test.rb
+++ b/test/multiverse/suites/hybrid_agent/span_test.rb
@@ -10,6 +10,11 @@ module NewRelic
           Segment = Struct.new(:guid)
           Transaction = Struct.new(:trace_id)
 
+          def teardown
+            NewRelic::Agent.instance.transaction_event_aggregator.reset!
+            NewRelic::Agent.instance.span_event_aggregator.reset!
+          end
+
           def test_span_has_context
             segment = Segment.new('123')
             transaction = Transaction.new('456')


### PR DESCRIPTION
Leverage New Relic's context methods for managing the current segment to update OpenTelemetry's current span by prepending onto our Transaction class when the OpenTelemetry Bridge is installed.

When the `current_segment_key` is fully removed from the Transaction, take this as a cue to fully detach from the OpenTelemetry context.

This implementation is drawn from the strategy used by [OpenTelemetry::Tracer.with_span](https://github.com/open-telemetry/opentelemetry-ruby/blob/b2cac915e2662f91e032097c4e0c6e9395128d64/api/lib/opentelemetry/trace.rb#L62-L71), which calls [OpenTelemetry::Context.with_value](https://github.com/open-telemetry/opentelemetry-ruby/blob/b2cac915e2662f91e032097c4e0c6e9395128d64/api/lib/opentelemetry/context.rb#L77-L91) to keep track of the current span.

Resolves #3142 