### PR TITLE
Update documented default for `error_collector.ignore_messages`

### DIFF
--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -762,7 +762,12 @@ module NewRelic
           DESCRIPTION
         },
         :'error_collector.ignore_messages' => {
+          # we have to keep the hash rocket in the actual default so the
+          # class name key is treated like a string rather than a symbol.
+          # however, this isn't valid yaml, so document something that is
+          # valid yaml
           :default => {'ThreadError' => ['queue empty']},
+          :documentation_default => {'ThreadError': ['queue empty']},
           :public => true,
           :type => Hash,
           :allowed_from_server => true,


### PR DESCRIPTION
The `error_collector.ignore_messages` config is our first Hash config with a default value that isn't an empty Hash.

The default needs to use a hash rocket instead of a symbol to keep the key as a String, but this isn't valid YAML.

This PR updates the documented default to be valid in YAML.

When this is merged in, we should run the config_docs workflow to update the published documentation.

Resolves #3157 