### PR TITLE
Use the bot PAT to create prerelease PR

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -39,7 +39,7 @@ jobs:
         git push --set-upstream origin "prerelease_updates_${{ env.prerelease_tag }}"
         gh pr create --label $LABEL --title "$TITLE" --body "$BODY"
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.NEWRELIC_RUBY_AGENT_BOT_TOKEN }}
         TITLE: "Prerelease ${{env.prerelease_tag}}"
         BODY: "Updates the version number, changelog, and newrelic.yml (if it needs updating). This is an automated PR."
         LABEL: prerelease


### PR DESCRIPTION
GITHUB_TOKEN values will not trigger other workflows when PRs are opened

We want the full CI to run when the prerelease PR is created, so use the PAT for our bot instead.

Context: 
* [Slack thread (internal)](https://newrelic.slack.com/archives/GGXADQ9F1/p1745952130062349)
* https://github.com/orgs/community/discussions/57484