### PR TITLE
Fix lambda release

### DIFF
--- a/.github/workflows/lambda_release.yml
+++ b/.github/workflows/lambda_release.yml
@@ -13,19 +13,24 @@ jobs:
       contents: write
       repository-projects: write
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # tag v4.2.2
-      with:
-        fetch-depth: 0
-
     - uses: ruby/setup-ruby@eaecf785f6a34567a6d97f686bbb7bccc1ac1e5c # tag v1.237.0
       with:
         ruby-version: 3.4
 
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # tag v4.2.2
+      with:
+        fetch-depth: 0
+
+    - run: bundle
+
+    - name: Set agent version
+      run: echo "agent_version=$(bundle exec rake newrelic:version:current)" >> $GITHUB_ENV
+
     - name: Create release tags for Lambda and K8s Init Containers
       run: |
-        RELEASE_TITLE="New Relic Ruby Agent v${GITHUB_REF_NAME}.0"
-        RELEASE_TAG="v${GITHUB_REF_NAME}.0_ruby"
-        RELEASE_NOTES="Automated release for [Ruby Agent v${GITHUB_REF_NAME}](https://github.com/newrelic/newrelic-ruby-agent/releases/tag/v${GITHUB_REF_NAME})"
+        RELEASE_TITLE="New Relic Ruby Agent v${{ env.agent_version }}.0"
+        RELEASE_TAG="v${{ env.agent_version }}.0_ruby"
+        RELEASE_NOTES="Automated release for [Ruby Agent v${{ env.agent_version }}](https://github.com/newrelic/newrelic-ruby-agent/releases/tag/v${{ env.agent_version }})"
         gh auth login --with-token <<< $GH_RELEASE_TOKEN
         echo "newrelic/newrelic-lambda-layers - Releasing ${RELEASE_TITLE} with tag ${RELEASE_TAG}"
         gh release create "${RELEASE_TAG}" --title=${RELEASE_TITLE} --repo=newrelic/newrelic-lambda-layers --notes=${RELEASE_NOTES}

--- a/.github/workflows/lambda_release.yml
+++ b/.github/workflows/lambda_release.yml
@@ -5,6 +5,7 @@ on:
     workflows: ["Release"]
     types:
       - completed
+  workflow_dispatch:
 
 jobs:
   release:


### PR DESCRIPTION
* Use the rake task that returns our version number instead of GITHUB_REF_NAME
* Add workflow_dispatch so we can rerun if there's failures 

Resolves #3170 