### PR TITLE
Update Envfile for async-http

### DIFF
--- a/test/multiverse/suites/async_http/Envfile
+++ b/test/multiverse/suites/async_http/Envfile
@@ -10,7 +10,7 @@ end
 
 ASYNC_HTTP_VERSIONS = [
   [nil, 3.0],
-  ['0.59.0', 2.5]
+  ['0.59.0', 2.5, 3.3]
 ]
 
 def async_gem_version(async_http_version)

--- a/test/multiverse/suites/async_http/Envfile
+++ b/test/multiverse/suites/async_http/Envfile
@@ -10,22 +10,13 @@ end
 
 ASYNC_HTTP_VERSIONS = [
   [nil, 3.0],
-  ['0.59.0', 2.5, 3.3]
+  ['0.59.0', 2.5, 3.0]
 ]
-
-def async_gem_version(async_http_version)
-  return if
-    Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.1') ||
-      async_http_version.nil?
-
-  ", '2.23.1'"
-end
 
 def gem_list(async_http_version = nil)
   <<~GEM_LIST
     gem 'async-http'#{async_http_version}
     gem 'rack'
-    gem 'async'#{async_gem_version(async_http_version)}
   GEM_LIST
 end
 

--- a/test/multiverse/suites/async_http/Envfile
+++ b/test/multiverse/suites/async_http/Envfile
@@ -13,6 +13,14 @@ ASYNC_HTTP_VERSIONS = [
   ['0.59.0', 2.5]
 ]
 
+def async_gem_version(async_http_version)
+  return if
+    Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.1') ||
+      async_http_version.nil?
+
+  ", '2.23.1'"
+end
+
 def gem_list(async_http_version = nil)
   <<~GEM_LIST
     gem 'async-http'#{async_http_version}


### PR DESCRIPTION
Forgot that older Rubies were passing. Just stop testing the oldest version on newer Rubies to avoid an incompatible version of `async` from getting matched. The newer Rubies are tested on their latest compatible version.

~~Full CI workflow to verify: https://github.com/newrelic/newrelic-ruby-agent/actions/runs/14843837242~~

~~Full CI workflow: https://github.com/newrelic/newrelic-ruby-agent/actions/runs/14844446919~~

🟢 [Scheduled Continuous Integration](https://github.com/newrelic/newrelic-ruby-agent/actions/runs/14846357604)