### PR TITLE
Disable the URL checker cron

### DIFF
--- a/.github/workflows/ci_special.yml
+++ b/.github/workflows/ci_special.yml
@@ -1,8 +1,8 @@
 name: URL Test CI
 
 on:
-  schedule:
-    - cron: '0 9 * * *'
+  # schedule:
+    # - cron: '0 9 * * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
GitHub has lowered their threshold before a 429 is hit for requests. This CI run hits the threshold, causing the workflow to fail despite the links being active.