### PR TITLE
Enable "Starting transaction tests" in hybrid agent CAT

### DIFF
--- a/lib/new_relic/agent/opentelemetry/trace/span.rb
+++ b/lib/new_relic/agent/opentelemetry/trace/span.rb
@@ -7,14 +7,10 @@ module NewRelic
     module OpenTelemetry
       module Trace
         class Span < ::OpenTelemetry::Trace::Span
-          attr_reader :context
+          attr_accessor :finishable
 
-          def initialize(segment:, transaction:)
-            @context = ::OpenTelemetry::Trace::SpanContext.new(
-              trace_id: transaction.trace_id,
-              span_id: segment.guid,
-              trace_flags: 1
-            )
+          def finish(end_timestamp: nil)
+            finishable&.finish
           end
         end
       end

--- a/lib/new_relic/agent/opentelemetry/trace/tracer.rb
+++ b/lib/new_relic/agent/opentelemetry/trace/tracer.rb
@@ -35,6 +35,7 @@ module NewRelic
             begin
               yield
             rescue => e
+              # TODO: Update for segment errors if finishable is a segment
               NewRelic::Agent.notice_error(e)
               raise
             end

--- a/lib/new_relic/agent/opentelemetry/trace/tracer.rb
+++ b/lib/new_relic/agent/opentelemetry/trace/tracer.rb
@@ -18,9 +18,9 @@ module NewRelic
             finishable = if can_start_transaction?(parent_span_context)
               return if internal_span_kind_with_invalid_parent?(kind, parent_span_context)
 
-              txn = NewRelic::Agent::Tracer.start_transaction_or_segment(name: name, category: :otel)
-              add_remote_partent_span_context_to_txn(txn, parent_span_context) if txn.is_a?(NewRelic::Agent::Transaction) && parent_span_context.remote?
-              txn
+              nr_obj = NewRelic::Agent::Tracer.start_transaction_or_segment(name: name, category: :otel)
+              add_remote_partent_span_context_to_txn(nr_obj, parent_span_context)
+              nr_obj
             else
               NewRelic::Agent::Tracer.start_segment(name: name)
             end
@@ -45,9 +45,10 @@ module NewRelic
           private
 
           def get_span_from_finishable(finishable)
-            if finishable.is_a?(NewRelic::Agent::Transaction)
+            case finishable
+            when NewRelic::Agent::Transaction
               finishable.segments.first.instance_variable_get(:@otel_span)
-            elsif finishable.is_a?(NewRelic::Agent::Transaction::Segment)
+            when NewRelic::Agent::Transaction::Segment
               finishable.instance_variable_get(:@otel_span)
             else
               NewRelic::Agent.logger.warn('Tracer#get_span_from_finishable failed to get span from finishable - finishable is not a transaction or segment')
@@ -63,9 +64,11 @@ module NewRelic
             !parent_span_context.valid? && kind == :internal
           end
 
-          def add_remote_partent_span_context_to_txn(finishable, parent_span_context)
-            finishable.trace_id = parent_span_context.trace_id
-            finishable.parent_span_id = parent_span_context.span_id
+          def add_remote_partent_span_context_to_txn(txn, parent_span_context)
+            return unless txn.is_a?(NewRelic::Agent::Transaction) && parent_span_context.remote?
+
+            txn.trace_id = parent_span_context.trace_id
+            txn.parent_span_id = parent_span_context.span_id
           end
         end
       end

--- a/lib/new_relic/agent/opentelemetry/transaction_patch.rb
+++ b/lib/new_relic/agent/opentelemetry/transaction_patch.rb
@@ -20,8 +20,15 @@ module NewRelic
               ::OpenTelemetry::Context.detach(opentelemetry_context[otel_current_span_key])
             end
 
+            span = nil
+
             # create an otel span for the new segment
-            span = Trace::Span.new(span_context: span_context_from_segment(new_segment))
+            if new_segment.instance_variable_defined?(:@otel_span)
+              span = new_segment.instance_variable_get(:@otel_span)
+            else
+              span = Trace::Span.new(span_context: span_context_from_segment(new_segment))
+              new_segment.instance_variable_set(:@otel_span, span)
+            end
 
             # set otel's current span to the newly created otel span
             ctx = ::OpenTelemetry::Context.current.set_value(otel_current_span_key, span)

--- a/test/multiverse/suites/hybrid_agent/Envfile
+++ b/test/multiverse/suites/hybrid_agent/Envfile
@@ -8,4 +8,5 @@ end
 
 gemfile <<~RB
   gem 'opentelemetry-api'
+  gem 'rack'
 RB

--- a/test/multiverse/suites/hybrid_agent/commands.rb
+++ b/test/multiverse/suites/hybrid_agent/commands.rb
@@ -10,11 +10,20 @@ module Commands
   end
 
   def do_work_in_span_with_remote_parent(span_name:, span_kind:, &block)
-    span = @tracer.start_span(span_name, kind: span_kind)
-    span.context.instance_variable_set(:@remote, true)
+    context = OpenTelemetry::Context.current
+    span_context = OpenTelemetry::Trace::SpanContext.new(
+      trace_id: 'ba8bc8cc6d062849b0efcf3c169afb5a',
+      span_id: '6d3efb1b173fecfa',
+      trace_flags: '01',
+      remote: true
+    )
+
+    span = OpenTelemetry::Trace.non_recording_span(span_context)
+    parent_context = OpenTelemetry::Trace.context_with_span(span, parent_context: context)
+
+    span = @tracer.start_span(span_name, with_parent: parent_context, kind: span_kind)
     yield if block
-  ensure
-    span&.finish
+    span.finish
   end
 
   def do_work_in_span_with_inbound_context(span_name:, span_kind:, trace_id_in_header:,

--- a/test/multiverse/suites/hybrid_agent/hybrid_agent_test.rb
+++ b/test/multiverse/suites/hybrid_agent/hybrid_agent_test.rb
@@ -20,11 +20,6 @@ class HybridAgentTest < Minitest::Test
     @tracer = OpenTelemetry.tracer_provider.tracer
   end
 
-  # def teardown
-  #   NewRelic::Agent.instance.transaction_event_aggregator.reset!
-  #   NewRelic::Agent.instance.span_event_aggregator.reset!
-  # end
-
   # This method, when returning a non-empty array, will cause the tests defined in the
   # JSON file to be skipped if they're not listed here. Useful for focusing on specific
   # failing tests.
@@ -35,10 +30,10 @@ class HybridAgentTest < Minitest::Test
   # Now that we're starting to implement, use this to add tests individually
   # until the full suite can be run on the CI
   def focus_tests
-    # creates_opentelemetry_segment_in_a_transaction
-    # creates_new_relic_span_as_child_of_opentelemetry_span
-    # does_not_create_segment_without_a_transaction
     %w[
+      creates_opentelemetry_segment_in_a_transaction
+      creates_new_relic_span_as_child_of_opentelemetry_span
+      does_not_create_segment_without_a_transaction
       starting_transaction_tests
     ]
   end

--- a/test/multiverse/suites/hybrid_agent/hybrid_agent_test.rb
+++ b/test/multiverse/suites/hybrid_agent/hybrid_agent_test.rb
@@ -35,6 +35,7 @@ class HybridAgentTest < Minitest::Test
       does_not_create_segment_without_a_transaction
       creates_opentelemetry_segment_in_a_transaction
       creates_new_relic_span_as_child_of_opentelemetry_span
+      starting_transaction_tests
     ]
   end
 
@@ -51,7 +52,7 @@ class HybridAgentTest < Minitest::Test
           parse_operation(o)
         end
 
-        harvest_and_verify_agent_output(test_case['agentOutput'])
+        verify_agent_output(test_case['agentOutput'])
       else
         skip('marked pending by exclusion from #focus_tests')
       end

--- a/test/multiverse/suites/hybrid_agent/hybrid_agent_test.rb
+++ b/test/multiverse/suites/hybrid_agent/hybrid_agent_test.rb
@@ -12,12 +12,13 @@ class HybridAgentTest < Minitest::Test
   include AssertionParameters
   include ParsingHelpers
 
-  include MultiverseHelpers
-  setup_and_teardown_agent
-
-  def after_setup
-    puts @NAME
+  def setup
     @tracer = OpenTelemetry.tracer_provider.tracer
+  end
+
+  def teardown
+    NewRelic::Agent.instance.transaction_event_aggregator.reset!
+    NewRelic::Agent.instance.span_event_aggregator.reset!
   end
 
   # This method, when returning a non-empty array, will cause the tests defined in the

--- a/test/multiverse/suites/hybrid_agent/hybrid_agent_test.rb
+++ b/test/multiverse/suites/hybrid_agent/hybrid_agent_test.rb
@@ -12,14 +12,18 @@ class HybridAgentTest < Minitest::Test
   include AssertionParameters
   include ParsingHelpers
 
-  def setup
+  include MultiverseHelpers
+  setup_and_teardown_agent
+
+  def after_setup
+    puts @NAME
     @tracer = OpenTelemetry.tracer_provider.tracer
   end
 
-  def teardown
-    NewRelic::Agent.instance.transaction_event_aggregator.reset!
-    NewRelic::Agent.instance.span_event_aggregator.reset!
-  end
+  # def teardown
+  #   NewRelic::Agent.instance.transaction_event_aggregator.reset!
+  #   NewRelic::Agent.instance.span_event_aggregator.reset!
+  # end
 
   # This method, when returning a non-empty array, will cause the tests defined in the
   # JSON file to be skipped if they're not listed here. Useful for focusing on specific
@@ -31,10 +35,10 @@ class HybridAgentTest < Minitest::Test
   # Now that we're starting to implement, use this to add tests individually
   # until the full suite can be run on the CI
   def focus_tests
+    # creates_opentelemetry_segment_in_a_transaction
+    # creates_new_relic_span_as_child_of_opentelemetry_span
+    # does_not_create_segment_without_a_transaction
     %w[
-      does_not_create_segment_without_a_transaction
-      creates_opentelemetry_segment_in_a_transaction
-      creates_new_relic_span_as_child_of_opentelemetry_span
       starting_transaction_tests
     ]
   end

--- a/test/multiverse/suites/hybrid_agent/span_test.rb
+++ b/test/multiverse/suites/hybrid_agent/span_test.rb
@@ -17,11 +17,6 @@ module NewRelic
             puts @NAME
           end
 
-          # def teardown
-          #   NewRelic::Agent.instance.transaction_event_aggregator.reset!
-          #   NewRelic::Agent.instance.span_event_aggregator.reset!
-          # end
-
           def test_finish_does_not_fail_if_no_finishable_present
             span = NewRelic::Agent::OpenTelemetry::Trace::Span.new
 

--- a/test/multiverse/suites/hybrid_agent/span_test.rb
+++ b/test/multiverse/suites/hybrid_agent/span_test.rb
@@ -7,15 +7,8 @@ module NewRelic
     module OpenTelemetry
       module Trace
         class SpanTest < Minitest::Test
-          include MultiverseHelpers
-          setup_and_teardown_agent
-
           Segment = Struct.new(:guid, :transaction)
           Transaction = Struct.new(:trace_id)
-
-          def after_setup
-            puts @NAME
-          end
 
           def test_finish_does_not_fail_if_no_finishable_present
             span = NewRelic::Agent::OpenTelemetry::Trace::Span.new

--- a/test/multiverse/suites/hybrid_agent/span_test.rb
+++ b/test/multiverse/suites/hybrid_agent/span_test.rb
@@ -7,13 +7,20 @@ module NewRelic
     module OpenTelemetry
       module Trace
         class SpanTest < Minitest::Test
+          include MultiverseHelpers
+          setup_and_teardown_agent
+
           Segment = Struct.new(:guid, :transaction)
           Transaction = Struct.new(:trace_id)
 
-          def teardown
-            NewRelic::Agent.instance.transaction_event_aggregator.reset!
-            NewRelic::Agent.instance.span_event_aggregator.reset!
+          def after_setup
+            puts @NAME
           end
+
+          # def teardown
+          #   NewRelic::Agent.instance.transaction_event_aggregator.reset!
+          #   NewRelic::Agent.instance.span_event_aggregator.reset!
+          # end
 
           def test_finish_does_not_fail_if_no_finishable_present
             span = NewRelic::Agent::OpenTelemetry::Trace::Span.new

--- a/test/multiverse/suites/hybrid_agent/tracer_provider_test.rb
+++ b/test/multiverse/suites/hybrid_agent/tracer_provider_test.rb
@@ -7,7 +7,11 @@ module NewRelic
     module OpenTelemetry
       module Trace
         class TracerProviderTest < Minitest::Test
-          def setup
+          include MultiverseHelpers
+          setup_and_teardown_agent
+
+          def after_setup
+            puts @NAME
             @tracer_provider = NewRelic::Agent::OpenTelemetry::Trace::TracerProvider.new
           end
 

--- a/test/multiverse/suites/hybrid_agent/tracer_provider_test.rb
+++ b/test/multiverse/suites/hybrid_agent/tracer_provider_test.rb
@@ -7,11 +7,7 @@ module NewRelic
     module OpenTelemetry
       module Trace
         class TracerProviderTest < Minitest::Test
-          include MultiverseHelpers
-          setup_and_teardown_agent
-
-          def after_setup
-            puts @NAME
+          def setup
             @tracer_provider = NewRelic::Agent::OpenTelemetry::Trace::TracerProvider.new
           end
 

--- a/test/multiverse/suites/hybrid_agent/tracer_test.rb
+++ b/test/multiverse/suites/hybrid_agent/tracer_test.rb
@@ -7,12 +7,13 @@ module NewRelic
     module OpenTelemetry
       module Trace
         class TracerTest < Minitest::Test
-          include MultiverseHelpers
-          setup_and_teardown_agent
-
-          def after_setup
-            puts @NAME
+          def setup
             @tracer = NewRelic::Agent::OpenTelemetry::Trace::Tracer.new
+          end
+
+          def teardown
+            NewRelic::Agent.instance.transaction_event_aggregator.reset!
+            NewRelic::Agent.instance.span_event_aggregator.reset!
           end
 
           def test_in_span_creates_segment_when_span_kind_internal

--- a/test/multiverse/suites/hybrid_agent/tracer_test.rb
+++ b/test/multiverse/suites/hybrid_agent/tracer_test.rb
@@ -16,14 +16,6 @@ module NewRelic
             NewRelic::Agent.instance.span_event_aggregator.reset!
           end
 
-          def test_in_span_logs_when_span_kind_unknown
-            NewRelic::Agent.stub(:logger, NewRelic::Agent::MemoryLogger.new) do
-              @tracer.in_span('fruit', kind: :mango) { 'yep' }
-
-              assert_logged(/Span kind: mango is not supported yet/)
-            end
-          end
-
           def test_in_span_creates_segment_when_span_kind_internal
             txn = in_transaction do
               @tracer.in_span('fruit', kind: :internal) { 'seeds' }

--- a/test/multiverse/suites/hybrid_agent/transaction_patch_test.rb
+++ b/test/multiverse/suites/hybrid_agent/transaction_patch_test.rb
@@ -56,9 +56,9 @@ module NewRelic
             child_segment = Tracer.start_segment(name: 'child')
             child_otel_span = child_segment.instance_variable_get(:@otel_span)
 
-            refute_equal first_segment.guid, ::OpenTelemetry::Trace.current_span.context.span_id, "OTel current span ID should have changed from first segment"
+            refute_equal first_segment.guid, ::OpenTelemetry::Trace.current_span.context.span_id, 'OTel current span ID should have changed from first segment'
             assert_equal child_segment.guid, ::OpenTelemetry::Trace.current_span.context.span_id, "OTel current span ID should match child segment's GUID"
-            assert_equal child_segment.guid, Tracer.current_segment.guid, "NR current segment should be the child segment"
+            assert_equal child_segment.guid, Tracer.current_segment.guid, 'NR current segment should be the child segment'
             assert_equal child_otel_span.context.span_id, child_segment.guid, "Child segment's @otel_span ID should match segment's GUID"
 
             child_segment.finish
@@ -88,12 +88,12 @@ module NewRelic
             child_nr_segment = child_otel_span.finishable
 
             assert_instance_of Transaction::Segment, child_nr_segment, "OTel span's finishable should be an NR Segment"
-            assert_equal txn, child_nr_segment.transaction, "NR segment created for OTel span should belong to the active transaction"
+            assert_equal txn, child_nr_segment.transaction, 'NR segment created for OTel span should belong to the active transaction'
             assert_equal child_otel_span, child_nr_segment.instance_variable_get(:@otel_span), "NR segment's @otel_span should be the one created by the OTel API call"
 
             # Verify context update
             assert_equal child_nr_segment.guid, ::OpenTelemetry::Trace.current_span.context.span_id, "OTel current span ID should match OTel API created span's GUID"
-            assert_equal child_nr_segment.guid, Tracer.current_segment.guid, "NR current segment GUID should match segment for OTel API span"
+            assert_equal child_nr_segment.guid, Tracer.current_segment.guid, 'NR current segment GUID should match segment for OTel API span'
 
             child_otel_span.finish
           end
@@ -107,8 +107,7 @@ module NewRelic
 
             child_otel_span.finish # Finish using OTel API
 
-            assert_predicate child_nr_segment, :finished?, "Linked NR segment should be marked as finished when OTel span is finished"
-
+            assert_predicate child_nr_segment, :finished?, 'Linked NR segment should be marked as finished when OTel span is finished'
           end
         end
 
@@ -123,7 +122,7 @@ module NewRelic
 
             # The transaction itself should not be finished by this action
             refute_predicate txn, :finished?, "NR transaction should not be finished by OTel API call on its root segment's OTel span"
-            refute_predicate segment, :finished?, "NR root segment should not be finished by OTel API call on its OTel span"
+            refute_predicate segment, :finished?, 'NR root segment should not be finished by OTel API call on its OTel span'
           end
         end
 
@@ -132,7 +131,7 @@ module NewRelic
           txn.stubs(:sampled?).returns(true)
           txn.finish
 
-          assert_predicate txn, :finished?, "NR transaction should be marked as finished by NR API"
+          assert_predicate txn, :finished?, 'NR transaction should be marked as finished by NR API'
         end
 
         def test_finish_transaction_resets_contexts

--- a/test/multiverse/suites/hybrid_agent/transaction_patch_test.rb
+++ b/test/multiverse/suites/hybrid_agent/transaction_patch_test.rb
@@ -1,0 +1,148 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+module NewRelic
+  module Agent
+    module OpenTelemetry
+      class TransactionPatchTest < Minitest::Test
+        include MultiverseHelpers
+        setup_and_teardown_agent
+        # We want to verify that the context switching works for both OTel
+        # and NR
+        # Since the context switching methods are somewhat hidden within
+        # the starting and finishing operations, we use the NR APIs to
+        # start transactions and the OTel APIs to inject spans
+        # rather than calling set_current_segment directly
+        def after_setup
+          puts @NAME
+          @tracer = NewRelic::Agent::OpenTelemetry::Trace::Tracer.new
+        end
+
+        def test_adds_otel_span_to_segment
+          txn = NewRelic::Agent::Tracer.start_transaction_or_segment(name: 'test', category: :otel)
+          first_segment = txn.segments.first
+
+          assert first_segment.instance_variable_defined?(:@otel_span), 'NR first segment should have an @otel_span'
+
+          txn.finish
+        end
+
+        def test_transaction_start_sets_initial_context
+          txn = NewRelic::Agent::Tracer.start_transaction(name: 'test', category: :otel)
+          first_segment = txn.segments.first
+
+          assert_equal first_segment.guid, ::OpenTelemetry::Trace.current_span.context.span_id, "OTel current span ID should match first segment's GUID"
+          assert_equal first_segment.guid, NewRelic::Agent::Tracer.current_segment.guid, "NR current segment GUID should match first segment's GUID"
+
+          txn.finish
+        end
+
+        def test_initial_nr_segment_linked_correctly_to_otel_span
+          txn = NewRelic::Agent::Tracer.start_transaction(name: 'test', category: :otel)
+          first_segment = txn.segments.first
+          first_otel_span = first_segment.instance_variable_get(:@otel_span)
+
+          assert_equal first_otel_span.context.span_id, first_segment.guid, "OTel span's ID should match first segment's GUID"
+          assert_nil first_otel_span.finishable, 'OTel span for NR-created initial segment should not have an OTel finishable'
+
+          txn.finish
+        end
+
+        def test_start_nr_segment_updates_context
+          txn = NewRelic::Agent::Tracer.start_transaction(name: 'test', category: :otel)
+          first_segment = txn.segments.first
+
+          child_segment = NewRelic::Agent::Tracer.start_segment(name: 'child')
+          child_otel_span = child_segment.instance_variable_get(:@otel_span)
+
+          refute_equal first_segment.guid, ::OpenTelemetry::Trace.current_span.context.span_id, "OTel current span ID should have changed from first segment"
+          assert_equal child_segment.guid, ::OpenTelemetry::Trace.current_span.context.span_id, "OTel current span ID should match child segment's GUID"
+          assert_equal child_segment.guid, NewRelic::Agent::Tracer.current_segment.guid, "NR current segment should be the child segment"
+          assert_equal child_otel_span.context.span_id, child_segment.guid, "Child segment's @otel_span ID should match segment's GUID"
+
+          child_segment.finish
+          txn.finish
+        end
+
+        def test_finish_nr_segment_reverts_context_to_parent
+          txn = NewRelic::Agent::Tracer.start_transaction(name: 'test', category: :otel)
+          first_segment = txn.segments.first
+
+          child_segment = NewRelic::Agent::Tracer.start_segment(name: 'child')
+          child_segment.finish
+
+          assert_equal first_segment.guid, ::OpenTelemetry::Trace.current_span.context.span_id, "OTel current span ID should revert to first segment's GUID"
+          assert_equal first_segment.guid, NewRelic::Agent::Tracer.current_segment.guid, "NR current segment GUID should revert to first segment's GUID"
+          assert_predicate child_segment, :finished?, 'Child segment should be marked as finished'
+
+          txn.finish
+        end
+
+        # def test_otel_api_starts_span_within_nr_transaction
+        #   txn = NewRelic::Agent::Tracer.start_transaction(name: 'test', category: :otel)
+
+        #   # Use the OTel API to start a span
+        #   child_otel_span = @tracer.start_span('otel_api_span')
+        #   # finishable should be set by the start_span API
+        #   child_nr_segment = child_otel_span.finishable
+
+        #   assert_instance_of NewRelic::Agent::Transaction::Segment, child_nr_segment, "OTel span's finishable should be an NR Segment"
+        #   assert_equal txn, child_nr_segment.transaction, "NR segment created for OTel span should belong to the active transaction"
+        #   assert_equal child_otel_span, child_nr_segment.instance_variable_get(:@otel_span), "NR segment's @otel_span should be the one created"
+
+        #   # Verify context update
+        #   assert_equal child_nr_segment.guid, ::OpenTelemetry::Trace.current_span.context.span_id, "OTel current span ID should match OTel API created span's GUID"
+        #   assert_equal child_nr_segment.guid, NewRelic::Agent::Tracer.current_segment.guid, "NR current segment GUID should match segment for OTel API span"
+
+        #   child_otel_span.finish
+        #   txn.finish
+        # end
+
+        # def test_otel_api_finish_span_finishes_linked_nr_segment
+        #   txn = NewRelic::Agent::Tracer.start_transaction(name: 'test', category: :otel)
+
+        #   child_otel_span = @tracer.start_span('otel_api_span_to_finish')
+        #   child_nr_segment = child_otel_span.finishable # This is the linked NR Segment
+
+        #   child_otel_span.finish # Finish using OTel API
+
+        #   assert_predicate child_nr_segment, :finished?, "Linked NR segment should be marked as finished when OTel span is finished"
+
+        #   txn.finish
+        # end
+
+        # def test_otel_api_cannot_finish_nr_api_created_elements
+        #   txn = NewRelic::Agent::Tracer.start_transaction(name: 'test', category: :otel)
+        #   first_segment = txn.segments.first
+        #   first_otel_span = first_segment.instance_variable_get(:@otel_span)
+
+        #   # Attempt to finish the OTel representation of the NR-created root segment
+        #   first_otel_span.finish
+
+        #   # The transaction itself should not be finished by this action
+        #   refute_predicate txn, :finished?, "NR transaction should not be finished by OTel API call on its root segment's OTel span"
+        #   refute_predicate first_segment, :finished?, "NR root segment should not be finished by OTel API call on its OTel span"
+
+        #   txn.finish
+        # end
+
+        #   def test_nr_api_finishes_nr_transaction
+        #     txn = NewRelic::Agent::Tracer.start_transaction(name: 'test', category: :otel)
+        #     txn.finish
+
+        #     assert_predicate txn, :finished?, "NR transaction should be marked as finished by NR API"
+        #   end
+
+        def test_finish_transaction_resets_contexts
+          txn = NewRelic::Agent::Tracer.start_transaction(name: 'test', category: :otel)
+          txn.finish
+
+          assert_equal ::OpenTelemetry::Trace::Span::INVALID, ::OpenTelemetry::Trace.current_span, 'OTel current span should be INVALID after transaction finish'
+          assert_nil NewRelic::Agent::Tracer.current_transaction, 'NR current transaction should be nil after transaction finish'
+          assert_nil NewRelic::Agent::Tracer.current_segment, 'NR current segment should be nil after transaction finish'
+        end
+      end
+    end
+  end
+end

--- a/test/multiverse/suites/hybrid_agent/transaction_patch_test.rb
+++ b/test/multiverse/suites/hybrid_agent/transaction_patch_test.rb
@@ -16,132 +16,125 @@ module NewRelic
         # rather than calling set_current_segment directly
         def after_setup
           puts @NAME
-          @tracer = NewRelic::Agent::OpenTelemetry::Trace::Tracer.new
         end
 
-        def test_adds_otel_span_to_segment
-          txn = NewRelic::Agent::Tracer.start_transaction_or_segment(name: 'test', category: :otel)
-          first_segment = txn.segments.first
+        # def test_adds_otel_span_to_segment
+        #   in_transaction do |txn|
+        #     first_segment = txn.segments.first
 
-          assert first_segment.instance_variable_defined?(:@otel_span), 'NR first segment should have an @otel_span'
+        #     assert first_segment.instance_variable_defined?(:@otel_span), 'Segment should have an @otel_span'
+        #   end
+        # end
 
-          txn.finish
-        end
+        # def test_transaction_start_sets_initial_context
+        #   in_transaction do |txn|
+        #     segment = txn.segments.first
 
-        def test_transaction_start_sets_initial_context
-          txn = NewRelic::Agent::Tracer.start_transaction(name: 'test', category: :otel)
-          first_segment = txn.segments.first
+        #     assert_equal segment.guid, ::OpenTelemetry::Trace.current_span.context.span_id, "OTel current span ID should match segment's GUID"
+        #     assert_equal segment.guid, NewRelic::Agent::Tracer.current_segment.guid, "Segment GUID should match first segment's GUID"
+        #   end
+        # end
 
-          assert_equal first_segment.guid, ::OpenTelemetry::Trace.current_span.context.span_id, "OTel current span ID should match first segment's GUID"
-          assert_equal first_segment.guid, NewRelic::Agent::Tracer.current_segment.guid, "NR current segment GUID should match first segment's GUID"
+        # def test_initial_nr_segment_linked_correctly_to_otel_span
+        #   in_transaction do |txn|
+        #     segment = txn.segments.first
+        #     otel_span = segment.instance_variable_get(:@otel_span)
 
-          txn.finish
-        end
+        #     assert_equal otel_span.context.span_id, segment.guid, "OTel span's ID should match segment's GUID"
+        #     assert_nil otel_span.finishable, 'OTel span for NR-created initial segment should not have an OTel finishable'
+        #   end
+        # end
 
-        def test_initial_nr_segment_linked_correctly_to_otel_span
-          txn = NewRelic::Agent::Tracer.start_transaction(name: 'test', category: :otel)
-          first_segment = txn.segments.first
-          first_otel_span = first_segment.instance_variable_get(:@otel_span)
+        # def test_start_nr_segment_updates_context
+        #   in_transaction do |txn|
+        #     first_segment = txn.segments.first
 
-          assert_equal first_otel_span.context.span_id, first_segment.guid, "OTel span's ID should match first segment's GUID"
-          assert_nil first_otel_span.finishable, 'OTel span for NR-created initial segment should not have an OTel finishable'
+        #     child_segment = Tracer.start_segment(name: 'child')
+        #     child_otel_span = child_segment.instance_variable_get(:@otel_span)
 
-          txn.finish
-        end
+        #     refute_equal first_segment.guid, ::OpenTelemetry::Trace.current_span.context.span_id, "OTel current span ID should have changed from first segment"
+        #     assert_equal child_segment.guid, ::OpenTelemetry::Trace.current_span.context.span_id, "OTel current span ID should match child segment's GUID"
+        #     assert_equal child_segment.guid, Tracer.current_segment.guid, "NR current segment should be the child segment"
+        #     assert_equal child_otel_span.context.span_id, child_segment.guid, "Child segment's @otel_span ID should match segment's GUID"
 
-        def test_start_nr_segment_updates_context
-          txn = NewRelic::Agent::Tracer.start_transaction(name: 'test', category: :otel)
-          first_segment = txn.segments.first
+        #     child_segment.finish
+        #   end
+        # end
 
-          child_segment = NewRelic::Agent::Tracer.start_segment(name: 'child')
-          child_otel_span = child_segment.instance_variable_get(:@otel_span)
+        # def test_finish_nr_segment_reverts_context_to_parent
+        #   in_transaction do |txn|
+        #     first_segment = txn.segments.first
 
-          refute_equal first_segment.guid, ::OpenTelemetry::Trace.current_span.context.span_id, "OTel current span ID should have changed from first segment"
-          assert_equal child_segment.guid, ::OpenTelemetry::Trace.current_span.context.span_id, "OTel current span ID should match child segment's GUID"
-          assert_equal child_segment.guid, NewRelic::Agent::Tracer.current_segment.guid, "NR current segment should be the child segment"
-          assert_equal child_otel_span.context.span_id, child_segment.guid, "Child segment's @otel_span ID should match segment's GUID"
+        #     child_segment = Tracer.start_segment(name: 'child')
+        #     child_segment.finish
 
-          child_segment.finish
-          txn.finish
-        end
-
-        def test_finish_nr_segment_reverts_context_to_parent
-          txn = NewRelic::Agent::Tracer.start_transaction(name: 'test', category: :otel)
-          first_segment = txn.segments.first
-
-          child_segment = NewRelic::Agent::Tracer.start_segment(name: 'child')
-          child_segment.finish
-
-          assert_equal first_segment.guid, ::OpenTelemetry::Trace.current_span.context.span_id, "OTel current span ID should revert to first segment's GUID"
-          assert_equal first_segment.guid, NewRelic::Agent::Tracer.current_segment.guid, "NR current segment GUID should revert to first segment's GUID"
-          assert_predicate child_segment, :finished?, 'Child segment should be marked as finished'
-
-          txn.finish
-        end
+        #     assert_equal first_segment.guid, ::OpenTelemetry::Trace.current_span.context.span_id, "OTel current span ID should revert to first segment's GUID"
+        #     assert_equal first_segment.guid, Tracer.current_segment.guid, "NR current segment GUID should revert to first segment's GUID"
+        #     assert_predicate child_segment, :finished?, 'Child segment should be marked as finished'
+        #   end
+        # end
 
         # def test_otel_api_starts_span_within_nr_transaction
-        #   txn = NewRelic::Agent::Tracer.start_transaction(name: 'test', category: :otel)
+        #   in_transaction do |txn|
 
-        #   # Use the OTel API to start a span
-        #   child_otel_span = @tracer.start_span('otel_api_span')
-        #   # finishable should be set by the start_span API
-        #   child_nr_segment = child_otel_span.finishable
+        #     # Use the OTel API to start a span
+        #     child_otel_span = ::OpenTelemetry.tracer_provider.tracer.start_span('otel_api_span')
+        #     # finishable should be set by the start_span API
+        #     child_nr_segment = child_otel_span.finishable
 
-        #   assert_instance_of NewRelic::Agent::Transaction::Segment, child_nr_segment, "OTel span's finishable should be an NR Segment"
-        #   assert_equal txn, child_nr_segment.transaction, "NR segment created for OTel span should belong to the active transaction"
-        #   assert_equal child_otel_span, child_nr_segment.instance_variable_get(:@otel_span), "NR segment's @otel_span should be the one created"
+        #     assert_instance_of Transaction::Segment, child_nr_segment, "OTel span's finishable should be an NR Segment"
+        #     assert_equal txn, child_nr_segment.transaction, "NR segment created for OTel span should belong to the active transaction"
+        #     assert_equal child_otel_span, child_nr_segment.instance_variable_get(:@otel_span), "NR segment's @otel_span should be the one created by the OTel API call"
 
-        #   # Verify context update
-        #   assert_equal child_nr_segment.guid, ::OpenTelemetry::Trace.current_span.context.span_id, "OTel current span ID should match OTel API created span's GUID"
-        #   assert_equal child_nr_segment.guid, NewRelic::Agent::Tracer.current_segment.guid, "NR current segment GUID should match segment for OTel API span"
+        #     # Verify context update
+        #     assert_equal child_nr_segment.guid, ::OpenTelemetry::Trace.current_span.context.span_id, "OTel current span ID should match OTel API created span's GUID"
+        #     assert_equal child_nr_segment.guid, Tracer.current_segment.guid, "NR current segment GUID should match segment for OTel API span"
 
-        #   child_otel_span.finish
-        #   txn.finish
+        #     child_otel_span.finish
+        #   end
         # end
 
         # def test_otel_api_finish_span_finishes_linked_nr_segment
-        #   txn = NewRelic::Agent::Tracer.start_transaction(name: 'test', category: :otel)
+        #   in_transaction do |txn|
+        #     child_otel_span = ::OpenTelemetry.tracer_provider.tracer.start_span('otel_api_span_to_finish')
+        #     child_nr_segment = child_otel_span.finishable # This is the linked NR Segment
 
-        #   child_otel_span = @tracer.start_span('otel_api_span_to_finish')
-        #   child_nr_segment = child_otel_span.finishable # This is the linked NR Segment
+        #     child_otel_span.finish # Finish using OTel API
 
-        #   child_otel_span.finish # Finish using OTel API
+        #     assert_predicate child_nr_segment, :finished?, "Linked NR segment should be marked as finished when OTel span is finished"
 
-        #   assert_predicate child_nr_segment, :finished?, "Linked NR segment should be marked as finished when OTel span is finished"
-
-        #   txn.finish
+        #   end
         # end
 
         # def test_otel_api_cannot_finish_nr_api_created_elements
-        #   txn = NewRelic::Agent::Tracer.start_transaction(name: 'test', category: :otel)
-        #   first_segment = txn.segments.first
-        #   first_otel_span = first_segment.instance_variable_get(:@otel_span)
+        #   in_transaction do |txn|
+        #     segment = txn.segments.first
+        #     otel_span = segment.instance_variable_get(:@otel_span)
 
-        #   # Attempt to finish the OTel representation of the NR-created root segment
-        #   first_otel_span.finish
+        #     # Attempt to finish the OTel representation of the NR-created root segment
+        #     otel_span.finish
 
-        #   # The transaction itself should not be finished by this action
-        #   refute_predicate txn, :finished?, "NR transaction should not be finished by OTel API call on its root segment's OTel span"
-        #   refute_predicate first_segment, :finished?, "NR root segment should not be finished by OTel API call on its OTel span"
-
-        #   txn.finish
+        #     # The transaction itself should not be finished by this action
+        #     refute_predicate txn, :finished?, "NR transaction should not be finished by OTel API call on its root segment's OTel span"
+        #     refute_predicate segment, :finished?, "NR root segment should not be finished by OTel API call on its OTel span"
+        #   end
         # end
 
-        #   def test_nr_api_finishes_nr_transaction
-        #     txn = NewRelic::Agent::Tracer.start_transaction(name: 'test', category: :otel)
-        #     txn.finish
+        # def test_nr_api_finishes_nr_transaction
+        #   txn = Tracer.start_transaction(name: 'test', category: :otel)
+        #   txn.finish
 
-        #     assert_predicate txn, :finished?, "NR transaction should be marked as finished by NR API"
-        #   end
+        #   assert_predicate txn, :finished?, "NR transaction should be marked as finished by NR API"
+        # end
 
-        def test_finish_transaction_resets_contexts
-          txn = NewRelic::Agent::Tracer.start_transaction(name: 'test', category: :otel)
-          txn.finish
+        # def test_finish_transaction_resets_contexts
+        #   txn = Tracer.start_transaction(name: 'test', category: :otel)
+        #   txn.finish
 
-          assert_equal ::OpenTelemetry::Trace::Span::INVALID, ::OpenTelemetry::Trace.current_span, 'OTel current span should be INVALID after transaction finish'
-          assert_nil NewRelic::Agent::Tracer.current_transaction, 'NR current transaction should be nil after transaction finish'
-          assert_nil NewRelic::Agent::Tracer.current_segment, 'NR current segment should be nil after transaction finish'
-        end
+        #   assert_equal ::OpenTelemetry::Trace::Span::INVALID, ::OpenTelemetry::Trace.current_span, 'OTel current span should be INVALID after transaction finish'
+        #   assert_nil Tracer.current_transaction, 'NR current transaction should be nil after transaction finish'
+        #   assert_nil Tracer.current_segment, 'NR current segment should be nil after transaction finish'
+        # end
       end
     end
   end


### PR DESCRIPTION
This PR changes the strategy used to create transactions and segments when OpenTelemetry APIs are called to cue off the parent_context rather than the span kind.

## Summary
* Add `finishable` to OpenTelemetry Span class to track the
corresponding New Relic segment/transaction
* Add `Tracer#start_span` patch for `:server` span kinds
* Refactor `Tracer#in_span` to use `#start_span`
* Start new transactions based on parent context rather than span kind
* Do not start a transaction if span kind is internal
* Update arguments for OpenTelemetry Span class to accept
only `span_context`, and create the span context in a
a separate method
* Update agent output tests to look at individual keys rather
than a full hash match

Closes #3145 