### PR TITLE
Add version_satisfied? method

### DIFF
--- a/lib/new_relic/agent/configuration/yaml_source.rb
+++ b/lib/new_relic/agent/configuration/yaml_source.rb
@@ -103,7 +103,7 @@ module NewRelic
             NewRelic::Agent.agent&.health_check&.update_status(NewRelic::Agent::HealthCheck::FAILED_TO_PARSE_CONFIG)
             message = 'Failed ERB processing configuration file. This is typically caused by a Ruby error in <% %> templating blocks in your newrelic.yml file.'
             failure_array = [message, e]
-            failure_array << e.backtrace[0] if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.4.0')
+            failure_array << e.backtrace[0] if NewRelic::Helper.version_satisfied?(RUBY_VERSION, '>=', '3.4.0')
             log_failure(*failure_array)
             nil
           end

--- a/lib/new_relic/agent/database.rb
+++ b/lib/new_relic/agent/database.rb
@@ -123,7 +123,7 @@ module NewRelic
         return @supports_with_connection if defined?(@supports_with_connection)
 
         @supports_with_connection = defined?(::ActiveRecord::VERSION::STRING) &&
-          Gem::Version.new(ActiveRecord::VERSION::STRING) >= Gem::Version.new('7.2.0')
+          NewRelic::Helper.version_satisfied?(ActiveRecord::VERSION::STRING, '>=', '7.2.0')
       end
 
       def close_connections

--- a/lib/new_relic/agent/database_adapter.rb
+++ b/lib/new_relic/agent/database_adapter.rb
@@ -25,7 +25,7 @@ module NewRelic
       end
 
       def value
-        match = VERSIONS.keys.find { |key| version >= Gem::Version.new(key) }
+        match = VERSIONS.keys.find { |key| NewRelic::Helper.version_satisfied?(version, '>=', key) }
         return unless match
 
         VERSIONS[match].call(env)

--- a/lib/new_relic/agent/datastores/redis.rb
+++ b/lib/new_relic/agent/datastores/redis.rb
@@ -83,7 +83,7 @@ module NewRelic
         end
 
         def self.is_supported_version?
-          Gem::Version.new(::Redis::VERSION) >= Gem::Version.new('3.0.0')
+          NewRelic::Helper.version_satisfied?(::Redis::VERSION, '>=', '3.0.0')
         end
 
         def self.ellipsize(result, string)

--- a/lib/new_relic/agent/instrumentation/action_dispatch.rb
+++ b/lib/new_relic/agent/instrumentation/action_dispatch.rb
@@ -16,7 +16,7 @@ DependencyDetection.defer do
       defined?(ActionDispatch) &&
       defined?(ActionPack) &&
       ActionPack.respond_to?(:gem_version) &&
-      ActionPack.gem_version >= Gem::Version.new('6.0.0') && # notifications for dispatch added in Rails 6
+      NewRelic::Helper.version_satisfied?(ActionPack.gem_version, '>=', '6.0.0') && # notifications for dispatch added in Rails 6
       !NewRelic::Agent::Instrumentation::ActionDispatchSubscriber.subscribed?
   end
 

--- a/lib/new_relic/agent/instrumentation/action_mailbox.rb
+++ b/lib/new_relic/agent/instrumentation/action_mailbox.rb
@@ -15,7 +15,7 @@ DependencyDetection.defer do
     defined?(ActiveSupport) &&
       defined?(ActionMailbox) &&
       ActionMailbox.respond_to?(:gem_version) && # 'require "action_mailbox"' doesn't require version...
-      ActionMailbox.gem_version >= Gem::Version.new('7.1.0.alpha') && # notifications added in Rails 7.1
+      NewRelic::Helper.version_satisfied?(ActionMailbox.gem_version, '>=', '7.1.0.alpha') && # notifications added in Rails 7.1
       !NewRelic::Agent::Instrumentation::ActionMailboxSubscriber.subscribed?
   end
 

--- a/lib/new_relic/agent/instrumentation/action_mailer.rb
+++ b/lib/new_relic/agent/instrumentation/action_mailer.rb
@@ -15,7 +15,7 @@ DependencyDetection.defer do
     defined?(ActiveSupport) &&
       defined?(ActionMailer) &&
       ActionMailer.respond_to?(:gem_version) &&
-      ActionMailer.gem_version >= Gem::Version.new('5.0') &&
+      NewRelic::Helper.version_satisfied?(ActionMailer.gem_version, '>=', '5.0') &&
       !NewRelic::Agent::Instrumentation::ActionMailerSubscriber.subscribed?
   end
 

--- a/lib/new_relic/agent/instrumentation/active_job.rb
+++ b/lib/new_relic/agent/instrumentation/active_job.rb
@@ -30,7 +30,7 @@ DependencyDetection.defer do
   executes do
     if defined?(ActiveSupport) &&
         ActiveJob.respond_to?(:gem_version) &&
-        ActiveJob.gem_version >= Gem::Version.new('6.0.0') &&
+        NewRelic::Helper.version_satisfied?(ActiveJob.gem_version, '>=', '6.0.0') &&
         !NewRelic::Agent.config[:disable_activejob] &&
         !NewRelic::Agent::Instrumentation::ActiveJobSubscriber.subscribed?
       NewRelic::Agent.logger.info('Installing notifications based ActiveJob instrumentation')

--- a/lib/new_relic/agent/instrumentation/active_record.rb
+++ b/lib/new_relic/agent/instrumentation/active_record.rb
@@ -13,7 +13,8 @@ module NewRelic
         end
 
         def self.insert_instrumentation
-          if defined?(::ActiveRecord::VERSION::MAJOR) && ::ActiveRecord::VERSION::MAJOR.to_i >= 3
+          if defined?(::ActiveRecord::VERSION::MAJOR) &&
+              NewRelic::Helper.version_satisfied?(::ActiveRecord::VERSION::MAJOR, '>=', 3)
             if ::NewRelic::Agent.config[:prepend_active_record_instrumentation]
               ::ActiveRecord::Base.prepend(::NewRelic::Agent::Instrumentation::ActiveRecordPrepend::BaseExtensions)
               ::ActiveRecord::Relation.prepend(::NewRelic::Agent::Instrumentation::ActiveRecordPrepend::RelationExtensions)
@@ -37,7 +38,7 @@ module NewRelic
           end
         end
 
-        if RUBY_VERSION < '2.7.0'
+        if NewRelic::Helper.version_satisfied?(RUBY_VERSION, '<', '2.7.0')
           def log_with_newrelic_instrumentation(*args, &block)
             state = NewRelic::Agent::Tracer.state
 
@@ -137,7 +138,7 @@ DependencyDetection.defer do
   depends_on do
     defined?(ActiveRecord) && defined?(ActiveRecord::Base) &&
       (!defined?(ActiveRecord::VERSION) ||
-        ActiveRecord::VERSION::MAJOR.to_i <= 3)
+        NewRelic::Helper.version_satisfied?(ActiveRecord::VERSION::MAJOR, '<=', 3))
   end
 
   depends_on do
@@ -151,7 +152,8 @@ DependencyDetection.defer do
   executes do
     require 'new_relic/agent/instrumentation/active_record_helper'
 
-    if defined?(Rails::VERSION::MAJOR) && Rails::VERSION::MAJOR.to_i == 3
+    if defined?(Rails::VERSION::MAJOR) &&
+        NewRelic::Helper.version_satisfied?(Rails::VERSION::MAJOR, '==', 3)
       ActiveSupport.on_load(:active_record) do
         NewRelic::Agent::Instrumentation::ActiveRecord.insert_instrumentation
       end

--- a/lib/new_relic/agent/instrumentation/active_record_helper.rb
+++ b/lib/new_relic/agent/instrumentation/active_record_helper.rb
@@ -49,7 +49,7 @@ module NewRelic
 
             alias_method(:delete_all_without_newrelic, :delete_all)
 
-            if RUBY_VERSION < '2.7.0'
+            if NewRelic::Helper.version_satisfied?(RUBY_VERSION, '<', '2.7.0')
               def delete_all(*args, &blk)
                 ::NewRelic::Agent.with_database_metric_name(self.name, nil, ACTIVE_RECORD) do
                   delete_all_without_newrelic(*args, &blk)

--- a/lib/new_relic/agent/instrumentation/active_record_notifications.rb
+++ b/lib/new_relic/agent/instrumentation/active_record_notifications.rb
@@ -28,7 +28,7 @@ module NewRelic
             ) { yield }
           rescue => e
             # The translate_exception_class method got introduced in 4.1
-            if ::ActiveRecord::VERSION::MINOR == 0
+            if NewRelic::Helper.version_satisfied?(::ActiveRecord::VERSION::MINOR, '==', 0)
               raise translate_exception(e, sql)
             else
               raise translate_exception_class(e, sql)
@@ -86,7 +86,7 @@ DependencyDetection.defer do
   depends_on do
     defined?(ActiveRecord) && defined?(ActiveRecord::Base) &&
       defined?(ActiveRecord::VERSION) &&
-      ActiveRecord::VERSION::MAJOR.to_i >= 4
+      NewRelic::Helper.version_satisfied?(ActiveRecord::VERSION::MAJOR, '>=', 4)
   end
 
   depends_on do
@@ -113,7 +113,7 @@ DependencyDetection.defer do
 
       # Default to .prepending, unless the ActiveRecord version is <=4
       # **AND** the :prepend_active_record_instrumentation config is false
-      if ActiveRecord::VERSION::MAJOR > 4 \
+      if NewRelic::Helper.version_satisfied?(ActiveRecord::VERSION::MAJOR, '>', 4) \
           || NewRelic::Agent.config[:prepend_active_record_instrumentation]
 
         ActiveRecord::Base.send(:prepend,
@@ -131,11 +131,13 @@ DependencyDetection.defer do
       major_version = ActiveRecord::VERSION::MAJOR.to_i
       minor_version = ActiveRecord::VERSION::MINOR.to_i
 
-      activerecord_extension = if major_version == 4
+      activerecord_extension = if NewRelic::Helper.version_satisfied?(major_version, '==', 4)
         NewRelic::Agent::Instrumentation::ActiveRecordNotifications::BaseExtensions4x
-      elsif major_version == 5 && minor_version == 0
+      elsif NewRelic::Helper.version_satisfied?(major_version, '==', 5) &&
+          NewRelic::Helper.version_satisfied?(minor_version, '==', 0)
         NewRelic::Agent::Instrumentation::ActiveRecordNotifications::BaseExtensions50
-      elsif major_version == 5 && minor_version == 1
+      elsif NewRelic::Helper.version_satisfied?(major_version, '==', 5) &&
+          NewRelic::Helper.version_satisfied?(minor_version, '==', 1)
         NewRelic::Agent::Instrumentation::ActiveRecordNotifications::BaseExtensions51
       end
 
@@ -146,9 +148,9 @@ DependencyDetection.defer do
   end
 
   executes do
-    if ActiveRecord::VERSION::MAJOR == 5 \
-        && ActiveRecord::VERSION::MINOR.to_i == 1 \
-        && ActiveRecord::VERSION::TINY.to_i >= 6
+    if NewRelic::Helper.version_satisfied?(ActiveRecord::VERSION::MAJOR, '==', 5) \
+        && NewRelic::Helper.version_satisfied?(ActiveRecord::VERSION::MINOR, '==', 1) \
+        && NewRelic::Helper.version_satisfied?(ActiveRecord::VERSION::TINY, '>=', 6)
 
       ActiveRecord::Base.prepend(NewRelic::Agent::Instrumentation::ActiveRecordPrepend::BaseExtensions516)
     end

--- a/lib/new_relic/agent/instrumentation/active_record_prepend.rb
+++ b/lib/new_relic/agent/instrumentation/active_record_prepend.rb
@@ -11,7 +11,7 @@ module NewRelic
         ACTIVE_RECORD = 'ActiveRecord'.freeze
 
         module BaseExtensions
-          if RUBY_VERSION < '2.7.0'
+          if NewRelic::Helper.version_satisfied?(RUBY_VERSION, '<', '2.7.0')
             def save(*args, &blk)
               ::NewRelic::Agent.with_database_metric_name(self.class.name, nil, ACTIVE_RECORD) do
                 super
@@ -46,7 +46,7 @@ module NewRelic
           # Starting in v5.1.6, this call no longer happens. We'll
           # have to set the database metrics explicitly now.
           #
-          if RUBY_VERSION < '2.7.0'
+          if NewRelic::Helper.version_satisfied?(RUBY_VERSION, '<', '2.7.0')
             def touch(*args, **kwargs, &blk)
               ::NewRelic::Agent.with_database_metric_name(self.class.name, nil, ACTIVE_RECORD) do
                 super

--- a/lib/new_relic/agent/instrumentation/async_http.rb
+++ b/lib/new_relic/agent/instrumentation/async_http.rb
@@ -11,7 +11,7 @@ DependencyDetection.defer do
 
   depends_on do
     defined?(Async::HTTP) &&
-      Gem::Version.new(Async::HTTP::VERSION) >= Gem::Version.new('0.59.0') &&
+      NewRelic::Helper.version_satisfied?(Async::HTTP::VERSION, '>=', '0.59.0') &&
       !defined?(Traces::Backend::NewRelic) # defined in the traces-backend-newrelic gem
   end
 

--- a/lib/new_relic/agent/instrumentation/concurrent_ruby.rb
+++ b/lib/new_relic/agent/instrumentation/concurrent_ruby.rb
@@ -12,7 +12,7 @@ DependencyDetection.defer do
   depends_on do
     defined?(Concurrent) &&
       defined?(Concurrent::VERSION) &&
-      Gem::Version.new(Concurrent::VERSION) >= Gem::Version.new('1.1.5')
+      NewRelic::Helper.version_satisfied?(Concurrent::VERSION, '>=', '1.1.5')
   end
 
   executes do

--- a/lib/new_relic/agent/instrumentation/curb.rb
+++ b/lib/new_relic/agent/instrumentation/curb.rb
@@ -12,7 +12,7 @@ DependencyDetection.defer do
 
   depends_on do
     defined?(Curl) && defined?(Curl::CURB_VERSION) &&
-      Gem::Version.new(Curl::CURB_VERSION) >= CURB_MIN_VERSION
+      NewRelic::Helper.version_satisfied?(Curl::CURB_VERSION, '>=', CURB_MIN_VERSION)
   end
 
   executes do

--- a/lib/new_relic/agent/instrumentation/elasticsearch.rb
+++ b/lib/new_relic/agent/instrumentation/elasticsearch.rb
@@ -14,7 +14,7 @@ DependencyDetection.defer do
   end
 
   executes do
-    to_instrument = if Gem::Version.create(Elasticsearch::VERSION) < Gem::Version.create('8.0.0')
+    to_instrument = if NewRelic::Helper.version_satisfied?(Elasticsearch::VERSION, '<', '8.0.0')
       Elasticsearch::Transport::Client
     else
       Elastic::Transport::Client

--- a/lib/new_relic/agent/instrumentation/elasticsearch/chain.rb
+++ b/lib/new_relic/agent/instrumentation/elasticsearch/chain.rb
@@ -5,8 +5,7 @@
 module NewRelic::Agent::Instrumentation
   module Elasticsearch::Chain
     def self.instrument!
-      to_instrument = if ::Gem::Version.create(::Elasticsearch::VERSION) <
-          ::Gem::Version.create('8.0.0')
+      to_instrument = if NewRelic::Helper.version_satisfied?(::Elasticsearch::VERSION, '<', '8.0.0')
         ::Elasticsearch::Transport::Client
       else
         ::Elastic::Transport::Client

--- a/lib/new_relic/agent/instrumentation/ethon.rb
+++ b/lib/new_relic/agent/instrumentation/ethon.rb
@@ -18,7 +18,7 @@ DependencyDetection.defer do
   end
 
   depends_on do
-    defined?(Ethon) && Gem::Version.new(Ethon::VERSION) >= Gem::Version.new('0.12.0')
+    defined?(Ethon) && NewRelic::Helper.version_satisfied?(Ethon::VERSION, '>=', '0.12.0')
   end
 
   executes do

--- a/lib/new_relic/agent/instrumentation/excon.rb
+++ b/lib/new_relic/agent/instrumentation/excon.rb
@@ -26,7 +26,7 @@ DependencyDetection.defer do
 
   executes do
     excon_version = Gem::Version.new(Excon::VERSION)
-    if excon_version >= EXCON_MIN_VERSION
+    if NewRelic::Helper.version_satisfied?(excon_version, '>=', EXCON_MIN_VERSION)
       install_excon_instrumentation(excon_version)
     else
       NewRelic::Agent.logger.warn("Excon instrumentation requires at least version #{EXCON_MIN_VERSION}")

--- a/lib/new_relic/agent/instrumentation/fiber/chain.rb
+++ b/lib/new_relic/agent/instrumentation/fiber/chain.rb
@@ -10,7 +10,7 @@ module NewRelic::Agent::Instrumentation
 
         alias_method(:initialize_without_new_relic, :initialize)
 
-        if RUBY_VERSION < '2.7.0'
+        if NewRelic::Helper.version_satisfied?(RUBY_VERSION, '<', '2.7.0')
           def initialize(*_args, &block)
             traced_block = add_thread_tracing(&block)
             initialize_with_newrelic_tracing { initialize_without_new_relic(&traced_block) }

--- a/lib/new_relic/agent/instrumentation/fiber/prepend.rb
+++ b/lib/new_relic/agent/instrumentation/fiber/prepend.rb
@@ -9,7 +9,7 @@ module NewRelic::Agent::Instrumentation
     module Prepend
       include NewRelic::Agent::Instrumentation::MonitoredFiber
 
-      if RUBY_VERSION < '2.7.0'
+      if NewRelic::Helper.version_satisfied?(RUBY_VERSION, '<', '2.7.0')
         def initialize(*_args, &block)
           traced_block = add_thread_tracing(&block)
           initialize_with_newrelic_tracing { super(&traced_block) }

--- a/lib/new_relic/agent/instrumentation/grape/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/grape/instrumentation.rb
@@ -30,7 +30,7 @@ module NewRelic::Agent::Instrumentation
       end
 
       def prepare!
-        if defined?(::Grape::VERSION) && NewRelic::Helper.version_satisfied?(::Grape::VERSION, '>=', '0.16.0')
+        if defined?(::Grape::VERSION) && Gem::Version.new(::Grape::VERSION) >= Gem::Version.new('0.16.0')
           send(:remove_method, :name_for_transaction_deprecated)
         else
           send(:remove_method, :name_for_transaction)
@@ -42,7 +42,7 @@ module NewRelic::Agent::Instrumentation
       API_VERSION = 'api.version'.freeze
       FORMAT_REGEX = /\(\/?\.[\:\w]*\)/.freeze # either :format (< 0.12.0) or .ext (>= 0.12.0)
       VERSION_REGEX = /:version(\/|$)/.freeze
-      MIN_VERSION = '0.2.0'
+      MIN_VERSION = Gem::Version.new('0.2.0')
       PIPE_STRING = '|'.freeze
 
       def handle_transaction(endpoint, class_name, version)

--- a/lib/new_relic/agent/instrumentation/grape/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/grape/instrumentation.rb
@@ -30,7 +30,7 @@ module NewRelic::Agent::Instrumentation
       end
 
       def prepare!
-        if defined?(::Grape::VERSION) && Gem::Version.new(::Grape::VERSION) >= Gem::Version.new('0.16.0')
+        if defined?(::Grape::VERSION) && NewRelic::Helper.version_satisfied?(::Grape::VERSION, '>=', '0.16.0')
           send(:remove_method, :name_for_transaction_deprecated)
         else
           send(:remove_method, :name_for_transaction)
@@ -42,7 +42,7 @@ module NewRelic::Agent::Instrumentation
       API_VERSION = 'api.version'.freeze
       FORMAT_REGEX = /\(\/?\.[\:\w]*\)/.freeze # either :format (< 0.12.0) or .ext (>= 0.12.0)
       VERSION_REGEX = /:version(\/|$)/.freeze
-      MIN_VERSION = Gem::Version.new('0.2.0')
+      MIN_VERSION = '0.2.0'
       PIPE_STRING = '|'.freeze
 
       def handle_transaction(endpoint, class_name, version)

--- a/lib/new_relic/agent/instrumentation/httpclient.rb
+++ b/lib/new_relic/agent/instrumentation/httpclient.rb
@@ -16,10 +16,7 @@ DependencyDetection.defer do
   end
 
   depends_on do
-    minimum_supported_version = Gem::Version.new(HTTPCLIENT_MIN_VERSION)
-    current_version = Gem::Version.new(HTTPClient::VERSION)
-
-    current_version >= minimum_supported_version
+    NewRelic::Helper.version_satisfied?(HTTPClient::VERSION, '>=', HTTPCLIENT_MIN_VERSION)
   end
 
   executes do

--- a/lib/new_relic/agent/instrumentation/httpx.rb
+++ b/lib/new_relic/agent/instrumentation/httpx.rb
@@ -10,7 +10,7 @@ DependencyDetection.defer do
   named :httpx
 
   depends_on do
-    defined?(HTTPX) && Gem::Version.new(HTTPX::VERSION) >= Gem::Version.new('1.0.0')
+    defined?(HTTPX) && NewRelic::Helper.version_satisfied?(HTTPX::VERSION, '>=', '1.0.0')
   end
 
   executes do

--- a/lib/new_relic/agent/instrumentation/logstasher.rb
+++ b/lib/new_relic/agent/instrumentation/logstasher.rb
@@ -11,7 +11,7 @@ DependencyDetection.defer do
 
   depends_on do
     defined?(LogStasher) &&
-      Gem::Version.new(LogStasher::VERSION) >= Gem::Version.new('1.0.0') &&
+      NewRelic::Helper.version_satisfied?(LogStasher::VERSION, '>=', '1.0.0') &&
       NewRelic::Agent.config[:'application_logging.enabled']
   end
 

--- a/lib/new_relic/agent/instrumentation/memcache/dalli.rb
+++ b/lib/new_relic/agent/instrumentation/memcache/dalli.rb
@@ -61,7 +61,7 @@ module NewRelic
               # TODO: MAJOR VERSION
               # Dalli - 3.1.0 renamed send_multiget to pipelined_get, but the method is otherwise the same
               # Once we no longer support Dalli < 3.1.0, remove this conditional logic
-              if Gem::Version.new(::Dalli::VERSION) >= Gem::Version.new('3.1.0')
+              if NewRelic::Helper.version_satisfied?(::Dalli::VERSION, '>=', '3.1.0')
                 alias_method(:pipelined_get_without_newrelic_trace, :pipelined_get)
                 def pipelined_get(keys)
                   send_multiget_with_newrelic_tracing(keys) { pipelined_get_without_newrelic_trace(keys) }

--- a/lib/new_relic/agent/instrumentation/memcache/helper.rb
+++ b/lib/new_relic/agent/instrumentation/memcache/helper.rb
@@ -9,11 +9,11 @@ module NewRelic::Agent::Instrumentation
       BINARY_PROTOCOL_SUPPORTED_VERSION = Gem::Version.new('3.0.2')
 
       def supports_datastore_instances?
-        DATASTORE_INSTANCES_SUPPORTED_VERSION <= Gem::Version.new(::Dalli::VERSION)
+        NewRelic::Helper.version_satisfied?(DATASTORE_INSTANCES_SUPPORTED_VERSION, '<=', ::Dalli::VERSION)
       end
 
       def supports_binary_protocol?
-        BINARY_PROTOCOL_SUPPORTED_VERSION <= Gem::Version.new(::Dalli::VERSION)
+        NewRelic::Helper.version_satisfied?(BINARY_PROTOCOL_SUPPORTED_VERSION, '<=', ::Dalli::VERSION)
       end
 
       def client_methods

--- a/lib/new_relic/agent/instrumentation/memcache/prepend.rb
+++ b/lib/new_relic/agent/instrumentation/memcache/prepend.rb
@@ -87,7 +87,7 @@ module NewRelic::Agent::Instrumentation
           # TODO: MAJOR VERSION
           # Dalli - 3.1.0 renamed send_multiget to pipelined_get, but the method is otherwise the same
           # Once we no longer support Dalli < 3.1.0, remove this conditional logic
-          if Gem::Version.new(::Dalli::VERSION) >= Gem::Version.new('3.1.0')
+          if NewRelic::Helper.version_satisfied?(::Dalli::VERSION, '>=', '3.1.0')
             def pipelined_get(keys)
               send_multiget_with_newrelic_tracing(keys) { super }
             end

--- a/lib/new_relic/agent/instrumentation/net_http.rb
+++ b/lib/new_relic/agent/instrumentation/net_http.rb
@@ -19,7 +19,8 @@ DependencyDetection.defer do
 
   # Airbrake uses method chaining on Net::HTTP in versions < 10.0.2 (10.0.2 updated to prepend for Net:HTTP)
   conflicts_with_prepend do
-    defined?(Airbrake) && defined?(Airbrake::AIRBRAKE_VERSION) && Gem::Version.create(Airbrake::AIRBRAKE_VERSION) < Gem::Version.create('10.0.2')
+    defined?(Airbrake) && defined?(Airbrake::AIRBRAKE_VERSION) &&
+      NewRelic::Helper.version_satisfied?(Airbrake::AIRBRAKE_VERSION, '<', '10.0.2')
   end
 
   conflicts_with_prepend do

--- a/lib/new_relic/agent/instrumentation/rake.rb
+++ b/lib/new_relic/agent/instrumentation/rake.rb
@@ -12,7 +12,7 @@ DependencyDetection.defer do
   configure_with :rake
 
   depends_on { defined?(Rake) && defined?(Rake::VERSION) }
-  depends_on { Gem::Version.new(Rake::VERSION) >= Gem::Version.new('10.0.0') }
+  depends_on { NewRelic::Helper.version_satisfied?(Rake::VERSION, '>=', '10.0.0') }
   depends_on { NewRelic::Agent.config[:'rake.tasks'].any? }
   depends_on { NewRelic::Agent::Instrumentation::Rake.safe_from_third_party_gem? }
 

--- a/lib/new_relic/agent/instrumentation/rdkafka/chain.rb
+++ b/lib/new_relic/agent/instrumentation/rdkafka/chain.rb
@@ -40,8 +40,8 @@ module NewRelic::Agent::Instrumentation
         alias_method(:producer_without_new_relic, :producer)
         alias_method(:consumer_without_new_relic, :consumer)
 
-        if Gem::Version.new(::Rdkafka::VERSION) >= Gem::Version.new('0.16.0') ||
-            (Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.7.0'))
+        if NewRelic::Helper.version_satisfied?(::Rdkafka::VERSION, '>=', '0.16.0') ||
+            NewRelic::Helper.version_satisfied?(RUBY_VERSION, '>=', '2.7.0')
           def producer(**kwargs)
             producer_without_new_relic(**kwargs).tap do |producer|
               set_nr_config(producer)

--- a/lib/new_relic/agent/instrumentation/rdkafka/prepend.rb
+++ b/lib/new_relic/agent/instrumentation/rdkafka/prepend.rb
@@ -36,8 +36,8 @@ module NewRelic::Agent::Instrumentation
     module Prepend
       include NewRelic::Agent::Instrumentation::RdkafkaConfig
 
-      if (defined?(::Rdkafka) && Gem::Version.new(::Rdkafka::VERSION) >= Gem::Version.new('0.16.0')) ||
-          (Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.7.0'))
+      if (defined?(::Rdkafka) && NewRelic::Helper.version_satisfied?(::Rdkafka::VERSION, '>=', '0.16.0')) ||
+          NewRelic::Helper.version_satisfied?(RUBY_VERSION, '>=', '2.7.0')
         def producer(**kwargs)
           super.tap do |producer|
             set_nr_config(producer)

--- a/lib/new_relic/agent/instrumentation/redis/constants.rb
+++ b/lib/new_relic/agent/instrumentation/redis/constants.rb
@@ -11,7 +11,7 @@ module NewRelic::Agent::Instrumentation::Redis
     MULTI_OPERATION = 'multi'
     PIPELINE_OPERATION = 'pipeline'
     HAS_REDIS_CLIENT = defined?(::Redis) &&
-      Gem::Version.new(::Redis::VERSION) >= Gem::Version.new('5.0.0') &&
+      NewRelic::Helper.version_satisfied?(::Redis::VERSION, '>=', '5.0.0') &&
       !defined?(::RedisClient).nil?
   end
 end

--- a/lib/new_relic/agent/instrumentation/resque.rb
+++ b/lib/new_relic/agent/instrumentation/resque.rb
@@ -15,7 +15,7 @@ DependencyDetection.defer do
 
   # Airbrake uses method chaining on Resque::Job on versions < 11.0.3
   conflicts_with_prepend do
-    defined?(Airbrake) && defined?(Airbrake::AIRBRAKE_VERSION) && Gem::Version.create(Airbrake::AIRBRAKE_VERSION) < Gem::Version.create('11.0.3')
+    defined?(Airbrake) && defined?(Airbrake::AIRBRAKE_VERSION) && NewRelic::Helper.version_satisfied?(Airbrake::AIRBRAKE_VERSION, '<', '11.0.3')
   end
 
   executes do
@@ -25,7 +25,7 @@ DependencyDetection.defer do
         # we don't believe this lib is still necessary for Ruby 3.4 users.
         # however, if we receive customer feedback to the contrary, we can find
         # an alternate approach.
-        Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3.4')
+        NewRelic::Helper.version_satisfied?(RUBY_VERSION, '<', '3.4')
       NewRelic::Agent.logger.info('Requiring resolv-replace')
       require 'resolv'
       require 'resolv-replace'

--- a/lib/new_relic/agent/instrumentation/roda.rb
+++ b/lib/new_relic/agent/instrumentation/roda.rb
@@ -11,7 +11,7 @@ DependencyDetection.defer do
 
   depends_on do
     defined?(Roda) &&
-      Gem::Version.new(Roda::RodaVersion) >= Gem::Version.new('3.19.0') &&
+      NewRelic::Helper.version_satisfied?(Roda::RodaVersion, '>=', '3.19.0') &&
       Roda::RodaPlugins::Base::ClassMethods.private_method_defined?(:build_rack_app) &&
       Roda::RodaPlugins::Base::InstanceMethods.method_defined?(:_roda_handle_main_route)
   end

--- a/lib/new_relic/agent/instrumentation/ruby_kafka/prepend.rb
+++ b/lib/new_relic/agent/instrumentation/ruby_kafka/prepend.rb
@@ -20,7 +20,7 @@ module NewRelic::Agent::Instrumentation
     module Prepend
       include NewRelic::Agent::Instrumentation::RubyKafka
 
-      if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3')
+      if NewRelic::Helper.version_satisfied?(RUBY_VERSION, '>=', '3')
         def each_message(**args)
           super do |message|
             each_message_with_new_relic(message) do

--- a/lib/new_relic/agent/instrumentation/ruby_openai.rb
+++ b/lib/new_relic/agent/instrumentation/ruby_openai.rb
@@ -12,13 +12,13 @@ DependencyDetection.defer do
   depends_on do
     NewRelic::Agent.config[:'ai_monitoring.enabled'] &&
       defined?(OpenAI) && defined?(OpenAI::Client) &&
-      Gem::Version.new(OpenAI::VERSION) >= Gem::Version.new('3.4.0')
+      NewRelic::Helper.version_satisfied?(OpenAI::VERSION, '>=', '3.4.0')
   end
 
   executes do
     if use_prepend?
       # TODO: Remove condition when we drop support for versions below 5.0.0
-      if Gem::Version.new(OpenAI::VERSION) >= Gem::Version.new('5.0.0')
+      if NewRelic::Helper.version_satisfied?(OpenAI::VERSION, '>=', '5.0.0')
         prepend_instrument OpenAI::Client,
           NewRelic::Agent::Instrumentation::OpenAI::Prepend,
           NewRelic::Agent::Instrumentation::OpenAI::VENDOR

--- a/lib/new_relic/agent/instrumentation/sidekiq/extensions/delayed_class.rb
+++ b/lib/new_relic/agent/instrumentation/sidekiq/extensions/delayed_class.rb
@@ -8,7 +8,7 @@
 #
 #       see https://github.com/sidekiq/sidekiq/issues/5076 for the discussion
 #       of the removal, which includes mentions of alternatives
-if defined?(Sidekiq::VERSION) && Sidekiq::VERSION < '7.0.0'
+if defined?(Sidekiq::VERSION) && NewRelic::Helper.version_satisfied?(Sidekiq::VERSION, '<', '7.0.0')
   class Sidekiq::Extensions::DelayedClass
     def newrelic_trace_args(msg, queue)
       (target, method_name, _args) = if YAML.respond_to?(:unsafe_load)

--- a/lib/new_relic/agent/instrumentation/stripe.rb
+++ b/lib/new_relic/agent/instrumentation/stripe.rb
@@ -13,7 +13,7 @@ DependencyDetection.defer do
 
   depends_on do
     defined?(Stripe) &&
-      Gem::Version.new(Stripe::VERSION) >= Gem::Version.new('5.38.0')
+      NewRelic::Helper.version_satisfied?(Stripe::VERSION, '>=', '5.38.0')
   end
 
   executes do

--- a/lib/new_relic/agent/instrumentation/typhoeus/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/typhoeus/instrumentation.rb
@@ -8,11 +8,11 @@ module NewRelic
       module Typhoeus
         HYDRA_SEGMENT_NAME = 'External/Multiple/Typhoeus::Hydra/run'
         NOTICEABLE_ERROR_CLASS = 'Typhoeus::Errors::TyphoeusError'
-        EARLIEST_VERSION = Gem::Version.new('0.5.3')
+        EARLIEST_VERSION = '0.5.3'
         INSTRUMENTATION_NAME = NewRelic::Agent.base_name(name)
 
         def self.is_supported_version?
-          Gem::Version.new(::Typhoeus::VERSION) >= EARLIEST_VERSION
+          NewRelic::Helper.version_satisfied?(::Typhoeus::VERSION, '>=', EARLIEST_VERSION)
         end
 
         def self.request_is_hydra_enabled?(request)

--- a/lib/new_relic/agent/llm/chat_completion_summary.rb
+++ b/lib/new_relic/agent/llm/chat_completion_summary.rb
@@ -32,7 +32,7 @@ module NewRelic
           # TODO: OLD RUBIES < 2.6
           # Hash#merge accepts multiple arguments in 2.6
           # Remove condition once support for Ruby <2.6 is dropped
-          if RUBY_VERSION >= '2.6.0'
+          if NewRelic::Helper.version_satisfied?(RUBY_VERSION, '>=', '2.6.0')
             LlmEvent::ATTRIBUTE_NAME_EXCEPTIONS.merge(ResponseHeaders::ATTRIBUTE_NAME_EXCEPTIONS, ATTRIBUTE_NAME_EXCEPTIONS)
           else
             LlmEvent::ATTRIBUTE_NAME_EXCEPTIONS.merge(ResponseHeaders::ATTRIBUTE_NAME_EXCEPTIONS).merge(ATTRIBUTE_NAME_EXCEPTIONS)

--- a/lib/new_relic/agent/llm/embedding.rb
+++ b/lib/new_relic/agent/llm/embedding.rb
@@ -25,7 +25,7 @@ module NewRelic
           # TODO: OLD RUBIES < 2.6
           # Hash#merge accepts multiple arguments in 2.6
           # Remove condition once support for Ruby <2.6 is dropped
-          if RUBY_VERSION >= '2.6.0'
+          if NewRelic::Helper.version_satisfied?(RUBY_VERSION, '>=', '2.6.0')
             LlmEvent::ATTRIBUTE_NAME_EXCEPTIONS.merge(ResponseHeaders::ATTRIBUTE_NAME_EXCEPTIONS, ATTRIBUTE_NAME_EXCEPTIONS)
           else
             LlmEvent::ATTRIBUTE_NAME_EXCEPTIONS.merge(ResponseHeaders::ATTRIBUTE_NAME_EXCEPTIONS).merge(ATTRIBUTE_NAME_EXCEPTIONS)

--- a/lib/new_relic/agent/local_log_decorator.rb
+++ b/lib/new_relic/agent/local_log_decorator.rb
@@ -43,7 +43,7 @@ module NewRelic
         # URI version 1.0+ will ship with Ruby 3.4
         # Once we drop support for Rubies below 3.4, we can use the
         # URI::RFC2396 parser exclusively.
-        if Gem::Version.new(URI::VERSION) >= Gem::Version.new('1.0')
+        if NewRelic::Helper.version_satisfied?(URI::VERSION, '>=', '1.0')
           URI::RFC2396_PARSER.escape(entity_name)
         else
           URI::DEFAULT_PARSER.escape(entity_name)

--- a/lib/new_relic/agent/logging.rb
+++ b/lib/new_relic/agent/logging.rb
@@ -165,7 +165,7 @@ module NewRelic
         # Positional and Keyword arguments are separated beginning with Ruby 2.7
         # Signature of ::Logger constructor changes in Ruby 2.4 to have both positional and keyword args
         # We pivot on Ruby 2.7 for widest supportability with least amount of hassle.
-        if RUBY_VERSION < '2.7.0'
+        if NewRelic::Helper.version_satisfied?(RUBY_VERSION, '<', '2.7.0')
           def initialize(*args)
             super(*args)
             self.formatter = DecoratingFormatter.new

--- a/lib/new_relic/agent/new_relic_service/json_marshaller.rb
+++ b/lib/new_relic/agent/new_relic_service/json_marshaller.rb
@@ -19,7 +19,7 @@ module NewRelic
         def warn_for_yajl
           if defined?(::Yajl)
             require 'yajl/version'
-            if Gem::Version.new(::Yajl::VERSION) < OK_YAJL_VERSION
+            if NewRelic::Helper.version_satisfied?(::Yajl::VERSION, '<', OK_YAJL_VERSION)
               ::NewRelic::Agent.logger.warn("Detected yajl-ruby version #{::Yajl::VERSION} which can cause segfaults with newrelic_rpm's thread profiling features. We strongly recommend you upgrade to the latest yajl-ruby version available.")
             end
           end

--- a/lib/new_relic/agent/parameter_filtering.rb
+++ b/lib/new_relic/agent/parameter_filtering.rb
@@ -9,7 +9,7 @@ module NewRelic
 
       ACTION_DISPATCH_PARAMETER_FILTER ||= 'action_dispatch.parameter_filter'.freeze
 
-      if defined?(Rails) && Gem::Version.new(::Rails::VERSION::STRING) >= Gem::Version.new('5.0.0')
+      if defined?(Rails) && NewRelic::Helper.version_satisfied?(::Rails::VERSION::STRING, '>=', '5.0.0')
         Rails.application.config.to_prepare do
           RAILS_FILTER_CLASS ||= if defined?(ActiveSupport::ParameterFilter)
             ActiveSupport::ParameterFilter

--- a/lib/new_relic/agent/samplers/cpu_sampler.rb
+++ b/lib/new_relic/agent/samplers/cpu_sampler.rb
@@ -42,7 +42,7 @@ module NewRelic
           # Process.times on JRuby < 1.7.0 reports wall clock elapsed time,
           # not actual cpu time used, so this sampler can only be used on JRuby >= 1.7.0.
           if defined?(JRuby)
-            return JRUBY_VERSION >= '1.7.0'
+            return NewRelic::Helper.version_satisfied?(JRUBY_VERSION, '>=', '1.7.0')
           end
 
           true

--- a/lib/new_relic/agent/vm/c_ruby_vm.rb
+++ b/lib/new_relic/agent/vm/c_ruby_vm.rb
@@ -61,7 +61,7 @@ module NewRelic
         end
 
         def gather_constant_cache_invalidations
-          RubyVM.stat[RUBY_VERSION >= '3.2.0' ? :constant_cache_invalidations : :global_constant_state]
+          RubyVM.stat[NewRelic::Helper.version_satisfied?(RUBY_VERSION, '>=', '3.2.0') ? :constant_cache_invalidations : :global_constant_state]
         end
 
         def gather_constant_cache_misses
@@ -86,9 +86,9 @@ module NewRelic
           when :gc_total_time
             NewRelic::LanguageSupport.gc_profiler_enabled?
           when :method_cache_invalidations
-            RUBY_VERSION < '3.0.0'
+            NewRelic::Helper.version_satisfied?(RUBY_VERSION, '<', '3.0.0')
           when :constant_cache_misses
-            RUBY_VERSION >= '3.2.0'
+            NewRelic::Helper.version_satisfied?(RUBY_VERSION, '>=', '3.2.0')
           else
             false
           end

--- a/lib/new_relic/control/instrumentation.rb
+++ b/lib/new_relic/control/instrumentation.rb
@@ -68,7 +68,7 @@ module NewRelic
     end
 
     def rails_32_deprecation
-      return unless defined?(Rails::VERSION) && Gem::Version.new(Rails::VERSION::STRING) <= Gem::Version.new('3.2')
+      return unless defined?(Rails::VERSION) && NewRelic::Helper.version_satisfied?(Rails::VERSION::STRING, '<=', '3.2')
 
       deprecation_msg = 'The Ruby agent is dropping support for Rails 3.2 ' \
         'in a future major release. Please upgrade your Rails version to continue receiving support. ' \

--- a/lib/new_relic/helper.rb
+++ b/lib/new_relic/helper.rb
@@ -90,7 +90,6 @@ module NewRelic
       left.public_send(operator, right)
     end
 
-
     # Bundler version 2.5.12 deprecated all_specs and added installed_specs.
     # To support newer Bundler versions, try to use installed_specs first,
     # then fall back to all_specs.

--- a/lib/new_relic/helper.rb
+++ b/lib/new_relic/helper.rb
@@ -83,6 +83,14 @@ module NewRelic
       end
     end
 
+    def version_satisfied?(left, operator, right)
+      left = Gem::Version.new(left) unless left.is_a?(Gem::Version)
+      right = Gem::Version.new(right) unless right.is_a?(Gem::Version)
+
+      left.public_send(operator, right)
+    end
+
+
     # Bundler version 2.5.12 deprecated all_specs and added installed_specs.
     # To support newer Bundler versions, try to use installed_specs first,
     # then fall back to all_specs.

--- a/lib/sequel/extensions/new_relic_instrumentation.rb
+++ b/lib/sequel/extensions/new_relic_instrumentation.rb
@@ -79,7 +79,7 @@ module Sequel
 
     THREAD_SAFE_CONNECTION_POOL_CLASSES = [
       (defined?(::Sequel::ThreadedConnectionPool) && ::Sequel::ThreadedConnectionPool),
-      (defined?(::Sequel::TimedQueueConnectionPool) && RUBY_VERSION >= '3.2' && ::Sequel::TimedQueueConnectionPool)
+      (defined?(::Sequel::TimedQueueConnectionPool) && NewRelic::Helper.version_satisfied?(RUBY_VERSION, '>=', '3.2') && ::Sequel::TimedQueueConnectionPool)
     ].compact.freeze
 
     def explainer_for(sql)

--- a/test/helpers/misc.rb
+++ b/test/helpers/misc.rb
@@ -153,7 +153,7 @@ def newest_ruby
 end
 
 def skip_unless_newest_ruby
-  return if Gem::Version.new(RUBY_VERSION) >= newest_ruby
+  return if NewRelic::Helper.version_satisfied?(RUBY_VERSION, '>=', newest_ruby)
 
   skip 'This test only runs on the latest CI cron Ruby version'
 end

--- a/test/multiverse/lib/multiverse/suite.rb
+++ b/test/multiverse/lib/multiverse/suite.rb
@@ -268,7 +268,7 @@ module Multiverse
     end
 
     def ruby3_gem_webrick
-      NewRelic::Helper.version_satisfied?(RUBY_VERSION, '>=', '3.0.0') ? "gem 'webrick'" : ''
+      RUBY_VERSION >= '3.0.0' ? "gem 'webrick'" : ''
     end
 
     def generate_gemfile(gemfile_text, env_index, local = true)
@@ -312,11 +312,11 @@ module Multiverse
     end
 
     def minitest_version
-      if NewRelic::Helper.version_satisfied?(RUBY_VERSION, '>=', '2.6')
+      if RUBY_VERSION >= '2.6'
         '5.16.2'
-      elsif NewRelic::Helper.version_satisfied?(RUBY_VERSION, '>=', '2.5')
+      elsif RUBY_VERSION >= '2.5'
         '5.15.0'
-      elsif NewRelic::Helper.version_satisfied?(RUBY_VERSION, '>=', '2.4')
+      elsif RUBY_VERSION >= '2.4'
         '5.10.1'
       else
         '4.7.5'
@@ -327,7 +327,7 @@ module Multiverse
     # rack v3 and rackup require Ruby 2.4+, so assume rack v2 or below
     # (which doesn't need the separate rackup) for older rubies
     def need_rackup?(gemfile_text)
-      return false unless gemfile_text =~ /^\s*gem\s+['"]rack['"](?:\s*,[^\d]+(\d))?/ && NewRelic::Helper.version_satisfied?(RUBY_VERSION, '>=', '2.4.0')
+      return false unless gemfile_text =~ /^\s*gem\s+['"]rack['"](?:\s*,[^\d]+(\d))?/ && RUBY_VERSION >= '2.4.0'
 
       rack_major_version = Regexp.last_match(1)
       return true if rack_major_version.nil? # no version constraint, latest rack, needs rackup
@@ -581,7 +581,7 @@ module Multiverse
 
       load(@after_file) if @after_file
 
-      if NewRelic::Helper.version_satisfied?(RUBY_VERSION, '>=', '2.7.0')
+      if RUBY_VERSION >= '2.7.0'
         # This is only used for SimpleCov at this time,
         # an error will be raised on Ruby versions that do not run
         # SimpleCov without this condition

--- a/test/multiverse/lib/multiverse/suite.rb
+++ b/test/multiverse/lib/multiverse/suite.rb
@@ -268,7 +268,7 @@ module Multiverse
     end
 
     def ruby3_gem_webrick
-      RUBY_VERSION >= '3.0.0' ? "gem 'webrick'" : ''
+      NewRelic::Helper.version_satisfied?(RUBY_VERSION, '>=', '3.0.0') ? "gem 'webrick'" : ''
     end
 
     def generate_gemfile(gemfile_text, env_index, local = true)
@@ -312,11 +312,11 @@ module Multiverse
     end
 
     def minitest_version
-      if RUBY_VERSION >= '2.6'
+      if NewRelic::Helper.version_satisfied?(RUBY_VERSION, '>=', '2.6')
         '5.16.2'
-      elsif RUBY_VERSION >= '2.5'
+      elsif NewRelic::Helper.version_satisfied?(RUBY_VERSION, '>=', '2.5')
         '5.15.0'
-      elsif RUBY_VERSION >= '2.4'
+      elsif NewRelic::Helper.version_satisfied?(RUBY_VERSION, '>=', '2.4')
         '5.10.1'
       else
         '4.7.5'
@@ -327,7 +327,7 @@ module Multiverse
     # rack v3 and rackup require Ruby 2.4+, so assume rack v2 or below
     # (which doesn't need the separate rackup) for older rubies
     def need_rackup?(gemfile_text)
-      return false unless gemfile_text =~ /^\s*gem\s+['"]rack['"](?:\s*,[^\d]+(\d))?/ && RUBY_VERSION >= '2.4.0'
+      return false unless gemfile_text =~ /^\s*gem\s+['"]rack['"](?:\s*,[^\d]+(\d))?/ && NewRelic::Helper.version_satisfied?(RUBY_VERSION, '>=', '2.4.0')
 
       rack_major_version = Regexp.last_match(1)
       return true if rack_major_version.nil? # no version constraint, latest rack, needs rackup
@@ -581,7 +581,7 @@ module Multiverse
 
       load(@after_file) if @after_file
 
-      if RUBY_VERSION >= '2.7.0'
+      if NewRelic::Helper.version_satisfied?(RUBY_VERSION, '>=', '2.7.0')
         # This is only used for SimpleCov at this time,
         # an error will be raised on Ruby versions that do not run
         # SimpleCov without this condition

--- a/test/multiverse/suites/agent_only/start_up_test.rb
+++ b/test/multiverse/suites/agent_only/start_up_test.rb
@@ -142,7 +142,7 @@ class StartUpTest < Minitest::Test
   end
 
   def jruby_9000
-    defined?(JRUBY_VERSION) && Gem::Version.new(JRUBY_VERSION) >= Gem::Version.new('9.0.0')
+    defined?(JRUBY_VERSION) && NewRelic::Helper.version_satisfied?(JRUBY_VERSION, '>=', '9.0.0')
   end
 
   def bundler_rubygem_conflicts?

--- a/test/multiverse/suites/agent_only/thread_profiling_test.rb
+++ b/test/multiverse/suites/agent_only/thread_profiling_test.rb
@@ -57,7 +57,7 @@ class ThreadProfilingTest < Minitest::Test
   # go only let a few cycles through, so we check less than 10
 
   def test_thread_profiling
-    skip 'Fails on Ruby 3.0+, see Issue #2947' if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.0')
+    skip 'Fails on Ruby 3.0+, see Issue #2947' if NewRelic::Helper.version_satisfied?(RUBY_VERSION, '>=', '3.0')
 
     run_transaction_in_thread(:controller)
     run_transaction_in_thread(:task)
@@ -78,7 +78,7 @@ class ThreadProfilingTest < Minitest::Test
   end
 
   def test_thread_profiling_can_stop
-    skip 'Fails on Ruby 3.0+, see Issue #2947' if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.0')
+    skip 'Fails on Ruby 3.0+, see Issue #2947' if NewRelic::Helper.version_satisfied?(RUBY_VERSION, '>=', '3.0')
 
     issue_command(START_COMMAND)
     issue_command(STOP_COMMAND)

--- a/test/multiverse/suites/capistrano/Capfile
+++ b/test/multiverse/suites/capistrano/Capfile
@@ -9,8 +9,7 @@ require 'capistrano/deploy'
 # Newer Capistrano versions need us to load
 # Git SCM support explicitly
 if defined?(Capistrano::VERSION) &&
-    Gem::Version.new(Capistrano::VERSION) >=
-        Gem::Version.new('3.7.0')
+    NewRelic::Helper.version_satisfied?(Capistrano::VERSION, '>=', '3.7.0')
 
   require 'capistrano/scm/git'
   install_plugin Capistrano::SCM::Git

--- a/test/multiverse/suites/capistrano/Capfile
+++ b/test/multiverse/suites/capistrano/Capfile
@@ -9,7 +9,8 @@ require 'capistrano/deploy'
 # Newer Capistrano versions need us to load
 # Git SCM support explicitly
 if defined?(Capistrano::VERSION) &&
-    NewRelic::Helper.version_satisfied?(Capistrano::VERSION, '>=', '3.7.0')
+    Gem::Version.new(Capistrano::VERSION) >=
+        Gem::Version.new('3.7.0')
 
   require 'capistrano/scm/git'
   install_plugin Capistrano::SCM::Git

--- a/test/multiverse/suites/delayed_job/delayed_job_instrumentation_test.rb
+++ b/test/multiverse/suites/delayed_job/delayed_job_instrumentation_test.rb
@@ -57,7 +57,7 @@ if defined?(Delayed::Backend::ActiveRecord) && Delayed::Worker.respond_to?(:dela
     # We can only test methods using delay and handle_asynchronously on versions that run jobs via
     # the invoke_job method.
     def self.dj_invokes_job_inline?
-      Gem.loaded_specs['delayed_job'].version >= Gem::Version.new('3.0.0')
+      NewRelic::Helper.version_satisfied?(Gem.loaded_specs['delayed_job'].version, '>=', '3.0.0')
     end
 
     if dj_invokes_job_inline?

--- a/test/multiverse/suites/elasticsearch/elasticsearch_instrumentation_test.rb
+++ b/test/multiverse/suites/elasticsearch/elasticsearch_instrumentation_test.rb
@@ -221,7 +221,7 @@ class ElasticsearchInstrumentationTest < Minitest::Test
   end
 
   def transport_error_class
-    if ::Gem::Version.create(Elasticsearch::VERSION) < ::Gem::Version.create('8.0.0')
+    if NewRelic::Helper.version_satisfied?(Elasticsearch::VERSION, '<', '8.0.0')
       ::Elasticsearch::Transport::Transport::Error
     else
       ::Elastic::Transport::Transport::Error
@@ -229,7 +229,7 @@ class ElasticsearchInstrumentationTest < Minitest::Test
   end
 
   def port
-    if ::Gem::Version.create(Elasticsearch::VERSION) < ::Gem::Version.create('8.0.0')
+    if NewRelic::Helper.version_satisfied?(Elasticsearch::VERSION, '<', '8.0.0')
       9200 # 9200 for elasticsearch 7
     else
       9250 # 9250 for elasticsearch 8

--- a/test/multiverse/suites/grape/grape_test.rb
+++ b/test/multiverse/suites/grape/grape_test.rb
@@ -233,9 +233,9 @@ class GrapeTest < Minitest::Test
       #
       # Rack >= 3.1 further changes things, so we also excuse an actual 0 value
       # when it is in play
-      if NewRelic::Helper.version_satisfied?(::Grape::VERSION, '>=', '1.3.0')
+      if Gem::Version.new(::Grape::VERSION) >= Gem::Version.new('1.3.0')
         rack31_plus_and_zero = Rack.respond_to?(:release) &&
-          NewRelic::Helper.version_satisfied?(Rack.release, '>=', '3.1.0') &&
+          Gem::Version.new(Rack.release) >= Gem::Version.new('3.1.0') &&
           actual['request.headers.contentLength'] == 0
 
         if expected['response.headers.contentLength'] == 0 || rack31_plus_and_zero
@@ -269,7 +269,7 @@ class GrapeApiInstanceTest < Minitest::Test
 
   setup_and_teardown_agent
 
-  if NewRelic::Helper.version_satisfied?(::Grape::VERSION, '>=', '1.2.0')
+  if ::Grape::VERSION >= '1.2.0'
     def app
       Rack::Builder.app { run(GrapeApiInstanceTestApi.new) }
     end

--- a/test/multiverse/suites/grape/grape_test.rb
+++ b/test/multiverse/suites/grape/grape_test.rb
@@ -233,9 +233,9 @@ class GrapeTest < Minitest::Test
       #
       # Rack >= 3.1 further changes things, so we also excuse an actual 0 value
       # when it is in play
-      if Gem::Version.new(::Grape::VERSION) >= Gem::Version.new('1.3.0')
+      if NewRelic::Helper.version_satisfied?(::Grape::VERSION, '>=', '1.3.0')
         rack31_plus_and_zero = Rack.respond_to?(:release) &&
-          Gem::Version.new(Rack.release) >= Gem::Version.new('3.1.0') &&
+          NewRelic::Helper.version_satisfied?(Rack.release, '>=', '3.1.0') &&
           actual['request.headers.contentLength'] == 0
 
         if expected['response.headers.contentLength'] == 0 || rack31_plus_and_zero
@@ -269,7 +269,7 @@ class GrapeApiInstanceTest < Minitest::Test
 
   setup_and_teardown_agent
 
-  if ::Grape::VERSION >= '1.2.0'
+  if NewRelic::Helper.version_satisfied?(::Grape::VERSION, '>=', '1.2.0')
     def app
       Rack::Builder.app { run(GrapeApiInstanceTestApi.new) }
     end

--- a/test/multiverse/suites/grape/grape_test_api.rb
+++ b/test/multiverse/suites/grape/grape_test_api.rb
@@ -56,7 +56,7 @@ class GrapeTestApi < Grape::API
   resource :grape_ape_fail_rescue do
     rescue_from :all do |e|
       err = {message: "rescued from #{e.class.name}"}
-      Gem::Version.new(Grape::VERSION) >= Gem::Version.new('2.1.0') ? error!(err) : error_response(err)
+      NewRelic::Helper.version_satisfied?(Grape::VERSION, '>=', '2.1.0') ? error!(err) : error_response(err)
     end
 
     post do
@@ -65,7 +65,7 @@ class GrapeTestApi < Grape::API
   end
 end
 
-if Grape::VERSION >= '1.2.0' && Grape::VERSION <= '1.2.4'
+if NewRelic::Helper.version_satisfied?(Grape::VERSION, '>=', '1.2.0') && NewRelic::Helper.version_satisfied?(Grape::VERSION, '<=', '1.2.4')
   class GrapeApiInstanceTestApi < Grape::API::Instance
     namespace :banjaxing do
       get do
@@ -75,7 +75,7 @@ if Grape::VERSION >= '1.2.0' && Grape::VERSION <= '1.2.4'
   end
 end
 
-if Grape::VERSION >= '1.2.5'
+if NewRelic::Helper.version_satisfied?(Grape::VERSION, '>=', '1.2.5')
   class GrapeApiInstanceTestApi < Grape::API
     namespace :banjaxing do
       get do

--- a/test/multiverse/suites/grape/grape_versioning_test.rb
+++ b/test/multiverse/suites/grape/grape_versioning_test.rb
@@ -2,7 +2,7 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
-unless NewRelic::Helper.version_satisfied?(Grape::VERSION, '==', '0.1.5')
+unless Grape::VERSION == '0.1.5'
   require './grape_versioning_test_api'
 
   class GrapeVersioningTest < Minitest::Test
@@ -52,7 +52,7 @@ unless NewRelic::Helper.version_satisfied?(Grape::VERSION, '==', '0.1.5')
     end
 
     # version from http accept header is not supported in older versions of grape
-    if NewRelic::Helper.version_satisfied?(Grape::VERSION, '>=', '0.16.0')
+    if Gem::Version.new(Grape::VERSION) >= Gem::Version.new('0.16.0')
       def test_version_from_accept_version_header_is_recorded_in_transaction_name
         @app_class = GrapeVersioning::ApiV4
         get('/fish', {}, 'HTTP_ACCEPT_VERSION' => 'v4')
@@ -118,7 +118,7 @@ unless NewRelic::Helper.version_satisfied?(Grape::VERSION, '==', '0.1.5')
     #
     # defaulting with header key/empty value does not set rack.env['api.version']
     #
-    if NewRelic::Helper.version_satisfied?(Grape::VERSION, '>=', '0.5.0')
+    if Gem::Version.new(Grape::VERSION) >= Gem::Version.new('0.5.0')
       def test_default_accept_version_header_version_in_transaction_names
         @app_class = GrapeVersioning::DefaultAcceptVersionHeaderApi
         get('/fish', nil, 'HTTP_ACCEPT_VERSION' => '')

--- a/test/multiverse/suites/grape/grape_versioning_test.rb
+++ b/test/multiverse/suites/grape/grape_versioning_test.rb
@@ -2,7 +2,7 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
-unless Grape::VERSION == '0.1.5'
+unless NewRelic::Helper.version_satisfied?(Grape::VERSION, '==', '0.1.5')
   require './grape_versioning_test_api'
 
   class GrapeVersioningTest < Minitest::Test
@@ -52,7 +52,7 @@ unless Grape::VERSION == '0.1.5'
     end
 
     # version from http accept header is not supported in older versions of grape
-    if Gem::Version.new(Grape::VERSION) >= Gem::Version.new('0.16.0')
+    if NewRelic::Helper.version_satisfied?(Grape::VERSION, '>=', '0.16.0')
       def test_version_from_accept_version_header_is_recorded_in_transaction_name
         @app_class = GrapeVersioning::ApiV4
         get('/fish', {}, 'HTTP_ACCEPT_VERSION' => 'v4')
@@ -118,7 +118,7 @@ unless Grape::VERSION == '0.1.5'
     #
     # defaulting with header key/empty value does not set rack.env['api.version']
     #
-    if Gem::Version.new(Grape::VERSION) >= Gem::Version.new('0.5.0')
+    if NewRelic::Helper.version_satisfied?(Grape::VERSION, '>=', '0.5.0')
       def test_default_accept_version_header_version_in_transaction_names
         @app_class = GrapeVersioning::DefaultAcceptVersionHeaderApi
         get('/fish', nil, 'HTTP_ACCEPT_VERSION' => '')

--- a/test/multiverse/suites/grape/grape_versioning_test_api.rb
+++ b/test/multiverse/suites/grape/grape_versioning_test_api.rb
@@ -2,7 +2,7 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
-unless NewRelic::Helper.version_satisfied?(Grape::VERSION, '==', '0.1.5')
+unless Grape::VERSION == '0.1.5'
   module GrapeVersioning
     class ApiV1 < Grape::API
       version 'v1'
@@ -46,7 +46,7 @@ unless NewRelic::Helper.version_satisfied?(Grape::VERSION, '==', '0.1.5')
 
     class ApiV4 < Grape::API
       # version from http accept header is not supported in older versions of grape
-      if NewRelic::Helper.version_satisfied?(Grape::VERSION, '>=', '0.16.0')
+      if Gem::Version.new(Grape::VERSION) >= Gem::Version.new('0.16.0')
         version %w[v4 v5], :using => :accept_version_header
       end
 
@@ -61,7 +61,7 @@ unless NewRelic::Helper.version_satisfied?(Grape::VERSION, '==', '0.1.5')
 
     class CascadingAPI < Grape::API
       # version from http accept header is not supported in older versions of grape
-      if NewRelic::Helper.version_satisfied?(Grape::VERSION, '>=', '0.16.0')
+      if Gem::Version.new(Grape::VERSION) >= Gem::Version.new('0.16.0')
         version 'v5', :using => :accept_version_header
       end
 

--- a/test/multiverse/suites/grape/grape_versioning_test_api.rb
+++ b/test/multiverse/suites/grape/grape_versioning_test_api.rb
@@ -2,7 +2,7 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
-unless Grape::VERSION == '0.1.5'
+unless NewRelic::Helper.version_satisfied?(Grape::VERSION, '==', '0.1.5')
   module GrapeVersioning
     class ApiV1 < Grape::API
       version 'v1'
@@ -46,7 +46,7 @@ unless Grape::VERSION == '0.1.5'
 
     class ApiV4 < Grape::API
       # version from http accept header is not supported in older versions of grape
-      if Gem::Version.new(Grape::VERSION) >= Gem::Version.new('0.16.0')
+      if NewRelic::Helper.version_satisfied?(Grape::VERSION, '>=', '0.16.0')
         version %w[v4 v5], :using => :accept_version_header
       end
 
@@ -61,7 +61,7 @@ unless Grape::VERSION == '0.1.5'
 
     class CascadingAPI < Grape::API
       # version from http accept header is not supported in older versions of grape
-      if Gem::Version.new(Grape::VERSION) >= Gem::Version.new('0.16.0')
+      if NewRelic::Helper.version_satisfied?(Grape::VERSION, '>=', '0.16.0')
         version 'v5', :using => :accept_version_header
       end
 

--- a/test/multiverse/suites/httprb/httprb_test.rb
+++ b/test/multiverse/suites/httprb/httprb_test.rb
@@ -14,7 +14,7 @@ class HTTPTest < Minitest::Test
   end
 
   def is_unsupported_1x?
-    defined?(::HTTP::VERSION) && HTTP::VERSION < '1.0.0'
+    defined?(::HTTP::VERSION) && NewRelic::Helper.version_satisfied?(HTTP::VERSION, '<', '1.0.0')
   end
 
   def get_response(url = nil, headers = nil)

--- a/test/multiverse/suites/httpx/httpx_instrumentation_test.rb
+++ b/test/multiverse/suites/httpx/httpx_instrumentation_test.rb
@@ -34,7 +34,7 @@ class HTTPXInstrumentationTest < Minitest::Test
     request.expect :response, :the_response
     2.times { request.expect :hash, 1138 }
 
-    error = if Gem::Version.new(::HTTPX::VERSION) >= Gem::Version.new('1.3.0')
+    error = if NewRelic::Helper.version_satisfied?(::HTTPX::VERSION, '>=', '1.3.0')
       request.expect :options, ::HTTPX::Options.new({})
       ::HTTPX::ErrorResponse.new(request, StandardError.new)
     else

--- a/test/multiverse/suites/memcache/dalli_test.rb
+++ b/test/multiverse/suites/memcache/dalli_test.rb
@@ -112,7 +112,7 @@ if defined?(Dalli)
     end
   end
 
-  if Dalli::VERSION >= '2.7'
+  if NewRelic::Helper.version_satisfied?(Dalli::VERSION, '>=', '2.7')
     require 'dalli/cas/client'
     DependencyDetection.detect!
 

--- a/test/multiverse/suites/memcache/memcache_client_test.rb
+++ b/test/multiverse/suites/memcache/memcache_client_test.rb
@@ -12,13 +12,13 @@ if defined?(MemCache)
       @cache = MemCache.new("#{memcached_host}:11211")
     end
 
-    if MemCache::VERSION <= '1.5.0'
+    if NewRelic::Helper.version_satisfied?(MemCache::VERSION, '<=', '1.5.0')
       undef_method :test_append_in_web, :test_prepend_in_web, :test_replace_in_web,
         :test_append_in_background, :test_prepend_in_background,
         :test_replace_in_background
     end
 
-    if MemCache::VERSION <= '1.7.0'
+    if NewRelic::Helper.version_satisfied?(MemCache::VERSION, '<=', '1.7.0')
       undef_method :test_cas_in_web, :test_cas_in_background
     end
 

--- a/test/multiverse/suites/memcache/memcached_test.rb
+++ b/test/multiverse/suites/memcache/memcached_test.rb
@@ -37,7 +37,7 @@ if defined?(Memcached)
     end
 
     def test_get_in_web
-      if Memcached::VERSION >= '1.8.0'
+      if NewRelic::Helper.version_satisfied?(Memcached::VERSION, '>=', '1.8.0')
         key = set_key_for_testcase
 
         expected_metrics = expected_web_metrics(:single_get)
@@ -54,7 +54,7 @@ if defined?(Memcached)
     end
 
     def test_get_multi_in_web
-      return unless Memcached::VERSION >= '1.8.0'
+      return unless NewRelic::Helper.version_satisfied?(Memcached::VERSION, '>=', '1.8.0')
 
       key = set_key_for_testcase
 
@@ -97,7 +97,7 @@ if defined?(Memcached)
     def test_cas_in_web
       key = set_key_for_testcase(1)
 
-      if Memcached::VERSION >= '1.8.0'
+      if NewRelic::Helper.version_satisfied?(Memcached::VERSION, '>=', '1.8.0')
         expected_metrics = (expected_web_metrics(:single_get) + expected_web_metrics(:single_cas)).uniq
         expected_metrics += additional_web_metrics_for(:cas)
       else
@@ -113,7 +113,7 @@ if defined?(Memcached)
     end
 
     def test_get_in_background
-      if Memcached::VERSION >= '1.8.0'
+      if NewRelic::Helper.version_satisfied?(Memcached::VERSION, '>=', '1.8.0')
         key = set_key_for_testcase
 
         expected_metrics = expected_bg_metrics(:single_get)
@@ -130,7 +130,7 @@ if defined?(Memcached)
     end
 
     def test_get_multi_in_background
-      return unless Memcached::VERSION >= '1.8.0'
+      return unless NewRelic::Helper.version_satisfied?(Memcached::VERSION, '>=', '1.8.0')
 
       key = set_key_for_testcase
 
@@ -172,7 +172,7 @@ if defined?(Memcached)
 
     def test_cas_in_background
       key = set_key_for_testcase(1)
-      if Memcached::VERSION >= '1.8.0'
+      if NewRelic::Helper.version_satisfied?(Memcached::VERSION, '>=', '1.8.0')
         expected_metrics = (expected_bg_metrics(:single_get) + expected_bg_metrics(:single_cas)).uniq
         expected_metrics += additional_bg_metrics_for(:cas)
       else

--- a/test/multiverse/suites/rack/rack_builder_test.rb
+++ b/test/multiverse/suites/rack/rack_builder_test.rb
@@ -90,7 +90,7 @@ class RackBuilderTest < Minitest::Test
   end
 
   def test_run_with_tracing
-    skip 'Requires MiniTest v5+' unless MiniTest::Unit::VERSION > '5.0'
+    skip 'Requires MiniTest v5+' unless NewRelic::Helper.version_satisfied?(MiniTest::Unit::VERSION, '>', '5.0')
 
     instance = TestBuilderClass.new
     app = :the_app
@@ -128,7 +128,7 @@ class RackBuilderTest < Minitest::Test
   end
 
   def test_use_with_tracing
-    skip 'Requires MiniTest v5+' unless MiniTest::Unit::VERSION > '5.0'
+    skip 'Requires MiniTest v5+' unless NewRelic::Helper.version_satisfied?(MiniTest::Unit::VERSION, '>', '5.0')
 
     instance = TestBuilderClass.new
     def instance.middleware_instrumentation_enabled?; true; end
@@ -156,7 +156,7 @@ class RackBuilderTest < Minitest::Test
   end
 
   def test_generate_traced_map
-    skip 'Requires MiniTest v5+' unless MiniTest::Unit::VERSION > '5.0'
+    skip 'Requires MiniTest v5+' unless NewRelic::Helper.version_satisfied?(MiniTest::Unit::VERSION, '>', '5.0')
 
     url = :url
     handler = 'handler'

--- a/test/multiverse/suites/rails/action_controller_other_test.rb
+++ b/test/multiverse/suites/rails/action_controller_other_test.rb
@@ -125,7 +125,7 @@ if defined?(ActionController::Live)
 
       # in Rails < 7 the context key is not present in this payload, so it changes the params and name
       # because we're using context info to create the name
-      rails7 = Gem::Version.new(Rails::VERSION::STRING) >= Gem::Version.new('7.0.0')
+      rails7 = NewRelic::Helper.version_satisfied?(Rails::VERSION::STRING, '>=', '7.0.0')
 
       segment_name = if rails7
         'Ruby/ActionController/data/unpermitted_parameters'

--- a/test/multiverse/suites/rails/rails_logger_test.rb
+++ b/test/multiverse/suites/rails/rails_logger_test.rb
@@ -18,7 +18,7 @@ class RailsLoggerTest < Minitest::Test
     @output = StringIO.new
     broadcasted_logger = Logger.new(@output)
 
-    if Gem::Version.new(Rails::VERSION::STRING) >= Gem::Version.new('7.1.0')
+    if NewRelic::Helper.version_satisfied?(Rails::VERSION::STRING, '>=', '7.1.0')
       Rails.logger.broadcast_to(broadcasted_logger)
     else
       Rails.logger.extend(ActiveSupport::Logger.broadcast(broadcasted_logger))

--- a/test/multiverse/suites/rails_prepend/prepended_supportability_test.rb
+++ b/test/multiverse/suites/rails_prepend/prepended_supportability_test.rb
@@ -8,7 +8,7 @@ class PrependedSupportabilityMetricsTest < Minitest::Test
   include MultiverseHelpers
 
   def test_action_view_prepended_metrics
-    value_for_haml_version = Gem::Version.new(Haml::VERSION) >= Gem::Version.new('6.0.0') ? 1 : 2
+    value_for_haml_version = NewRelic::Helper.version_satisfied?(Haml::VERSION, '>=', '6.0.0') ? 1 : 2
 
     assert_metrics_recorded({
 

--- a/test/multiverse/suites/rake/instrumentation_test.rb
+++ b/test/multiverse/suites/rake/instrumentation_test.rb
@@ -16,7 +16,7 @@ class RakeInstrumentationTest < Minitest::Test
   class ErrorClass < StandardError; end
 
   def test_invoke_with_newrelic_tracing_happy_path
-    skip 'Requires MiniTest v5+' unless MiniTest::Unit::VERSION > '5.0'
+    skip 'Requires MiniTest v5+' unless NewRelic::Helper.version_satisfied?(MiniTest::Unit::VERSION, '>', '5.0')
 
     instance = TesterClass.new
     instance_mock = MiniTest::Mock.new
@@ -38,7 +38,7 @@ class RakeInstrumentationTest < Minitest::Test
   end
 
   def test_invoke_with_newrelic_tracing_when_tracing_is_disabled
-    skip 'Requires MiniTest v5+' unless MiniTest::Unit::VERSION > '5.0'
+    skip 'Requires MiniTest v5+' unless NewRelic::Helper.version_satisfied?(MiniTest::Unit::VERSION, '>', '5.0')
 
     instance = TesterClass.new
     NewRelic::Agent::Instrumentation::Rake.stub :should_trace?, false, [instance.name] do
@@ -52,7 +52,7 @@ class RakeInstrumentationTest < Minitest::Test
   end
 
   def test_invoke_with_tracing_with_exception
-    skip 'Requires MiniTest v5+' unless MiniTest::Unit::VERSION > '5.0'
+    skip 'Requires MiniTest v5+' unless NewRelic::Helper.version_satisfied?(MiniTest::Unit::VERSION, '>', '5.0')
 
     instance = TesterClass.new
     NewRelic::Agent::Instrumentation::Rake.stub :should_trace?, true, [instance.name] do
@@ -70,7 +70,7 @@ class RakeInstrumentationTest < Minitest::Test
   end
 
   def test_we_should_install_if_newrelic_rake_is_absent
-    skip 'Requires MiniTest v5+' unless MiniTest::Unit::VERSION > '5.0'
+    skip 'Requires MiniTest v5+' unless NewRelic::Helper.version_satisfied?(MiniTest::Unit::VERSION, '>', '5.0')
 
     NewRelic::LanguageSupport.stub :bundled_gem?, false, 'newrelic-rake' do
       assert_predicate NewRelic::Agent::Instrumentation::Rake, :should_install?
@@ -78,7 +78,7 @@ class RakeInstrumentationTest < Minitest::Test
   end
 
   def test_we_should_not_install_if_newrelic_rake_is_present
-    skip 'Requires MiniTest v5+' unless MiniTest::Unit::VERSION > '5.0'
+    skip 'Requires MiniTest v5+' unless NewRelic::Helper.version_satisfied?(MiniTest::Unit::VERSION, '>', '5.0')
 
     NewRelic::LanguageSupport.stub :bundled_gem?, true, 'newrelic-rake' do
       refute_predicate NewRelic::Agent::Instrumentation::Rake, :should_install?
@@ -98,7 +98,7 @@ class RakeInstrumentationTest < Minitest::Test
   end
 
   def test_a_task_is_monkeypatched_for_execution_instrumentation
-    skip 'Requires MiniTest v5+' unless MiniTest::Unit::VERSION > '5.0'
+    skip 'Requires MiniTest v5+' unless NewRelic::Helper.version_satisfied?(MiniTest::Unit::VERSION, '>', '5.0')
 
     name = 'Call the Ships to Port'
     task = OpenStruct.new
@@ -192,7 +192,7 @@ class RakeInstrumentationTest < Minitest::Test
   end
 
   def test_record_attributes_without_named_args
-    skip 'Requires MiniTest v5+' unless MiniTest::Unit::VERSION > '5.0'
+    skip 'Requires MiniTest v5+' unless NewRelic::Helper.version_satisfied?(MiniTest::Unit::VERSION, '>', '5.0')
 
     top_level_tasks = %w[James Meowth]
     named_args = []

--- a/test/multiverse/suites/ruby_openai/openai_helpers.rb
+++ b/test/multiverse/suites/ruby_openai/openai_helpers.rb
@@ -5,7 +5,7 @@
 module OpenAIHelpers
   class ChatResponse
     def body(return_value: false)
-      if Gem::Version.new(::OpenAI::VERSION) >= Gem::Version.new('6.0.0') || return_value
+      if NewRelic::Helper.version_satisfied?(::OpenAI::VERSION, '>=', '6.0.0') || return_value
         {'id' => 'chatcmpl-8nEZg6Gb5WFOwAz34Hivh4IXH0GHq',
          'object' => 'chat.completion',
          'created' => 1706744788,
@@ -23,7 +23,7 @@ module OpenAIHelpers
     end
 
     def error_response(return_value: false)
-      if Gem::Version.new(::OpenAI::VERSION) >= Gem::Version.new('4.3.2') || return_value
+      if NewRelic::Helper.version_satisfied?(::OpenAI::VERSION, '>=', '4.3.2') || return_value
         nil
       else
         {'error' => {'message' => 'you must provide a model parameter', 'type' => 'invalid_request_error', 'param' => nil, 'code' => nil}}
@@ -33,7 +33,7 @@ module OpenAIHelpers
 
   class EmbeddingsResponse
     def body(return_value: false)
-      if Gem::Version.new(::OpenAI::VERSION) >= Gem::Version.new('6.0.0') || return_value
+      if NewRelic::Helper.version_satisfied?(::OpenAI::VERSION, '>=', '6.0.0') || return_value
         {'object' => 'list',
          'data' => [{
            'object' => 'embedding',
@@ -54,7 +54,7 @@ module OpenAIHelpers
 
   def connection_client
     client # can cause failure if this has never been created before on older versions for the test that uses connection_client
-    Gem::Version.new(::OpenAI::VERSION) <= Gem::Version.new('4.3.2') ? OpenAI::Client : client
+    NewRelic::Helper.version_satisfied?(::OpenAI::VERSION, '<=', '4.3.2') ? OpenAI::Client : client
   end
 
   def embeddings_params
@@ -148,7 +148,7 @@ module OpenAIHelpers
   end
 
   def simulate_error(&blk)
-    if Gem::Version.new(::OpenAI::VERSION) < Gem::Version.new('4.0.0')
+    if NewRelic::Helper.version_satisfied?(::OpenAI::VERSION, '<', '4.0.0')
       error_httparty_connection
       yield
     else
@@ -184,7 +184,7 @@ module OpenAIHelpers
   end
 
   def stub_post_request(&blk)
-    if Gem::Version.new(::OpenAI::VERSION) <= Gem::Version.new('3.4.0')
+    if NewRelic::Helper.version_satisfied?(::OpenAI::VERSION, '<=', '3.4.0')
       HTTParty.stub(:post, ChatResponse.new.body(return_value: true)) do
         yield
       end
@@ -196,7 +196,7 @@ module OpenAIHelpers
   end
 
   def stub_error_post_request(&blk)
-    if Gem::Version.new(::OpenAI::VERSION) <= Gem::Version.new('3.4.0')
+    if NewRelic::Helper.version_satisfied?(::OpenAI::VERSION, '<=', '3.4.0')
       HTTParty.stub(:post, ChatResponse.new.error_response(return_value: true)) do
         yield
       end
@@ -208,7 +208,7 @@ module OpenAIHelpers
   end
 
   def stub_embeddings_post_request(&blk)
-    if Gem::Version.new(::OpenAI::VERSION) <= Gem::Version.new('3.4.0')
+    if NewRelic::Helper.version_satisfied?(::OpenAI::VERSION, '<=', '3.4.0')
       HTTParty.stub(:post, EmbeddingsResponse.new.body(return_value: true)) do
         yield
       end

--- a/test/multiverse/suites/ruby_openai/ruby_openai_instrumentation_test.rb
+++ b/test/multiverse/suites/ruby_openai/ruby_openai_instrumentation_test.rb
@@ -159,7 +159,7 @@ class RubyOpenAIInstrumentationTest < Minitest::Test
       end
     end
 
-    if Gem::Version.new(::OpenAI::VERSION) >= Gem::Version.new('6.0.0')
+    if NewRelic::Helper.version_satisfied?(::OpenAI::VERSION, '>=', '6.0.0')
       assert_equal ChatResponse.new.body, result
     else
       assert_equal ChatResponse.new.body(return_value: true), result

--- a/test/multiverse/suites/sidekiq/sidekiq_instrumentation_test.rb
+++ b/test/multiverse/suites/sidekiq/sidekiq_instrumentation_test.rb
@@ -61,7 +61,7 @@ class SidekiqInstrumentationTest < Minitest::Test
     # Sidekiq version 6.4.2 ends up invoking String#constantize, which is only
     # delivered by ActiveSupport, which this test suite doesn't currently
     # include.
-    skip 'This test requires Sidekiq v7+' unless Gem::Version.new(Sidekiq::VERSION) >= Gem::Version.new('7.0.0')
+    skip 'This test requires Sidekiq v7+' unless NewRelic::Helper.version_satisfied?(Sidekiq::VERSION, '>=', '7.0.0')
 
     in_transaction do |txn|
       NRDeadEndJob.perform_inline

--- a/test/multiverse/suites/sidekiq/sidekiq_with_redis_test.rb
+++ b/test/multiverse/suites/sidekiq/sidekiq_with_redis_test.rb
@@ -78,7 +78,7 @@ class SidekiqWithRedisTest < MiniTest::Test
   # work as expected.
   def sidekiq_without_redis?
     require 'sidekiq'
-    return false unless Gem::Version.new(Sidekiq::VERSION) >= Gem::Version.new('7.0.0')
+    return false unless NewRelic::Helper.version_satisfied?(Sidekiq::VERSION, '>=', '7.0.0')
     return false if defined?(RedisClient).nil?
 
     # NOTE: introspection through Bundler/RubyGems methods produces warnings,

--- a/test/multiverse/suites/sinatra/sinatra_test_cases.rb
+++ b/test/multiverse/suites/sinatra/sinatra_test_cases.rb
@@ -21,7 +21,7 @@ module SinatraTestCases
       'GET /route/no_match'
     end
 
-    if Gem::Version.new(Sinatra::VERSION).segments[0] < 2
+    if NewRelic::Helper.version_satisfied?(Sinatra::VERSION, '<', '2.0.0')
       # get /\/regex.*/
       def regex_segment
         'GET (?-mix:\/regex.*)'
@@ -163,7 +163,7 @@ module SinatraTestCases
 
     get('/pass')
 
-    expected_status = Gem::Version.new(Sinatra::VERSION).segments[0] < 2 ? 200 : 400
+    expected_status = NewRelic::Helper.version_satisfied?(Sinatra::VERSION, '<', '2.0.0') ? 200 : 400
 
     assert_equal expected_status, last_response.status
   end
@@ -197,7 +197,7 @@ module SinatraTestCases
     app.build(@app)
   end
 
-  if Gem::Version.new(Sinatra::VERSION).segments[0] < 2
+  if NewRelic::Helper.version_satisfied?(Sinatra::VERSION, '<', '2.0.0')
     def trigger_error_on_params
       Sinatra::Request.any_instance
         .stubs(:params).returns({})

--- a/test/multiverse/suites/stripe/stripe_instrumentation_test.rb
+++ b/test/multiverse/suites/stripe/stripe_instrumentation_test.rb
@@ -29,7 +29,7 @@ class StripeInstrumentation < Minitest::Test
   end
 
   def test_version_supported
-    assert(Gem::Version.new(Stripe::VERSION) >= Gem::Version.new('5.38.0'))
+    assert(NewRelic::Helper.version_satisfied?(Stripe::VERSION, '>=', '5.38.0'))
   end
 
   def test_subscribed_request_begin
@@ -201,7 +201,7 @@ class StripeInstrumentation < Minitest::Test
   def with_stubbed_connection_manager(&block)
     # Stripe moved StripeClient and requestor logic to APIRequestor in v13.0.0
     # https://github.com/stripe/stripe-ruby/pull/1458
-    if Gem::Version.new(Stripe::VERSION) >= Gem::Version.new('13.0.0')
+    if NewRelic::Helper.version_satisfied?(Stripe::VERSION, '>=', '13.0.0')
       Stripe::APIRequestor.stub(:default_connection_manager, @connection) do
         @connection.stub(:execute_request, @response) do
           yield

--- a/test/multiverse/suites/tilt/tilt_instrumentation_test.rb
+++ b/test/multiverse/suites/tilt/tilt_instrumentation_test.rb
@@ -16,7 +16,7 @@ class TiltInstrumentationTest < Minitest::Test
   end
 
   def haml_render_metric(filename = 'test.haml')
-    if Gem::Version.new(Haml::VERSION) >= Gem::Version.new('6.0.0')
+    if NewRelic::Helper.version_satisfied?(Haml::VERSION, '>=', '6.0.0')
       "View/Haml::Template/#{filename}/Rendering"
     else
       "View/Tilt::HamlTemplate/#{filename}/Rendering"

--- a/test/new_relic/agent/instrumentation/action_dispatch_subscriber_test.rb
+++ b/test/new_relic/agent/instrumentation/action_dispatch_subscriber_test.rb
@@ -9,7 +9,7 @@ if defined?(ActiveSupport) &&
     defined?(ActionDispatch) &&
     defined?(ActionPack) &&
     ActionPack.respond_to?(:gem_version) &&
-    ActionPack.gem_version >= Gem::Version.new('6.0.0') # notifications for dispatch added in Rails 6
+    NewRelic::Helper.version_satisfied?(ActionPack.gem_version, '>=', '6.0.0') # notifications for dispatch added in Rails 6
   require_relative 'rails/action_dispatch_subscriber'
 else
   puts "Skipping tests in #{File.basename(__FILE__)} because ActionDispatch is unavailable or < 6.0" if ENV['VERBOSE_TEST_OUTPUT']

--- a/test/new_relic/agent/instrumentation/action_mailbox_subscriber_test.rb
+++ b/test/new_relic/agent/instrumentation/action_mailbox_subscriber_test.rb
@@ -7,7 +7,7 @@ require 'new_relic/agent/instrumentation/action_mailbox_subscriber'
 
 if defined?(ActionMailbox) &&
     ActionMailbox.respond_to?(:gem_version) && # 'require "actionmailbox"' doesn't require version...
-    ActionMailbox.gem_version >= Gem::Version.new('7.1.0.alpha') # notifications added in Rails 7.1
+    NewRelic::Helper.version_satisfied?(ActionMailbox.gem_version, '>=', '7.1.0.alpha') # notifications added in Rails 7.1
   require_relative 'rails/action_mailbox_subscriber'
 else
   puts "Skipping tests in #{File.basename(__FILE__)} because ActionMailbox is unavailable or < 7.1" if ENV['VERBOSE_TEST_OUTPUT']

--- a/test/new_relic/agent/instrumentation/action_mailer_subscriber_test.rb
+++ b/test/new_relic/agent/instrumentation/action_mailer_subscriber_test.rb
@@ -8,7 +8,7 @@ require 'new_relic/agent/instrumentation/action_mailer_subscriber'
 if defined?(ActiveSupport) &&
     defined?(ActionMailer) &&
     ActionMailer.respond_to?(:gem_version) &&
-    ActionMailer.gem_version >= Gem::Version.new('5.0') && RUBY_VERSION > '2.4.0'
+    NewRelic::Helper.version_satisfied?(ActionMailer.gem_version, '>=', '5.0') && NewRelic::Helper.version_satisfied?(RUBY_VERSION, '>', '2.4.0')
   require_relative 'rails/action_mailer_subscriber'
 else
   puts "Skipping tests in #{File.basename(__FILE__)} because ActionMailer is unavailable" if ENV['VERBOSE_TEST_OUTPUT']

--- a/test/new_relic/agent/instrumentation/active_job_subscriber_test.rb
+++ b/test/new_relic/agent/instrumentation/active_job_subscriber_test.rb
@@ -7,7 +7,7 @@ require 'new_relic/agent/instrumentation/active_job_subscriber'
 
 if defined?(ActiveJob) &&
     ActiveJob.respond_to?(:gem_version) &&
-    ActiveJob.gem_version >= Gem::Version.new('6.0.0')
+    NewRelic::Helper.version_satisfied?(ActiveJob.gem_version, '>=', '6.0.0')
   require_relative 'rails/active_job_subscriber'
 else
   puts "Skipping tests in #{File.basename(__FILE__)} because ActiveJob is unavailable or < 6.0" if ENV['VERBOSE_TEST_OUPUT']

--- a/test/new_relic/agent/instrumentation/rails/action_mailer_subscriber.rb
+++ b/test/new_relic/agent/instrumentation/rails/action_mailer_subscriber.rb
@@ -167,7 +167,7 @@ module NewRelic::Agent::Instrumentation
         assert_equal "Ruby/ActionMailer/#{TestMailer.name}/deliver", segment.name
         assert_equal TestMailer.name, params[:mailer]
         assert_equal TestMailer::SUBJECT, params[:subject]
-        assert params[:perform_deliveries] if Gem::Version.new(Rails::VERSION::STRING) >= Gem::Version.new('6.0.0') # only exists in rails 6+
+        assert params[:perform_deliveries] if NewRelic::Helper.version_satisfied?(Rails::VERSION::STRING, '>=', '6.0.0') # only exists in rails 6+
       end
     end
   end

--- a/test/new_relic/agent/instrumentation/rails/active_job_subscriber.rb
+++ b/test/new_relic/agent/instrumentation/rails/active_job_subscriber.rb
@@ -113,7 +113,7 @@ module NewRelic::Agent::Instrumentation
 
         assert segment
 
-        if defined?(Rails) && Rails.respond_to?(:version) && Gem::Version.new(Rails.version) >= Gem::Version.new('7.1')
+        if defined?(Rails) && Rails.respond_to?(:version) && NewRelic::Helper.version_satisfied?(Rails.version, '>=', '7.1')
           assert_match(/ActiveJob::QueueAdapters::(?:Test|Async)Adapter/, segment.params[:adapter].class.name)
         else
           assert_equal 'ActiveJob::QueueAdapters::AsyncAdapter', segment.params[:adapter].class.name

--- a/test/new_relic/agent/instrumentation/rails/active_support_subscriber.rb
+++ b/test/new_relic/agent/instrumentation/rails/active_support_subscriber.rb
@@ -173,7 +173,7 @@ module NewRelic
             assert_equal 2, txn.segments.size
 
             # the :store key is only in the payload for Rails 6.1+
-            rails61 = Gem::Version.new(ActiveSupport::VERSION::STRING) >= Gem::Version.new('6.1.0')
+            rails61 = NewRelic::Helper.version_satisfied?(ActiveSupport::VERSION::STRING, '>=', '6.1.0')
             segment_name = if rails61
               "Ruby/ActiveSupport/#{store}/write"
             else

--- a/test/new_relic/agent/method_tracer_params_test.rb
+++ b/test/new_relic/agent/method_tracer_params_test.rb
@@ -29,7 +29,7 @@ class NewRelic::Agent::MethodTracerParamsTest < Minitest::Test
 
   class UntracedMethods
     def expect_deprecation_warnings?
-      RUBY_VERSION >= '2.7.0' && RUBY_VERSION < '3.0.0'
+      NewRelic::Helper.version_satisfied?(RUBY_VERSION, '>=', '2.7.0') && NewRelic::Helper.version_satisfied?(RUBY_VERSION, '<', '3.0.0')
     end
 
     def no_args
@@ -153,7 +153,7 @@ class NewRelic::Agent::MethodTracerParamsTest < Minitest::Test
       refute_deprecation_warning { instance.last_arg_is_a_keyword(:foo, bar: 'foobar') }
       refute_deprecation_warning { instance.all_args_are_keywords(foo: :foo, bar: {bar: 'foobar'}) }
       refute_deprecation_warning { instance.args_and_kwargs(:foo, bar: 'foobar') }
-      if RUBY_VERSION < '2.7.0'
+      if NewRelic::Helper.version_satisfied?(RUBY_VERSION, '<', '2.7.0')
         refute_deprecation_warning { instance.last_arg_is_a_keyword(:foo, {bar: 'foobar'}) }
         refute_deprecation_warning { instance.args_and_kwargs(:foo, {bar: 'foobar'}) }
       end
@@ -168,7 +168,7 @@ class NewRelic::Agent::MethodTracerParamsTest < Minitest::Test
       assert_equal expected369, instance.modifies_hash
 
       # This is what changes in 3.0!
-      version_specific_expected = RUBY_VERSION >= '3.0.0' ? {foo: {}} : expected
+      version_specific_expected = NewRelic::Helper.version_satisfied?(RUBY_VERSION, '>=', '3.0.0') ? {foo: {}} : expected
 
       silence_expected_warnings { assert_equal version_specific_expected, instance.args_and_kwargs(:foo, {bar: 'foobar'}) }
     end

--- a/test/new_relic/agent/serverless_handler_test.rb
+++ b/test/new_relic/agent/serverless_handler_test.rb
@@ -77,7 +77,7 @@ module NewRelic::Agent
       }
 
       def setup
-        skip 'Serverless usage is limited to Ruby v3.2+' unless ruby_version_float >= 3.2
+        skip 'Serverless usage is limited to Ruby v3.2+' unless NewRelic::Helper.version_satisfied?(RUBY_VERSION, '>=', '3.2')
 
         config_hash = {:'serverless_mode.enabled' => true}
         @test_config = NewRelic::Agent::Configuration::DottedHash.new(config_hash, true)

--- a/test/new_relic/agent/threading/backtrace_node_test.rb
+++ b/test/new_relic/agent/threading/backtrace_node_test.rb
@@ -243,7 +243,7 @@ module NewRelic::Agent::Threading
     # These tests have examples with the old the and new formats
     # When we drop support for Ruby 3.3, we can remove the condition
     def ruby_3_4_0_or_above?
-      Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.4.0')
+      NewRelic::Helper.version_satisfied?(RUBY_VERSION, '>=', '3.4.0')
     end
   end
 end

--- a/test/new_relic/agent/threading/thread_profile_test.rb
+++ b/test/new_relic/agent/threading/thread_profile_test.rb
@@ -254,7 +254,7 @@ if NewRelic::Agent::Threading::BacktraceService.is_supported?
       # These tests have examples with the old the and new formats
       # When we drop support for Ruby 3.3, we can remove the condition
       def ruby_3_4_0_or_above?
-        Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.4.0')
+        NewRelic::Helper.version_satisfied?(RUBY_VERSION, '>=', '3.4.0')
       end
     end
   end

--- a/test/new_relic/helper_test.rb
+++ b/test/new_relic/helper_test.rb
@@ -82,43 +82,43 @@ end
   # version_satisfied?
   #
   def test_version_satisfied_greater_than
-    assert_equal true, NewRelic::Helper.version_satisfied?('1.2.3', '<', '1.2.4')
-    assert_equal true, NewRelic::Helper.version_satisfied?(1, '<', 2)
-    assert_equal true, NewRelic::Helper.version_satisfied?(1.2, '<', 1.3)
-    assert_equal true, NewRelic::Helper.version_satisfied?(Gem::Version.new('1.2'), '<', Gem::Version.new('1.3'))
-    assert_equal true, NewRelic::Helper.version_satisfied?(nil, '<', 1)
-    assert_equal true, NewRelic::Helper.version_satisfied?('', '<', 1)
-    assert_equal true, NewRelic::Helper.version_satisfied?('1.2', '<', 1.3)
+    assert(true, NewRelic::Helper.version_satisfied?('1.2.3', '<', '1.2.4'))
+    assert(true, NewRelic::Helper.version_satisfied?(1, '<', 2))
+    assert(true, NewRelic::Helper.version_satisfied?(1.2, '<', 1.3))
+    assert(true, NewRelic::Helper.version_satisfied?(Gem::Version.new('1.2'), '<', Gem::Version.new('1.3')))
+    assert(true, NewRelic::Helper.version_satisfied?(nil, '<', 1))
+    assert(true, NewRelic::Helper.version_satisfied?('', '<', 1))
+    assert(true, NewRelic::Helper.version_satisfied?('1.2', '<', 1.3))
   end
 
   def test_version_satisfied_greater_than_or_equal_to
-    assert_equal true, NewRelic::Helper.version_satisfied?('1.2.3', '<=', '1.2.4')
-    assert_equal true, NewRelic::Helper.version_satisfied?(1, '<=', 2)
-    assert_equal true, NewRelic::Helper.version_satisfied?(1.2, '<=', 1.3)
-    assert_equal true, NewRelic::Helper.version_satisfied?(Gem::Version.new('1.2'), '<=', Gem::Version.new('1.3'))
-    assert_equal true, NewRelic::Helper.version_satisfied?(nil, '<=', 1)
-    assert_equal true, NewRelic::Helper.version_satisfied?('', '<=', 1)
-    assert_equal true, NewRelic::Helper.version_satisfied?('1.2', '<=', 1.3)
+    assert(true, NewRelic::Helper.version_satisfied?('1.2.3', '<=', '1.2.4'))
+    assert(true, NewRelic::Helper.version_satisfied?(1, '<=', 2))
+    assert(true, NewRelic::Helper.version_satisfied?(1.2, '<=', 1.3))
+    assert(true, NewRelic::Helper.version_satisfied?(Gem::Version.new('1.2'), '<=', Gem::Version.new('1.3')))
+    assert(true, NewRelic::Helper.version_satisfied?(nil, '<=', 1))
+    assert(true, NewRelic::Helper.version_satisfied?('', '<=', 1))
+    assert(true, NewRelic::Helper.version_satisfied?('1.2', '<=', 1.3))
   end
 
   def test_version_satisfied_less_than
-    assert_equal true, NewRelic::Helper.version_satisfied?('1.2.4', '>', '1.2.3')
-    assert_equal true, NewRelic::Helper.version_satisfied?(2, '>', 1)
-    assert_equal true, NewRelic::Helper.version_satisfied?(1.3, '>', 1.2)
-    assert_equal true, NewRelic::Helper.version_satisfied?(Gem::Version.new('1.3'), '>', Gem::Version.new('1.2'))
-    assert_equal true, NewRelic::Helper.version_satisfied?(1, '>', nil)
-    assert_equal true, NewRelic::Helper.version_satisfied?(1, '>', '')
-    assert_equal true, NewRelic::Helper.version_satisfied?(1.3, '>', '1.2')
+    assert(true, NewRelic::Helper.version_satisfied?('1.2.4', '>', '1.2.3'))
+    assert(true, NewRelic::Helper.version_satisfied?(2, '>', 1))
+    assert(true, NewRelic::Helper.version_satisfied?(1.3, '>', 1.2))
+    assert(true, NewRelic::Helper.version_satisfied?(Gem::Version.new('1.3'), '>', Gem::Version.new('1.2')))
+    assert(true, NewRelic::Helper.version_satisfied?(1, '>', nil))
+    assert(true, NewRelic::Helper.version_satisfied?(1, '>', ''))
+    assert(true, NewRelic::Helper.version_satisfied?(1.3, '>', '1.2'))
   end
 
   def test_version_satisfied_less_than_or_equal_to
-    assert_equal true, NewRelic::Helper.version_satisfied?('1.2.4', '>=', '1.2.3')
-    assert_equal true, NewRelic::Helper.version_satisfied?(2, '>=', 1)
-    assert_equal true, NewRelic::Helper.version_satisfied?(1.3, '>=', 1.2)
-    assert_equal true, NewRelic::Helper.version_satisfied?(Gem::Version.new('1.3'), '>=', Gem::Version.new('1.2'))
-    assert_equal true, NewRelic::Helper.version_satisfied?(1, '>=', nil)
-    assert_equal true, NewRelic::Helper.version_satisfied?(1, '>=', '')
-    assert_equal true, NewRelic::Helper.version_satisfied?(1.3, '>=', '1.2')
+    assert(true, NewRelic::Helper.version_satisfied?('1.2.4', '>=', '1.2.3'))
+    assert(true, NewRelic::Helper.version_satisfied?(2, '>=', 1))
+    assert(true, NewRelic::Helper.version_satisfied?(1.3, '>=', 1.2))
+    assert(true, NewRelic::Helper.version_satisfied?(Gem::Version.new('1.3'), '>=', Gem::Version.new('1.2')))
+    assert(true, NewRelic::Helper.version_satisfied?(1, '>=', nil))
+    assert(true, NewRelic::Helper.version_satisfied?(1, '>=', ''))
+    assert(true, NewRelic::Helper.version_satisfied?(1.3, '>=', '1.2'))
   end
 
   #

--- a/test/new_relic/helper_test.rb
+++ b/test/new_relic/helper_test.rb
@@ -75,7 +75,50 @@ class HelperTest < Minitest::Test
     Open3.stubs('capture2e').raises(exception)
     assert_raises(NewRelic::CommandRunFailedError, "#{exception.class} - #{exception.message}") do
       NewRelic::Helper.run_command('executable that existed at detection time but is not there now')
-    end
+end   
+  end
+
+  #
+  # version_satisfied?
+  #
+  def test_version_satisfied_greater_than
+    assert_equal true, NewRelic::Helper.version_satisfied?('1.2.3', '<', '1.2.4')
+    assert_equal true, NewRelic::Helper.version_satisfied?(1, '<', 2)
+    assert_equal true, NewRelic::Helper.version_satisfied?(1.2, '<', 1.3)
+    assert_equal true, NewRelic::Helper.version_satisfied?(Gem::Version.new('1.2'), '<', Gem::Version.new('1.3'))
+    assert_equal true, NewRelic::Helper.version_satisfied?(nil, '<', 1)
+    assert_equal true, NewRelic::Helper.version_satisfied?('', '<', 1)
+    assert_equal true, NewRelic::Helper.version_satisfied?('1.2', '<', 1.3)
+  end
+
+  def test_version_satisfied_greater_than_or_equal_to
+    assert_equal true, NewRelic::Helper.version_satisfied?('1.2.3', '<=', '1.2.4')
+    assert_equal true, NewRelic::Helper.version_satisfied?(1, '<=', 2)
+    assert_equal true, NewRelic::Helper.version_satisfied?(1.2, '<=', 1.3)
+    assert_equal true, NewRelic::Helper.version_satisfied?(Gem::Version.new('1.2'), '<=', Gem::Version.new('1.3'))
+    assert_equal true, NewRelic::Helper.version_satisfied?(nil, '<=', 1)
+    assert_equal true, NewRelic::Helper.version_satisfied?('', '<=', 1)
+    assert_equal true, NewRelic::Helper.version_satisfied?('1.2', '<=', 1.3)
+  end
+
+  def test_version_satisfied_less_than
+    assert_equal true, NewRelic::Helper.version_satisfied?('1.2.4', '>', '1.2.3')
+    assert_equal true, NewRelic::Helper.version_satisfied?(2, '>', 1)
+    assert_equal true, NewRelic::Helper.version_satisfied?(1.3, '>', 1.2)
+    assert_equal true, NewRelic::Helper.version_satisfied?(Gem::Version.new('1.3'), '>', Gem::Version.new('1.2'))
+    assert_equal true, NewRelic::Helper.version_satisfied?(1, '>', nil)
+    assert_equal true, NewRelic::Helper.version_satisfied?(1, '>', '')
+    assert_equal true, NewRelic::Helper.version_satisfied?(1.3, '>', '1.2')
+  end
+
+  def test_version_satisfied_less_than_or_equal_to
+    assert_equal true, NewRelic::Helper.version_satisfied?('1.2.4', '>=', '1.2.3')
+    assert_equal true, NewRelic::Helper.version_satisfied?(2, '>=', 1)
+    assert_equal true, NewRelic::Helper.version_satisfied?(1.3, '>=', 1.2)
+    assert_equal true, NewRelic::Helper.version_satisfied?(Gem::Version.new('1.3'), '>=', Gem::Version.new('1.2'))
+    assert_equal true, NewRelic::Helper.version_satisfied?(1, '>=', nil)
+    assert_equal true, NewRelic::Helper.version_satisfied?(1, '>=', '')
+    assert_equal true, NewRelic::Helper.version_satisfied?(1.3, '>=', '1.2')
   end
 
   #

--- a/test/new_relic/helper_test.rb
+++ b/test/new_relic/helper_test.rb
@@ -75,54 +75,54 @@ class HelperTest < Minitest::Test
     Open3.stubs('capture2e').raises(exception)
     assert_raises(NewRelic::CommandRunFailedError, "#{exception.class} - #{exception.message}") do
       NewRelic::Helper.run_command('executable that existed at detection time but is not there now')
-end   
+    end
   end
 
   #
   # version_satisfied?
   #
   def test_version_satisfied_greater_than
-    assert(true, NewRelic::Helper.version_satisfied?('1.2.3', '<', '1.2.4'))
+    assert(NewRelic::Helper.version_satisfied?('1.2.3', '<', '1.2.4'))
     assert_false(NewRelic::Helper.version_satisfied?('1.2.3', '<', '1.2.3'))
-    assert(true, NewRelic::Helper.version_satisfied?(1, '<', 2))
-    assert(true, NewRelic::Helper.version_satisfied?(1.2, '<', 1.3))
-    assert(true, NewRelic::Helper.version_satisfied?(Gem::Version.new('1.2'), '<', Gem::Version.new('1.3')))
-    assert(true, NewRelic::Helper.version_satisfied?(nil, '<', 1))
-    assert(true, NewRelic::Helper.version_satisfied?('', '<', 1))
-    assert(true, NewRelic::Helper.version_satisfied?('1.2', '<', 1.3))
+    assert(NewRelic::Helper.version_satisfied?(1, '<', 2))
+    assert(NewRelic::Helper.version_satisfied?(1.2, '<', 1.3))
+    assert(NewRelic::Helper.version_satisfied?(Gem::Version.new('1.2'), '<', Gem::Version.new('1.3')))
+    assert(NewRelic::Helper.version_satisfied?(nil, '<', 1))
+    assert(NewRelic::Helper.version_satisfied?('', '<', 1))
+    assert(NewRelic::Helper.version_satisfied?('1.2', '<', 1.3))
   end
 
   def test_version_satisfied_greater_than_or_equal_to
-    assert(true, NewRelic::Helper.version_satisfied?('1.2.3', '<=', '1.2.4'))
+    assert(NewRelic::Helper.version_satisfied?('1.2.3', '<=', '1.2.4'))
     assert_false(NewRelic::Helper.version_satisfied?('1.2.3', '<=', '1.2.2'))
-    assert(true, NewRelic::Helper.version_satisfied?(1, '<=', 2))
-    assert(true, NewRelic::Helper.version_satisfied?(1.2, '<=', 1.3))
-    assert(true, NewRelic::Helper.version_satisfied?(Gem::Version.new('1.2'), '<=', Gem::Version.new('1.3')))
-    assert(true, NewRelic::Helper.version_satisfied?(nil, '<=', 1))
-    assert(true, NewRelic::Helper.version_satisfied?('', '<=', 1))
-    assert(true, NewRelic::Helper.version_satisfied?('1.2', '<=', 1.3))
+    assert(NewRelic::Helper.version_satisfied?(1, '<=', 2))
+    assert(NewRelic::Helper.version_satisfied?(1.2, '<=', 1.3))
+    assert(NewRelic::Helper.version_satisfied?(Gem::Version.new('1.2'), '<=', Gem::Version.new('1.3')))
+    assert(NewRelic::Helper.version_satisfied?(nil, '<=', 1))
+    assert(NewRelic::Helper.version_satisfied?('', '<=', 1))
+    assert(NewRelic::Helper.version_satisfied?('1.2', '<=', 1.3))
   end
 
   def test_version_satisfied_less_than
-    assert(true, NewRelic::Helper.version_satisfied?('1.2.3', '>', '1.2.2'))
+    assert(NewRelic::Helper.version_satisfied?('1.2.3', '>', '1.2.2'))
     assert_false(NewRelic::Helper.version_satisfied?('1.2.3', '>', '1.2.3'))
-    assert(true, NewRelic::Helper.version_satisfied?(2, '>', 1))
-    assert(true, NewRelic::Helper.version_satisfied?(1.3, '>', 1.2))
-    assert(true, NewRelic::Helper.version_satisfied?(Gem::Version.new('1.3'), '>', Gem::Version.new('1.2')))
-    assert(true, NewRelic::Helper.version_satisfied?(1, '>', nil))
-    assert(true, NewRelic::Helper.version_satisfied?(1, '>', ''))
-    assert(true, NewRelic::Helper.version_satisfied?(1.3, '>', '1.2'))
+    assert(NewRelic::Helper.version_satisfied?(2, '>', 1))
+    assert(NewRelic::Helper.version_satisfied?(1.3, '>', 1.2))
+    assert(NewRelic::Helper.version_satisfied?(Gem::Version.new('1.3'), '>', Gem::Version.new('1.2')))
+    assert(NewRelic::Helper.version_satisfied?(1, '>', nil))
+    assert(NewRelic::Helper.version_satisfied?(1, '>', ''))
+    assert(NewRelic::Helper.version_satisfied?(1.3, '>', '1.2'))
   end
 
   def test_version_satisfied_less_than_or_equal_to
-    assert(true, NewRelic::Helper.version_satisfied?('1.2.3', '>=', '1.2.2'))
+    assert(NewRelic::Helper.version_satisfied?('1.2.3', '>=', '1.2.2'))
     assert_false(NewRelic::Helper.version_satisfied?('1.2.3', '>=', '1.2.4'))
-    assert(true, NewRelic::Helper.version_satisfied?(2, '>=', 1))
-    assert(true, NewRelic::Helper.version_satisfied?(1.3, '>=', 1.2))
-    assert(true, NewRelic::Helper.version_satisfied?(Gem::Version.new('1.3'), '>=', Gem::Version.new('1.2')))
-    assert(true, NewRelic::Helper.version_satisfied?(1, '>=', nil))
-    assert(true, NewRelic::Helper.version_satisfied?(1, '>=', ''))
-    assert(true, NewRelic::Helper.version_satisfied?(1.3, '>=', '1.2'))
+    assert(NewRelic::Helper.version_satisfied?(2, '>=', 1))
+    assert(NewRelic::Helper.version_satisfied?(1.3, '>=', 1.2))
+    assert(NewRelic::Helper.version_satisfied?(Gem::Version.new('1.3'), '>=', Gem::Version.new('1.2')))
+    assert(NewRelic::Helper.version_satisfied?(1, '>=', nil))
+    assert(NewRelic::Helper.version_satisfied?(1, '>=', ''))
+    assert(NewRelic::Helper.version_satisfied?(1.3, '>=', '1.2'))
   end
 
   #

--- a/test/new_relic/helper_test.rb
+++ b/test/new_relic/helper_test.rb
@@ -83,6 +83,7 @@ end
   #
   def test_version_satisfied_greater_than
     assert(true, NewRelic::Helper.version_satisfied?('1.2.3', '<', '1.2.4'))
+    assert_false(NewRelic::Helper.version_satisfied?('1.2.3', '<', '1.2.3'))
     assert(true, NewRelic::Helper.version_satisfied?(1, '<', 2))
     assert(true, NewRelic::Helper.version_satisfied?(1.2, '<', 1.3))
     assert(true, NewRelic::Helper.version_satisfied?(Gem::Version.new('1.2'), '<', Gem::Version.new('1.3')))
@@ -93,6 +94,7 @@ end
 
   def test_version_satisfied_greater_than_or_equal_to
     assert(true, NewRelic::Helper.version_satisfied?('1.2.3', '<=', '1.2.4'))
+    assert_false(NewRelic::Helper.version_satisfied?('1.2.3', '<=', '1.2.2'))
     assert(true, NewRelic::Helper.version_satisfied?(1, '<=', 2))
     assert(true, NewRelic::Helper.version_satisfied?(1.2, '<=', 1.3))
     assert(true, NewRelic::Helper.version_satisfied?(Gem::Version.new('1.2'), '<=', Gem::Version.new('1.3')))
@@ -102,7 +104,8 @@ end
   end
 
   def test_version_satisfied_less_than
-    assert(true, NewRelic::Helper.version_satisfied?('1.2.4', '>', '1.2.3'))
+    assert(true, NewRelic::Helper.version_satisfied?('1.2.3', '>', '1.2.2'))
+    assert_false(NewRelic::Helper.version_satisfied?('1.2.3', '>', '1.2.3'))
     assert(true, NewRelic::Helper.version_satisfied?(2, '>', 1))
     assert(true, NewRelic::Helper.version_satisfied?(1.3, '>', 1.2))
     assert(true, NewRelic::Helper.version_satisfied?(Gem::Version.new('1.3'), '>', Gem::Version.new('1.2')))
@@ -112,7 +115,8 @@ end
   end
 
   def test_version_satisfied_less_than_or_equal_to
-    assert(true, NewRelic::Helper.version_satisfied?('1.2.4', '>=', '1.2.3'))
+    assert(true, NewRelic::Helper.version_satisfied?('1.2.3', '>=', '1.2.2'))
+    assert_false(NewRelic::Helper.version_satisfied?('1.2.3', '>=', '1.2.4'))
     assert(true, NewRelic::Helper.version_satisfied?(2, '>=', 1))
     assert(true, NewRelic::Helper.version_satisfied?(1.3, '>=', 1.2))
     assert(true, NewRelic::Helper.version_satisfied?(Gem::Version.new('1.3'), '>=', Gem::Version.new('1.2')))

--- a/test/new_relic/http_client_test_cases.rb
+++ b/test/new_relic/http_client_test_cases.rb
@@ -506,7 +506,7 @@ module HttpClientTestCases
     # transaction in which the error occurs. That, coupled with the fact that
     # fixing it for old versions of Typhoeus would require large changes to
     # the instrumentation, makes us say 'meh'.
-    skip 'Not tested with Typhoeus < 0.5.4' if client_name == 'Typhoeus' && Typhoeus::VERSION < '0.5.4'
+    skip 'Not tested with Typhoeus < 0.5.4' if client_name == 'Typhoeus' && NewRelic::Helper.version_satisfied?(Typhoeus::VERSION, '<', '0.5.4')
 
     evil_server = NewRelic::EvilServer.new
     evil_server.start

--- a/test/new_relic/test_time_reporter_test.rb
+++ b/test/new_relic/test_time_reporter_test.rb
@@ -3,7 +3,7 @@
 # frozen_string_literal: true
 
 # disabling for anything that might run Minitest 4.x
-if RUBY_VERSION >= '2.7.0'
+if NewRelic::Helper.version_satisfied?(RUBY_VERSION, '>=', '2.7.0')
   require 'fileutils'
   require 'minitest/autorun'
   require 'minitest/stub_const'


### PR DESCRIPTION
## Summary

I've added a helper method to compare RubyGem versions, addressing issue #1124.


## Changes

- Added `NewRelic::Helper.version_satisfied?` method to compare RubyGem versions
- Added tests for `NewRelic::Helper.version_satisfied?`
- Replaced version comparison code with `NewRelic::Helper.version_satisfied?`


## Notes

<!-- Additional information (design intent, limitations, unimplemented parts, etc.) -->
- Based on the sample in the issue, I consolidated the functionality into a single method that can handle various comparison scenarios
- The version comparison in Envfile was excluded from the replacement as it would cause multiverse tests to fail


## Checklist

<!-- Add as needed. Below is an example -->
- [x] Tests added
- [x] rubocop passed(locally)
- [x] `bundle exec rake` passed (locally)
- [x] `bundle exec rake test:multiverse:gem_manifest` passed (locally)
