### PR TITLE
Remove httpx 1.5.0

### DIFF
--- a/test/multiverse/suites/httpx/Envfile
+++ b/test/multiverse/suites/httpx/Envfile
@@ -5,7 +5,8 @@
 instrumentation_methods :chain, :prepend
 
 HTTPX_VERSIONS = [
-  [nil, 2.7],
+  # [nil, 2.7],
+  ['1.4.4', 2.7],
   ['1.0.0', 2.7]
 ]
 


### PR DESCRIPTION
We need to remove the failing new httpx version, 1.5.0, from testing until we've investigated the issue and added support for this new version.

related to https://github.com/newrelic/newrelic-ruby-agent/issues/3187