### PR TITLE
Hybrid Agent Cross-Agent Tests: Inbound distributed tracing tests

### DIFF
--- a/lib/new_relic/agent/opentelemetry/trace/tracer.rb
+++ b/lib/new_relic/agent/opentelemetry/trace/tracer.rb
@@ -19,7 +19,7 @@ module NewRelic
               return if internal_span_kind_with_invalid_parent?(kind, parent_otel_context)
 
               nr_item = NewRelic::Agent::Tracer.start_transaction_or_segment(name: name, category: :otel)
-              add_remote_parent_otel_context_to_txn(nr_item, parent_otel_context)
+              add_remote_context_to_txn(nr_item, parent_otel_context)
               nr_item
             else
               NewRelic::Agent::Tracer.start_segment(name: name)
@@ -70,7 +70,7 @@ module NewRelic
             txn.is_a?(NewRelic::Agent::Transaction) && parent_otel_context.remote?
           end
 
-          def add_remote_parent_otel_context_to_txn(txn, parent_otel_context)
+          def add_remote_context_to_txn(txn, parent_otel_context)
             return unless transaction_and_remote_parent?(txn, parent_otel_context)
 
             txn.trace_id = parent_otel_context.trace_id

--- a/lib/new_relic/agent/opentelemetry/trace/tracer.rb
+++ b/lib/new_relic/agent/opentelemetry/trace/tracer.rb
@@ -13,21 +13,22 @@ module NewRelic
           end
 
           def start_span(name, with_parent: nil, attributes: nil, links: nil, start_timestamp: nil, kind: nil)
-            parent_span_context = ::OpenTelemetry::Trace.current_span(with_parent).context
+            parent_otel_context = ::OpenTelemetry::Trace.current_span(with_parent).context
 
-            finishable = if can_start_transaction?(parent_span_context)
-              return if internal_span_kind_with_invalid_parent?(kind, parent_span_context)
+            finishable = if can_start_transaction?(parent_otel_context)
+              return if internal_span_kind_with_invalid_parent?(kind, parent_otel_context)
 
-              nr_obj = NewRelic::Agent::Tracer.start_transaction_or_segment(name: name, category: :otel)
-              add_remote_partent_span_context_to_txn(nr_obj, parent_span_context)
-              nr_obj
+              nr_item = NewRelic::Agent::Tracer.start_transaction_or_segment(name: name, category: :otel)
+              add_remote_parent_otel_context_to_txn(nr_item, parent_otel_context)
+              nr_item
             else
               NewRelic::Agent::Tracer.start_segment(name: name)
             end
 
-            span = get_span_from_finishable(finishable)
-            span.finishable = finishable
-            span
+            otel_span = get_otel_span_from_finishable(finishable)
+            otel_span.finishable = finishable
+            add_remote_context_to_otel_span(otel_span, parent_otel_context)
+            otel_span
           end
 
           def in_span(name, attributes: nil, links: nil, start_timestamp: nil, kind: nil)
@@ -45,31 +46,41 @@ module NewRelic
 
           private
 
-          def get_span_from_finishable(finishable)
+          def get_otel_span_from_finishable(finishable)
             case finishable
             when NewRelic::Agent::Transaction
               finishable.segments.first.instance_variable_get(:@otel_span)
             when NewRelic::Agent::Transaction::Segment
               finishable.instance_variable_get(:@otel_span)
             else
-              NewRelic::Agent.logger.warn('Tracer#get_span_from_finishable failed to get span from finishable - finishable is not a transaction or segment')
+              NewRelic::Agent.logger.warn('Tracer#get_otel_span_from_finishable failed to get span from finishable - finishable is not a transaction or segment')
               nil
             end
           end
 
-          def can_start_transaction?(parent_span_context)
-            parent_span_context.remote? || !parent_span_context.valid?
+          def can_start_transaction?(parent_otel_context)
+            parent_otel_context.remote? || !parent_otel_context.valid?
           end
 
-          def internal_span_kind_with_invalid_parent?(kind, parent_span_context)
-            !parent_span_context.valid? && kind == :internal
+          def internal_span_kind_with_invalid_parent?(kind, parent_otel_context)
+            !parent_otel_context.valid? && kind == :internal
           end
 
-          def add_remote_partent_span_context_to_txn(txn, parent_span_context)
-            return unless txn.is_a?(NewRelic::Agent::Transaction) && parent_span_context.remote?
+          def transaction_and_remote_parent?(txn, parent_otel_context)
+            txn.is_a?(NewRelic::Agent::Transaction) && parent_otel_context.remote?
+          end
 
-            txn.trace_id = parent_span_context.trace_id
-            txn.parent_span_id = parent_span_context.span_id
+          def add_remote_parent_otel_context_to_txn(txn, parent_otel_context)
+            return unless transaction_and_remote_parent?(txn, parent_otel_context)
+
+            txn.trace_id = parent_otel_context.trace_id
+            txn.parent_span_id = parent_otel_context.span_id
+          end
+
+          def add_remote_context_to_otel_span(otel_span, parent_otel_context)
+            return unless transaction_and_remote_parent?(otel_span.finishable, parent_otel_context)
+
+            otel_span.context.instance_variable_set(:@trace_id, otel_span.finishable.trace_id)
           end
         end
       end

--- a/lib/new_relic/agent/opentelemetry/trace/tracer.rb
+++ b/lib/new_relic/agent/opentelemetry/trace/tracer.rb
@@ -28,7 +28,7 @@ module NewRelic
             otel_span = get_otel_span_from_finishable(finishable)
             otel_span.finishable = finishable
             add_remote_context_to_otel_span(otel_span, parent_otel_context)
-            otel_span.add_attributes(attributes) if attributes          
+            otel_span.add_attributes(attributes) if attributes
             otel_span
           end
 

--- a/lib/new_relic/agent/opentelemetry/trace/tracer.rb
+++ b/lib/new_relic/agent/opentelemetry/trace/tracer.rb
@@ -75,6 +75,10 @@ module NewRelic
 
             txn.trace_id = parent_otel_context.trace_id
             txn.parent_span_id = parent_otel_context.span_id
+
+            txn.distributed_tracer.instance_variable_set(:@trace_state_payload, parent_otel_context.tracestate)
+            txn.distributed_tracer.parent_transaction_id = txn.distributed_tracer.trace_state_payload.transaction_id
+            txn.distributed_tracer.determine_sampling_decision(parent_otel_context.tracestate, parent_otel_context.trace_flags)
           end
 
           def add_remote_context_to_otel_span(otel_span, parent_otel_context)

--- a/lib/new_relic/agent/opentelemetry/transaction_patch.rb
+++ b/lib/new_relic/agent/opentelemetry/transaction_patch.rb
@@ -55,7 +55,6 @@ module NewRelic
           ::OpenTelemetry::Trace::SpanContext.new(
             trace_id: segment.transaction.trace_id,
             span_id: segment.guid,
-            trace_flags: ::OpenTelemetry::Trace::TraceFlags::SAMPLED,
             remote: false
           )
         end

--- a/lib/new_relic/agent/transaction/trace_context.rb
+++ b/lib/new_relic/agent/transaction/trace_context.rb
@@ -136,7 +136,7 @@ module NewRelic
 
           transaction.distributed_tracer.parent_transaction_id = payload.transaction_id
 
-          determine_sampling_decision(payload, header_data)
+          determine_sampling_decision(payload, header_data.trace_parent['trace_flags'])
 
           NewRelic::Agent.increment_metric(ACCEPT_SUCCESS_METRIC)
           true
@@ -146,10 +146,10 @@ module NewRelic
           false
         end
 
-        def determine_sampling_decision(payload, header_data)
-          if header_data.trace_parent['trace_flags'] == '01'
+        def determine_sampling_decision(payload, trace_flags)
+          if trace_flags == '01'
             set_priority_and_sampled(NewRelic::Agent.config[:'distributed_tracing.sampler.remote_parent_sampled'], payload)
-          elsif header_data.trace_parent['trace_flags'] == '00'
+          elsif trace_flags == '00'
             set_priority_and_sampled(NewRelic::Agent.config[:'distributed_tracing.sampler.remote_parent_not_sampled'], payload)
           else
             use_nr_tracestate_sampled(payload)

--- a/test/multiverse/suites/hybrid_agent/commands.rb
+++ b/test/multiverse/suites/hybrid_agent/commands.rb
@@ -28,8 +28,15 @@ module Commands
 
   def do_work_in_span_with_inbound_context(span_name:, span_kind:, trace_id_in_header:,
     span_id_in_header:, sampled_flag_in_header:, &block)
+    sampled = sampled_flag_in_header == '0' ? '00' : '01'
 
-    carrier = {'traceparent' => "00-#{trace_id_in_header}-#{span_id_in_header}-0#{sampled_flag_in_header}"}
+    carrier = {
+      'traceparent' => "00-#{trace_id_in_header}-#{span_id_in_header}-#{sampled}",
+      # 190 is the account ID stubbed in the config during setup
+      # 46954 is the parent app ID stubbed in the config during setup
+      'tracestate' => "190@nr=0-0-1-46954-#{span_id_in_header}-e8b91a159289ff74-#{sampled}-#{sampled}.23456-1518469636035"
+    }
+
     parent_context = OpenTelemetry.propagation.extract(carrier)
     span = @tracer.start_span(span_name, with_parent: parent_context, kind: span_kind)
 

--- a/test/multiverse/suites/hybrid_agent/hybrid_agent_test.rb
+++ b/test/multiverse/suites/hybrid_agent/hybrid_agent_test.rb
@@ -45,6 +45,7 @@ class HybridAgentTest < Minitest::Test
       does_not_create_segment_without_a_transaction
       starting_transaction_tests
       opentelemetry_api_and_new_relic_api_can_inject_outbound_trace_context
+      inbound_distributed_tracing_tests
     ]
   end
 

--- a/test/multiverse/suites/hybrid_agent/hybrid_agent_test.rb
+++ b/test/multiverse/suites/hybrid_agent/hybrid_agent_test.rb
@@ -36,8 +36,7 @@ class HybridAgentTest < Minitest::Test
   # Ex: %w[does_not_create_segment_without_a_transaction] would only run
   # `"testDescription": "Does not create segment without a transaction"`
   def focus_tests
-    %w[
-    ]
+    %w[]
   end
 
   test_cases = load_cross_agent_test('hybrid_agent')

--- a/test/multiverse/suites/hybrid_agent/span_test.rb
+++ b/test/multiverse/suites/hybrid_agent/span_test.rb
@@ -10,6 +10,11 @@ module NewRelic
           Segment = Struct.new(:guid, :transaction)
           Transaction = Struct.new(:trace_id)
 
+          def teardown
+            NewRelic::Agent.instance.transaction_event_aggregator.reset!
+            NewRelic::Agent.instance.span_event_aggregator.reset!
+          end
+
           def test_finish_does_not_fail_if_no_finishable_present
             span = NewRelic::Agent::OpenTelemetry::Trace::Span.new
 

--- a/test/multiverse/suites/hybrid_agent/trace_propagator_test.rb
+++ b/test/multiverse/suites/hybrid_agent/trace_propagator_test.rb
@@ -10,13 +10,53 @@ module NewRelic
           class TracePropagatorTest < Minitest::Test
             class FakePropError < StandardError; end
 
+            def setup
+              @propagator = OpenTelemetry::Context::Propagation::TracePropagator.new
+            end
+
             def test_inject_calls_distributed_tracing_api
-              @propagator = NewRelic::Agent::OpenTelemetry::Context::Propagation::TracePropagator.new
               fake_carrier = {}
 
-              NewRelic::Agent::DistributedTracing.stub(:insert_distributed_trace_headers, ->(carrier) { raise FakePropError.new }) do
+              DistributedTracing.stub(:insert_distributed_trace_headers, ->(carrier) { raise FakePropError.new }) do
                 assert_raises(FakePropError) { @propagator.inject(fake_carrier) }
               end
+            end
+
+            def test_extract_returns_context_with_standard_headers
+
+            end
+
+            def test_extract_rescues_errors_and_returns_empty_context
+              carrier = {}
+              result = @propagator.extract(carrier)
+              assert_raises
+              assert_instance_of(::OpenTelemetry::Context, result)
+            end
+
+            def test_extract_handles_rack_getter
+              # This getter class is deprecated and may go away someday
+              # The other getter class in the code is from a different library
+              # If we want to test with it, we need to add opentelemetry-common to
+              # the Envfile
+              with_config(:account_id => '190', primary_application_id: '46954') do
+                rack_carrier = {
+                  'HTTP_TRACEPARENT' => "00-da8bc8cc6d062849b0efcf3c169afb5a-7d3efb1b173fecfa-01",
+                  'HTTP_TRACESTATE' => "190@nr=0-0-1-46954-7d3efb1b173fecfa-e8b91a159289ff74-01-01.23456-1518469636035"
+                }
+                result = @propagator.extract(rack_carrier, getter: ::OpenTelemetry::Context::Propagation.rack_env_getter)
+
+                # it's difficult to access the spancontext information
+                # from a context object. parsing the string will help us
+                # check the values with fewer shenanigans
+                context_string = result.instance_variable_get(:@entries).to_s
+                assert_match(/trace_id=\"da8bc8cc6d062849b0efcf3c169afb5a"/, context_string, 'trace_id does not match')
+                assert_match(/span_id=\"7d3efb1b173fecfa"/, context_string, "span_id doesn't match")
+                assert_match(/trace_flags=\"00\"/, context_string, "trace_flags doesn't match")
+                assert_match(/@transaction_id=\"e8b91a159289ff74\"/, context_string, "transaction_id doesn't match")
+                assert_match(/@sampled=true/, context_string, "sampled doesn't match")
+                assert_match(/@parent_app_id=\"46954/, context_string, "parent_app_id doesn't match")
+              end
+
             end
           end
         end

--- a/test/multiverse/suites/hybrid_agent/trace_propagator_test.rb
+++ b/test/multiverse/suites/hybrid_agent/trace_propagator_test.rb
@@ -23,13 +23,32 @@ module NewRelic
             end
 
             def test_extract_returns_context_with_standard_headers
+              with_config(:account_id => '190', primary_application_id: '46954') do
+                carrier = {
+                  'traceparent' => "00-da8bc8cc6d062849b0efcf3c169afb5a-7d3efb1b173fecfa-00",
+                  'tracestate' => "190@nr=0-0-1-46954-7d3efb1b173fecfa-e8b91a159289ff74-00-00.23456-1518469636035"
+                }
 
+                result = @propagator.extract(carrier)
+
+                # it's difficult to access the spancontext information
+                # from a context object. parsing the string will help us
+                # check the values with fewer shenanigans
+                context_string = result.instance_variable_get(:@entries).to_s
+                assert_match(/trace_id=\"da8bc8cc6d062849b0efcf3c169afb5a"/, context_string, 'trace_id does not match')
+                assert_match(/span_id=\"7d3efb1b173fecfa"/, context_string, "span_id doesn't match")
+                assert_match(/trace_flags=\"00\"/, context_string, "trace_flags doesn't match")
+                assert_match(/@transaction_id=\"e8b91a159289ff74\"/, context_string, "transaction_id doesn't match")
+                assert_match(/@sampled=false/, context_string, "sampled doesn't match")
+                assert_match(/@priority=0.23456/, context_string, "priority doesn't match")
+                assert_match(/@timestamp=1518469636035>/, context_string, "timestamp doesn't match")
+                assert_match(/@parent_app_id=\"46954/, context_string, "parent_app_id doesn't match")
+              end
             end
 
-            def test_extract_rescues_errors_and_returns_empty_context
+            def test_extract_with_empty_carrier_returns_context
               carrier = {}
               result = @propagator.extract(carrier)
-              assert_raises
               assert_instance_of(::OpenTelemetry::Context, result)
             end
 
@@ -51,12 +70,13 @@ module NewRelic
                 context_string = result.instance_variable_get(:@entries).to_s
                 assert_match(/trace_id=\"da8bc8cc6d062849b0efcf3c169afb5a"/, context_string, 'trace_id does not match')
                 assert_match(/span_id=\"7d3efb1b173fecfa"/, context_string, "span_id doesn't match")
-                assert_match(/trace_flags=\"00\"/, context_string, "trace_flags doesn't match")
+                assert_match(/trace_flags=\"01\"/, context_string, "trace_flags doesn't match")
                 assert_match(/@transaction_id=\"e8b91a159289ff74\"/, context_string, "transaction_id doesn't match")
                 assert_match(/@sampled=true/, context_string, "sampled doesn't match")
+                assert_match(/@priority=1.23456/, context_string, "priority doesn't match")
+                assert_match(/@timestamp=1518469636035>/, context_string, "timestamp doesn't match")
                 assert_match(/@parent_app_id=\"46954/, context_string, "parent_app_id doesn't match")
               end
-
             end
           end
         end

--- a/test/multiverse/suites/hybrid_agent/tracer_test.rb
+++ b/test/multiverse/suites/hybrid_agent/tracer_test.rb
@@ -50,6 +50,125 @@ module NewRelic
             assert_predicate otel_finishable, :finished?, 'OTel span should finish NR transaction'
           end
 
+          def test_parse_trace_flags_with_string
+            assert_equal '42', @tracer.send(:parse_trace_flags, '42')
+          end
+
+          def test_parse_trace_flags_with_integer
+            assert_equal '1', @tracer.send(:parse_trace_flags, 1)
+          end
+
+          def test_parse_trace_flags_with_sampled_otel_trace_flags
+            flags = ::OpenTelemetry::Trace::TraceFlags::SAMPLED
+
+            assert_equal '01', @tracer.send(:parse_trace_flags, flags)
+          end
+
+          def test_parse_trace_flags_with_unsampled_otel_trace_flags
+            flags = ::OpenTelemetry::Trace::TraceFlags::DEFAULT
+
+            assert_equal '00', @tracer.send(:parse_trace_flags, flags)
+          end
+
+          def test_set_nr_tracestate
+            with_config(:account_id => '190', primary_application_id: '46954') do
+              carrier = {
+                'traceparent' => '00-da8bc8cc6d062849b0efcf3c169afb5a-7d3efb1b173fecfa-00',
+                'tracestate' => '190@nr=0-0-1-46954-7d3efb1b173fecfa-e8b91a159289ff74-00-00.23456-1518469636035'
+              }
+              propagator = NewRelic::Agent::OpenTelemetry::Context::Propagation::TracePropagator.new
+              parent_context = propagator.extract(carrier)
+              span = @tracer.start_span('test', with_parent: parent_context, kind: :server)
+
+              distributed_tracer = span.finishable.distributed_tracer
+              trace_state_payload = distributed_tracer.trace_state_payload
+
+              assert_instance_of(NewRelic::Agent::TraceContextPayload, trace_state_payload)
+              assert_equal('e8b91a159289ff74', trace_state_payload.transaction_id)
+              refute_predicate span.finishable, :sampled?
+
+              span.finish
+            end
+          end
+
+          def test_set_otel_tracestate_with_newrelic_entry
+            with_config(:account_id => '190', primary_application_id: '46954') do
+              carrier = {
+                'traceparent' => '00-da8bc8cc6d062849b0efcf3c169afb5a-7d3efb1b173fecfa-00',
+                'tracestate' => '190@nr=0-0-1-46954-7d3efb1b173fecfa-e8b91a159289ff74-00-00.23456-1518469636035'
+              }
+
+              prop = ::OpenTelemetry::Trace::Propagation::TraceContext::TextMapPropagator.new
+
+              parent_context = prop.extract(carrier)
+              span = @tracer.start_span('test', with_parent: parent_context, kind: :server)
+
+              distributed_tracer = span.finishable.distributed_tracer
+              trace_state_payload = distributed_tracer.trace_state_payload
+
+              assert_instance_of(NewRelic::Agent::TraceContextPayload, trace_state_payload)
+              assert_equal('e8b91a159289ff74', trace_state_payload.transaction_id)
+              refute_predicate span.finishable, :sampled?
+
+              span.finish
+            end
+          end
+
+          def test_set_otel_tracestate_without_newrelic_entry
+            with_config(:account_id => '190', primary_application_id: '46954') do
+              carrier = {
+                'traceparent' => '00-da8bc8cc6d062849b0efcf3c169afb5a-7d3efb1b173fecfa-01',
+                'tracestate' => ''
+              }
+
+              prop = ::OpenTelemetry::Trace::Propagation::TraceContext::TextMapPropagator.new
+
+              parent_context = prop.extract(carrier)
+              span = @tracer.start_span('test', with_parent: parent_context, kind: :server)
+
+              distributed_tracer = span.finishable.distributed_tracer
+              trace_state_payload = distributed_tracer.trace_state_payload
+
+              assert_nil(trace_state_payload)
+              # true because of the traceparent payload
+              assert_predicate span.finishable, :sampled?
+
+              span.finish
+            end
+          end
+
+          def test_set_tracestate_with_nr_payload
+            mock_distributed_tracer = Minitest::Mock.new
+            mock_otel_context = Minitest::Mock.new
+            nr_payload = NewRelic::Agent::TraceContextPayload.create(transaction_id: 'txn123')
+
+            mock_otel_context.expect :tracestate, nr_payload
+
+            @tracer.stub :set_nr_trace_state, ->(dt, oc) { :set_nr_trace_state_called } do
+              result = @tracer.send(:set_tracestate, mock_distributed_tracer, mock_otel_context)
+
+              assert_equal :set_nr_trace_state_called, result
+            end
+
+            mock_otel_context.verify
+          end
+
+          # def test_set_tracestate_with_otel_tracestate
+          #   mock_distributed_tracer = Minitest::Mock.new
+          #   mock_otel_context = Minitest::Mock.new
+          #   otel_tracestate = ::OpenTelemetry::Trace::Tracestate.create('nr' => 'payload')
+
+          #   mock_otel_context.expect :tracestate, otel_tracestate
+
+          #   @tracer.stub :set_otel_trace_state, ->(dt, oc) { :set_otel_trace_state_called } do
+          #     result = @tracer.send(:set_tracestate, mock_distributed_tracer, mock_otel_context)
+
+          #     assert_equal :set_otel_trace_state_called, result
+          #   end
+
+          #   mock_otel_context.verify
+          # end
+
           private
 
           def assert_logged(expected)

--- a/test/multiverse/suites/hybrid_agent/tracer_test.rb
+++ b/test/multiverse/suites/hybrid_agent/tracer_test.rb
@@ -153,21 +153,21 @@ module NewRelic
             mock_otel_context.verify
           end
 
-          # def test_set_tracestate_with_otel_tracestate
-          #   mock_distributed_tracer = Minitest::Mock.new
-          #   mock_otel_context = Minitest::Mock.new
-          #   otel_tracestate = ::OpenTelemetry::Trace::Tracestate.create('nr' => 'payload')
+          def test_set_tracestate_with_otel_tracestate
+            mock_distributed_tracer = Minitest::Mock.new
+            mock_otel_context = Minitest::Mock.new
+            otel_tracestate = ::OpenTelemetry::Trace::Tracestate.create('nr' => 'payload')
 
-          #   mock_otel_context.expect :tracestate, otel_tracestate
+            mock_otel_context.expect :tracestate, otel_tracestate
 
-          #   @tracer.stub :set_otel_trace_state, ->(dt, oc) { :set_otel_trace_state_called } do
-          #     result = @tracer.send(:set_tracestate, mock_distributed_tracer, mock_otel_context)
+            @tracer.stub :set_otel_trace_state, ->(dt, oc) { :set_otel_trace_state_called } do
+              result = @tracer.send(:set_tracestate, mock_distributed_tracer, mock_otel_context)
 
-          #     assert_equal :set_otel_trace_state_called, result
-          #   end
+              assert_equal :set_otel_trace_state_called, result
+            end
 
-          #   mock_otel_context.verify
-          # end
+            mock_otel_context.verify
+          end
 
           private
 

--- a/test/multiverse/suites/hybrid_agent/transaction_patch_test.rb
+++ b/test/multiverse/suites/hybrid_agent/transaction_patch_test.rb
@@ -11,8 +11,7 @@ module NewRelic
           NewRelic::Agent.instance.span_event_aggregator.reset!
         end
 
-        # We want to verify that the context switching works for both OTel
-        # and NR
+        # We want to verify the context switching works for both OTel and NR
         # Since the context switching methods are somewhat hidden within
         # the starting and finishing operations, we use the NR APIs to
         # start transactions and the OTel APIs to inject spans


### PR DESCRIPTION
This PR adds an `extract` method to the TracePropagator to handle inbound distributed tracing context.

When spans have remote parents, the information is updated after the transaction/segment is started, but before yielding [(example)](https://github.com/newrelic/newrelic-ruby-agent/blob/5ca88b7a2f46d1b94e9540543c7b72e8aaa2ccf0/lib/new_relic/agent/instrumentation/rdkafka/instrumentation.rb#L28). The OpenTelemetry bridge follows this approach. 

There's also some renaming of variables to make things more clear.

These changes allow the ["Inbound distributed tracing tests"](https://github.com/newrelic/newrelic-ruby-agent/blob/f7a989066d88818fce0a0b599ad036bb918d67ae/test/fixtures/cross_agent_tests/hybrid_agent.json#L524-L629) described in the hybrid_agent.json file to pass.