### PR TITLE
Fix for HTTPX 1.5.0

### DIFF
--- a/lib/new_relic/agent/instrumentation/httpx/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/httpx/instrumentation.rb
@@ -30,7 +30,7 @@ module NewRelic::Agent::Instrumentation::HTTPX
 
   def nr_finish_segment
     proc do |request, segment|
-      response = @responses[request]
+      response = request.response if request
 
       unless response
         NewRelic::Agent.logger.debug('Processed an on-response callback for HTTPX but could not find the response!')

--- a/test/multiverse/suites/httpx/Envfile
+++ b/test/multiverse/suites/httpx/Envfile
@@ -5,7 +5,7 @@
 instrumentation_methods :chain, :prepend
 
 HTTPX_VERSIONS = [
-  # [nil, 2.7],
+  [nil, 2.7],
   ['1.4.4', 2.7],
   ['1.0.0', 2.7]
 ]

--- a/test/multiverse/suites/httpx/httpx_instrumentation_test.rb
+++ b/test/multiverse/suites/httpx/httpx_instrumentation_test.rb
@@ -31,8 +31,8 @@ class HTTPXInstrumentationTest < Minitest::Test
 
   def test_finish_with_error
     request = Minitest::Mock.new
-    request.expect :response, :the_response
-    2.times { request.expect :hash, 1138 }
+    2.times { request.expect :response, :the_response }
+    request.expect :hash, 1138
 
     error = if Gem::Version.new(::HTTPX::VERSION) >= Gem::Version.new('1.3.0')
       request.expect :options, ::HTTPX::Options.new({})


### PR DESCRIPTION
HTTPX 1.5.0 introduced a change that affected the way we access the response of the request, ([commit](https://gitlab.com/os85/httpx/-/commit/3c22f36a6ca52e8f5f46ffedd952c99a36d96dd0)). Instead of using the `@responses` hash, we should instead be using the response off of the request object (mentioned in the linked commit message). We were using the callback on the request object anyways. 

This works on all supported HTTPX versions. 

Also, I had to change one of the tests expectations for the mocked request.