### PR TITLE
Set up elasticsearch 9 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -710,7 +710,7 @@ jobs:
 
 
   simplecov:
-    needs: [unit_tests, multiverse, infinite_tracing]
+    needs: [unit_tests, multiverse, infinite_tracing, multiverse_services_1, multiverse_services_2, multiverse_elasticsearch, multiverse_services_kafka, multiverse_services_mysql_pg]
     runs-on: ubuntu-22.04
     if: github.event.pull_request.head.repo.full_name == github.repository
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -366,7 +366,7 @@ jobs:
           path: gem_manifest_${{ matrix.ruby-version }}_services_2.json
           retention-days: 2
 
-  multiverse_elasticsearch:
+  multiverse_services_elasticsearch:
     needs: run_rubocop
     runs-on: ubuntu-22.04
     services:
@@ -438,7 +438,7 @@ jobs:
       - name: Save coverage results
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # tag v4.6.2
         with:
-          name: coverage-report-multiverse-${{ matrix.ruby-version }}-elasticsearch
+          name: coverage-report-multiverse-${{ matrix.ruby-version }}-services_elasticsearch
           path: lib/coverage_*/.resultset.json
           include-hidden-files: true
           retention-days: 2
@@ -449,8 +449,8 @@ jobs:
       - name: Save gem manifest
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # tag v4.6.2
         with:
-          name: gem_manifest_${{ matrix.ruby-version }}_elasticsearch.json
-          path: gem_manifest_${{ matrix.ruby-version }}_elasticsearch.json
+          name: gem_manifest_${{ matrix.ruby-version }}_services_elasticsearch.json
+          path: gem_manifest_${{ matrix.ruby-version }}_services_elasticsearch.json
           retention-days: 2
 
 
@@ -710,7 +710,7 @@ jobs:
 
 
   simplecov:
-    needs: [unit_tests, multiverse, infinite_tracing, multiverse_services_1, multiverse_services_2, multiverse_elasticsearch, multiverse_services_kafka, multiverse_services_mysql_pg]
+    needs: [unit_tests, multiverse, infinite_tracing, multiverse_services_1, multiverse_services_2, multiverse_services_elasticsearch, multiverse_services_kafka, multiverse_services_mysql_pg]
     runs-on: ubuntu-22.04
     if: github.event.pull_request.head.repo.full_name == github.repository
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,18 +191,6 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 10
-      elasticsearch8:
-        image: elasticsearch:8.13.0
-        env:
-          discovery.type: single-node
-          xpack.security.enabled: false
-        ports:
-          - 9250:9200
-        options: >-
-          --health-cmd "curl http://localhost:9200/_cluster/health"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 10
       elasticsearch9:
         image: elasticsearch:9.0.2
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,6 +203,18 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 10
+      elasticsearch9:
+        image: elasticsearch:9.0.2
+        env:
+          discovery.type: single-node
+          xpack.security.enabled: false
+        ports:
+          - 9253:9200
+        options: >-
+          --health-cmd "curl http://localhost:9200/_cluster/health"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
       mongodb:
         image: ${{ contains(fromJson('["2.4.10"]'), matrix.ruby-version) && 'mongo:5.0.11' || 'mongo:latest' }}
         ports:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -424,7 +424,7 @@ jobs:
         with:
           timeout_minutes: 60
           max_attempts: 2
-          command: bundle exec rake test:multiverse[group="elasticsearch"]
+          command: bundle exec rake test:multiverse[group="services_elasticsearch"]
         env:
           VERBOSE_TEST_OUTPUT: true
           SERIALIZE: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -396,7 +396,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: [3.4.4]
+        ruby-version: [2.4.10, 3.4.4]
 
     steps:
       - name: Configure git

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -387,7 +387,7 @@ jobs:
           discovery.type: single-node
           xpack.security.enabled: false
         ports:
-          - 9253:9200
+          - 9252:9200
         options: >-
           --health-cmd "curl http://localhost:9200/_cluster/health"
           --health-interval 10s

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,29 +180,6 @@ jobs:
     needs: run_rubocop
     runs-on: ubuntu-22.04
     services:
-      elasticsearch7:
-        image: elasticsearch:7.16.2
-        env:
-          discovery.type: single-node
-        ports:
-          - 9200:9200
-        options: >-
-          --health-cmd "curl http://localhost:9200/_cluster/health"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 10
-      elasticsearch9:
-        image: elasticsearch:9.0.2
-        env:
-          discovery.type: single-node
-          xpack.security.enabled: false
-        ports:
-          - 9253:9200
-        options: >-
-          --health-cmd "curl http://localhost:9200/_cluster/health"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 10
       mongodb:
         image: ${{ contains(fromJson('["2.4.10"]'), matrix.ruby-version) && 'mongo:5.0.11' || 'mongo:latest' }}
         ports:
@@ -387,6 +364,93 @@ jobs:
         with:
           name: gem_manifest_${{ matrix.ruby-version }}_services_2.json
           path: gem_manifest_${{ matrix.ruby-version }}_services_2.json
+          retention-days: 2
+
+  multiverse_elasticsearch:
+    needs: run_rubocop
+    runs-on: ubuntu-22.04
+    services:
+      elasticsearch7:
+        image: elasticsearch:7.16.2
+        env:
+          discovery.type: single-node
+        ports:
+          - 9200:9200
+        options: >-
+          --health-cmd "curl http://localhost:9200/_cluster/health"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+      elasticsearch9:
+        image: elasticsearch:9.0.2
+        env:
+          discovery.type: single-node
+          xpack.security.enabled: false
+        ports:
+          - 9253:9200
+        options: >-
+          --health-cmd "curl http://localhost:9200/_cluster/health"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby-version: [3.4.4]
+
+    steps:
+      - name: Configure git
+        run: 'git config --global init.defaultBranch main'
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # tag v4.2.2
+
+        # - curl is needed for Curb
+        # - xslt is needed for older Nokogiris, RUBY_VERSION < 2.5
+        # - sasl is needed for memcached
+      - name: Install OS packages
+        run: sudo apt-get update; sudo apt-get install -y --no-install-recommends libcurl4-nss-dev libsasl2-dev libxslt1-dev
+
+      - name: Install Ruby ${{ matrix.ruby-version }}
+        uses: ruby/setup-ruby@13e7a03dc3ac6c3798f4570bfead2aed4d96abfb # tag v1.244.0
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+
+      - name: Setup bundler
+        run: ./.github/workflows/scripts/setup_bundler
+        env:
+          RUBY_VERSION: ${{ matrix.ruby-version }}
+
+      - name: Run Multiverse Tests
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # tag v3.0.2
+        with:
+          timeout_minutes: 60
+          max_attempts: 2
+          command: bundle exec rake test:multiverse[group="elasticsearch"]
+        env:
+          VERBOSE_TEST_OUTPUT: true
+          SERIALIZE: 1
+          COVERAGE: true
+          CI_FOR_PR: true
+
+      - name: Annotate errors
+        if: ${{ failure() }}
+        uses: ./.github/actions/annotate
+
+      - name: Save coverage results
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # tag v4.6.2
+        with:
+          name: coverage-report-multiverse-${{ matrix.ruby-version }}-elasticsearch
+          path: lib/coverage_*/.resultset.json
+          include-hidden-files: true
+          retention-days: 2
+
+      - name: Generate gem manifest
+        run: rake test:multiverse:gem_manifest
+
+      - name: Save gem manifest
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # tag v4.6.2
+        with:
+          name: gem_manifest_${{ matrix.ruby-version }}_elasticsearch.json
+          path: gem_manifest_${{ matrix.ruby-version }}_elasticsearch.json
           retention-days: 2
 
 

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -181,8 +181,8 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 10
-      elasticsearch8:
-        image: elasticsearch:8.13.0
+      elasticsearch9:
+        image: elasticsearch:9.0.2
         env:
           discovery.type: single-node
           xpack.security.enabled: false

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -337,7 +337,7 @@ jobs:
           discovery.type: single-node
           xpack.security.enabled: false
         ports:
-          - 9250:9200
+          - 9252:9200
         options: >-
           --health-cmd "curl http://localhost:9200/_cluster/health"
           --health-interval 10s

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -170,29 +170,6 @@ jobs:
     needs: run_rubocop
     runs-on: ubuntu-22.04
     services:
-      elasticsearch7:
-        image: elasticsearch:7.16.2
-        env:
-          discovery.type: single-node
-        ports:
-          - 9200:9200
-        options: >-
-          --health-cmd "curl http://localhost:9200/_cluster/health"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 10
-      elasticsearch9:
-        image: elasticsearch:9.0.2
-        env:
-          discovery.type: single-node
-          xpack.security.enabled: false
-        ports:
-          - 9250:9200
-        options: >-
-          --health-cmd "curl http://localhost:9200/_cluster/health"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 10
       mongodb:
         image: ${{ contains(fromJson('["2.4.10"]'), matrix.ruby-version) && 'mongo:5.0.11' || 'mongo:latest' }}
         ports:
@@ -334,6 +311,73 @@ jobs:
           SERIALIZE: 1
           POSTGRES_USERNAME: postgres
           POSTGRES_PASSWORD: password
+
+      - name: Annotate errors
+        if: ${{ failure() }}
+        uses: ./.github/actions/annotate
+
+  multiverse_elasticsearch:
+    needs: run_rubocop
+    runs-on: ubuntu-22.04
+    services:
+      elasticsearch7:
+        image: elasticsearch:7.16.2
+        env:
+          discovery.type: single-node
+        ports:
+          - 9200:9200
+        options: >-
+          --health-cmd "curl http://localhost:9200/_cluster/health"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+      elasticsearch9:
+        image: elasticsearch:9.0.2
+        env:
+          discovery.type: single-node
+          xpack.security.enabled: false
+        ports:
+          - 9250:9200
+        options: >-
+          --health-cmd "curl http://localhost:9200/_cluster/health"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby-version: [2.5.9, 2.6.10, 2.7.8, 3.0.7, 3.1.7, 3.2.8, 3.3.8, 3.4.4]
+
+    steps:
+      - name: Configure git
+        run: 'git config --global init.defaultBranch main'
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # tag v4.2.2
+
+        # - curl is needed for Curb
+        # - xslt is needed for older Nokogiris, RUBY_VERSION < 2.5
+        # - sasl is needed for memcached
+      - name: Install OS packages
+        run: sudo apt-get update; sudo apt-get install -y --no-install-recommends libcurl4-nss-dev libsasl2-dev libxslt1-dev
+
+      - name: Install Ruby ${{ matrix.ruby-version }}
+        uses: ruby/setup-ruby@13e7a03dc3ac6c3798f4570bfead2aed4d96abfb # tag v1.244.0
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+
+      - name: Setup bundler
+        run: ./.github/workflows/scripts/setup_bundler
+        env:
+          RUBY_VERSION: ${{ matrix.ruby-version }}
+
+      - name: Run Multiverse Tests
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # tag v3.0.2
+        with:
+          timeout_minutes: 60
+          max_attempts: 2
+          command: bundle exec rake test:multiverse[group="elasticsearch"]
+        env:
+          VERBOSE_TEST_OUTPUT: true
+          SERIALIZE: 1
 
       - name: Annotate errors
         if: ${{ failure() }}

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -374,7 +374,7 @@ jobs:
         with:
           timeout_minutes: 60
           max_attempts: 2
-          command: bundle exec rake test:multiverse[group="elasticsearch"]
+          command: bundle exec rake test:multiverse[group="services_elasticsearch"]
         env:
           VERBOSE_TEST_OUTPUT: true
           SERIALIZE: 1

--- a/test/multiverse/lib/multiverse/runner.rb
+++ b/test/multiverse/lib/multiverse/runner.rb
@@ -109,9 +109,10 @@ module Multiverse
       'rails' => %w[active_support_broadcast_logger active_support_logger rails rails_prepend activemerchant],
 
       # these need services running in github actions, so they are separated
-      'services_1' => %w[elasticsearch mongo bunny],
+      'services_1' => %w[mongo bunny],
       'services_2' => %w[redis sidekiq sidekiq_delay_extensions memcache],
       'services_kafka' => %w[rdkafka ruby_kafka],
+      'services_elasticsearch' => %w[elasticsearch],
       'services_mysql_pg' => %w[active_record active_record_pg],
 
       'infinite_tracing' => %w[infinite_tracing],

--- a/test/multiverse/suites/elasticsearch/Envfile
+++ b/test/multiverse/suites/elasticsearch/Envfile
@@ -6,7 +6,7 @@ instrumentation_methods :chain, :prepend
 
 ELASTICSEARCH_VERSIONS = [
   # only testing 7 and 9 to prevent memory issues in the CI (8 and 9 are the same)
-  [nil, 2.5],
+  [nil, 2.6],
   ['7.17.1', 2.4]
 ]
 

--- a/test/multiverse/suites/elasticsearch/Envfile
+++ b/test/multiverse/suites/elasticsearch/Envfile
@@ -5,6 +5,7 @@
 instrumentation_methods :chain, :prepend
 
 ELASTICSEARCH_VERSIONS = [
+  # only testing 7 and 9 to prevent memory issues in the CI (8 and 9 are the same)
   [nil, 2.5],
   ['7.17.1', 2.4]
 ]

--- a/test/multiverse/suites/elasticsearch/Envfile
+++ b/test/multiverse/suites/elasticsearch/Envfile
@@ -5,7 +5,7 @@
 instrumentation_methods :chain, :prepend
 
 ELASTICSEARCH_VERSIONS = [
-  # [nil, 2.5], # temporarily stop testing elasticsearch 9
+  [nil, 2.5],
   ['8.12.0', 2.5],
   ['7.17.1', 2.4]
 ]

--- a/test/multiverse/suites/elasticsearch/Envfile
+++ b/test/multiverse/suites/elasticsearch/Envfile
@@ -6,7 +6,6 @@ instrumentation_methods :chain, :prepend
 
 ELASTICSEARCH_VERSIONS = [
   [nil, 2.5],
-  ['8.12.0', 2.5],
   ['7.17.1', 2.4]
 ]
 

--- a/test/multiverse/suites/elasticsearch/elasticsearch_instrumentation_test.rb
+++ b/test/multiverse/suites/elasticsearch/elasticsearch_instrumentation_test.rb
@@ -10,6 +10,8 @@
 #
 #       Step 1: define these shell aliases:
 #
+#         alias elastic9='docker run --rm --name elasticsearch -p 9252:9200 -p 9300:9300 -e "discovery.type=single-node" -e "xpack.security.enabled=false" -e "xpack.security.enrollment.enabled=false" docker.elastic.co/elasticsearch/elasticsearch:9.0.2'
+#
 #         alias elastic8='docker run --rm --name elasticsearch -p 9250:9200 -p 9300:9300 -e "discovery.type=single-node" -e "xpack.security.enabled=false" -e "xpack.security.enrollment.enabled=false" docker.elastic.co/elasticsearch/elasticsearch:8.13.4'
 #
 #         alias elastic7='docker run --rm --name elasticsearch -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch:7.16.2'

--- a/test/multiverse/suites/elasticsearch/elasticsearch_instrumentation_test.rb
+++ b/test/multiverse/suites/elasticsearch/elasticsearch_instrumentation_test.rb
@@ -231,8 +231,10 @@ class ElasticsearchInstrumentationTest < Minitest::Test
   def port
     if ::Gem::Version.create(Elasticsearch::VERSION) < ::Gem::Version.create('8.0.0')
       9200 # 9200 for elasticsearch 7
-    else
+    elsif ::Gem::Version.create(Elasticsearch::VERSION) < ::Gem::Version.create('9.0.0')
       9250 # 9250 for elasticsearch 8
+    else
+      9252 # 9252 for elasticsearch 9
     end
   end
 end


### PR DESCRIPTION
Adds elasticsearch 9 service to the CI and allows those tests to start running again\
Ran into some docker memory usage issues so I took out elasticsearch 8 from the CI since its the same as 9. Also moved elasticsearch into its own group.

closes https://github.com/newrelic/newrelic-ruby-agent/issues/3153

schedule ci https://github.com/newrelic/newrelic-ruby-agent/actions/runs/15542099551