### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Ruby agent code owners:
-*       @fallwith @hannahramadan @kaylareopelle @tannalynn
+*       @newrelic/RUBY


### PR DESCRIPTION
Updating `CODEOWNERS` to point to the Ruby Agent team rather than individuals.