### PR TITLE
add code.stacktrace attribute to datastore span

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
   The agent has a new helper method to simplify version comparison. `NewRelic::Helper.version_satisfied?` accepts three arguments: a left-side version number, the comparison operator as a string, and a right-side version number. Our thanks go to [@kekke-n](https://github.com/kekke-n) for this contribution. [PR#3182](https://github.com/newrelic/newrelic-ruby-agent/pull/3182)
 
+- **Feature: Add code.stacktrace attribute on datastore spans when duration exceeds configured threshold**
+
+  The agent will now add the `code.stacktrace` attribute to datastore spans when the duration exceeds the configured threshold. The threshold is configured using the `transaction_tracer.stack_trace_threshold` configuration option. [PR#3220](https://github.com/newrelic/newrelic-ruby-agent/pull/3220)
+
 - **Bugfix: Fix Brewfile source links**
 
   Previously, the multiverse README's links to the Brewfile were broken. Our thanks go to [@emmanuel-ferdman](https://github.com/emmanuel-ferdman) for submitting a PR to fix them! [PR#3191](https://github.com/newrelic/newrelic-ruby-agent/pull/3191)

--- a/lib/new_relic/agent/span_event_primitive.rb
+++ b/lib/new_relic/agent/span_event_primitive.rb
@@ -123,7 +123,7 @@ module NewRelic
           agent_attributes[DB_STATEMENT_KEY] = truncate(segment.nosql_statement, DB_STATEMENT_MAX_BYTES)
         end
 
-        if segment.duration > NewRelic::Agent.config[:'transaction_tracer.stack_trace_threshold'] && segment.params[:backtrace]
+        if segment.params[:backtrace]
           agent_attributes[STACKTRACE_KEY] = segment.params[:backtrace]
         end
 

--- a/lib/new_relic/agent/span_event_primitive.rb
+++ b/lib/new_relic/agent/span_event_primitive.rb
@@ -40,6 +40,7 @@ module NewRelic
       SERVER_ADDRESS_KEY = 'server.address'
       SERVER_PORT_KEY = 'server.port'
       SPAN_KIND_KEY = 'span.kind'
+      STACKTRACE_KEY = 'code.stacktrace'
       ENTRY_POINT_KEY = 'nr.entryPoint'
       TRUSTED_PARENT_KEY = 'trustedParentId'
       TRACING_VENDORS_KEY = 'tracingVendors'
@@ -120,6 +121,10 @@ module NewRelic
           agent_attributes[DB_STATEMENT_KEY] = truncate(segment.sql_statement.safe_sql, DB_STATEMENT_MAX_BYTES)
         elsif segment.nosql_statement && allowed?(DB_STATEMENT_KEY)
           agent_attributes[DB_STATEMENT_KEY] = truncate(segment.nosql_statement, DB_STATEMENT_MAX_BYTES)
+        end
+
+        if segment.duration > NewRelic::Agent.config[:'transaction_tracer.stack_trace_threshold'] && segment.params[:backtrace]
+          agent_attributes[STACKTRACE_KEY] = segment.params[:backtrace]
         end
 
         [intrinsics, custom_attributes(segment), agent_attributes.merge(agent_attributes(segment))]


### PR DESCRIPTION
When the duration is over the threshold, we should capture the stacktrace as an attribute on spans. Previously, the stacktrace was only on slowsql statements and not added to spans.

resolves https://github.com/newrelic/newrelic-ruby-agent/issues/2357