### PR TITLE
Add JRuby CI slack notifications

### DIFF
--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -551,7 +551,7 @@ jobs:
 
   notify_slack_fail:
     name: Notify slack fail
-    needs: [unit_tests, multiverse, infinite_tracing]
+    needs: [unit_tests, multiverse, infinite_tracing, multiverse_services_1, multiverse_services_2, multiverse_services_kafka, multiverse_services_mysql_pg]
     runs-on: ubuntu-22.04
     if: always()
     steps:
@@ -569,7 +569,7 @@ jobs:
 
   notify_slack_success:
     name: Notify slack success
-    needs: [unit_tests, multiverse, infinite_tracing]
+    needs: [unit_tests, multiverse, infinite_tracing, multiverse_services_1, multiverse_services_2, multiverse_services_kafka, multiverse_services_mysql_pg]
     runs-on: ubuntu-22.04
     if: always()
     steps:

--- a/.github/workflows/ci_jruby.yml
+++ b/.github/workflows/ci_jruby.yml
@@ -119,3 +119,43 @@ jobs:
       - name: Annotate errors
         if: ${{ failure() }}
         uses: ./.github/actions/annotate
+
+  notify_slack_fail:
+    name: Notify slack fail
+    needs: [jruby_unit_tests, jruby_multiverse, jruby_sidekiq]
+    runs-on: ubuntu-22.04
+    if: always()
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # tag v4.2.2
+      - uses: ./.github/actions/workflow-conclusion
+      - uses: voxmedia/github-action-slack-notify-build@373da97827332b19e753c84d1e5b7937dbe0fbfa # tag v2
+        if: ${{ env.WORKFLOW_CONCLUSION == 'failure' && github.event_name != 'workflow_dispatch' }}
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.RUBY_GITHUB_ACTIONS_BOT_WEBHOOK }}
+        with:
+          channel: ruby-agent-notifications
+          status: FAILED
+          color: danger
+
+
+  notify_slack_success:
+    name: Notify slack success
+    needs: [jruby_unit_tests, jruby_multiverse, jruby_sidekiq]
+    runs-on: ubuntu-22.04
+    if: always()
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # tag v4.2.2
+      - uses: ./.github/actions/workflow-conclusion
+      - run: echo ${{ github.event_name }}
+      - uses: Mercymeilya/last-workflow-status@3418710aefe8556d73b6f173a0564d38bcfd9a43 # tag v0.3.3
+        id: last_status
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: voxmedia/github-action-slack-notify-build@373da97827332b19e753c84d1e5b7937dbe0fbfa # tag v2
+        if: ${{ env.WORKFLOW_CONCLUSION == 'success' && steps.last_status.outputs.last_status == 'failure' && github.event_name != 'workflow_dispatch' }}
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.RUBY_GITHUB_ACTIONS_BOT_WEBHOOK }}
+        with:
+          channel: ruby-agent-notifications
+          status: SUCCESS
+          color: good


### PR DESCRIPTION
Add fail/success slack notifications for the JRuby CI workflow. 

This PR also makes a small update to the Cron CI slack notifications to wait for the all jobs to finish before running.

Closes #3214 