### PR TITLE
Add CI notifications for JRuby

### DIFF
--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -306,7 +306,7 @@ jobs:
 
   notify_slack_fail:
     name: Notify slack fail
-    needs: [unit_tests, multiverse, infinite_tracing]
+    needs: [unit_tests, multiverse, infinite_tracing, multiverse_services_1, multiverse_services_2, multiverse_elasticsearch, multiverse_services_kafka, multiverse_services_mysql_pg]
     runs-on: ubuntu-22.04
     if: always()
     steps:
@@ -324,7 +324,7 @@ jobs:
 
   notify_slack_success:
     name: Notify slack success
-    needs: [unit_tests, multiverse, infinite_tracing]
+    needs: [unit_tests, multiverse, infinite_tracing, multiverse_services_1, multiverse_services_2, multiverse_elasticsearch, multiverse_services_kafka, multiverse_services_mysql_pg]
     runs-on: ubuntu-22.04
     if: always()
     steps:

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -309,6 +309,8 @@ jobs:
     needs: [unit_tests, multiverse, infinite_tracing, multiverse_services_1, multiverse_services_2, multiverse_elasticsearch, multiverse_services_kafka, multiverse_services_mysql_pg]
     runs-on: ubuntu-22.04
     if: always()
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # tag v4.2.2
       - uses: ./.github/actions/workflow-conclusion
@@ -327,6 +329,8 @@ jobs:
     needs: [unit_tests, multiverse, infinite_tracing, multiverse_services_1, multiverse_services_2, multiverse_elasticsearch, multiverse_services_kafka, multiverse_services_mysql_pg]
     runs-on: ubuntu-22.04
     if: always()
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # tag v4.2.2
       - uses: ./.github/actions/workflow-conclusion

--- a/.github/workflows/ci_jruby.yml
+++ b/.github/workflows/ci_jruby.yml
@@ -119,3 +119,43 @@ jobs:
       - name: Annotate errors
         if: ${{ failure() }}
         uses: ./.github/actions/annotate
+  
+  notify_slack_fail:
+    name: Notify slack fail
+    needs: [jruby_unit_tests, jruby_multiverse, jruby_sidekiq]
+    runs-on: ubuntu-22.04
+    if: always()
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # tag v4.2.2
+      - uses: ./.github/actions/workflow-conclusion
+      - uses: voxmedia/github-action-slack-notify-build@373da97827332b19e753c84d1e5b7937dbe0fbfa # tag v2
+        if: ${{ env.WORKFLOW_CONCLUSION == 'failure' && github.event_name != 'workflow_dispatch' }}
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.RUBY_GITHUB_ACTIONS_BOT_WEBHOOK }}
+        with:
+          channel: ruby-agent-notifications
+          status: FAILED
+          color: danger
+
+
+  notify_slack_success:
+    name: Notify slack success
+    needs: [jruby_unit_tests, jruby_multiverse, jruby_sidekiq]
+    runs-on: ubuntu-22.04
+    if: always()
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # tag v4.2.2
+      - uses: ./.github/actions/workflow-conclusion
+      - run: echo ${{ github.event_name }}
+      - uses: Mercymeilya/last-workflow-status@3418710aefe8556d73b6f173a0564d38bcfd9a43 # tag v0.3.3
+        id: last_status
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: voxmedia/github-action-slack-notify-build@373da97827332b19e753c84d1e5b7937dbe0fbfa # tag v2
+        if: ${{ env.WORKFLOW_CONCLUSION == 'success' && steps.last_status.outputs.last_status == 'failure' && github.event_name != 'workflow_dispatch' }}
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.RUBY_GITHUB_ACTIONS_BOT_WEBHOOK }}
+        with:
+          channel: ruby-agent-notifications
+          status: SUCCESS
+          color: good

--- a/.github/workflows/ci_jruby.yml
+++ b/.github/workflows/ci_jruby.yml
@@ -125,6 +125,8 @@ jobs:
     needs: [jruby_unit_tests, jruby_multiverse, jruby_sidekiq]
     runs-on: ubuntu-22.04
     if: always()
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # tag v4.2.2
       - uses: ./.github/actions/workflow-conclusion
@@ -143,6 +145,8 @@ jobs:
     needs: [jruby_unit_tests, jruby_multiverse, jruby_sidekiq]
     runs-on: ubuntu-22.04
     if: always()
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # tag v4.2.2
       - uses: ./.github/actions/workflow-conclusion

--- a/.github/workflows/ci_special.yml
+++ b/.github/workflows/ci_special.yml
@@ -46,6 +46,8 @@ jobs:
     needs: [unit_tests]
     runs-on: ubuntu-22.04
     if: always()
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # tag v4.2.2
       - uses: ./.github/actions/workflow-conclusion
@@ -64,6 +66,8 @@ jobs:
     needs: [unit_tests]
     runs-on: ubuntu-22.04
     if: always()
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # tag v4.2.2
       - uses: ./.github/actions/workflow-conclusion


### PR DESCRIPTION
This PR:
- Adds fail/success slack notifications for the JRuby CI workflow.
- Updates the Cron CI slack notifications to wait for the all jobs to finish before running
- Adds a read-only permission to slack jobs (security recommendation)

Closes https://github.com/newrelic/newrelic-ruby-agent/issues/3214