### PR TITLE
Edit test regex

### DIFF
--- a/test/multiverse/suites/hybrid_agent/trace_propagator_test.rb
+++ b/test/multiverse/suites/hybrid_agent/trace_propagator_test.rb
@@ -42,7 +42,7 @@ module NewRelic
                 assert_match(/@transaction_id=\"e8b91a159289ff74\"/, context_string, "transaction_id doesn't match")
                 assert_match(/@sampled=false/, context_string, "sampled doesn't match")
                 assert_match(/@priority=0.23456/, context_string, "priority doesn't match")
-                assert_match(/@timestamp=1518469636035>/, context_string, "timestamp doesn't match")
+                assert_match(/@timestamp=1518469636035/, context_string, "timestamp doesn't match")
                 assert_match(/@parent_app_id=\"46954/, context_string, "parent_app_id doesn't match")
               end
             end
@@ -77,7 +77,7 @@ module NewRelic
                 assert_match(/@transaction_id=\"e8b91a159289ff74\"/, context_string, "transaction_id doesn't match")
                 assert_match(/@sampled=true/, context_string, "sampled doesn't match")
                 assert_match(/@priority=1.23456/, context_string, "priority doesn't match")
-                assert_match(/@timestamp=1518469636035>/, context_string, "timestamp doesn't match")
+                assert_match(/@timestamp=1518469636035/, context_string, "timestamp doesn't match")
                 assert_match(/@parent_app_id=\"46954/, context_string, "parent_app_id doesn't match")
               end
             end


### PR DESCRIPTION
An extra `>` was included in an assert, and JRuby was looking to match exactly that. The extra character has been removed (it isn't present in the payload, so was never needed anyways). 

JRuby CI Run: https://github.com/newrelic/newrelic-ruby-agent/actions/runs/16325584078
Closes [#3213](https://github.com/newrelic/newrelic-ruby-agent/issues/3213)
Payload:
```ruby
=> "{#<OpenTelemetry::Context::Key:0x62ec4146 @name=\"current-span\">=>#<OpenTelemetry::Trace::Span:0x4c941d19 @context=#<OpenTelemetry::Trace::SpanContext:0x5248c05a @tracestate=#<NewRelic::Agent::TraceContextPayload:0x151f1734 @priority=0.23456, @timestamp=1518469636035, @parent_app_id=\"46954\", @sampled=false, @version=0, @transaction_id=\"e8b91a159289ff74\", @id=\"7d3efb1b173fecfa\", @parent_type_id=0, @parent_account_id=\"1\">, @span_id=\"7d3efb1b173fecfa\", @trace_id=\"da8bc8cc6d062849b0efcf3c169afb5a\", @trace_flags=\"00\", @remote=true>>}"
```