### PR TITLE
Force ruby platform for rdkafka tests

### DIFF
--- a/test/multiverse/suites/rdkafka/Envfile
+++ b/test/multiverse/suites/rdkafka/Envfile
@@ -14,17 +14,18 @@ VERSIONS = [
 
 def gem_list(version = nil)
   <<-RB
-    gem 'rdkafka'#{version}, force_ruby_platform: true
-    #{ffi}
+    gem 'rdkafka'#{version}#{force_ruby_platform}
+    gem 'ffi'#{ffi_version}#{force_ruby_platform}
   RB
 end
 
-def ffi
-  if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.7')
-    "gem 'ffi', '< 1.17.0'"
-  else
-    "gem 'ffi', force_ruby_platform: true"
-  end
+# rdkafka 0.22.0 (compatible with Ruby 3.1+) introduced new binary platform releases
+def force_ruby_platform
+  ", force_ruby_platform: true" if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.1')
+end
+
+def ffi_version
+  ", '< 1.17.0'" if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.7')
 end
 
 create_gemfiles(VERSIONS)


### PR DESCRIPTION
The latest `rdkafka` release included new platform binaries. GitHub actions automatically picked up the `x86_64-linux-gnu` platform. Even though the same platform was used for `ffi`, the Envfile would fail to install.

Forcing the Ruby platform for both gems got the tests to run again.

Since this only impacts 0.22.0+ versions of `rdkafka`/versions 3.1+ of Ruby, I don't think we need to make changes to the older FFI install call.

### Failure output text
```output
Stopped processing SimpleCov as a previous error not related to SimpleCov has been detected
/opt/hostedtoolcache/Ruby/3.4.4/x64/lib/ruby/gems/3.4.0/gems/ffi-1.17.2-x86_64-linux-gnu/lib/ffi/dynamic_library.rb:94:in 'FFI::DynamicLibrary.load_library': Could not open library '/opt/hostedtoolcache/Ruby/3.4.4/x64/lib/ruby/gems/3.4.0/gems/rdkafka-0.22.1-x86_64-linux-gnu/lib/rdkafka/../../ext/librdkafka.so': /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by /opt/hostedtoolcache/Ruby/3.4.4/x64/lib/ruby/gems/3.4.0/gems/rdkafka-0.22.1-x86_64-linux-gnu/lib/rdkafka/../../ext/librdkafka.so). (LoadError)
Searched in <system library path>
	from /opt/hostedtoolcache/Ruby/3.4.4/x64/lib/ruby/gems/3.4.0/gems/ffi-1.17.2-x86_64-linux-gnu/lib/ffi/library.rb:95:in 'block in FFI::Library#ffi_lib'
	from /opt/hostedtoolcache/Ruby/3.4.4/x64/lib/ruby/gems/3.4.0/gems/ffi-1.17.2-x86_64-linux-gnu/lib/ffi/library.rb:94:in 'Array#map'
	from /opt/hostedtoolcache/Ruby/3.4.4/x64/lib/ruby/gems/3.4.0/gems/ffi-1.17.2-x86_64-linux-gnu/lib/ffi/library.rb:94:in 'FFI::Library#ffi_lib'
	from /opt/hostedtoolcache/Ruby/3.4.4/x64/lib/ruby/gems/3.4.0/gems/rdkafka-0.22.1-x86_64-linux-gnu/lib/rdkafka/bindings.rb:16:in '<module:Bindings>'
	from /opt/hostedtoolcache/Ruby/3.4.4/x64/lib/ruby/gems/3.4.0/gems/rdkafka-0.22.1-x86_64-linux-gnu/lib/rdkafka/bindings.rb:5:in '<module:Rdkafka>'
	from /opt/hostedtoolcache/Ruby/3.4.4/x64/lib/ruby/gems/3.4.0/gems/rdkafka-0.22.1-x86_64-linux-gnu/lib/rdkafka/bindings.rb:3:in '<top (required)>'
	from /opt/hostedtoolcache/Ruby/3.4.4/x64/lib/ruby/gems/3.4.0/gems/rdkafka-0.22.1-x86_64-linux-gnu/lib/rdkafka.rb:34:in 'Kernel#require'
	from /opt/hostedtoolcache/Ruby/3.4.4/x64/lib/ruby/gems/3.4.0/gems/rdkafka-0.22.1-x86_64-linux-gnu/lib/rdkafka.rb:34:in '<top (required)>'
	from /opt/hostedtoolcache/Ruby/3.4.4/x64/lib/ruby/site_ruby/3.4.0/bundler/runtime.rb:60:in 'Kernel#require'
	from /opt/hostedtoolcache/Ruby/3.4.4/x64/lib/ruby/site_ruby/3.4.0/bundler/runtime.rb:60:in 'block (2 levels) in Bundler::Runtime#require'
	from /opt/hostedtoolcache/Ruby/3.4.4/x64/lib/ruby/site_ruby/3.4.0/bundler/runtime.rb:55:in 'Array#each'
	from /opt/hostedtoolcache/Ruby/3.4.4/x64/lib/ruby/site_ruby/3.4.0/bundler/runtime.rb:55:in 'block in Bundler::Runtime#require'
	from /opt/hostedtoolcache/Ruby/3.4.4/x64/lib/ruby/site_ruby/3.4.0/bundler/runtime.rb:44:in 'Array#each'
	from /opt/hostedtoolcache/Ruby/3.4.4/x64/lib/ruby/site_ruby/3.4.0/bundler/runtime.rb:44:in 'Bundler::Runtime#require'
	from /opt/hostedtoolcache/Ruby/3.4.4/x64/lib/ruby/site_ruby/3.4.0/bundler.rb:195:in 'Bundler.require'
	from /home/runner/work/newrelic-ruby-agent/newrelic-ruby-agent/test/multiverse/lib/multiverse/suite.rb:236:in 'block in Multiverse::Suite#ensure_bundle'
	from /ho
```