### PR TITLE
Replace all calls to JSON.load with JSON.parse

### DIFF
--- a/lib/new_relic/agent/distributed_tracing/cross_app_tracing.rb
+++ b/lib/new_relic/agent/distributed_tracing/cross_app_tracing.rb
@@ -207,7 +207,7 @@ module NewRelic
         decoded_appdata.set_encoding(::Encoding::UTF_8) if
           decoded_appdata.respond_to?(:set_encoding)
 
-        ::JSON.load(decoded_appdata)
+        ::JSON.parse(decoded_appdata)
       end
 
       def valid_cross_app_id?(xp_id)

--- a/lib/new_relic/agent/monitors/inbound_request_monitor.rb
+++ b/lib/new_relic/agent/monitors/inbound_request_monitor.rb
@@ -32,7 +32,7 @@ module NewRelic
 
       def deserialize_header(encoded_header, key)
         decoded_header = obfuscator.deobfuscate(encoded_header)
-        ::JSON.load(decoded_header)
+        ::JSON.parse(decoded_header)
       rescue => err
         # If we have a failure of any type here, just return nil and carry on
         NewRelic::Agent.logger.debug("Failure deserializing encoded header '#{key}' in #{self.class}, #{err.class}, #{err.message}")

--- a/lib/new_relic/agent/monitors/synthetics_monitor.rb
+++ b/lib/new_relic/agent/monitors/synthetics_monitor.rb
@@ -35,7 +35,7 @@ module NewRelic
       end
 
       def load_json(header, key)
-        ::JSON.load(header)
+        ::JSON.parse(header)
       rescue => err
         NewRelic::Agent.logger.debug("Failure loading json header '#{key}' in #{self.class}, #{err.class}, #{err.message}")
         nil

--- a/lib/new_relic/agent/transaction/distributed_tracer.rb
+++ b/lib/new_relic/agent/transaction/distributed_tracer.rb
@@ -127,7 +127,7 @@ module NewRelic
         def consume_message_synthetics_headers(headers)
           synthetics_header = headers[CrossAppTracing::NR_MESSAGE_BROKER_SYNTHETICS_HEADER]
           if synthetics_header and
-              incoming_payload = ::JSON.load(deobfuscate(synthetics_header)) and
+              incoming_payload = ::JSON.parse(deobfuscate(synthetics_header)) and
               SyntheticsMonitor.is_valid_payload?(incoming_payload) and
               SyntheticsMonitor.is_supported_version?(incoming_payload) and
               SyntheticsMonitor.is_trusted?(incoming_payload)
@@ -167,7 +167,7 @@ module NewRelic
           return unless CrossAppTracing.trusted_valid_cross_app_id?(decoded_id)
 
           txn_header = headers[CrossAppTracing::NR_MESSAGE_BROKER_TXN_HEADER]
-          txn_info = ::JSON.load(deobfuscate(txn_header))
+          txn_info = ::JSON.parse(deobfuscate(txn_header))
           payload = CrossAppPayload.new(decoded_id, transaction, txn_info)
 
           @cross_app_payload = payload


### PR DESCRIPTION
`JSON.parse` is the safer of the two methods.