### PR TITLE
Lambda txn name event source

### DIFF
--- a/lib/new_relic/agent/serverless_handler.rb
+++ b/lib/new_relic/agent/serverless_handler.rb
@@ -43,7 +43,7 @@ module NewRelic
         txn_name = function_name
         if ENV['NEW_RELIC_APM_LAMBDA_MODE'] == 'true'
           source = event_source_event_info['name']
-          "#{source} #{txn_name}" if source
+          txn_name = "#{source} #{txn_name}" if source
         end
 
         NewRelic::Agent::Tracer.in_transaction(category: category, name: txn_name) do

--- a/lib/new_relic/agent/serverless_handler.rb
+++ b/lib/new_relic/agent/serverless_handler.rb
@@ -43,7 +43,7 @@ module NewRelic
         txn_name = function_name
         if ENV['NEW_RELIC_APM_LAMBDA_MODE'] == 'true'
           source = event_source_event_info['name']
-          txn_name = "#{source} #{txn_name}" if source
+          txn_name = "#{source.upcase} #{txn_name}" if source
         end
 
         NewRelic::Agent::Tracer.in_transaction(category: category, name: txn_name) do

--- a/lib/new_relic/agent/serverless_handler.rb
+++ b/lib/new_relic/agent/serverless_handler.rb
@@ -40,7 +40,13 @@ module NewRelic
 
         @event, @context = event, context
 
-        NewRelic::Agent::Tracer.in_transaction(category: category, name: function_name) do
+        txn_name = function_name
+        if ENV['NEW_RELIC_APM_LAMBDA_MODE'] == 'true'
+          source = event_source_event_info['name']
+          "#{source} #{txn_name}" if source
+        end
+
+        NewRelic::Agent::Tracer.in_transaction(category: category, name: txn_name) do
           prep_transaction
 
           process_response(NewRelic::LanguageSupport.constantize(namespace)


### PR DESCRIPTION

We are already determining the event source in order to add it as an agent attribute in serverless mode. Previously our transaction names for lambda were just the function name, now when the NEW_RELIC_APM_LAMBDA_MODE env variable is enabled, the event source is added (upcased) to the transaction name.

resolves https://github.com/newrelic/newrelic-ruby-agent/issues/3197