### PR TITLE
Fix intermittently failing test for serverless tests

### DIFF
--- a/test/new_relic/agent/serverless_handler_test.rb
+++ b/test/new_relic/agent/serverless_handler_test.rb
@@ -83,10 +83,10 @@ module NewRelic::Agent
         @test_config = NewRelic::Agent::Configuration::DottedHash.new(config_hash, true)
         NewRelic::Agent.config.add_config_for_testing(@test_config, true)
         handler.send(:reset!)
+        harvest_transaction_events!
       end
 
       def teardown
-        harvest_transaction_events!
         skip unless defined?(@test_config)
 
         NewRelic::Agent.config.remove_config(@test_config)


### PR DESCRIPTION
Moved the txn harvest into setup, because we want to be sure it's always empty for each test, so it should be in setup instead of teardown.