### PR TITLE
pin karafka-rdkafka version

### DIFF
--- a/test/multiverse/suites/rdkafka/Envfile
+++ b/test/multiverse/suites/rdkafka/Envfile
@@ -34,6 +34,6 @@ create_gemfiles(VERSIONS)
 # but we don't need to test it on every ruby version bc it should just be the same as rdkafka
 if Gem::Version.new(RUBY_VERSION) > Gem::Version.new('3.3.0')
   gemfile <<~RB
-    gem 'karafka-rdkafka', require: 'rdkafka'
+    gem 'karafka-rdkafka', '< 0.21.0', require: 'rdkafka'
   RB
 end


### PR DESCRIPTION
A new version (0.21.0) of karafka-rdkafka was released and it is causing one of our kafka tests to fail intermittently. This pins the version in our tests to a known working version while we investigate the issue and see what needs to be done to support the new version