### PR TITLE
Fix for intermittently failing karafka_rdkafka 0.21.0 test

### DIFF
--- a/test/multiverse/suites/rdkafka/Envfile
+++ b/test/multiverse/suites/rdkafka/Envfile
@@ -34,6 +34,6 @@ create_gemfiles(VERSIONS)
 # but we don't need to test it on every ruby version bc it should just be the same as rdkafka
 if Gem::Version.new(RUBY_VERSION) > Gem::Version.new('3.3.0')
   gemfile <<~RB
-    gem 'karafka-rdkafka', '< 0.21.0', require: 'rdkafka'
+    gem 'karafka-rdkafka', require: 'rdkafka'
   RB
 end

--- a/test/multiverse/suites/rdkafka/rdkafka_instrumentation_test.rb
+++ b/test/multiverse/suites/rdkafka/rdkafka_instrumentation_test.rb
@@ -4,7 +4,7 @@
 
 class RdkafkaInstrumentationTest < Minitest::Test
   def setup
-    @topic = 'ruby-test-topic' + Time.now.to_i.to_s
+    @topic = 'ruby-test-topic' + Time.now.to_i.to_s + rand(1000).to_s
     Rdkafka::Config.logger = Logger.new(STDOUT, level: :error)
     @stats_engine = NewRelic::Agent.instance.stats_engine
   end


### PR DESCRIPTION
The new version of karafka_rdkafka runs faster than the previous version, which lead to some tests running with the same timestamp on the topic name. Each test uses a unique topic because only some tests consume the messages produced. The failures we were seeing were caused by a shared topic between multiple tests, but the first tests only produced messages, and did not consume that message. So when the DT test ran and consumed the first message in the topic, it was a message from a previous test leaking into the DT test. That's why the trace IDs wouldn't match. So now we also slap a rand on the topic name to avoid this problem.