### PR TITLE
Deprecate `newrelic deployments` CLI command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
   Support for recording deployments using the `newrelic deployments` command is now deprecated and will be removed in agent version 10.0.0. 
 
-  Going forward, there are a number of automated and manual ways ways to record changes in New Relic. Please see our guide to [Change Tracking](https://docs.newrelic.com/docs/change-tracking/change-tracking-introduction/) for a list of avaliable options.
+  Going forward, there are a number of automated and manual ways ways to record changes in New Relic. Please see our guide to [Change Tracking](https://docs.newrelic.com/docs/change-tracking/change-tracking-introduction/) for a list of available options.
 
 - **Feature: Ensure compatibility with Ruby 3.5 change to Method#source_location**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## dev
 
+- **Feature: Deprecation notice for the `newrelic deployments` command**
+
+  Support for recording deployments using the `newrelic deployments` command is now deprecated and will be removed in agent version 10.0.0. 
+
+  Going forward, there are a number of automated and manual ways ways to record changes in New Relic. Please see our guide to [Change Tracking](https://docs.newrelic.com/docs/change-tracking/change-tracking-introduction/) for a list of avaliable options.
+
 - **Feature: Ensure compatibility with Ruby 3.5 change to Method#source_location**
 
   Updated the agent to correctly parse the return value of Method#source_location, which is changing in Ruby 3.5 from a two-element to a five-element array. This change maintains support for older Ruby versions while adding support for the future release.

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -428,7 +428,7 @@ module NewRelic
           :type => String,
           :allowed_from_server => false,
           :exclude_from_reported_settings => true,
-          :description => 'Your New Relic <InlinePopover type="userKey" />. Required when using the New Relic REST API v2 to record deployments using the `newrelic deployments` command.'
+          :description => '# DEPRECATED: The `api_key` config setting is now deprecated. Its only use was for the `newrelic deployments` command, which is being removed in agent version 10.0.0.'
         },
         :backport_fast_active_record_connection_lookup => {
           :default => false,

--- a/lib/new_relic/cli/commands/deployments.rb
+++ b/lib/new_relic/cli/commands/deployments.rb
@@ -15,6 +15,19 @@ require 'new_relic/agent/hostname'
 require 'new_relic/control' unless defined? NewRelic::Control
 
 class NewRelic::Cli::Deployments < NewRelic::Cli::Command
+  # DEPRECATION NOTICE (Effective September 2025)
+  #
+  # The entire `NewRelic::Cli::Deployments` class and its associated
+  # `newrelic deployments` command are deprecated and will be removed in
+  # agent version 10.0.0.
+  #
+  # Users should migrate to recording deployments directly via New Relic's
+  # APIs. For more information, please see the official Change Tracking
+  # documentation: https://docs.newrelic.com/docs/change-tracking/change-tracking-introduction/
+  #
+  # @api public
+  #
+
   attr_reader :control
   def self.command; 'deployments'; end
 
@@ -64,6 +77,12 @@ class NewRelic::Cli::Deployments < NewRelic::Cli::Command
   # Run the Deployment upload in New Relic via Active Resource.
   # Will possibly print errors and exit the VM
   def run
+    msg = <<~TEXT
+      DEPRECATED: The `newrelic deployments` command will be removed in v10.0.0. Learn more about the alternate options: https://docs.newrelic.com/docs/change-tracking/change-tracking-introduction/
+    TEXT
+    NewRelic::Agent.logger.log_once(:warn, 'newrelic_deployments'.to_sym, msg)
+    warn msg
+
     begin
       @description = nil if @description && @description.strip.empty?
 


### PR DESCRIPTION
Deprecate `newrelic deployments` CLI command

Users should refer to [Change Tracking](https://docs.newrelic.com/docs/change-tracking/change-tracking-introduction/#start-tracking) for alternative deployment tracking options.

Related to #3259 