### PR TITLE
Fix BigDecimal in Rails42 tests

### DIFF
--- a/.github/workflows/scripts/setup_bundler
+++ b/.github/workflows/scripts/setup_bundler
@@ -75,25 +75,37 @@ function install_ruby_version_specific_gems {
   fi
 
     echo "DEBUG: running 'gem install' on specific gem versions"
-  if [[ $RUBY_VERSION =~ ^2\.[^7] ]]; then
-    gem install --default cgi:0.1.1
-    gem install --default date:3.3.1
-    gem install --default digest:3.0.0
-    gem install --default erb:2.2.2
-    gem install --default logger:1.5.3
-    gem install --default securerandom:0.1.1
-    gem install --default set:1.0.3
-    gem install --default strscan:3.0.4
-  else
     gem install --default cgi:0.5.0
     gem install --default date:3.4.1
+    gem install --default digest:3.1.0
     gem install --default digest:3.2.0
+    gem install --default erb:4.0.4
     gem install --default erb:5.0.1
     gem install --default logger:1.7.0
+    gem install --default securerandom:0.3.2
     gem install --default securerandom:0.4.1
     gem install --default set:1.1.2
+    gem install --default strscan:3.0.4
     gem install --default strscan:3.1.5
-  fi
+  # if [[ $RUBY_VERSION =~ ^2\.[^7] ]]; then
+  #   gem install --default cgi:0.1.1
+  #   gem install --default date:3.3.1
+  #   gem install --default digest:3.0.0
+  #   gem install --default erb:2.2.2
+  #   gem install --default logger:1.5.3
+  #   gem install --default securerandom:0.1.1
+  #   gem install --default set:1.0.3
+  #   gem install --default strscan:3.0.4
+  # else
+  #   gem install --default cgi:0.5.0
+  #   gem install --default date:3.4.1
+  #   gem install --default digest:3.2.0
+  #   gem install --default erb:5.0.1
+  #   gem install --default logger:1.7.0
+  #   gem install --default securerandom:0.4.1
+  #   gem install --default set:1.1.2
+  #   gem install --default strscan:3.1.5
+  # fi
     echo "DEBUG: Completed installing gems"
 }
 

--- a/.github/workflows/scripts/setup_bundler
+++ b/.github/workflows/scripts/setup_bundler
@@ -75,9 +75,8 @@ function install_ruby_version_specific_gems {
   fi
 
     echo "DEBUG: running 'gem install' on specific gem versions"
-    gem install --default cgi:0.1.1
+    # The doubles below are needed for older Ruby versions, since the newer one won't install on the older Ruby versions
     gem install --default cgi:0.5.0
-    gem install --default date:3.3.1
     gem install --default date:3.4.1
     gem install --default digest:3.1.0
     gem install --default digest:3.2.0
@@ -89,26 +88,9 @@ function install_ruby_version_specific_gems {
     gem install --default set:1.1.2
     gem install --default strscan:3.0.4
     gem install --default strscan:3.1.5
-  # if [[ $RUBY_VERSION =~ ^2\.[^7] ]]; then
-  #   gem install --default cgi:0.1.1
-  #   gem install --default date:3.3.1
-  #   gem install --default digest:3.0.0
-  #   gem install --default erb:2.2.2
-  #   gem install --default logger:1.5.3
-  #   gem install --default securerandom:0.1.1
-  #   gem install --default set:1.0.3
-  #   gem install --default strscan:3.0.4
-  # else
-  #   gem install --default cgi:0.5.0
-  #   gem install --default date:3.4.1
-  #   gem install --default digest:3.2.0
-  #   gem install --default erb:5.0.1
-  #   gem install --default logger:1.7.0
-  #   gem install --default securerandom:0.4.1
-  #   gem install --default set:1.1.2
-  #   gem install --default strscan:3.1.5
-  # fi
+
     echo "DEBUG: Completed installing gems"
+
 }
 
 function set_up_bundler {

--- a/.github/workflows/scripts/setup_bundler
+++ b/.github/workflows/scripts/setup_bundler
@@ -76,15 +76,19 @@ function install_ruby_version_specific_gems {
 
     echo "DEBUG: running 'gem install' on specific gem versions"
     # The doubles below are needed for older Ruby versions, since the newer one won't install on the older Ruby versions
+    gem install --default cgi:0.1.1
     gem install --default cgi:0.5.0
+    gem install --default date:3.3.1
     gem install --default date:3.4.1
-    gem install --default digest:3.1.0
+    gem install --default digest:3.0.0
     gem install --default digest:3.2.0
-    gem install --default erb:4.0.4
+    gem install --default erb:2.2.2
     gem install --default erb:5.0.1
+    gem install --default logger:1.5.3
     gem install --default logger:1.7.0
-    gem install --default securerandom:0.3.2
+    gem install --default securerandom:0.1.1
     gem install --default securerandom:0.4.1
+    gem install --default set:1.0.3
     gem install --default set:1.1.2
     gem install --default strscan:3.0.4
     gem install --default strscan:3.1.5

--- a/.github/workflows/scripts/setup_bundler
+++ b/.github/workflows/scripts/setup_bundler
@@ -75,7 +75,9 @@ function install_ruby_version_specific_gems {
   fi
 
     echo "DEBUG: running 'gem install' on specific gem versions"
+    gem install --default cgi:0.1.1
     gem install --default cgi:0.5.0
+    gem install --default date:3.3.1
     gem install --default date:3.4.1
     gem install --default digest:3.1.0
     gem install --default digest:3.2.0

--- a/.github/workflows/scripts/setup_bundler
+++ b/.github/workflows/scripts/setup_bundler
@@ -75,26 +75,26 @@ function install_ruby_version_specific_gems {
   fi
 
     echo "DEBUG: running 'gem install' on specific gem versions"
-    # The doubles below are needed for older Ruby versions, since the newer one won't install on the older Ruby versions
+  if [[ $RUBY_VERSION =~ ^2\.[^7] ]]; then
     gem install --default cgi:0.1.1
-    gem install --default cgi:0.5.0
     gem install --default date:3.3.1
-    gem install --default date:3.4.1
     gem install --default digest:3.0.0
-    gem install --default digest:3.2.0
     gem install --default erb:2.2.2
-    gem install --default erb:5.0.1
     gem install --default logger:1.5.3
-    gem install --default logger:1.7.0
     gem install --default securerandom:0.1.1
-    gem install --default securerandom:0.4.1
     gem install --default set:1.0.3
-    gem install --default set:1.1.2
     gem install --default strscan:3.0.4
+  else
+    gem install --default cgi:0.5.0
+    gem install --default date:3.4.1
+    gem install --default digest:3.2.0
+    gem install --default erb:5.0.1
+    gem install --default logger:1.7.0
+    gem install --default securerandom:0.4.1
+    gem install --default set:1.1.2
     gem install --default strscan:3.1.5
-
+  fi
     echo "DEBUG: Completed installing gems"
-
 }
 
 function set_up_bundler {

--- a/test/environments/rails42/Gemfile
+++ b/test/environments/rails42/Gemfile
@@ -11,6 +11,7 @@ gem 'mocha', '~> 1.16', :require => false
 gem 'rack', '~> 1.6'
 gem 'rack-test'
 gem 'sprockets', '3.7.2'
+gem 'bigdecimal', '1.4.2'
 
 platforms :jruby do
   gem 'activerecord-jdbcmysql-adapter', '~>1.3.0'


### PR DESCRIPTION
We started seeing this error for testing rails42 with rubies 2.4, 2.5, and 2.6.

`NoMethodError: undefined method `new' for BigDecimal:Class`

Explicitly adding the BigDecimal version compatible with > 2.4, the error is resolved. 

Full CI run: https://github.com/newrelic/newrelic-ruby-agent/actions/runs/17964455821