### PR TITLE
Enable cron on URL Test CI

### DIFF
--- a/.github/workflows/ci_special.yml
+++ b/.github/workflows/ci_special.yml
@@ -1,8 +1,8 @@
 name: URL Test CI
 
 on:
-  # schedule:
-    # - cron: '0 9 * * *'
+  schedule:
+    - cron: '0 9 * * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Previously, we hit rate limits on GitHub when checking repository links. This problem is now resolved.

See: https://github.com/newrelic/newrelic-ruby-agent/actions/runs/17871614451 