### PR TITLE
Revert token change for prerelease workflow

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -39,7 +39,7 @@ jobs:
         git push --set-upstream origin "prerelease_updates_${{ env.prerelease_tag }}"
         gh pr create --label $LABEL --title "$TITLE" --body "$BODY"
       env:
-        GITHUB_TOKEN: ${{ secrets.NEWRELIC_RUBY_AGENT_BOT_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         TITLE: "Prerelease ${{env.prerelease_tag}}"
         BODY: "Updates the version number, changelog, and newrelic.yml (if it needs updating). This is an automated PR."
         LABEL: prerelease


### PR DESCRIPTION
GITHUB_TOKEN may let us add labels again. Though the bot token was helpful to get the CI to run automatically...

See: https://github.com/newrelic/newrelic-ruby-agent/pull/3161