### PR TITLE
add sidekiq_notice_only_once configuration to reduce noise from retriable sidekiq failures

### DIFF
--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -1416,7 +1416,7 @@ module NewRelic
           :public => true,
           :type => Boolean,
           :allowed_from_server => false,
-          :description => 'If `true`, the agent will ignore exceptions raised during Sidekiq's retry attempts and will only report the error if the job permanently fails.'
+          :description => %Q(If `true`, the agent will ignore exceptions raised during Sidekiq's retry attempts and will only report the error if the job permanently fails.)
         },
         :disable_roda_auto_middleware => {
           :default => false,


### PR DESCRIPTION
# Overview
instrumentation for sidekiq, configures the server to call `NewRelic::Agent.notice_error`[ on any error that occurs](https://github.com/newrelic/newrelic-ruby-agent/blob/dev/lib/new_relic/agent/instrumentation/sidekiq.rb#L43-L49), this means there will be a call also for each failed retry, generating a lot of noise. 
(any temporary error that will be retried will be reported). 

This can be annoying. 

Adding sidekiq_notice_only_once configuration, by configuring it the user can decide not to report exceptions that will be retried, but only report an error on a job before it goes to the dead queue. 
Thus reducing noise from temporary issues. (logging is advised)

Submitter Checklist:
- [ ] Include a link to the related GitHub issue, if applicable
- [ ] Add new tests for your change, if applicable

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
GitHub Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Confirm all checks passed
- [ ] Open a separate PR to add a CHANGELOG entry
