### PR TITLE
Stepping stone: Accept default, adaptive, always_on and always off for three samplers

### DIFF
--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -1458,6 +1458,7 @@ module NewRelic
           :public => true,
           :type => String,
           :allowed_from_server => true,
+          :allowlist => %w[default adaptive always_on always_off],
           :description => 'This setting controls the behavior of transaction sampling for transactions without a remote parent, traces that originate within this instance of the New Relic agent. Available values are `default`, `adaptive`, `always_on`, `always_off`. At this time `default` and `adaptive` are the same.'
         },
         :'distributed_tracing.sampler.remote_parent_sampled' => {
@@ -1465,6 +1466,7 @@ module NewRelic
           :public => true,
           :type => String,
           :allowed_from_server => true,
+          :allowlist => %w[default adaptive always_on always_off],
           :description => 'This setting controls the behavior of transaction sampling when a remote parent is sampled. Available values are `default`, `adaptive`, `always_on`, `always_off`. At this time `default` and `adaptive` are the same.'
         },
         :'distributed_tracing.sampler.remote_parent_not_sampled' => {
@@ -1472,6 +1474,7 @@ module NewRelic
           :public => true,
           :type => String,
           :allowed_from_server => true,
+          :allowlist => %w[default adaptive always_on always_off],
           :description => 'This setting controls the behavior of transaction sampling when a remote parent is not sampled. Available values are `default`, `adaptive`, `always_on`, `always_off`. At this time `default` and `adaptive` are the same.'
         },
         # Elasticsearch

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -281,16 +281,6 @@ module NewRelic
           constants.compact!
           constants
         end
-
-        def self.enforce_fallback(allowed_values: nil, fallback: nil)
-          proc do |configured_value|
-            if allowed_values.any? { |v| v =~ /#{configured_value}/i }
-              configured_value
-            else
-              fallback
-            end
-          end
-        end
       end
 
       AUTOSTART_DENYLISTED_RAKE_TASKS = [

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -1463,19 +1463,26 @@ module NewRelic
           :allowed_from_server => true,
           :description => 'Distributed tracing lets you see the path that a request takes through your distributed system. Enabling distributed tracing changes the behavior of some New Relic features, so carefully consult the [transition guide](/docs/transition-guide-distributed-tracing) before you enable this feature.'
         },
+        :'distributed_tracing.sampler.root' => {
+          :default => 'default',
+          :public => true,
+          :type => String,
+          :allowed_from_server => true,
+          :description => 'This setting controls the behavior of transaction sampling for transactions without a remote parent, traces that originate within this instance of the New Relic agent. Available values are `default`, `adaptive`, `always_on`, `always_off`. At this time `default` and `adaptive` are the same.'
+        },
         :'distributed_tracing.sampler.remote_parent_sampled' => {
           :default => 'default',
           :public => true,
           :type => String,
           :allowed_from_server => true,
-          :description => 'This setting controls the behavior of transaction sampling when a remote parent is sampled and the trace flag is set in the traceparent. Available values are `default`, `always_on`, and `always_off`.'
+          :description => 'This setting controls the behavior of transaction sampling when a remote parent is sampled. Available values are `default`, `adaptive`, `always_on`, `always_off`. At this time `default` and `adaptive` are the same.'
         },
         :'distributed_tracing.sampler.remote_parent_not_sampled' => {
           :default => 'default',
           :public => true,
           :type => String,
           :allowed_from_server => true,
-          :description => 'This setting controls the behavior of transaction sampling when a remote parent is not sampled and the trace flag is not set in the traceparent. Available values are `default`, `always_on`, and `always_off`.'
+          :description => 'This setting controls the behavior of transaction sampling when a remote parent is not sampled. Available values are `default`, `adaptive`, `always_on`, `always_off`. At this time `default` and `adaptive` are the same.'
         },
         # Elasticsearch
         :'elasticsearch.capture_cluster_name' => {

--- a/lib/new_relic/agent/transaction/distributed_tracing.rb
+++ b/lib/new_relic/agent/transaction/distributed_tracing.rb
@@ -172,16 +172,23 @@ module NewRelic
           end
         end
 
+        def default_sampling(payload)
+          transaction.sampled = payload.sampled
+          transaction.priority = payload.priority if payload.priority
+        end
+
         def set_priority_and_sampled_newrelic_header(config, payload)
-          if config == 'always_on'
+          case config
+          when 'default'
+            default_sampling(payload)
+          when 'always_on'
             transaction.sampled = true
             transaction.priority = 2.0
-          elsif config == 'always_off'
+          when 'always_off'
             transaction.sampled = false
             transaction.priority = 0
-          else # case for 'default' value
-            transaction.sampled = payload.sampled
-            transaction.priority = payload.priority if payload.priority
+          when 'adaptive'
+            default_sampling(payload)
           end
         end
       end

--- a/lib/new_relic/agent/transaction/trace_context.rb
+++ b/lib/new_relic/agent/transaction/trace_context.rb
@@ -172,13 +172,16 @@ module NewRelic
         end
 
         def set_priority_and_sampled(config, payload)
-          if config == 'always_on'
+          case config
+          when 'default'
+            use_nr_tracestate_sampled(payload)
+          when 'always_on'
             transaction.sampled = true
             transaction.priority = 2.0
-          elsif config == 'always_off'
+          when 'always_off'
             transaction.sampled = false
             transaction.priority = 0
-          else # default
+          when 'adaptive'
             use_nr_tracestate_sampled(payload)
           end
         end

--- a/test/fixtures/cross_agent_tests/distributed_tracing/trace_context.json
+++ b/test/fixtures/cross_agent_tests/distributed_tracing/trace_context.json
@@ -263,7 +263,7 @@
     }
   },
   {
-    "test_name": "skip_no_headers_root_always_off",
+    "test_name": "no_headers_root_always_off",
     "comment": "Traces originating from current service are never sampled",
     "trusted_account_key": "33",
     "account_id": "33",
@@ -284,6 +284,33 @@
         "exact": {
           "priority": 0.0,
           "sampled": false
+        },
+        "expected": [ "guid", "traceId" ]
+      }
+    }
+  },
+  {
+    "test_name": "no_headers_root_always_on",
+    "comment": "Traces originating from current service are always sampled",
+    "trusted_account_key": "33",
+    "account_id": "33",
+    "web_transaction": true,
+    "raises_exception": false,
+    "span_events_enabled": true,
+    "transport_type": "HTTP",
+    "root": "always_on",
+    "remote_parent_sampled": "default",
+    "remote_parent_not_sampled": "default",
+    "force_adaptive_sampled_true": true,
+    "inbound_headers": [
+      {}
+    ],
+    "intrinsics": {
+      "target_events": [ "Transaction" ],
+      "common": {
+        "exact": {
+          "priority": 2.0,
+          "sampled": true
         },
         "expected": [ "guid", "traceId" ]
       }

--- a/test/new_relic/agent/distributed_tracing/trace_context_cross_agent_test.rb
+++ b/test/new_relic/agent/distributed_tracing/trace_context_cross_agent_test.rb
@@ -51,6 +51,7 @@ module NewRelic
                 :'transaction_events.enabled' => test_case.fetch('transaction_events_enabled', true),
                 :trusted_account_key => test_case['trusted_account_key'],
                 :'span_events.enabled' => test_case.fetch('span_events_enabled', true),
+                :'distributed_tracing.sampler.root' => test_case.fetch('root', 'default'),
                 :'distributed_tracing.sampler.remote_parent_sampled' => test_case.fetch('remote_parent_sampled', 'default'),
                 :'distributed_tracing.sampler.remote_parent_not_sampled' => test_case.fetch('remote_parent_not_sampled', 'default')
               }


### PR DESCRIPTION
This is just a step toward implementing the trace ID ratio based sampler. 

This PR creates a consistent pattern for the root sampler, as well as when the sampling decision is made in trace context, or using the newrelic header (in `lib/new_relic/agent/transaction/distributed_tracing.rb`). 

It also removes old code that isn't being used, the `enforce_fallback` method. The configs that used this option no longer exist. The `allowlist` functionality is much more performant and is used here instead. 

Case statements are evaluated in order, so I ordered the when statements by my best judgment of what is most and least likely to occur. 