### PR TITLE
Rename OpenTelemetry configs

### DIFF
--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2510,7 +2510,7 @@ module NewRelic
           :description => 'Number of seconds betwixt connections to the New Relic span event collection services.'
         },
         # TODO: Sync with the other agents to see what the config should be named, how it should be enabled, how it should be described
-        :'opentelemetry_bridge.enabled' => {
+        :'opentelemetry.enabled' => {
           :default => false,
           :public => false,
           :type => Boolean,

--- a/lib/new_relic/agent/opentelemetry_bridge.rb
+++ b/lib/new_relic/agent/opentelemetry_bridge.rb
@@ -8,7 +8,7 @@ module NewRelic
       def initialize
         # no-op without OpenTelemetry API & config
         return unless defined?(OpenTelemetry) &&
-          NewRelic::Agent.config[:'opentelemetry_bridge.enabled']
+          NewRelic::Agent.config[:'opentelemetry.enabled']
 
         OpenTelemetryBridge.install
       end

--- a/test/multiverse/suites/hybrid_agent/config/newrelic.yml
+++ b/test/multiverse/suites/hybrid_agent/config/newrelic.yml
@@ -15,4 +15,4 @@ development:
     stack_trace_threshold: 0.5
     transaction_threshold: 1.0
   capture_params: false
-  opentelemetry_bridge.enabled: true
+  opentelemetry.enabled: true

--- a/test/new_relic/agent/opentelemetry_bridge_test.rb
+++ b/test/new_relic/agent/opentelemetry_bridge_test.rb
@@ -11,13 +11,13 @@ module NewRelic
       class BridgeInstallationError < StandardError; end
 
       def test_does_not_run_requires_without_opentelemetry_api_gem
-        with_config(:'opentelemetry_bridge.enabled' => true) do
+        with_config(:'opentelemetry.enabled' => true) do
           assert NewRelic::Agent::OpenTelemetryBridge.new
         end
       end
 
       def test_does_not_run_requires_without_config
-        with_config(:'opentelemetry_bridge.enabled' => false) do
+        with_config(:'opentelemetry.enabled' => false) do
           Object.stub_const(:OpenTelemetry, nil) do
             assert NewRelic::Agent::OpenTelemetryBridge.new
           end
@@ -25,7 +25,7 @@ module NewRelic
       end
 
       def test_installs_bridge_when_configured
-        with_config(:'opentelemetry_bridge.enabled' => true) do
+        with_config(:'opentelemetry.enabled' => true) do
           Object.stub_const(:OpenTelemetry, nil) do
             NewRelic::Agent::OpenTelemetryBridge.stub(:install, -> { raise BridgeInstallationError.new }) do
               assert_raises(BridgeInstallationError) { NewRelic::Agent::OpenTelemetryBridge.new }


### PR DESCRIPTION
These configs are private so this doesn't need to be a breaking change. The name we've agreed on across the agents is `opentelemetry.*`