### PR TITLE
Rename ActiveJob segments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,16 @@
 
 ## dev
 
-- **Breaking Change: Removed support for Ruby 2.4 and 2.5**
+- **Breaking Change: Remove support for Ruby 2.4 and 2.5**
   Support for Ruby versions 2.4 and 2.5 has been removed. The new minimum required Ruby version is now 2.6. [PR#3314](https://github.com/newrelic/newrelic-ruby-agent/pull/3314)
 
 - **Breaking Change: Rename ActiveJob metrics**
   ActiveJob metrics have been updated to include the job's class name for more specific reporting. This is a breaking change and may require updating custom dashboards or alerts. [PR#3320](https://github.com/newrelic/newrelic-ruby-agent/pull/3320)
     - Old format: `Ruby/ActiveJob/<QueueName>/<Method>`
     - New format: `Ruby/ActiveJob/<ClassName>/<QueueName>/<Method>`
+
+- **Breaking Change: Rename `bin/newrelic` command to `bin/newrelic_rpm`**
+  The executable file for the agent's CLI has been renamed from `bin/newrelic` to `bin/newrelic_rpm`. This change resolves a name collision with the standalone New Relic CLI tool. [PR#3323](https://github.com/newrelic/newrelic-ruby-agent/pull/3323)
 
 ## v9.23.0
 

--- a/bin/newrelic
+++ b/bin/newrelic
@@ -1,8 +1,0 @@
-#!/usr/bin/env ruby
-# frozen_string_literal: true
-
-# This command has been renamed "newrelic_rpm"
-# executes one of the commands in the new_relic/commands directory
-# pass the name of the command as an argument
-
-load File.dirname(__FILE__) + '/newrelic_rpm'

--- a/lib/new_relic/cli/command.rb
+++ b/lib/new_relic/cli/command.rb
@@ -60,12 +60,6 @@ module NewRelic
         options = ARGV.options do |opts|
           script_name = File.basename($0)
 
-          # TODO: MAJOR VERSION - remove newrelic, deprecated since version x.xx
-          if /newrelic$/.match?(script_name)
-            $stdout.puts "warning: the 'newrelic' script has been renamed 'newrelic_rpm'"
-            script_name = 'newrelic_rpm'
-          end
-
           opts.banner = "Usage: #{script_name} [ #{@command_names.join(' | ')} ] [options]"
           opts.separator("use '#{script_name} <command> -h' to see detailed command options")
           opts


### PR DESCRIPTION
Active Job segments have been renamed to include their job class.

`Ruby/ActiveJob/#{queue}/#{method}` is now `Ruby/ActiveJob/#{job_class}/#{queue}/#{method}`