### PR TITLE
unpin connection_pool

### DIFF
--- a/test/multiverse/suites/sidekiq/Envfile
+++ b/test/multiverse/suites/sidekiq/Envfile
@@ -13,7 +13,6 @@ def gem_list(sidekiq_version = nil)
   <<-RB
     gem 'sidekiq'#{sidekiq_version}
     gem 'newrelic_rpm', :require => false, :path => File.expand_path('../../../../')
-    gem 'connection_pool', '< 3.0.0'
   RB
 end
 

--- a/test/multiverse/suites/sidekiq_ignore_retry_errors_enabled/Envfile
+++ b/test/multiverse/suites/sidekiq_ignore_retry_errors_enabled/Envfile
@@ -13,7 +13,6 @@ def gem_list(sidekiq_version = nil)
   <<-RB
     gem 'sidekiq'#{sidekiq_version}
     gem 'newrelic_rpm', :require => false, :path => File.expand_path('../../../../')
-    gem 'connection_pool', '< 3.0.0'
   RB
 end
 


### PR DESCRIPTION
Turns out it wasn't just us, the no :name error seemed to plague many. Apparently this change broke sidekiq (and rails), so they added name back in 3.0.2, so we can remove our version pin on connection_pool.

https://github.com/mperham/connection_pool/commit/955c64f96de81f5b2cee2546d3ea4c93ec11f6e9

resolves https://github.com/newrelic/newrelic-ruby-agent/issues/3367