### PR TITLE
Add `entity_guid` to Agent Health Check files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # New Relic Ruby Agent Release Notes
 
+## dev
+
+- **Feature: Add Entity GUID to Agent Control health check files**
+
+  When the agent is started within an [Agent Control](https://docs-preview.newrelic.com/docs/new-relic-agent-control) environment, a health check file is created at the configured file location for every agent process. This file now includes the guid of the entity related to the agent when available. [PR#3371](https://github.com/newrelic/newrelic-ruby-agent/pull/3371)
+
 ## v9.24.0
 
 - **Feature: Deprecation reminder for SqlSampler#notice_sql API**

--- a/lib/new_relic/agent/health_check.rb
+++ b/lib/new_relic/agent/health_check.rb
@@ -93,6 +93,7 @@ module NewRelic
 
       def contents
         <<~CONTENTS
+          entity_guid: #{NewRelic::Agent.config[:entity_guid]}
           healthy: #{@status[:healthy]}
           status: #{@status[:message]}#{last_error}
           start_time_unix_nano: #{@start_time}


### PR DESCRIPTION
The `entity_guid` field is the first field in the file. For a health file written out prior to the entity GUID being available, the agent includes the `entity_guid` key with an empty value.

Closes: #3298

This isn't v10 dependent, so it doesn't inherit from that branch. happy to rebase from that branch to merge the diverged change logs.