### PR TITLE
Fix async-http CI failures

### DIFF
--- a/test/multiverse/suites/async_http/Envfile
+++ b/test/multiverse/suites/async_http/Envfile
@@ -17,6 +17,7 @@ def gem_list(async_http_version = nil)
   <<~GEM_LIST
     gem 'async-http'#{async_http_version}
     gem 'rack'
+    gem 'protocol-http', '< 0.56.0'
   GEM_LIST
 end
 


### PR DESCRIPTION
pins the protocol-http version. A new protocol-http version has come out and it appears to break the way we insert headers when an array is being used for the headers in our test.