### PR TITLE
Fix async http test

### DIFF
--- a/test/multiverse/suites/async_http/Envfile
+++ b/test/multiverse/suites/async_http/Envfile
@@ -17,7 +17,6 @@ def gem_list(async_http_version = nil)
   <<~GEM_LIST
     gem 'async-http'#{async_http_version}
     gem 'rack'
-    gem 'protocol-http', '< 0.56.0'
   GEM_LIST
 end
 

--- a/test/multiverse/suites/async_http/async_http_instrumentation_test.rb
+++ b/test/multiverse/suites/async_http/async_http_instrumentation_test.rb
@@ -116,7 +116,7 @@ class AsyncHttpInstrumentationTest < Minitest::Test
     in_transaction do
       NewRelic::Agent::Tracer.current_transaction.raw_synthetics_header = 'boo'
 
-      get_response(default_url, ::Protocol::HTTP::Headers[%w[itsaheader itsavalue]])
+      get_response(default_url, ::Protocol::HTTP::Headers[[%w[itsaheader itsavalue]]])
 
       assert_equal 'boo', server.requests.last['HTTP_X_NEWRELIC_SYNTHETICS']
     end


### PR DESCRIPTION
So, turns out the headers are actually supposed to be double nested if its an array. So it wasn't the agent breaking, it was just creating the headeres incorrectly in the test, and the old version of protocol-http managed to not blow up in the test somehow, but the new version does because it's doing more about making headers consistent. 