### PR TITLE
Fix test compatibility with Bundler 4.0+ (all_specs removal)

### DIFF
--- a/test/new_relic/helper_test.rb
+++ b/test/new_relic/helper_test.rb
@@ -134,6 +134,8 @@ class HelperTest < Minitest::Test
   end
 
   def test_rubygems_specs_works_with_all_specs_when_installed_specs_is_absent
+    skip 'all_specs has been removed in Bundler 4.0+' if Gem::Version.new(Bundler::VERSION) >= Gem::Version.new('4.0.0')
+
     Bundler.rubygems.stub(:respond_to?, nil) do
       assert_equal Bundler.rubygems.all_specs, NewRelic::Helper.rubygems_specs
     end


### PR DESCRIPTION
# Overview
Fixes test failure when running with Bundler 4.0+ by skipping a test that validates behavior for old Bundler versions that no longer applies.

## Problem
The test `test_rubygems_specs_works_with_all_specs_when_installed_specs_is_absent` was failing with Bundler 4.0.3+ because:
- Bundler 4.0 removed `Bundler.rubygems.all_specs` in favor of `Bundler.rubygems.installed_specs`
- The test was attempting to simulate old Bundler behavior by stubbing `respond_to?` and then calling `all_specs`
- Since `all_specs` no longer exists in Bundler 4.0+, this raises a `Bundler::RemovedError`

## Solution
Added a skip condition to the test when running with Bundler 4.0+, as the scenario it tests (old Bundler without `installed_specs`) is no longer relevant for modern Bundler versions.

The implementation code in `lib/new_relic/helper.rb` already handles this correctly by:
1. First checking if `installed_specs` is available (Bundler 2.5.12+)
2. Falling back to `all_specs` only for very old Bundler versions

_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

Submitter Checklist:
- [x] Include a link to the related GitHub issue, if applicable
- [-] Add new tests for your change, if applicable

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
GitHub Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Confirm all checks passed
- [ ] Open a separate PR to add a CHANGELOG entry
