### PR TITLE
Bump minimum Ruby version for Rails edge to to 3.3

### DIFF
--- a/test/multiverse/lib/multiverse/envfile.rb
+++ b/test/multiverse/lib/multiverse/envfile.rb
@@ -164,7 +164,7 @@ module Multiverse
       # NOTE: The Rails Edge version is not tested unless the Ruby version in
       #       play is greater than or equal to (>=) the version number at the
       #       end of the unshifted inner array
-      gem_version_array.unshift(["github: 'rails'", 3.2])
+      gem_version_array.unshift(["github: 'rails'", 3.3])
     end
 
     # are we running in a CI context intended for PR approvals?

--- a/test/multiverse/suites/rails/Envfile
+++ b/test/multiverse/suites/rails/Envfile
@@ -3,8 +3,10 @@
 # frozen_string_literal: true
 
 RAILS_VERSIONS = [
-  [nil, 3.2],
-  ['8.0.0', 3.2],
+  # Multiverse::Envfile#unshift_rails_edge controls what Ruby versions run on
+  # Rails edge / master branch
+  [nil, 3.2], # 8.1
+  ['8.0.0', 3.3],
   ['7.2.0', 3.1],
   ['7.1.0', 2.7],
   ['7.0.4', 2.7],


### PR DESCRIPTION
Fixes [failed CI](https://github.com/newrelic/newrelic-ruby-agent/actions/runs/20710433359/job/59490885813#step:4:8086) 

🟢 [New CI run on this branch](https://github.com/newrelic/newrelic-ruby-agent/actions/runs/20724840404/job/59497716761) 

The `Multiverse::Envfile#unshift_rails_edge` method controls what Ruby versions run Rails edge, aka the Rails master branch.

In a Gemfile it looks like:
`gem 'rails', github: 'rails'`

The Rails team began work on 8.2, which has a new minimum Ruby version of 3.3.

https://github.com/newrelic/newrelic-ruby-agent/blob/ca5a61b912576024a532b0361600a340206f4f07/test/multiverse/lib/multiverse/envfile.rb#L149-L168