### PR TITLE
Fix CI 

### DIFF
--- a/.github/actions/run_unit_tests/action.yml
+++ b/.github/actions/run_unit_tests/action.yml
@@ -47,7 +47,7 @@ runs:
             "3.3.8": {
               "rails": "norails,rails61,rails70,rails71,rails72,rails80"
             },
-            "3.4.7": {
+            "3.4.8": {
               "rails": "norails,rails61,rails70,rails71,rails72,rails80"
             },
             "4.0.0": {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: [2.6.10, 3.4.7, 4.0.0]
+        ruby-version: [2.6.10, 3.4.8, 4.0.0]
     steps:
       - name: Configure git
         run: 'git config --global init.defaultBranch main'
@@ -56,7 +56,7 @@ jobs:
       fail-fast: false
       matrix:
         multiverse: [agent, ai, background, background_2, frameworks, httpclients, httpclients_2, hybrid_agent, rails, rest]
-        ruby-version: [2.6.10, 3.4.7, 4.0.0]
+        ruby-version: [2.6.10, 3.4.8, 4.0.0]
     steps:
       - name: Configure git
         run: 'git config --global init.defaultBranch main'
@@ -89,7 +89,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: [2.6.10, 3.4.7, 4.0.0]
+        ruby-version: [2.6.10, 3.4.8, 4.0.0]
     steps:
       - name: Configure git
         run: 'git config --global init.defaultBranch main'
@@ -139,7 +139,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: [2.6.10, 3.4.7, 4.0.0]
+        ruby-version: [2.6.10, 3.4.8, 4.0.0]
     steps:
       - name: Configure git
         run: 'git config --global init.defaultBranch main'
@@ -182,7 +182,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: [2.6.10, 3.4.7, 4.0.0]
+        ruby-version: [2.6.10, 3.4.8, 4.0.0]
     steps:
       - name: Configure git
         run: 'git config --global init.defaultBranch main'
@@ -229,7 +229,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: [2.6.10, 3.4.7, 4.0.0]
+        ruby-version: [2.6.10, 3.4.8, 4.0.0]
     steps:
       - name: Configure git
         run: 'git config --global init.defaultBranch main'
@@ -268,7 +268,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: [2.6.10, 3.4.7, 4.0.0]
+        ruby-version: [2.6.10, 3.4.8, 4.0.0]
     steps:
       - name: Configure git
         run: 'git config --global init.defaultBranch main'
@@ -287,7 +287,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: [2.7.8, 3.4.7]
+        ruby-version: [2.7.8, 3.4.8]
     steps:
       - name: Configure git
         run: 'git config --global init.defaultBranch main'

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: [2.6.10, 2.7.8, 3.0.7, 3.1.7, 3.2.8, 3.3.8, 3.4.4, 4.0.0]
+        ruby-version: [2.6.10, 2.7.8, 3.0.7, 3.1.7, 3.2.8, 3.3.8, 3.4.8, 4.0.0]
     steps:
       - name: Configure git
         run: 'git config --global init.defaultBranch main'
@@ -291,7 +291,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: [2.7.8, 3.0.7, 3.1.7, 3.2.9, 3.3.10, 3.4.7, 4.0.0]
+        ruby-version: [2.7.8, 3.0.7, 3.1.7, 3.2.9, 3.3.10, 3.4.8, 4.0.0]
     steps:
       - name: Configure git
         run: 'git config --global init.defaultBranch main'


### PR DESCRIPTION
schedule ci unit tests were running on 3.4.4, but the map for rails version to ruby version was changed to 3.4.7, but also 3.4.8 is being used in a bunch of places so i just combined everything to be 3.4.8.

passing run https://github.com/newrelic/newrelic-ruby-agent/actions/runs/20754990787