### PR TITLE
Don't notice errors when `sidekiq_ignore_errors` is `true`

### DIFF
--- a/lib/new_relic/agent/instrumentation/sidekiq/server.rb
+++ b/lib/new_relic/agent/instrumentation/sidekiq/server.rb
@@ -24,18 +24,73 @@ module NewRelic::Agent::Instrumentation::Sidekiq
       end
       trace_headers = msg.delete(NewRelic::NEWRELIC_KEY)
 
-      perform_action_with_newrelic_trace(trace_args) do
-        NewRelic::Agent::Transaction.merge_untrusted_agent_attributes(
-          NewRelic::Agent::AttributePreFiltering.pre_filter(msg['args'], self.class.nr_attribute_options),
-          ATTRIBUTE_JOB_NAMESPACE,
-          NewRelic::Agent::AttributeFilter::DST_NONE
+      if NewRelic::Agent.config[:'sidekiq.ignore_retry_errors']
+        perform_action_with_newrelic_trace_without_error_reporting(trace_args) do
+          NewRelic::Agent::Transaction.merge_untrusted_agent_attributes(
+            NewRelic::Agent::AttributePreFiltering.pre_filter(msg['args'], self.class.nr_attribute_options),
+            ATTRIBUTE_JOB_NAMESPACE,
+            NewRelic::Agent::AttributeFilter::DST_NONE
+          )
+
+          if ::NewRelic::Agent.config[:'distributed_tracing.enabled'] && trace_headers&.any?
+            ::NewRelic::Agent::DistributedTracing::accept_distributed_trace_headers(trace_headers, 'Other')
+          end
+
+          yield
+        end
+      else
+        perform_action_with_newrelic_trace(trace_args) do
+          NewRelic::Agent::Transaction.merge_untrusted_agent_attributes(
+            NewRelic::Agent::AttributePreFiltering.pre_filter(msg['args'], self.class.nr_attribute_options),
+            ATTRIBUTE_JOB_NAMESPACE,
+            NewRelic::Agent::AttributeFilter::DST_NONE
+          )
+
+          if ::NewRelic::Agent.config[:'distributed_tracing.enabled'] && trace_headers&.any?
+            ::NewRelic::Agent::DistributedTracing::accept_distributed_trace_headers(trace_headers, 'Other')
+          end
+
+          yield
+        end
+      end
+    end
+
+    private
+
+    # Version of perform_action_with_newrelic_trace that doesn't report errors
+    def perform_action_with_newrelic_trace_without_error_reporting(*args, &block)
+      NewRelic::Agent.record_api_supportability_metric(:perform_action_with_newrelic_trace_without_error_reporting)
+      state = NewRelic::Agent::Tracer.state
+      request = newrelic_request(args)
+      queue_start_time = detect_queue_start_time(request)
+
+      skip_tracing = do_not_trace? || !state.is_execution_traced?
+
+      if skip_tracing
+        state.current_transaction&.ignore!
+        NewRelic::Agent.disable_all_tracing { return yield }
+      end
+
+      trace_options = args.last.is_a?(Hash) ? args.last : NewRelic::EMPTY_HASH
+      category = trace_options[:category] || :controller
+      txn_options = create_transaction_options(trace_options, category, state, queue_start_time)
+
+      begin
+        finishable = NewRelic::Agent::Tracer.start_transaction_or_segment(
+          name: txn_options[:transaction_name],
+          category: category,
+          options: txn_options
         )
 
-        if ::NewRelic::Agent.config[:'distributed_tracing.enabled'] && trace_headers&.any?
-          ::NewRelic::Agent::DistributedTracing::accept_distributed_trace_headers(trace_headers, 'Other')
+        begin
+          yield
+        rescue => e
+          # Don't report errors when ignore_retry_errors is enabled
+          # death_handlers will handle final failures
+          raise
         end
-
-        yield
+      ensure
+        finishable.finish if finishable
       end
     end
 

--- a/lib/new_relic/agent/instrumentation/sidekiq/server.rb
+++ b/lib/new_relic/agent/instrumentation/sidekiq/server.rb
@@ -82,13 +82,7 @@ module NewRelic::Agent::Instrumentation::Sidekiq
           options: txn_options
         )
 
-        begin
-          yield
-        rescue
-          # Don't report errors when ignore_retry_errors is enabled
-          # death_handlers will handle final failures
-          raise
-        end
+        yield
       ensure
         finishable&.finish
       end

--- a/lib/new_relic/agent/instrumentation/sidekiq/server.rb
+++ b/lib/new_relic/agent/instrumentation/sidekiq/server.rb
@@ -84,13 +84,13 @@ module NewRelic::Agent::Instrumentation::Sidekiq
 
         begin
           yield
-        rescue => e
+        rescue
           # Don't report errors when ignore_retry_errors is enabled
           # death_handlers will handle final failures
           raise
         end
       ensure
-        finishable.finish if finishable
+        finishable&.finish
       end
     end
 

--- a/test/multiverse/suites/sidekiq_ignore_retry_errors_enabled/sidekiq_ignore_retry_errors_enabled_test.rb
+++ b/test/multiverse/suites/sidekiq_ignore_retry_errors_enabled/sidekiq_ignore_retry_errors_enabled_test.rb
@@ -76,6 +76,38 @@ class SidekiqIgnoreRetryErrorEnabledTest < Minitest::Test
       'Expected middleware to NOT report errors when sidekiq.ignore_retry_errors is true'
   end
 
+  def test_death_handler_reports_final_errors_when_sidekiq_ignore_retry_errors_is_true
+    # TODO: MAJOR VERSION - remove this when Sidekiq v5 is no longer supported
+    skip 'Test requires Sidekiq v6+' unless Sidekiq::VERSION.split('.').first.to_i >= 6
+
+    noticed_errors = []
+
+    NewRelic::Agent.stub :notice_error, proc { |error| noticed_errors.push(error) } do
+      config = if Sidekiq::VERSION.split('.').first.to_i >= 7
+        Sidekiq.default_configuration
+      else
+        Sidekiq
+      end
+
+      death_handlers = if config.respond_to?(:death_handlers)
+        config.death_handlers
+      else
+        config[:death_handlers] || []
+      end
+
+      nr_death_handler = death_handlers.find do |handler|
+        handler.is_a?(Proc) && handler.source_location&.first&.include?('newrelic')
+      end
+
+      error = StandardError.new(NRDeadEndJob::ERROR_MESSAGE)
+      nr_death_handler&.call({}, error)
+    end
+
+    refute_empty noticed_errors,
+      'Expected death handler to report final errors when sidekiq.ignore_retry_errors is true'
+    assert_equal NRDeadEndJob::ERROR_MESSAGE, noticed_errors.first.message
+  end
+
   def test_basic_job_execution_still_works
     segment = run_job
 


### PR DESCRIPTION
When `sidekiq_ignore_errors` is `true`, instrumentation should create transaction traces for retry jobs, but not errors on those jobs. We should only report errors that make it to Sidekiq's Dead Set.