### PR TITLE
Fix warnings for Otel bridge record_metric

### DIFF
--- a/lib/new_relic/agent/opentelemetry_bridge.rb
+++ b/lib/new_relic/agent/opentelemetry_bridge.rb
@@ -11,8 +11,9 @@ module NewRelic
         if defined?(OpenTelemetry) && Agent.config[:'opentelemetry.enabled'] && Agent.config[:'opentelemetry.traces.enabled']
           OpenTelemetryBridge.install
           NewRelic::Agent.record_metric('Supportability/Tracing/Ruby/OpenTelemetryBridge/enabled', 0.0)
-        else
-          NewRelic::Agent.record_metric('Supportability/Tracing/Ruby/OpenTelemetryBridge/disabled', 0.0)
+          # else
+          # This record metric calls happen before the agent is fully started, which causes us to log warnings every single time the agent runs.
+          # NewRelic::Agent.record_metric('Supportability/Tracing/Ruby/OpenTelemetryBridge/disabled', 0.0)
         end
       end
 

--- a/test/new_relic/agent/opentelemetry_bridge_test.rb
+++ b/test/new_relic/agent/opentelemetry_bridge_test.rb
@@ -68,13 +68,13 @@ module NewRelic
         end
       end
 
-      def test_adds_supportability_metric_when_opentelemetry_disabled
-        with_config(:'opentelemetry.enabled' => false) do
-          NewRelic::Agent::OpenTelemetryBridge.new
+      # def test_adds_supportability_metric_when_opentelemetry_disabled
+      #   with_config(:'opentelemetry.enabled' => false) do
+      #     NewRelic::Agent::OpenTelemetryBridge.new
 
-          assert_metrics_recorded('Supportability/Tracing/Ruby/OpenTelemetryBridge/disabled')
-        end
-      end
+      #     assert_metrics_recorded('Supportability/Tracing/Ruby/OpenTelemetryBridge/disabled')
+      #   end
+      # end
     end
   end
 end


### PR DESCRIPTION
Comments out the disabled metric for the otel bridge, and the related test. We will change how this works more in depth in the future.