### PR TITLE
Fix typo in changelog

### DIFF
--- a/.github/workflows/scripts/generate_release_notes.rb
+++ b/.github/workflows/scripts/generate_release_notes.rb
@@ -70,7 +70,6 @@ class GenerateReleaseNotes
   def major_bump?
     # look for a line that starts with 'v' followed by a version number
     # then grab the first match (the version number)
-    binding.irb
     previous_release_version = @split_changelog[2][/^ v(\d+\.\d+\.\d+)$/, 1]
     previous_major_version = previous_release_version.split('.')[0].to_i
 

--- a/.github/workflows/scripts/generate_release_notes.rb
+++ b/.github/workflows/scripts/generate_release_notes.rb
@@ -24,7 +24,7 @@ class GenerateReleaseNotes
   # pass the filename as an arg to simplify testing
   def initialize(changelog_filename = 'CHANGELOG.md')
     changelog = File.read(changelog_filename)
-    @split_changelog = changelog.split('##')
+    @split_changelog = changelog.split("\n##")
   end
 
   def build_metadata
@@ -70,6 +70,7 @@ class GenerateReleaseNotes
   def major_bump?
     # look for a line that starts with 'v' followed by a version number
     # then grab the first match (the version number)
+    binding.irb
     previous_release_version = @split_changelog[2][/^ v(\d+\.\d+\.\d+)$/, 1]
     previous_major_version = previous_release_version.split('.')[0].to_i
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,8 +115,8 @@
   When the agent is started within an [Agent Control](https://docs-preview.newrelic.com/docs/new-relic-agent-control) environment, a health check file is created at the configured file location for every agent process. This file now includes the guid of the entity related to the agent when available. [PR#3371](https://github.com/newrelic/newrelic-ruby-agent/pull/3371)
 
 - **Bugfix: Resolve a `NoMethodError` in GCP utilization detection.**
-  
-  The GCP metadata discovery logic will now gracefully handle `nil` or unexpected values, preventing service initialization crashes. [PR##3388](https://github.com/newrelic/newrelic-ruby-agent/pull/#3388)
+
+  The GCP metadata discovery logic will now gracefully handle `nil` or unexpected values, preventing service initialization crashes. [PR#3388](https://github.com/newrelic/newrelic-ruby-agent/pull/#3388)
 
 ## v9.24.0
 


### PR DESCRIPTION
We accidentally had a double `##` within one of our PR links, which caused the changelog splitting to occur earlier than expected. 

This PR also updates the generate_release_notes.rb script to split on the newline+## to hopefully prevent against this in the future.

I don't remember if the release notes tests are running in the CI, but here's a local run JIC:
```
➜  newrelic-ruby-agent git:(changelog-typo) ✗ be ruby test/new_relic/github/workflows/scripts/generate_release_notes_test.rb
Run options: --seed 26674

# Running:

..............

Fabulous run in 0.011504s, 1216.9680 runs/s, 5215.5772 assertions/s.
```