### PR TITLE
Update config description with STDOUT logging tip

### DIFF
--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -458,7 +458,7 @@ module NewRelic
           :public => true,
           :type => String,
           :allowed_from_server => false,
-          :description => 'Defines a path to the agent log file, excluding the filename.'
+          :description => 'Defines a path to the agent log file, excluding the filename. If you want to send your agent logs to standard out, set this to STDOUT.'
         },
         :marshaller => {
           :default => 'json',


### PR DESCRIPTION
I was looking for this recently and was surprised not to see it in our config description. [A nice Medium Article](https://medium.com/@edgar/logging-inside-docker-newrelic-gem-and-stdout-91b6fd708c47) helped me quickly confirm the process.

Thanks, @edgar!