### PR TITLE
Support Grape 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # New Relic Ruby Agent Release Notes
 
+## dev
+
+- **Feature: Add support for Grape v3.1.0**
+
+  Grape's release of v3.1.0 introduced changes that were incompatible with the agent's instrumentation, causing issues when collecting transaction names. The agent has been updated to properly extract class names for transaction naming in the updated Grape API structure. [PR#3413](https://github.com/newrelic/newrelic-ruby-agent/pull/3413)
+
 ## v10.0.0
 
 - **Breaking Change: Remove support for Ruby 2.4 and 2.5**

--- a/lib/new_relic/agent/instrumentation/grape/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/grape/instrumentation.rb
@@ -22,7 +22,7 @@ module NewRelic::Agent::Instrumentation
           endpoint = env[API_ENDPOINT]
           version = env[API_VERSION]
 
-          api_class = context.class.instance_variable_get(:@base) || context.class             
+          api_class = context.class.instance_variable_get(:@base) || context.class 
           handle_transaction(endpoint, api_class.name, version)
         rescue => e
           ::NewRelic::Agent.logger.warn('Error in Grape instrumentation', e)

--- a/lib/new_relic/agent/instrumentation/grape/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/grape/instrumentation.rb
@@ -22,8 +22,7 @@ module NewRelic::Agent::Instrumentation
           endpoint = env[API_ENDPOINT]
           version = env[API_VERSION]
 
-          class_name = (context.class.respond_to?(:base) && context.class.base) || 
-                      context.class
+          class_name = (context.class.respond_to?(:base) && context.class.base) || context.class
 
           handle_transaction(endpoint, class_name, version)
         rescue => e

--- a/lib/new_relic/agent/instrumentation/grape/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/grape/instrumentation.rb
@@ -22,9 +22,7 @@ module NewRelic::Agent::Instrumentation
           endpoint = env[API_ENDPOINT]
           version = env[API_VERSION]
 
-          class_name = (context.class.respond_to?(:base) && context.class.base) || context.class
-
-          handle_transaction(endpoint, class_name, version)
+          handle_transaction(endpoint, context.class.to_s, version)
         rescue => e
           ::NewRelic::Agent.logger.warn('Error in Grape instrumentation', e)
         end

--- a/lib/new_relic/agent/instrumentation/grape/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/grape/instrumentation.rb
@@ -22,7 +22,7 @@ module NewRelic::Agent::Instrumentation
           endpoint = env[API_ENDPOINT]
           version = env[API_VERSION]
 
-          api_class = context.class.instance_variable_get(:@base) || context.class 
+          api_class = context.class.instance_variable_get(:@base) || context.class
           handle_transaction(endpoint, api_class.name, version)
         rescue => e
           ::NewRelic::Agent.logger.warn('Error in Grape instrumentation', e)

--- a/lib/new_relic/agent/instrumentation/grape/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/grape/instrumentation.rb
@@ -22,8 +22,19 @@ module NewRelic::Agent::Instrumentation
           endpoint = env[API_ENDPOINT]
           version = env[API_VERSION]
 
-          api_class = (context.class.respond_to?(:base) && context.class.base) || context.class
-          handle_transaction(endpoint, api_class.name, version)
+          binding.irb
+
+          class_name = endpoint.instance_variable_get(:@options)[:for].to_s ||
+                      (context.class.respond_to?(:base) && context.class.base) || 
+                      context.class
+
+
+          if class_name.nil?
+            api_class = env[API_ENDPOINT].instance_variable_get(:@options)[:for]                                                                                   
+            class_name = api_class.to_s  
+          end
+
+          handle_transaction(endpoint, class_name, version)
         rescue => e
           ::NewRelic::Agent.logger.warn('Error in Grape instrumentation', e)
         end

--- a/lib/new_relic/agent/instrumentation/grape/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/grape/instrumentation.rb
@@ -22,17 +22,8 @@ module NewRelic::Agent::Instrumentation
           endpoint = env[API_ENDPOINT]
           version = env[API_VERSION]
 
-          binding.irb
-
-          class_name = endpoint.instance_variable_get(:@options)[:for].to_s ||
-                      (context.class.respond_to?(:base) && context.class.base) || 
+          class_name = (context.class.respond_to?(:base) && context.class.base) || 
                       context.class
-
-
-          if class_name.nil?
-            api_class = env[API_ENDPOINT].instance_variable_get(:@options)[:for]                                                                                   
-            class_name = api_class.to_s  
-          end
 
           handle_transaction(endpoint, class_name, version)
         rescue => e

--- a/lib/new_relic/agent/instrumentation/grape/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/grape/instrumentation.rb
@@ -22,7 +22,8 @@ module NewRelic::Agent::Instrumentation
           endpoint = env[API_ENDPOINT]
           version = env[API_VERSION]
 
-          handle_transaction(endpoint, context.class.to_s, version)
+          api_class = context.class.instance_variable_get(:@base) || context.class             
+          handle_transaction(endpoint, api_class.name, version)
         rescue => e
           ::NewRelic::Agent.logger.warn('Error in Grape instrumentation', e)
         end


### PR DESCRIPTION
Grape v3.1.0 made a [change](https://github.com/ruby-grape/grape/pull/2633): Removed attr_readers: Replaced instance and base attr_readers with direct @instance and @base instance variable access

Causing our check to get the API class, `(context.class.respond_to?(:base) && context.class.base)`, to fail. 

We now access @base though the instance variable.

Full CI Run: https://github.com/newrelic/newrelic-ruby-agent/actions/runs/21405695803

closes #3412 

