### PR TITLE
Fix: local log decorating for Logstasher

### DIFF
--- a/lib/new_relic/agent/instrumentation/logstasher/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/logstasher/instrumentation.rb
@@ -16,7 +16,7 @@ module NewRelic::Agent::Instrumentation
 
       ::NewRelic::Agent.record_instrumentation_invocation(INSTRUMENTATION_NAME)
       ::NewRelic::Agent.agent.log_event_aggregator.record_logstasher_event(log)
-      ::NewRelic::Agent::LocalLogDecorator.decorate(log)
+      log['message'] = ::NewRelic::Agent::LocalLogDecorator.decorate(log['message'])
 
       logstasher_event
     end


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-ruby-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
Describe the changes present in the pull request

Submitter Checklist:
- [ ] Include a link to the related GitHub issue, if applicable
- [ ] Add new tests for your change, if applicable

# Testing
The agent includes a suite of unit and functional tests which should be used to
verify your changes don't break existing functionality. These tests will run with 
GitHub Actions when a pull request is made. More details on running the tests locally can be found 
[here for our unit tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/README.md), 
and [here for our functional tests](https://github.com/newrelic/newrelic-ruby-agent/blob/main/test/multiverse/README.md).
For most contributions it is strongly recommended to add additional tests which
exercise your changes. 

# Reviewer Checklist
- [ ] Perform code review
- [ ] Confirm all checks passed
- [ ] Open a separate PR to add a CHANGELOG entry
