### PR TITLE
Create datastore segments for database client spans

### DIFF
--- a/lib/new_relic/agent/opentelemetry/segments/datastore.rb
+++ b/lib/new_relic/agent/opentelemetry/segments/datastore.rb
@@ -1,0 +1,22 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+module NewRelic
+  module Agent
+    module OpenTelemetry
+      module Segments
+        module Datastore
+          def parse_operation(name, attributes)
+            return attributes['db.operation'] if attributes['db.operation']
+
+            name_downcased = name.downcase
+            return name_downcased if NewRelic::Agent::Database::KNOWN_OPERATIONS.include?(name_downcased)
+
+            NewRelic::Agent::Database.parse_operation_from_query(attributes['db.statement']) if attributes['db.statement']
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/new_relic/agent/opentelemetry/trace/span.rb
+++ b/lib/new_relic/agent/opentelemetry/trace/span.rb
@@ -18,6 +18,7 @@ module NewRelic
           def update_client_span
             if finishable.is_a?(NewRelic::Agent::Transaction::ExternalRequestSegment) &&
                 finishable.http_status_code.nil?
+              # TODO: Delete duplicate attrs from custom attributes
               finishable_attrs = finishable.attributes.custom_attributes
               code = finishable_attrs['http.response.status_code'] || finishable_attrs['http.status_code']
 

--- a/lib/new_relic/agent/opentelemetry/trace/tracer.rb
+++ b/lib/new_relic/agent/opentelemetry/trace/tracer.rb
@@ -3,6 +3,7 @@
 # frozen_string_literal: true
 
 require_relative '../segments/http_external'
+require_relative '../segments/datastore'
 
 module NewRelic
   module Agent
@@ -10,6 +11,7 @@ module NewRelic
       module Trace
         class Tracer < ::OpenTelemetry::Trace::Tracer
           include NewRelic::Agent::OpenTelemetry::Segments::HttpExternal
+          include NewRelic::Agent::OpenTelemetry::Segments::Datastore
 
           VALID_KINDS = [:server, :client, :consumer, :producer, :internal, nil].freeze
           KINDS_THAT_START_TRANSACTIONS = %i[server consumer].freeze
@@ -70,11 +72,11 @@ module NewRelic
             end
           end
 
-          # TODO: Database client spans also have the :client kind
-          # We need to add logic to differentiate between HTTP and DB client spans
-          # and start the appropriate segment type
           def start_otel_client_segment(name:, attributes: nil, start_timestamp: nil, kind: nil)
             attributes = NewRelic::EMPTY_HASH if attributes.nil?
+
+            return start_db_client_segment(name: name, attributes: attributes) if attributes.key?('db.system')
+
             uri = create_uri(attributes)
 
             # We need to have a URI to create an External Request Segment
@@ -89,6 +91,26 @@ module NewRelic
               start_time: start_timestamp,
               parent: nil
             )
+          end
+
+          # TODO: Connection spans from PG instrumentation don't have
+          # db.system attributes until after they've started,
+          # so they won't be datastore segments.
+          def start_db_client_segment(name:, attributes:, start_timestamp: nil)
+            operation = parse_operation(name, attributes)
+            segment = NewRelic::Agent::Tracer.start_datastore_segment(
+              product: attributes['db.system'],
+              operation: operation,
+              collection: attributes['db.collection.name'],
+              host: attributes['net.peer.name'],
+              port_path_or_id: attributes['net.peer.port'],
+              database_name: attributes['db.name'],
+              start_time: start_timestamp
+            )
+
+            segment._notice_sql(attributes['db.statement'])
+
+            segment
           end
 
           def start_transaction_from_otel(name, parent_otel_context, kind)

--- a/test/multiverse/suites/hybrid_agent/datastore_test.rb
+++ b/test/multiverse/suites/hybrid_agent/datastore_test.rb
@@ -1,0 +1,122 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+module NewRelic
+  module Agent
+    class DatastoreTest < Minitest::Test
+      class TestClass
+        include NewRelic::Agent::OpenTelemetry::Segments::Datastore
+      end
+
+      def setup
+        @test_instance = TestClass.new
+      end
+
+      def test_parse_operation_returns_db_operation_when_present
+        attributes = {'db.operation' => 'SELECT'}
+        result = @test_instance.parse_operation('some_name', attributes)
+
+        assert_equal 'SELECT', result
+      end
+
+      def test_parse_operation_prefers_db_operation_over_name
+        attributes = {'db.operation' => 'insert', 'db.statement' => 'SELECT * FROM users'}
+        result = @test_instance.parse_operation('SELECT', attributes)
+
+        assert_equal 'insert', result
+      end
+
+      def test_parse_operation_returns_downcased_name_for_select
+        attributes = {}
+        result = @test_instance.parse_operation('SELECT', attributes)
+
+        assert_equal 'select', result
+      end
+
+      def test_parse_operation_returns_downcased_name_for_insert
+        attributes = {}
+        result = @test_instance.parse_operation('INSERT', attributes)
+
+        assert_equal 'insert', result
+      end
+
+      def test_parse_operation_handles_mixed_case_known_operation
+        attributes = {}
+        result = @test_instance.parse_operation('CrEaTe', attributes)
+
+        assert_equal 'create', result
+      end
+
+      def test_parse_operation_handles_already_lowercase_known_operation
+        attributes = {}
+        result = @test_instance.parse_operation('select', attributes)
+
+        assert_equal 'select', result
+      end
+
+      def test_parse_operation_parses_from_db_statement_for_unknown_name
+        attributes = {'db.statement' => 'SELECT * FROM users WHERE id = 1'}
+        result = @test_instance.parse_operation('unknown', attributes)
+
+        assert_equal 'select', result
+      end
+
+      def test_parse_operation_parses_from_db_statement_when_name_has_more_than_operation
+        attributes = {'db.statement' => 'SELECT * FROM users WHERE id = 1'}
+        result = @test_instance.parse_operation('INSERT users', attributes)
+
+        assert_equal 'select', result
+      end
+
+      def test_parse_operation_returns_nil_when_name_has_more_than_operation_and_missing_attributes
+        attributes = {}
+        result = @test_instance.parse_operation('INSERT users', attributes)
+
+        assert_nil result
+      end
+
+      def test_parse_operation_parses_from_db_statement_returns_other_for_unknown_operation
+        attributes = {'db.statement' => 'UNKNOWN_OPERATION FROM users'}
+        result = @test_instance.parse_operation('unknown', attributes)
+
+        assert_equal 'other', result
+      end
+
+      def test_parse_operation_parses_from_db_statement_with_update
+        attributes = {'db.statement' => 'UPDATE users SET name = ? WHERE id = ?'}
+        result = @test_instance.parse_operation('unknown', attributes)
+
+        assert_equal 'update', result
+      end
+
+      def test_parse_operation_parses_from_db_statement_with_delete
+        attributes = {'db.statement' => 'DELETE FROM users WHERE id = ?'}
+        result = @test_instance.parse_operation('unknown', attributes)
+
+        assert_equal 'delete', result
+      end
+
+      def test_parse_operation_parses_from_db_statement_with_comments
+        attributes = {'db.statement' => '/* comment */ SELECT * FROM users'}
+        result = @test_instance.parse_operation('unknown', attributes)
+
+        assert_equal 'select', result
+      end
+
+      def test_parse_operation_parses_from_db_statement_with_multiline_comments
+        attributes = {'db.statement' => "/* multi\nline\ncomment */ INSERT INTO users VALUES (?)"}
+        result = @test_instance.parse_operation('unknown', attributes)
+
+        assert_equal 'insert', result
+      end
+
+      def test_parse_operation_returns_nil_when_db_statement_is_empty
+        attributes = {'db.statement' => ''}
+        result = @test_instance.parse_operation('unknown', attributes)
+
+        assert_nil result
+      end
+    end
+  end
+end

--- a/test/multiverse/suites/hybrid_agent/db_mapping_test.rb
+++ b/test/multiverse/suites/hybrid_agent/db_mapping_test.rb
@@ -1,0 +1,121 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+module NewRelic
+  module Agent
+    module OpenTelemetry
+      module Trace
+        class DbMappingTest < Minitest::Test
+          def setup
+            @tracer = NewRelic::Agent::OpenTelemetry::Trace::Tracer.new('OTelClient')
+          end
+
+          def teardown
+            mocha_teardown
+            NewRelic::Agent.instance.transaction_event_aggregator.reset!
+            NewRelic::Agent.instance.span_event_aggregator.reset!
+          end
+
+          def db_attrs
+            {
+              'db.system' => 'trilogy',
+              'db.statement' => 'SELECT * FROM users WHERE users.id = 1 and users.email = "test@test.com"',
+              'db.name' => 'customers',
+              'db.user' => 'user',
+              'peer.service' => 'readonly:mysql',
+              'db.instance.id' => '123456',
+              'net.peer.name' => 'example.host',
+              'net.peer.port' => '3306'
+            }
+          end
+
+          def start_db_client_segment
+            in_transaction(category: :web) do |txn|
+              txn.stubs(:sampled?).returns(true)
+
+              @tracer.in_span('select', attributes: db_attrs.dup, kind: :client) do |span|
+                # noop
+              end
+            end
+          end
+
+          def test_db_system_segment_v_1_17_segment_properties
+            transaction = start_db_client_segment
+
+            segment = transaction.segments[1]
+
+            assert_instance_of NewRelic::Agent::Transaction::DatastoreSegment, segment
+
+            assert_equal 'Datastore/operation/trilogy/select', segment.name
+            assert_equal db_attrs['net.peer.name'], segment.host
+          end
+
+          def test_db_system_segment_v_1_17_metrics
+            start_db_client_segment
+
+            assert_metrics_recorded([
+              'Datastore/all',
+              'Datastore/allWeb',
+              'Datastore/instance/trilogy/example.host/3306',
+              'Datastore/operation/trilogy/select',
+              'Datastore/trilogy/all'
+            ])
+          end
+
+          def test_db_system_segment_v_1_17_intrinsic_attributes
+            start_db_client_segment
+
+            spans = harvest_span_events!
+            span = spans[1][0]
+            intrinsics = span[0]
+
+            assert_equal db_attrs['db.system'], intrinsics['component']
+            assert_equal 'client', intrinsics['span.kind']
+            assert_equal 'datastore', intrinsics['category']
+          end
+
+          def test_db_system_segment_v_1_17_agent_attributes
+            start_db_client_segment
+
+            spans = harvest_span_events!
+            span = spans[1][0]
+            agent = span[2]
+
+            assert_equal db_attrs['db.name'], agent['db.instance']
+            assert_equal "#{db_attrs['net.peer.name']}:#{db_attrs['net.peer.port']}", agent['peer.address']
+            assert_equal db_attrs['net.peer.name'], agent['peer.hostname']
+            assert_equal db_attrs['net.peer.name'], agent['server.address']
+            assert_equal db_attrs['net.peer.port'], agent['server.port']
+            assert_equal db_attrs['db.system'], agent['db.system']
+            # statement is obfuscated by the _notice_sql call
+            assert_equal 'SELECT * FROM users WHERE users.id = ? and users.email = ?', agent['db.statement']
+          end
+
+          # TODO: The only custom attributes that should be attached
+          # are values that aren't present in the other attribute categories.
+          # All attributes are represented here so that a test fails when the
+          # change is made.
+          # Expected custom attributes to remain are:
+          # db.name, db.user, peer.service, db.instance.id
+          def test_db_system_segment_v_1_17_custom_attributes
+            start_db_client_segment
+
+            spans = harvest_span_events!
+            span = spans[1][0]
+            custom = span[1]
+
+            assert_equal db_attrs['db.system'], custom['db.system']
+            assert_equal db_attrs['db.statement'], custom['db.statement']
+            assert_equal db_attrs['db.name'], custom['db.name']
+            assert_equal db_attrs['db.user'], custom['db.user']
+            assert_equal db_attrs['peer.service'], custom['peer.service']
+            assert_equal db_attrs['db.instance.id'], custom['db.instance.id']
+            assert_equal db_attrs['net.peer.name'], custom['net.peer.name']
+            assert_equal db_attrs['net.peer.port'], custom['net.peer.port']
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
When a `:client` span is received with a `'db.system'` attribute, we attempt to use the `start_datastore_segment` API to start a segment and pass OTel attributes in the corresponding argument fields.

Since operation is important for NR span names, we will attempt to parse it from a few different sources: db.operation, the name of the span, and from the query.

Relates to #3279 

**Note:** The v.1.17 pre-stable attributes are the only ones tested in this PR because they are the only ones included in the agent spec at this time. After launch, the stable DB attributes will be added to the spec and can be added here too.