### PR TITLE
Defer recording the otel bridge metrics until after connect

### DIFF
--- a/lib/new_relic/agent/agent.rb
+++ b/lib/new_relic/agent/agent.rb
@@ -107,7 +107,7 @@ module NewRelic
         @adaptive_sampler_remote_parent_not_sampled = AdaptiveSampler.new(Agent.config[:sampling_target],
           Agent.config[:sampling_target_period_in_seconds])
         @serverless_handler = ServerlessHandler.new
-        @opentelemetry_bridge = OpenTelemetryBridge.new
+        @opentelemetry_bridge = OpenTelemetryBridge.new(@events)
       end
 
       def init_event_handlers

--- a/lib/new_relic/agent/opentelemetry_bridge.rb
+++ b/lib/new_relic/agent/opentelemetry_bridge.rb
@@ -5,15 +5,18 @@
 module NewRelic
   module Agent
     class OpenTelemetryBridge
-      def initialize
+      def initialize(events)
         # currently, we only have support for traces
         # this method should change when we add support for metrics and logs.
         if defined?(OpenTelemetry) && Agent.config[:'opentelemetry.enabled'] && Agent.config[:'opentelemetry.traces.enabled']
           OpenTelemetryBridge.install
-          NewRelic::Agent.record_metric('Supportability/Tracing/Ruby/OpenTelemetryBridge/enabled', 0.0)
-          # else
-          # This record metric calls happen before the agent is fully started, which causes us to log warnings every single time the agent runs.
-          # NewRelic::Agent.record_metric('Supportability/Tracing/Ruby/OpenTelemetryBridge/disabled', 0.0)
+          events.subscribe(:initial_configuration_complete) do
+            NewRelic::Agent.record_metric('Supportability/Tracing/Ruby/OpenTelemetryBridge/enabled', 0.0)
+          end
+        else
+          events.subscribe(:initial_configuration_complete) do
+            NewRelic::Agent.record_metric('Supportability/Tracing/Ruby/OpenTelemetryBridge/disabled', 0.0)
+          end
         end
       end
 


### PR DESCRIPTION
Uses the `initial_configuration_complete` agent hook to defer the metrics being recorded until after the server side config has been received, which will always occur after the fully agent is started. 

