### PR TITLE
Add instrumentation registry to Tracer Provider

### DIFF
--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2453,7 +2453,7 @@ module NewRelic
           :description => 'A global configuration option for disabling all OpenTelemetry signals sent through New Relic. If false, no OpenTelemetry signals will be sent to New Relic. If true, the signal-specific enabled config option (e.g. opentelemetry.traces.enabled) determines whether telemetry of that signal type will be reported to New Relic.'
         },
         :'opentelemetry.traces.enabled' => {
-          :default => false,
+          :default => true,
           :public => false,
           :type => Boolean,
           :allowed_from_server => false,
@@ -2467,7 +2467,7 @@ module NewRelic
           :description => 'A comma-delimited list of OpenTelemetry Tracers, represented as a string (e.g. "AppTracer1,OpenTelemetry::Instrumentation::Net::HTTP"), that **will** have their trace signals sent to New Relic. **WARNING**: This is not feature complete and is not intended to be enabled yet.'
         },
         # Exclude Net::HTTP because it currently instruments the NR agent's requests
-        # Could list all OTel instrumentation with matches... 
+        # Could list all OTel instrumentation with matches...
         :'opentelemetry.traces.exclude' => {
           :default => 'OpenTelemetry::Instrumentation::Net::HTTP',
           :public => false,

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2459,6 +2459,22 @@ module NewRelic
           :allowed_from_server => false,
           :description => 'Enables the creation of Transaction Trace segments and timeslice metrics from OpenTelemetry Spans. This will help drive New Relic UI experience for opentelemetry spans. **WARNING**: This is not feature complete and is not intended to be enabled yet.'
         },
+        :'opentelemetry.traces.include' => {
+          :default => '',
+          :public => false,
+          :type => String,
+          :allowed_from_server => false,
+          :description => 'A comma-delimited list of OpenTelemetry Tracers, represented as a string (e.g. "AppTracer1,OpenTelemetry::Instrumentation::Net::HTTP"), that **will** have their trace signals sent to New Relic. **WARNING**: This is not feature complete and is not intended to be enabled yet.'
+        },
+        # Exclude Net::HTTP because it currently instruments the NR agent's requests
+        # Could list all OTel instrumentation with matches... 
+        :'opentelemetry.traces.exclude' => {
+          :default => 'OpenTelemetry::Instrumentation::Net::HTTP',
+          :public => false,
+          :type => String,
+          :allowed_from_server => false,
+          :description => 'A comma-delimited list of OpenTelemetry Tracers, represented as a string (e.g. "AppTracer1,OpenTelemetry::Instrumentation::Net::HTTP"), that will **not** have their trace signals sent to New Relic. **WARNING**: This is not feature complete and is not intended to be enabled yet.'
+        },
         :force_reconnect => {
           :default => false,
           :public => false,

--- a/lib/new_relic/agent/opentelemetry/trace/tracer_provider.rb
+++ b/lib/new_relic/agent/opentelemetry/trace/tracer_provider.rb
@@ -18,7 +18,7 @@ module NewRelic
           def excluded_tracers
             @excluded ||= (NewRelic::Agent.config[:'opentelemetry.traces.exclude'].split(',') -
               NewRelic::Agent.config[:'opentelemetry.traces.include'].split(',')
-            )
+                          )
           end
 
           def tracer(name = nil, version = nil)

--- a/lib/new_relic/agent/opentelemetry/trace/tracer_provider.rb
+++ b/lib/new_relic/agent/opentelemetry/trace/tracer_provider.rb
@@ -16,9 +16,7 @@ module NewRelic
           end
 
           def excluded_tracers
-            @excluded ||= (NewRelic::Agent.config[:'opentelemetry.traces.exclude'].split(',') -
-              NewRelic::Agent.config[:'opentelemetry.traces.include'].split(',')
-                          )
+            @excluded ||= NewRelic::Agent::OpenTelemetryBridge.calculate_excluded_tracers
           end
 
           def tracer(name = nil, version = nil)

--- a/lib/new_relic/agent/opentelemetry/trace/tracer_provider.rb
+++ b/lib/new_relic/agent/opentelemetry/trace/tracer_provider.rb
@@ -23,6 +23,8 @@ module NewRelic
 
           def tracer(name = nil, version = nil)
             # We create a no-op tracer if the tracer is configured to be excluded
+            # This should only be run when a custom tracer that isn't defined by
+            # OpenTelemetry instrumentation is excluded
             return ::OpenTelemetry::Trace::Tracer.new if excluded_tracers.include?(name)
 
             NewRelic::Agent.logger.warn 'OpenTelemetry::Trace::TracerProvider#tracer called without providing a tracer name.' if name.nil? || name.empty?

--- a/lib/new_relic/agent/opentelemetry_bridge.rb
+++ b/lib/new_relic/agent/opentelemetry_bridge.rb
@@ -5,7 +5,11 @@
 module NewRelic
   module Agent
     class OpenTelemetryBridge
-      DEFAULT_EXCLUDED_TRACERS = %w[elasticsearch-api dalli].freeze
+            # Exclude tracers from native OTel instrumentation by default to prevent double-reporting.
+            # Affects libraries that the Ruby agent already instruments automatically.
+            # Can be overridden via the opentelemetry.traces.include configuration.
+            # https://opentelemetry.io/ecosystem/registry/?language=ruby&flag=native
+            DEFAULT_EXCLUDED_TRACERS = %w[elasticsearch-api dalli].freeze
 
       def initialize(events)
         # currently, we only have support for traces

--- a/lib/new_relic/agent/opentelemetry_bridge.rb
+++ b/lib/new_relic/agent/opentelemetry_bridge.rb
@@ -7,7 +7,7 @@ module NewRelic
     class OpenTelemetryBridge
       DEFAULT_EXCLUDED_TRACERS = %w[elasticsearch-api dalli].freeze
 
-      def initialize
+      def initialize(events)
         # currently, we only have support for traces
         # this method should change when we add support for metrics and logs.
         if defined?(OpenTelemetry) && Agent.config[:'opentelemetry.enabled'] && Agent.config[:'opentelemetry.traces.enabled']

--- a/lib/new_relic/agent/opentelemetry_bridge.rb
+++ b/lib/new_relic/agent/opentelemetry_bridge.rb
@@ -5,11 +5,11 @@
 module NewRelic
   module Agent
     class OpenTelemetryBridge
-            # Exclude tracers from native OTel instrumentation by default to prevent double-reporting.
-            # Affects libraries that the Ruby agent already instruments automatically.
-            # Can be overridden via the opentelemetry.traces.include configuration.
-            # https://opentelemetry.io/ecosystem/registry/?language=ruby&flag=native
-            DEFAULT_EXCLUDED_TRACERS = %w[elasticsearch-api dalli].freeze
+      # Exclude tracers from native OTel instrumentation by default to prevent double-reporting.
+      # Affects libraries that the Ruby agent already instruments automatically.
+      # Can be overridden via the opentelemetry.traces.include configuration.
+      # https://opentelemetry.io/ecosystem/registry/?language=ruby&flag=native
+      DEFAULT_EXCLUDED_TRACERS = %w[elasticsearch-api dalli].freeze
 
       def initialize(events)
         # currently, we only have support for traces

--- a/lib/new_relic/agent/opentelemetry_bridge.rb
+++ b/lib/new_relic/agent/opentelemetry_bridge.rb
@@ -30,6 +30,10 @@ module NewRelic
         ::OpenTelemetry.tracer_provider = OpenTelemetry::Trace::TracerProvider.new
         Transaction.prepend(OpenTelemetry::TransactionPatch)
         ::OpenTelemetry.propagation = OpenTelemetry::Context::Propagation::TracePropagator.new
+        # TODO: Currently, we'll get a successful install message logged by the OpenTelemetry logger via the registry even if the instrumentation is on the exclude list
+        if defined?(::OpenTelemetry::Instrumentation::Registry)
+          ::OpenTelemetry::Instrumentation.registry.install_all
+        end
       end
     end
   end

--- a/test/multiverse/suites/hybrid_agent/tracer_provider_test.rb
+++ b/test/multiverse/suites/hybrid_agent/tracer_provider_test.rb
@@ -140,6 +140,7 @@ module NewRelic
             threads.each(&:join)
 
             unique_tracers = tracers.uniq
+
             assert_equal 1, unique_tracers.size, 'Expected all threads to receive the same tracer instance'
           end
         end

--- a/test/multiverse/suites/hybrid_agent/tracer_provider_test.rb
+++ b/test/multiverse/suites/hybrid_agent/tracer_provider_test.rb
@@ -11,8 +11,12 @@ module NewRelic
             @tracer_provider = NewRelic::Agent::OpenTelemetry::Trace::TracerProvider.new
           end
 
+          def teardown
+            NewRelic::Agent.config.reset_to_defaults
+          end
+
           def test_tracer_returns_a_tracer
-            assert @tracer_provider.tracer.is_a?(NewRelic::Agent::OpenTelemetry::Trace::Tracer)
+            assert @tracer_provider.tracer('test_tracer').is_a?(NewRelic::Agent::OpenTelemetry::Trace::Tracer)
           end
 
           def test_tracer_returns_a_tracer_with_name_and_version
@@ -20,6 +24,123 @@ module NewRelic
 
             assert_equal 'newrelic_rpm', tracer.instance_variable_get(:@name)
             assert_equal '1.2.3', tracer.instance_variable_get(:@version)
+          end
+
+          def test_tracer_caches_tracers_in_registry
+            tracer1 = @tracer_provider.tracer('my_tracer', '1.0.0')
+            tracer2 = @tracer_provider.tracer('my_tracer', '1.0.0')
+
+            assert_same tracer1, tracer2, 'Expected the same tracer instance to be returned from the registry'
+          end
+
+          def test_tracer_creates_different_tracers_for_different_names
+            tracer1 = @tracer_provider.tracer('tracer_a', '1.0.0')
+            tracer2 = @tracer_provider.tracer('tracer_b', '1.0.0')
+
+            refute_same tracer1, tracer2, 'Expected different tracer instances for different names'
+          end
+
+          def test_tracer_creates_different_tracers_for_different_versions
+            tracer1 = @tracer_provider.tracer('my_tracer', '1.0.0')
+            tracer2 = @tracer_provider.tracer('my_tracer', '2.0.0')
+
+            refute_same tracer1, tracer2, 'Expected different tracer instances for different versions'
+          end
+
+          def test_tracer_returns_noop_tracer_for_excluded_tracer
+            with_config(:'opentelemetry.traces.exclude' => 'ExcludedTracer') do
+              tracer = @tracer_provider.tracer('ExcludedTracer')
+
+              assert_instance_of ::OpenTelemetry::Trace::Tracer, tracer
+              refute_instance_of NewRelic::Agent::OpenTelemetry::Trace::Tracer, tracer
+            end
+          end
+
+          def test_tracer_returns_noop_tracer_for_multiple_excluded_tracers
+            with_config(:'opentelemetry.traces.exclude' => 'TracerA,TracerB,TracerC') do
+              tracer_a = @tracer_provider.tracer('TracerA')
+              tracer_b = @tracer_provider.tracer('TracerB')
+              tracer_c = @tracer_provider.tracer('TracerC')
+
+              assert_instance_of ::OpenTelemetry::Trace::Tracer, tracer_a
+              assert_instance_of ::OpenTelemetry::Trace::Tracer, tracer_b
+              assert_instance_of ::OpenTelemetry::Trace::Tracer, tracer_c
+            end
+          end
+
+          def test_tracer_returns_nr_tracer_for_non_excluded_tracer
+            with_config(:'opentelemetry.traces.exclude' => 'ExcludedTracer') do
+              tracer = @tracer_provider.tracer('IncludedTracer')
+
+              assert_instance_of NewRelic::Agent::OpenTelemetry::Trace::Tracer, tracer
+            end
+          end
+
+          def test_include_list_overrides_exclude_list
+            with_config(
+              :'opentelemetry.traces.exclude' => 'TracerA,TracerB',
+              :'opentelemetry.traces.include' => 'TracerA'
+            ) do
+              excluded_tracers = @tracer_provider.excluded_tracers
+
+              refute_includes excluded_tracers, 'TracerA', 'TracerA should not be excluded when it is in the include list'
+              assert_includes excluded_tracers, 'TracerB', 'TracerB should still be excluded'
+            end
+          end
+
+          def test_include_list_allows_excluded_tracer_through
+            with_config(
+              :'opentelemetry.traces.exclude' => 'MyTracer',
+              :'opentelemetry.traces.include' => 'MyTracer'
+            ) do
+              tracer = @tracer_provider.tracer('MyTracer')
+
+              assert_instance_of NewRelic::Agent::OpenTelemetry::Trace::Tracer, tracer
+            end
+          end
+
+          def test_excluded_tracers_memoizes_result
+            with_config(
+              :'opentelemetry.traces.exclude' => 'TracerA',
+              :'opentelemetry.traces.include' => ''
+            ) do
+              result1 = @tracer_provider.excluded_tracers
+              result2 = @tracer_provider.excluded_tracers
+
+              assert_same result1, result2, 'Expected excluded_tracers to be memoized'
+            end
+          end
+
+          def test_tracer_logs_warning_when_called_with_empty_name
+            NewRelic::Agent.logger.expects(:warn).with(includes('called without providing a tracer name'))
+
+            with_config(:'opentelemetry.traces.exclude' => '') do
+              @tracer_provider.tracer('')
+            end
+          end
+
+          def test_tracer_does_not_log_warning_with_valid_name
+            NewRelic::Agent.logger.expects(:warn).never
+
+            with_config(:'opentelemetry.traces.exclude' => '') do
+              @tracer_provider.tracer('valid_tracer_name')
+            end
+          end
+
+          def test_tracer_is_thread_safe
+            tracers = []
+            threads = []
+
+            10.times do |i|
+              threads << Thread.new do
+                tracers << @tracer_provider.tracer('concurrent_tracer', '1.0.0')
+              end
+            end
+
+            threads.each(&:join)
+
+            unique_tracers = tracers.uniq
+            assert_equal 1, unique_tracers.size, 'Expected all threads to receive the same tracer instance'
           end
         end
       end

--- a/test/new_relic/agent/opentelemetry_bridge_test.rb
+++ b/test/new_relic/agent/opentelemetry_bridge_test.rb
@@ -75,6 +75,186 @@ module NewRelic
       #     assert_metrics_recorded('Supportability/Tracing/Ruby/OpenTelemetryBridge/disabled')
       #   end
       # end
+
+      def test_install_instrumentation_returns_early_when_registry_not_defined
+        otel_module = Module.new
+
+        Object.stub_const(:OpenTelemetry, otel_module) do
+          # Should not raise an error even though registry doesn't exist
+          assert_nil NewRelic::Agent::OpenTelemetryBridge.send(:install_instrumentation)
+        end
+      end
+
+      def test_install_instrumentation_filters_excluded_instrumentation
+        with_config(
+          :'opentelemetry.traces.exclude' => 'OpenTelemetry::Instrumentation::Redis,OpenTelemetry::Instrumentation::PG',
+          :'opentelemetry.traces.include' => ''
+        ) do
+          mock_registry = Minitest::Mock.new
+          mock_lock = Mutex.new
+
+          # Create simple objects that respond to to_s
+          redis_inst = Object.new
+          pg_inst = Object.new
+          rails_inst = Object.new
+          redis_inst.define_singleton_method(:to_s) { 'OpenTelemetry::Instrumentation::Redis' }
+          pg_inst.define_singleton_method(:to_s) { 'OpenTelemetry::Instrumentation::PG' }
+          rails_inst.define_singleton_method(:to_s) { 'OpenTelemetry::Instrumentation::Rails' }
+
+          mock_instrumentation = [redis_inst, pg_inst, rails_inst]
+
+          mock_registry.expect(:instance_variable_get, mock_lock, [:@lock])
+          mock_registry.expect(:instance_variable_get, mock_instrumentation, [:@instrumentation])
+          mock_registry.expect(:instance_variable_set, nil) do |var, value|
+            assert_equal :@instrumentation, var
+            assert_equal 1, value.length
+            assert_equal 'OpenTelemetry::Instrumentation::Rails', value.first.to_s
+            true
+          end
+          mock_registry.expect(:install_all, nil)
+
+          otel_module = Module.new
+          instrumentation_module = Module.new
+          registry_class = Class.new
+
+          instrumentation_module.define_singleton_method(:registry) { mock_registry }
+
+          Object.stub_const(:OpenTelemetry, otel_module) do
+            otel_module.stub_const(:Instrumentation, instrumentation_module) do
+              instrumentation_module.stub_const(:Registry, registry_class) do
+                NewRelic::Agent::OpenTelemetryBridge.send(:install_instrumentation)
+              end
+            end
+          end
+
+          mock_registry.verify
+        end
+      end
+
+      def test_install_instrumentation_handles_whitespace_in_config
+        with_config(
+          :'opentelemetry.traces.exclude' => ' OpenTelemetry::Instrumentation::Redis , OpenTelemetry::Instrumentation::PG ',
+          :'opentelemetry.traces.include' => ''
+        ) do
+          mock_registry = Minitest::Mock.new
+          mock_lock = Mutex.new
+
+          redis_inst = Object.new
+          pg_inst = Object.new
+          redis_inst.define_singleton_method(:to_s) { 'OpenTelemetry::Instrumentation::Redis' }
+          pg_inst.define_singleton_method(:to_s) { 'OpenTelemetry::Instrumentation::PG' }
+
+          mock_instrumentation = [redis_inst, pg_inst]
+
+          mock_registry.expect(:instance_variable_get, mock_lock, [:@lock])
+          mock_registry.expect(:instance_variable_get, mock_instrumentation, [:@instrumentation])
+          mock_registry.expect(:instance_variable_set, nil) do |var, value|
+            assert_equal :@instrumentation, var
+            assert_equal 0, value.length, 'Should filter both items despite whitespace'
+            true
+          end
+          mock_registry.expect(:install_all, nil)
+
+          otel_module = Module.new
+          instrumentation_module = Module.new
+          registry_class = Class.new
+
+          instrumentation_module.define_singleton_method(:registry) { mock_registry }
+
+          Object.stub_const(:OpenTelemetry, otel_module) do
+            otel_module.stub_const(:Instrumentation, instrumentation_module) do
+              instrumentation_module.stub_const(:Registry, registry_class) do
+                NewRelic::Agent::OpenTelemetryBridge.send(:install_instrumentation)
+              end
+            end
+          end
+
+          mock_registry.verify
+        end
+      end
+
+      def test_install_instrumentation_include_overrides_exclude
+        with_config(
+          :'opentelemetry.traces.exclude' => 'OpenTelemetry::Instrumentation::Redis,OpenTelemetry::Instrumentation::PG',
+          :'opentelemetry.traces.include' => 'OpenTelemetry::Instrumentation::Redis'
+        ) do
+          mock_registry = Minitest::Mock.new
+          mock_lock = Mutex.new
+
+          redis_inst = Object.new
+          pg_inst = Object.new
+          rails_inst = Object.new
+          redis_inst.define_singleton_method(:to_s) { 'OpenTelemetry::Instrumentation::Redis' }
+          pg_inst.define_singleton_method(:to_s) { 'OpenTelemetry::Instrumentation::PG' }
+          rails_inst.define_singleton_method(:to_s) { 'OpenTelemetry::Instrumentation::Rails' }
+
+          mock_instrumentation = [redis_inst, pg_inst, rails_inst]
+
+          mock_registry.expect(:instance_variable_get, mock_lock, [:@lock])
+          mock_registry.expect(:instance_variable_get, mock_instrumentation, [:@instrumentation])
+          mock_registry.expect(:instance_variable_set, nil) do |var, value|
+            assert_equal :@instrumentation, var
+            assert_equal 2, value.length
+            assert_includes value.map(&:to_s), 'OpenTelemetry::Instrumentation::Redis'
+            assert_includes value.map(&:to_s), 'OpenTelemetry::Instrumentation::Rails'
+            refute_includes value.map(&:to_s), 'OpenTelemetry::Instrumentation::PG'
+            true
+          end
+          mock_registry.expect(:install_all, nil)
+
+          otel_module = Module.new
+          instrumentation_module = Module.new
+          registry_class = Class.new
+
+          instrumentation_module.define_singleton_method(:registry) { mock_registry }
+
+          Object.stub_const(:OpenTelemetry, otel_module) do
+            otel_module.stub_const(:Instrumentation, instrumentation_module) do
+              instrumentation_module.stub_const(:Registry, registry_class) do
+                NewRelic::Agent::OpenTelemetryBridge.send(:install_instrumentation)
+              end
+            end
+          end
+
+          mock_registry.verify
+        end
+      end
+
+      def test_install_instrumentation_with_empty_exclude_list
+        with_config(
+          :'opentelemetry.traces.exclude' => '',
+          :'opentelemetry.traces.include' => ''
+        ) do
+          mock_registry = Minitest::Mock.new
+
+          redis_inst = Object.new
+          pg_inst = Object.new
+          redis_inst.define_singleton_method(:to_s) { 'OpenTelemetry::Instrumentation::Redis' }
+          pg_inst.define_singleton_method(:to_s) { 'OpenTelemetry::Instrumentation::PG' }
+
+          mock_instrumentation = [redis_inst, pg_inst]
+
+          # we don't add expects for the lock and instance variable changes
+          # because they're skipped if we don't have anything to exclude
+          mock_registry.expect(:install_all, nil)
+
+          otel_module = Module.new
+          instrumentation_module = Module.new
+          registry_class = Class.new
+
+          instrumentation_module.define_singleton_method(:registry) { mock_registry }
+
+          Object.stub_const(:OpenTelemetry, otel_module) do
+            otel_module.stub_const(:Instrumentation, instrumentation_module) do
+              instrumentation_module.stub_const(:Registry, registry_class) do
+                NewRelic::Agent::OpenTelemetryBridge.send(:install_instrumentation)
+              end
+            end
+          end
+
+          mock_registry.verify
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
An instrumentation registry is needed to keep track of the tracers we're instrumenting:
* We need to make sure unique tracers are created for every unique name provided
* We need to access an already existing tracer for a given name rather than create a new one
* The `opentelemetry.traces.include` / `exclude` configuration options also determine what tracers we will instrument
* We skip excluded tracers when we install instrumentation to prevent unnecessary prepending

In addition, this PR also updates the default for opentelemetry.traces.enabled to match the current spec.

See [Tracing API Spec - Include/Exclude Rules](https://source.datanerd.us/agents/agent-specs/blob/main/otel_bridge/Tracing-API.md#includeexclude-rules) (Internal) for details.

Closes #3407