### PR TITLE
Add instrumentation scope

### DIFF
--- a/lib/new_relic/agent/opentelemetry/trace/tracer.rb
+++ b/lib/new_relic/agent/opentelemetry/trace/tracer.rb
@@ -16,10 +16,6 @@ module NewRelic
           KINDS_THAT_DO_NOT_START_TXNS_WITHOUT_REMOTE_PARENT = [:client, :producer, :internal, nil].freeze
 
           def initialize(name = nil, version = nil)
-            # TODO: likely needs to transform to:
-            # args: name, version, tracer_provider
-            # instrumentation_scope = ::InstrumentationScope.new(name, version)
-            # tracer_provider = tracer_provider
             @name = name || ''
             @version = version || ''
           end
@@ -38,10 +34,9 @@ module NewRelic
             otel_span = get_otel_span_from_finishable(finishable)
 
             otel_span.finishable = finishable
-            # TODO: Update status to apply as an agent attribute
-            # rather than as a custom attribute
             otel_span.status = ::OpenTelemetry::Trace::Status.unset
             add_remote_context_to_otel_span(otel_span, parent_otel_context)
+            otel_span.add_instrumentation_scope(@name, @version)
             otel_span.add_attributes(attributes) if attributes
             otel_span
           end

--- a/test/multiverse/suites/hybrid_agent/span_test.rb
+++ b/test/multiverse/suites/hybrid_agent/span_test.rb
@@ -226,6 +226,106 @@ module NewRelic
 
             assert_equal expected['status.code'], last_span_agent_attrs['status.code']
           end
+
+          def test_transaction_returns_transaction_when_finishable_is_transaction
+            span = @tracer.start_span('test', kind: :server)
+
+            assert_instance_of NewRelic::Agent::Transaction, span.finishable
+            assert_equal span.finishable, span.transaction
+
+            span.finish
+          end
+
+          def test_transaction_returns_transaction_when_finishable_is_segment
+            in_transaction do |txn|
+              span = @tracer.start_span('test_segment')
+
+              assert_instance_of NewRelic::Agent::Transaction::Segment, span.finishable
+              assert_equal txn, span.transaction
+
+              span.finish
+            end
+          end
+
+          def test_transaction_memoizes_result
+            span = @tracer.start_span('test', kind: :server)
+            txn = span.finishable
+
+            first_call = span.transaction
+            second_call = span.transaction
+
+            assert_equal txn, first_call
+            assert_equal txn, second_call
+            assert_same first_call, second_call
+
+            span.finish
+          end
+
+          def test_transaction_returns_nil_when_finishable_is_nil
+            span = NewRelic::Agent::OpenTelemetry::Trace::Span.new
+
+            assert_nil span.finishable
+            assert_nil span.transaction
+          end
+
+          def test_add_instrumentation_scope_adds_name_and_version_attributes
+            scope_name = 'my-instrumentation-library'
+            scope_version = '1.2.3'
+
+            span = @tracer.start_span('test', kind: :server)
+            txn = span.finishable
+            txn.stubs(:sampled?).returns(true)
+
+            span.add_instrumentation_scope(scope_name, scope_version)
+            span.finish
+
+            segment_attrs = txn.segments.first.attributes
+            segment_agent_attrs = segment_attrs.instance_variable_get(:@agent_attributes)
+
+            assert_equal scope_name, segment_agent_attrs['otel.scope.name']
+            assert_equal scope_version, segment_agent_attrs['otel.scope.version']
+
+            # index 2 of the last_span_event array is for agent attributes
+            last_span_agent_attrs = last_span_event[2]
+
+            assert_equal scope_name, last_span_agent_attrs['otel.scope.name']
+            assert_equal scope_version, last_span_agent_attrs['otel.scope.version']
+          end
+
+          def test_add_instrumentation_scope_works_with_segment_finishable
+            scope_name = 'segment-instrumentation'
+            scope_version = '2.0.0'
+
+            in_transaction do |txn|
+              txn.stubs(:sampled?).returns(true)
+              span = @tracer.start_span('test_segment')
+
+              assert_instance_of NewRelic::Agent::Transaction::Segment, span.finishable
+
+              span.add_instrumentation_scope(scope_name, scope_version)
+              span.finish
+
+              segment_attrs = txn.segments[1].attributes
+              segment_agent_attrs = segment_attrs.instance_variable_get(:@agent_attributes)
+
+              assert_equal scope_name, segment_agent_attrs['otel.scope.name']
+              assert_equal scope_version, segment_agent_attrs['otel.scope.version']
+            end
+          end
+
+          def test_add_instrumentation_scope_does_not_fail_with_nil_transaction
+            span = NewRelic::Agent::OpenTelemetry::Trace::Span.new
+
+            assert_nil span.transaction
+            refute_raises { span.add_instrumentation_scope('test-scope', '1.0.0') }
+          end
+
+          def test_status_does_not_fail_with_nil_transaction
+            span = NewRelic::Agent::OpenTelemetry::Trace::Span.new
+
+            assert_nil span.transaction
+            refute_raises { span.status = ::OpenTelemetry::Trace::Status.ok }
+          end
         end
       end
     end


### PR DESCRIPTION
Instrumentation scope attributes are provided by the OTel Ruby SDK when a span is created based on the tracer's name and version.

NR's agent spec expects these to be added as agent attributes to spans.

This also refactors the way transactions are accessed in spans to be used by multiple methods.

Closes: #3431 