### PR TITLE
Translate server attributes

### DIFF
--- a/lib/new_relic/agent/opentelemetry/segments/server.rb
+++ b/lib/new_relic/agent/opentelemetry/segments/server.rb
@@ -1,0 +1,45 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+module NewRelic
+  module Agent
+    module OpenTelemetry
+      module Segments
+        module Server
+          def set_server_transaction_name(original_name, tracer_name, attributes)
+            attributes ||= NewRelic::EMPTY_HASH
+            host = attributes['server.address'] || attributes['http.host']
+            method = attributes['http.request.method'] || attributes['http.method']
+            path = attributes['url.path'] || attributes['http.target']
+
+            if [host, method, path].any?(&:nil?)
+              original_name
+            else
+              "Controller/#{tracer_name}/#{host}/#{method} #{path}"
+            end
+          end
+
+          def update_request_attributes(nr_item, attributes)
+            return unless nr_item.is_a?(Transaction)
+
+            request_attributes = nr_item.instance_variable_get(:@request_attributes)
+
+            return unless request_attributes.is_a?(NewRelic::Agent::Transaction::RequestAttributes)
+
+            attributes ||= NewRelic::EMPTY_HASH
+            host = attributes['server.address'] || attributes['http.host']
+            method = attributes['http.request.method'] || attributes['http.method']
+            path = attributes['url.path'] || attributes['http.target']
+            user_agent = attributes['user_agent.original'] || attributes['http.user_agent']
+
+            request_attributes.instance_variable_set(:@host, host) if host
+            request_attributes.instance_variable_set(:@request_method, method) if method
+            request_attributes.instance_variable_set(:@request_path, path) if path
+            request_attributes.instance_variable_set(:@user_agent, user_agent) if user_agent
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/new_relic/agent/opentelemetry/trace/span.rb
+++ b/lib/new_relic/agent/opentelemetry/trace/span.rb
@@ -16,6 +16,9 @@ module NewRelic
             finishable&.finish
           end
 
+          # TODO: This method can probably be combined with update_client_span
+          # and turned into something more generic when we refactor the way
+          # attributes are stored on NR items
           def update_server_span
             if finishable.is_a?(NewRelic::Agent::Transaction) && finishable.category == :web
               finishable_segment_attrs = finishable.segments.first.attributes.custom_attributes

--- a/lib/new_relic/agent/opentelemetry/trace/span.rb
+++ b/lib/new_relic/agent/opentelemetry/trace/span.rb
@@ -12,7 +12,16 @@ module NewRelic
 
           def finish(end_timestamp: nil)
             update_client_span
+            update_server_span
             finishable&.finish
+          end
+
+          def update_server_span
+            if finishable.is_a?(NewRelic::Agent::Transaction) && finishable.category == :web
+              finishable_segment_attrs = finishable.segments.first.attributes.custom_attributes
+              code = finishable_segment_attrs['http.response.status_code'] || finishable_segment_attrs['http.status_code']
+              finishable.http_response_code = code if code
+            end
           end
 
           def update_client_span

--- a/lib/new_relic/agent/opentelemetry/trace/tracer.rb
+++ b/lib/new_relic/agent/opentelemetry/trace/tracer.rb
@@ -115,7 +115,7 @@ module NewRelic
 
             case kind
             when :server
-              name = set_server_transaction_name(name, @name, attributes)
+              name = create_server_transaction_name(name, @name, attributes)
               nr_item = NewRelic::Agent::Tracer.start_transaction_or_segment(name: name, category: :web, options: {request: attributes})
               update_request_attributes(nr_item, attributes)
             when :client

--- a/lib/new_relic/agent/opentelemetry/trace/tracer.rb
+++ b/lib/new_relic/agent/opentelemetry/trace/tracer.rb
@@ -4,6 +4,7 @@
 
 require_relative '../segments/http_external'
 require_relative '../segments/datastore'
+require_relative '../segments/server'
 
 module NewRelic
   module Agent
@@ -12,6 +13,7 @@ module NewRelic
         class Tracer < ::OpenTelemetry::Trace::Tracer
           include NewRelic::Agent::OpenTelemetry::Segments::HttpExternal
           include NewRelic::Agent::OpenTelemetry::Segments::Datastore
+          include NewRelic::Agent::OpenTelemetry::Segments::Server
 
           VALID_KINDS = [:server, :client, :consumer, :producer, :internal, nil].freeze
           KINDS_THAT_START_TRANSACTIONS = %i[server consumer].freeze
@@ -28,7 +30,7 @@ module NewRelic
             return ::OpenTelemetry::Trace::Span::INVALID if should_not_create_telemetry?(parent_otel_context, kind)
 
             finishable = if can_start_transaction?(parent_otel_context, kind)
-              start_transaction_from_otel(name, parent_otel_context, kind)
+              start_transaction_from_otel(name, parent_otel_context, kind, attributes: attributes)
             else
               start_segment_from_otel(name: name, attributes: attributes, start_timestamp: start_timestamp, kind: kind)
             end
@@ -108,12 +110,16 @@ module NewRelic
             segment
           end
 
-          def start_transaction_from_otel(name, parent_otel_context, kind)
+          def start_transaction_from_otel(name, parent_otel_context, kind, attributes: {})
             nr_item = nil
 
             case kind
-            when :server, :client
-              nr_item = NewRelic::Agent::Tracer.start_transaction_or_segment(name: name, category: :web)
+            when :server
+              name = set_server_transaction_name(name, @name, attributes)
+              nr_item = NewRelic::Agent::Tracer.start_transaction_or_segment(name: name, category: :web, options: {request: attributes})
+              update_request_attributes(nr_item, attributes)
+            when :client
+              nr_item = NewRelic::Agent::Tracer.start_transaction_or_segment(name: name, category: :web, options: {request: attributes})
             when :consumer, :producer, :internal, nil
               nr_item = NewRelic::Agent::Tracer.start_transaction_or_segment(name: name, category: :task)
             end

--- a/test/multiverse/suites/hybrid_agent/db_mapping_test.rb
+++ b/test/multiverse/suites/hybrid_agent/db_mapping_test.rb
@@ -9,12 +9,12 @@ module NewRelic
         class DbMappingTest < Minitest::Test
           def setup
             @tracer = NewRelic::Agent::OpenTelemetry::Trace::Tracer.new('OTelClient')
+            harvest_span_events!
+            harvest_transaction_events!
           end
 
           def teardown
             mocha_teardown
-            NewRelic::Agent.instance.transaction_event_aggregator.reset!
-            NewRelic::Agent.instance.span_event_aggregator.reset!
           end
 
           def db_attrs

--- a/test/multiverse/suites/hybrid_agent/http_mapping_test.rb
+++ b/test/multiverse/suites/hybrid_agent/http_mapping_test.rb
@@ -9,12 +9,12 @@ module NewRelic
         class HttpMappingTest < Minitest::Test
           def setup
             @tracer = NewRelic::Agent::OpenTelemetry::Trace::Tracer.new('OTelClient')
+            harvest_transaction_events!
+            harvest_span_events!
           end
 
           def teardown
             mocha_teardown
-            NewRelic::Agent.instance.transaction_event_aggregator.reset!
-            NewRelic::Agent.instance.span_event_aggregator.reset!
           end
 
           # Drawing from the HTTP.rb OTel Contrib client.rb instrumentation
@@ -109,6 +109,7 @@ module NewRelic
             ])
 
             spans = harvest_span_events!
+            # binding.irb
             span = spans[1][0]
             intrinsics = span[0]
             custom = span[1]

--- a/test/multiverse/suites/hybrid_agent/hybrid_agent_test.rb
+++ b/test/multiverse/suites/hybrid_agent/hybrid_agent_test.rb
@@ -14,7 +14,8 @@ class HybridAgentTest < Minitest::Test
 
   def setup
     @tracer = OpenTelemetry.tracer_provider.tracer
-
+    harvest_transaction_events!
+    harvest_span_events!
     # in order to inject headers, there must be a parent account ID and a
     # parent application ID
     @config = {

--- a/test/multiverse/suites/hybrid_agent/server_mapping_test.rb
+++ b/test/multiverse/suites/hybrid_agent/server_mapping_test.rb
@@ -9,12 +9,12 @@ module NewRelic
         class ServerMappingTest < Minitest::Test
           def setup
             @tracer = NewRelic::Agent::OpenTelemetry::Trace::Tracer.new('OTelClient')
+            harvest_transaction_events!
+            harvest_span_events!
           end
 
           def teardown
             mocha_teardown
-            NewRelic::Agent.instance.transaction_event_aggregator.reset!
-            NewRelic::Agent.instance.span_event_aggregator.reset!
           end
 
           # The Agent Spec for attribute translation has specific version

--- a/test/multiverse/suites/hybrid_agent/server_mapping_test.rb
+++ b/test/multiverse/suites/hybrid_agent/server_mapping_test.rb
@@ -76,7 +76,7 @@ module NewRelic
             txn = txns[1][0]
             intrinsics = txn[0]
 
-            assert_equal 'Controller/OTelClient/potatoes.com/GET /sustainable-spuds', intrinsics['name']
+            assert_equal 'Controller/OTelClient/GET /sustainable-spuds', intrinsics['name']
           end
 
           def test_server_old_transaction_metrics
@@ -85,9 +85,9 @@ module NewRelic
             # TODO: dunno what these should be either
             assert_metrics_recorded([
               'HttpDispatcher',
-              'Controller/OTelClient/potatoes.com/GET /sustainable-spuds',
+              'Controller/OTelClient/GET /sustainable-spuds',
               'WebTransactionTotalTime',
-              'WebTransactionTotalTime/Controller/OTelClient/potatoes.com/GET /sustainable-spuds'
+              'WebTransactionTotalTime/Controller/OTelClient/GET /sustainable-spuds'
             ])
           end
 
@@ -147,7 +147,7 @@ module NewRelic
             txn = txns[1][0]
             intrinsics = txn[0]
 
-            assert_equal 'Controller/OTelClient/potatoes.com/GET /sustainable-spuds', intrinsics['name']
+            assert_equal 'Controller/OTelClient/GET /sustainable-spuds', intrinsics['name']
           end
 
           def test_server_stable_transaction_metrics
@@ -155,9 +155,9 @@ module NewRelic
 
             assert_metrics_recorded([
               'HttpDispatcher',
-              'Controller/OTelClient/potatoes.com/GET /sustainable-spuds',
+              'Controller/OTelClient/GET /sustainable-spuds',
               'WebTransactionTotalTime',
-              'WebTransactionTotalTime/Controller/OTelClient/potatoes.com/GET /sustainable-spuds'
+              'WebTransactionTotalTime/Controller/OTelClient/GET /sustainable-spuds'
             ])
           end
 

--- a/test/multiverse/suites/hybrid_agent/server_mapping_test.rb
+++ b/test/multiverse/suites/hybrid_agent/server_mapping_test.rb
@@ -17,6 +17,13 @@ module NewRelic
             NewRelic::Agent.instance.span_event_aggregator.reset!
           end
 
+          # The Agent Spec for attribute translation has specific version
+          # numbers it uses. Ruby's semantic conventions for HTTP don't exactly
+          # align with those versions.
+          # Our agent will instead translate the "old" and "stable" semconv
+          # versions used by the OTEL_SEMCONV_STABILITY_OPT_IN environment
+          # variable.
+          #
           # These attributes match what appear in a Rack request using old semconv
           def old_name
             'HTTP GET'
@@ -82,7 +89,6 @@ module NewRelic
           def test_server_old_transaction_metrics
             run_server_transaction(old_name, old_req_attrs, old_res_attrs)
 
-            # TODO: dunno what these should be either
             assert_metrics_recorded([
               'HttpDispatcher',
               'Controller/OTelClient/GET /sustainable-spuds',

--- a/test/multiverse/suites/hybrid_agent/server_mapping_test.rb
+++ b/test/multiverse/suites/hybrid_agent/server_mapping_test.rb
@@ -1,0 +1,217 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+module NewRelic
+  module Agent
+    module OpenTelemetry
+      module Trace
+        class ServerMappingTest < Minitest::Test
+          def setup
+            @tracer = NewRelic::Agent::OpenTelemetry::Trace::Tracer.new('OTelClient')
+          end
+
+          def teardown
+            mocha_teardown
+            NewRelic::Agent.instance.transaction_event_aggregator.reset!
+            NewRelic::Agent.instance.span_event_aggregator.reset!
+          end
+
+          # These attributes match what appear in a Rack request using old semconv
+          def old_name
+            'HTTP GET'
+          end
+
+          def old_req_attrs
+            {
+              'http.method' => 'GET',
+              'http.host' => 'potatoes.com',
+              'http.scheme' => 'http',
+              'http.target' => '/sustainable-spuds',
+              'http.user_agent' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/144.0.0.0 Safari/537.36'
+            }
+          end
+
+          def old_res_attrs
+            {
+              'http.status_code' => 418
+            }
+          end
+
+          # These attributes match what appear in a Rack request using stable semconv
+          def stable_name
+            'GET'
+          end
+
+          def stable_req_attrs
+            {
+              'http.request.method' => 'GET',
+              'server.address' => 'potatoes.com',
+              'url.scheme' => 'http',
+              'url.path' => '/sustainable-spuds',
+              'url.query' => 'query=true',
+              'user_agent.original' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/144.0.0.0 Safari/537.36'
+            }
+          end
+
+          def stable_res_attrs
+            {
+              'http.response.status_code' => 418
+            }
+          end
+
+          # This roughly mimics the calls made by opentelemetry rack
+          # instrumentation, but we ignore headers
+          def run_server_transaction(name, request_attrs, response_attrs)
+            span = @tracer.start_span(name, attributes: request_attrs.dup, kind: :server)
+            span.finishable.stubs(:sampled?).returns(true)
+            span.add_attributes(response_attrs)
+            span.finish
+          end
+
+          def test_server_old_transaction_name
+            run_server_transaction(old_name, old_req_attrs, old_res_attrs)
+
+            txns = harvest_transaction_events!
+            txn = txns[1][0]
+            intrinsics = txn[0]
+
+            assert_equal 'Controller/OTelClient/potatoes.com/GET /sustainable-spuds', intrinsics['name']
+          end
+
+          def test_server_old_transaction_metrics
+            run_server_transaction(old_name, old_req_attrs, old_res_attrs)
+
+            # TODO: dunno what these should be either
+            assert_metrics_recorded([
+              'HttpDispatcher',
+              'Controller/OTelClient/potatoes.com/GET /sustainable-spuds',
+              'WebTransactionTotalTime',
+              'WebTransactionTotalTime/Controller/OTelClient/potatoes.com/GET /sustainable-spuds'
+            ])
+          end
+
+          def test_server_old_transaction_agent_attributes
+            attrs = old_req_attrs
+            run_server_transaction(old_name, attrs, old_res_attrs)
+
+            txns = harvest_transaction_events!
+            txn = txns[1][0]
+            agent = txn[2]
+
+            assert_equal 418, agent[:'http.statusCode']
+            assert_equal attrs['http.target'], agent[:'request.uri']
+            assert_equal attrs['http.host'], agent[:'request.headers.host']
+            assert_equal attrs['http.user_agent'], agent[:'request.headers.userAgent']
+            assert_equal attrs['http.method'], agent[:'request.method']
+          end
+
+          def test_server_old_span_agent_attributes
+            attrs = old_req_attrs
+            run_server_transaction(old_name, attrs, old_res_attrs)
+
+            spans = harvest_span_events!
+            span = spans[1][0]
+            agent = span[2]
+
+            assert_equal 418, agent[:'http.statusCode']
+            assert_equal attrs['http.target'], agent[:'request.uri']
+            assert_equal attrs['http.host'], agent[:'request.headers.host']
+            assert_equal attrs['http.user_agent'], agent[:'request.headers.userAgent']
+            assert_equal attrs['http.method'], agent[:'request.method']
+          end
+
+          def test_server_old_span_custom_attributes
+            attrs = old_req_attrs
+            run_server_transaction(old_name, attrs, old_res_attrs)
+
+            spans = harvest_span_events!
+            span = spans[1][0]
+            custom = span[1]
+
+            # Currently, all attributes are being applied as custom attributes
+            # eventually, only the attributes that aren't assigned as agent
+            # attributes will remain in custom attributes.
+            # When that change is made, this test will fail.
+            assert_equal attrs['http.method'], custom['http.method']
+            assert_equal attrs['http.host'], custom['http.host']
+            assert_equal attrs['http.target'], custom['http.target']
+            assert_equal attrs['http.user_agent'], custom['http.user_agent']
+            assert_equal 418, custom['http.status_code']
+          end
+
+          def test_server_stable_transaction_name
+            run_server_transaction(stable_name, stable_req_attrs, stable_res_attrs)
+
+            txns = harvest_transaction_events!
+            txn = txns[1][0]
+            intrinsics = txn[0]
+
+            assert_equal 'Controller/OTelClient/potatoes.com/GET /sustainable-spuds', intrinsics['name']
+          end
+
+          def test_server_stable_transaction_metrics
+            run_server_transaction(stable_name, stable_req_attrs, stable_res_attrs)
+
+            assert_metrics_recorded([
+              'HttpDispatcher',
+              'Controller/OTelClient/potatoes.com/GET /sustainable-spuds',
+              'WebTransactionTotalTime',
+              'WebTransactionTotalTime/Controller/OTelClient/potatoes.com/GET /sustainable-spuds'
+            ])
+          end
+
+          def test_server_stable_transaction_agent_attributes
+            attrs = stable_req_attrs
+            run_server_transaction(stable_name, attrs, stable_res_attrs)
+
+            txns = harvest_transaction_events!
+            txn = txns[1][0]
+            agent = txn[2]
+
+            assert_equal 418, agent[:'http.statusCode']
+            assert_equal attrs['url.path'], agent[:'request.uri']
+            assert_equal attrs['server.address'], agent[:'request.headers.host']
+            assert_equal attrs['user_agent.original'], agent[:'request.headers.userAgent']
+            assert_equal attrs['http.request.method'], agent[:'request.method']
+          end
+
+          def test_server_stable_span_agent_attributes
+            attrs = stable_req_attrs
+            run_server_transaction(stable_name, attrs, stable_res_attrs)
+
+            spans = harvest_span_events!
+            span = spans[1][0]
+            agent = span[2]
+
+            assert_equal 418, agent[:'http.statusCode']
+            assert_equal attrs['url.path'], agent[:'request.uri']
+            assert_equal attrs['server.address'], agent[:'request.headers.host']
+            assert_equal attrs['user_agent.original'], agent[:'request.headers.userAgent']
+            assert_equal attrs['http.request.method'], agent[:'request.method']
+          end
+
+          def test_server_stable_span_custom_attributes
+            attrs = stable_req_attrs
+            run_server_transaction(stable_name, attrs, stable_res_attrs)
+
+            spans = harvest_span_events!
+            span = spans[1][0]
+            custom = span[1]
+
+            # Currently, all attributes are being applied as custom attributes
+            # eventually, only the attributes that aren't assigned as agent
+            # attributes will remain in custom attributes.
+            # When that change is made, this test will fail.
+            assert_equal attrs['http.request.method'], custom['http.request.method']
+            assert_equal attrs['server.address'], custom['server.address']
+            assert_equal attrs['url.path'], custom['url.path']
+            assert_equal attrs['url.query'], custom['url.query']
+            assert_equal attrs['user_agent.original'], custom['user_agent.original']
+            assert_equal 418, custom['http.response.status_code']
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/multiverse/suites/hybrid_agent/server_test.rb
+++ b/test/multiverse/suites/hybrid_agent/server_test.rb
@@ -13,66 +13,52 @@ module NewRelic
         @test_instance = TestClass.new
       end
 
-      def test_set_server_transaction_name_with_stable_attributes
+      def teardown
+        mocha_teardown
+      end
+
+      def test_create_server_transaction_name_with_stable_attributes
         original_name = 'GET'
         tracer_name = 'MyTracer'
         attributes = {
-          'server.address' => 'example.com',
           'http.request.method' => 'GET',
           'url.path' => '/api/users'
         }
 
-        result = @test_instance.set_server_transaction_name(original_name, tracer_name, attributes)
+        result = @test_instance.create_server_transaction_name(original_name, tracer_name, attributes)
 
-        assert_equal 'Controller/MyTracer/example.com/GET /api/users', result
+        assert_equal 'Controller/MyTracer/GET /api/users', result
       end
 
-      def test_set_server_transaction_name_with_old_attributes
+      def test_create_server_transaction_name_with_old_attributes
         original_name = 'HTTP GET'
         tracer_name = 'MyTracer'
         attributes = {
-          'http.host' => 'example.com',
           'http.method' => 'POST',
           'http.target' => '/api/posts'
         }
 
-        result = @test_instance.set_server_transaction_name(original_name, tracer_name, attributes)
+        result = @test_instance.create_server_transaction_name(original_name, tracer_name, attributes)
 
-        assert_equal 'Controller/MyTracer/example.com/POST /api/posts', result
+        assert_equal 'Controller/MyTracer/POST /api/posts', result
       end
 
-      def test_set_server_transaction_name_prefers_stable_attributes
+      def test_create_server_transaction_name_prefers_stable_attributes
         original_name = 'GET'
         tracer_name = 'MyTracer'
-        # Mix of stable and old attributes - stable should be preferred
         attributes = {
-          'server.address' => 'stable.example.com',
-          'http.host' => 'old.example.com',
           'http.request.method' => 'PUT',
           'http.method' => 'GET',
           'url.path' => '/stable/path',
           'http.target' => '/old/path'
         }
 
-        result = @test_instance.set_server_transaction_name(original_name, tracer_name, attributes)
+        result = @test_instance.create_server_transaction_name(original_name, tracer_name, attributes)
 
-        assert_equal 'Controller/MyTracer/stable.example.com/PUT /stable/path', result
+        assert_equal 'Controller/MyTracer/PUT /stable/path', result
       end
 
-      def test_set_server_transaction_name_returns_original_when_host_missing
-        original_name = 'GET'
-        tracer_name = 'MyTracer'
-        attributes = {
-          'http.request.method' => 'GET',
-          'url.path' => '/api/users'
-        }
-
-        result = @test_instance.set_server_transaction_name(original_name, tracer_name, attributes)
-
-        assert_equal original_name, result
-      end
-
-      def test_set_server_transaction_name_returns_original_when_method_missing
+      def test_create_server_transaction_name_returns_original_when_method_missing
         original_name = 'GET'
         tracer_name = 'MyTracer'
         attributes = {
@@ -80,48 +66,47 @@ module NewRelic
           'url.path' => '/api/users'
         }
 
-        result = @test_instance.set_server_transaction_name(original_name, tracer_name, attributes)
+        result = @test_instance.create_server_transaction_name(original_name, tracer_name, attributes)
 
         assert_equal original_name, result
       end
 
-      def test_set_server_transaction_name_returns_original_when_path_missing
+      def test_create_server_transaction_name_returns_original_when_path_missing
         original_name = 'GET'
         tracer_name = 'MyTracer'
         attributes = {
-          'server.address' => 'example.com',
           'http.request.method' => 'GET'
         }
 
-        result = @test_instance.set_server_transaction_name(original_name, tracer_name, attributes)
+        result = @test_instance.create_server_transaction_name(original_name, tracer_name, attributes)
 
         assert_equal original_name, result
       end
 
-      def test_set_server_transaction_name_returns_original_when_all_missing
-        original_name = 'GET'
+      def test_create_server_transaction_name_returns_original_when_all_missing
+        original_name = 'HTTP GET'
         tracer_name = 'MyTracer'
         attributes = {}
 
-        result = @test_instance.set_server_transaction_name(original_name, tracer_name, attributes)
+        result = @test_instance.create_server_transaction_name(original_name, tracer_name, attributes)
 
         assert_equal original_name, result
       end
 
-      def test_set_server_transaction_name_with_nil_attributes
+      def test_create_server_transaction_name_with_nil_attributes
         original_name = 'GET'
         tracer_name = 'MyTracer'
 
-        result = @test_instance.set_server_transaction_name(original_name, tracer_name, nil)
+        result = @test_instance.create_server_transaction_name(original_name, tracer_name, nil)
 
         assert_equal original_name, result
       end
 
-      # update_request_attributes tests
-
       def test_update_request_attributes_with_stable_attributes
+        # A :request key must be in the options hash to create an instance of
+        # RequestAttributes for the trasaction when it starts
         txn = in_transaction(request: {}) do |t|
-          t
+          t.stubs(:sampled?).returns(true)
         end
 
         attributes = {
@@ -142,8 +127,10 @@ module NewRelic
       end
 
       def test_update_request_attributes_with_old_attributes
+        # A :request key must be in the options hash to create an instance of
+        # RequestAttributes for the trasaction when it starts
         txn = in_transaction(request: {}) do |t|
-          t
+          t.stubs(:sampled?).returns(true)
         end
 
         attributes = {
@@ -164,8 +151,10 @@ module NewRelic
       end
 
       def test_update_request_attributes_prefers_stable_attributes
+        # A :request key must be in the options hash to create an instance of
+        # RequestAttributes for the trasaction when it starts
         txn = in_transaction(request: {}) do |t|
-          t
+          t.stubs(:sampled?).returns(true)
         end
 
         # Mix of stable and old attributes - stable should be preferred
@@ -191,8 +180,10 @@ module NewRelic
       end
 
       def test_update_request_attributes_with_partial_attributes
+        # A :request key must be in the options hash to create an instance of
+        # RequestAttributes for the trasaction when it starts
         txn = in_transaction(request: {}) do |t|
-          t
+          t.stubs(:sampled?).returns(true)
         end
 
         request_attributes = txn.instance_variable_get(:@request_attributes)
@@ -210,12 +201,14 @@ module NewRelic
         assert_equal 'DELETE', request_attributes.instance_variable_get(:@request_method)
 
         assert_equal original_path, request_attributes.instance_variable_get(:@request_path)
-        assert_equal original_user_agent, request_attributes.instance_variable_get(:@user_agent)
+        assert_nil request_attributes.instance_variable_get(:@user_agent)
       end
 
       def test_update_request_attributes_with_nil_attributes
+        # A :request key must be in the options hash to create an instance of
+        # RequestAttributes for the trasaction when it starts
         txn = in_transaction(request: {}) do |t|
-          t
+          t.stubs(:sampled?).returns(true)
         end
 
         @test_instance.update_request_attributes(txn, nil)

--- a/test/multiverse/suites/hybrid_agent/server_test.rb
+++ b/test/multiverse/suites/hybrid_agent/server_test.rb
@@ -11,6 +11,7 @@ module NewRelic
 
       def setup
         @test_instance = TestClass.new
+        harvest_transaction_events!
       end
 
       def teardown

--- a/test/multiverse/suites/hybrid_agent/server_test.rb
+++ b/test/multiverse/suites/hybrid_agent/server_test.rb
@@ -1,0 +1,255 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+module NewRelic
+  module Agent
+    class ServerTest < Minitest::Test
+      class TestClass
+        include NewRelic::Agent::OpenTelemetry::Segments::Server
+      end
+
+      def setup
+        @test_instance = TestClass.new
+      end
+
+      def test_set_server_transaction_name_with_stable_attributes
+        original_name = 'GET'
+        tracer_name = 'MyTracer'
+        attributes = {
+          'server.address' => 'example.com',
+          'http.request.method' => 'GET',
+          'url.path' => '/api/users'
+        }
+
+        result = @test_instance.set_server_transaction_name(original_name, tracer_name, attributes)
+
+        assert_equal 'Controller/MyTracer/example.com/GET /api/users', result
+      end
+
+      def test_set_server_transaction_name_with_old_attributes
+        original_name = 'HTTP GET'
+        tracer_name = 'MyTracer'
+        attributes = {
+          'http.host' => 'example.com',
+          'http.method' => 'POST',
+          'http.target' => '/api/posts'
+        }
+
+        result = @test_instance.set_server_transaction_name(original_name, tracer_name, attributes)
+
+        assert_equal 'Controller/MyTracer/example.com/POST /api/posts', result
+      end
+
+      def test_set_server_transaction_name_prefers_stable_attributes
+        original_name = 'GET'
+        tracer_name = 'MyTracer'
+        # Mix of stable and old attributes - stable should be preferred
+        attributes = {
+          'server.address' => 'stable.example.com',
+          'http.host' => 'old.example.com',
+          'http.request.method' => 'PUT',
+          'http.method' => 'GET',
+          'url.path' => '/stable/path',
+          'http.target' => '/old/path'
+        }
+
+        result = @test_instance.set_server_transaction_name(original_name, tracer_name, attributes)
+
+        assert_equal 'Controller/MyTracer/stable.example.com/PUT /stable/path', result
+      end
+
+      def test_set_server_transaction_name_returns_original_when_host_missing
+        original_name = 'GET'
+        tracer_name = 'MyTracer'
+        attributes = {
+          'http.request.method' => 'GET',
+          'url.path' => '/api/users'
+        }
+
+        result = @test_instance.set_server_transaction_name(original_name, tracer_name, attributes)
+
+        assert_equal original_name, result
+      end
+
+      def test_set_server_transaction_name_returns_original_when_method_missing
+        original_name = 'GET'
+        tracer_name = 'MyTracer'
+        attributes = {
+          'server.address' => 'example.com',
+          'url.path' => '/api/users'
+        }
+
+        result = @test_instance.set_server_transaction_name(original_name, tracer_name, attributes)
+
+        assert_equal original_name, result
+      end
+
+      def test_set_server_transaction_name_returns_original_when_path_missing
+        original_name = 'GET'
+        tracer_name = 'MyTracer'
+        attributes = {
+          'server.address' => 'example.com',
+          'http.request.method' => 'GET'
+        }
+
+        result = @test_instance.set_server_transaction_name(original_name, tracer_name, attributes)
+
+        assert_equal original_name, result
+      end
+
+      def test_set_server_transaction_name_returns_original_when_all_missing
+        original_name = 'GET'
+        tracer_name = 'MyTracer'
+        attributes = {}
+
+        result = @test_instance.set_server_transaction_name(original_name, tracer_name, attributes)
+
+        assert_equal original_name, result
+      end
+
+      def test_set_server_transaction_name_with_nil_attributes
+        original_name = 'GET'
+        tracer_name = 'MyTracer'
+
+        result = @test_instance.set_server_transaction_name(original_name, tracer_name, nil)
+
+        assert_equal original_name, result
+      end
+
+      # update_request_attributes tests
+
+      def test_update_request_attributes_with_stable_attributes
+        txn = in_transaction(request: {}) do |t|
+          t
+        end
+
+        attributes = {
+          'server.address' => 'example.com',
+          'http.request.method' => 'GET',
+          'url.path' => '/api/users',
+          'user_agent.original' => 'Mozilla/5.0'
+        }
+
+        @test_instance.update_request_attributes(txn, attributes)
+
+        request_attributes = txn.instance_variable_get(:@request_attributes)
+
+        assert_equal 'example.com', request_attributes.instance_variable_get(:@host)
+        assert_equal 'GET', request_attributes.instance_variable_get(:@request_method)
+        assert_equal '/api/users', request_attributes.instance_variable_get(:@request_path)
+        assert_equal 'Mozilla/5.0', request_attributes.instance_variable_get(:@user_agent)
+      end
+
+      def test_update_request_attributes_with_old_attributes
+        txn = in_transaction(request: {}) do |t|
+          t
+        end
+
+        attributes = {
+          'http.host' => 'old.example.com',
+          'http.method' => 'POST',
+          'http.target' => '/api/posts',
+          'http.user_agent' => 'Chrome/144.0'
+        }
+
+        @test_instance.update_request_attributes(txn, attributes)
+
+        request_attributes = txn.instance_variable_get(:@request_attributes)
+
+        assert_equal 'old.example.com', request_attributes.instance_variable_get(:@host)
+        assert_equal 'POST', request_attributes.instance_variable_get(:@request_method)
+        assert_equal '/api/posts', request_attributes.instance_variable_get(:@request_path)
+        assert_equal 'Chrome/144.0', request_attributes.instance_variable_get(:@user_agent)
+      end
+
+      def test_update_request_attributes_prefers_stable_attributes
+        txn = in_transaction(request: {}) do |t|
+          t
+        end
+
+        # Mix of stable and old attributes - stable should be preferred
+        attributes = {
+          'server.address' => 'stable.example.com',
+          'http.host' => 'old.example.com',
+          'http.request.method' => 'PUT',
+          'http.method' => 'GET',
+          'url.path' => '/stable/path',
+          'http.target' => '/old/path',
+          'user_agent.original' => 'Firefox/144.0',
+          'http.user_agent' => 'Safari/144.0'
+        }
+
+        @test_instance.update_request_attributes(txn, attributes)
+
+        request_attributes = txn.instance_variable_get(:@request_attributes)
+
+        assert_equal 'stable.example.com', request_attributes.instance_variable_get(:@host)
+        assert_equal 'PUT', request_attributes.instance_variable_get(:@request_method)
+        assert_equal '/stable/path', request_attributes.instance_variable_get(:@request_path)
+        assert_equal 'Firefox/144.0', request_attributes.instance_variable_get(:@user_agent)
+      end
+
+      def test_update_request_attributes_with_partial_attributes
+        txn = in_transaction(request: {}) do |t|
+          t
+        end
+
+        request_attributes = txn.instance_variable_get(:@request_attributes)
+        original_path = request_attributes.instance_variable_get(:@request_path)
+        original_user_agent = request_attributes.instance_variable_get(:@user_agent)
+
+        attributes = {
+          'server.address' => 'example.com',
+          'http.request.method' => 'DELETE'
+        }
+
+        @test_instance.update_request_attributes(txn, attributes)
+
+        assert_equal 'example.com', request_attributes.instance_variable_get(:@host)
+        assert_equal 'DELETE', request_attributes.instance_variable_get(:@request_method)
+
+        assert_equal original_path, request_attributes.instance_variable_get(:@request_path)
+        assert_equal original_user_agent, request_attributes.instance_variable_get(:@user_agent)
+      end
+
+      def test_update_request_attributes_with_nil_attributes
+        txn = in_transaction(request: {}) do |t|
+          t
+        end
+
+        @test_instance.update_request_attributes(txn, nil)
+
+        request_attributes = txn.instance_variable_get(:@request_attributes)
+
+        assert_instance_of NewRelic::Agent::Transaction::RequestAttributes, request_attributes
+      end
+
+      def test_update_request_attributes_does_not_update_non_transaction
+        segment = NewRelic::Agent::Transaction::Segment.new
+
+        attributes = {
+          'server.address' => 'example.com',
+          'http.request.method' => 'GET'
+        }
+
+        result = @test_instance.update_request_attributes(segment, attributes)
+
+        assert_nil result
+      end
+
+      def test_update_request_attributes_does_not_update_without_request_attributes
+        mock_txn = Object.new
+        mock_txn.instance_variable_set(:@request_attributes, nil)
+
+        attributes = {
+          'server.address' => 'example.com'
+        }
+
+        result = @test_instance.update_request_attributes(mock_txn, attributes)
+
+        assert_nil result
+      end
+    end
+  end
+end

--- a/test/multiverse/suites/hybrid_agent/span_test.rb
+++ b/test/multiverse/suites/hybrid_agent/span_test.rb
@@ -304,7 +304,8 @@ module NewRelic
           end
 
           def test_update_server_span_does_not_update_non_web_transaction
-            # Consumer spans create task transactions, not web transactions
+            # Consumer spans create transactions with a :task category,
+            # not with a :web category
             span = @tracer.start_span('test_span', kind: :consumer)
             txn = span.finishable
 
@@ -412,20 +413,11 @@ module NewRelic
             refute_raises { span.status = ::OpenTelemetry::Trace::Status.ok }
           end
 
-          def test_update_server_span_handles_nil_finishable
-            span = NewRelic::Agent::OpenTelemetry::Trace::Span.new
-
-            assert_nil span.finishable
-
-            # Should not raise an error
-            span.finish
-          end
-
-          def test_update_server_span_handles_string_status_code
+          def test_update_server_span_handles_string_http_response_status_code
             span = @tracer.start_span('test_span', kind: :server)
             txn = span.finishable
+            txn.stubs(:sampled?).returns(true)
 
-            # Some instrumentation might pass status codes as strings
             span.add_attributes({'http.response.status_code' => '503'})
 
             span.finish

--- a/test/multiverse/suites/hybrid_agent/span_test.rb
+++ b/test/multiverse/suites/hybrid_agent/span_test.rb
@@ -242,7 +242,92 @@ module NewRelic
 
               assert_instance_of NewRelic::Agent::Transaction::Segment, span.finishable
               assert_equal txn, span.transaction
+              span.finish
+            end
+          end
 
+          def test_update_server_span_sets_response_code_with_stable_attribute
+            span = @tracer.start_span('test_span', kind: :server)
+            txn = span.finishable
+
+            assert_instance_of NewRelic::Agent::Transaction, txn
+            assert_equal :web, txn.category
+
+            span.add_attributes({'http.response.status_code' => 200})
+
+            span.finish
+
+            assert_equal 200, txn.http_response_code
+          end
+
+          def test_update_server_span_sets_response_code_with_old_attribute
+            span = @tracer.start_span('test_span', kind: :server)
+            txn = span.finishable
+
+            assert_instance_of NewRelic::Agent::Transaction, txn
+            assert_equal :web, txn.category
+
+            span.add_attributes({'http.status_code' => 404})
+
+            span.finish
+
+            assert_equal 404, txn.http_response_code
+          end
+
+          def test_update_server_span_prefers_stable_over_old_attribute
+            span = @tracer.start_span('test_span', kind: :server)
+            txn = span.finishable
+
+            assert_instance_of NewRelic::Agent::Transaction, txn
+            assert_equal :web, txn.category
+
+            span.add_attributes({
+              'http.response.status_code' => 201,
+              'http.status_code' => 200
+            })
+
+            span.finish
+
+            assert_equal 201, txn.http_response_code
+          end
+
+          def test_update_server_span_does_not_set_code_when_no_attributes_present
+            span = @tracer.start_span('test_span', kind: :server)
+            txn = span.finishable
+
+            assert_instance_of NewRelic::Agent::Transaction, txn
+            assert_equal :web, txn.category
+
+            span.finish
+
+            assert_nil txn.http_response_code
+          end
+
+          def test_update_server_span_does_not_update_non_web_transaction
+            # Consumer spans create task transactions, not web transactions
+            span = @tracer.start_span('test_span', kind: :consumer)
+            txn = span.finishable
+
+            assert_instance_of NewRelic::Agent::Transaction, txn
+            assert_equal :task, txn.category
+
+            span.add_attributes({'http.response.status_code' => 200})
+
+            span.finish
+
+            assert_nil txn.http_response_code
+          end
+
+          def test_update_server_span_does_not_update_segment
+            in_transaction do
+              span = @tracer.start_span('test_span')
+              segment = span.finishable
+
+              assert_instance_of NewRelic::Agent::Transaction::Segment, segment
+
+              span.add_attributes({'http.response.status_code' => 200})
+
+              # Should not raise an error, just return early
               span.finish
             end
           end
@@ -325,6 +410,27 @@ module NewRelic
 
             assert_nil span.transaction
             refute_raises { span.status = ::OpenTelemetry::Trace::Status.ok }
+          end
+
+          def test_update_server_span_handles_nil_finishable
+            span = NewRelic::Agent::OpenTelemetry::Trace::Span.new
+
+            assert_nil span.finishable
+
+            # Should not raise an error
+            span.finish
+          end
+
+          def test_update_server_span_handles_string_status_code
+            span = @tracer.start_span('test_span', kind: :server)
+            txn = span.finishable
+
+            # Some instrumentation might pass status codes as strings
+            span.add_attributes({'http.response.status_code' => '503'})
+
+            span.finish
+
+            assert_equal '503', txn.http_response_code
           end
         end
       end

--- a/test/multiverse/suites/hybrid_agent/span_test.rb
+++ b/test/multiverse/suites/hybrid_agent/span_test.rb
@@ -13,12 +13,12 @@ module NewRelic
 
           def setup
             @tracer = NewRelic::Agent::OpenTelemetry::Trace::Tracer.new
+            harvest_transaction_events!
+            harvest_span_events!
           end
 
           def teardown
             mocha_teardown
-            NewRelic::Agent.instance.transaction_event_aggregator.reset!
-            NewRelic::Agent.instance.span_event_aggregator.reset!
           end
 
           def test_finish_does_not_fail_if_no_finishable_present

--- a/test/multiverse/suites/hybrid_agent/tracer_test.rb
+++ b/test/multiverse/suites/hybrid_agent/tracer_test.rb
@@ -9,12 +9,12 @@ module NewRelic
         class TracerTest < Minitest::Test
           def setup
             @tracer = NewRelic::Agent::OpenTelemetry::Trace::Tracer.new
+            harvest_transaction_events!
+            harvest_span_events!
           end
 
           def teardown
             mocha_teardown
-            NewRelic::Agent.instance.transaction_event_aggregator.reset!
-            NewRelic::Agent.instance.span_event_aggregator.reset!
           end
 
           def test_in_span_creates_segment_when_span_kind_internal

--- a/test/multiverse/suites/hybrid_agent/transaction_patch_test.rb
+++ b/test/multiverse/suites/hybrid_agent/transaction_patch_test.rb
@@ -6,9 +6,9 @@ module NewRelic
   module Agent
     module OpenTelemetry
       class TransactionPatchTest < Minitest::Test
-        def teardown
-          NewRelic::Agent.instance.transaction_event_aggregator.reset!
-          NewRelic::Agent.instance.span_event_aggregator.reset!
+        def setup
+          harvest_transaction_events!
+          harvest_span_events!
         end
 
         # We want to verify the context switching works for both OTel and NR

--- a/test/multiverse/suites/hybrid_agent/transaction_starting_test.rb
+++ b/test/multiverse/suites/hybrid_agent/transaction_starting_test.rb
@@ -11,13 +11,8 @@ module NewRelic
 
           def setup
             @tracer = NewRelic::Agent::OpenTelemetry::Trace::Tracer.new
-            # just to be extra safe to make sure finishable is the correct class
-            NewRelic::Agent::Tracer.current_transaction&.finish
-          end
-
-          def teardown
-            NewRelic::Agent.instance.transaction_event_aggregator.reset!
-            NewRelic::Agent.instance.span_event_aggregator.reset!
+            harvest_transaction_events!
+            harvest_span_events!
           end
 
           def test_span_with_remote_parent_makes_web_transaction_when_kind_client


### PR DESCRIPTION
This is the final attribute translation PR before our initial release.

This one maps server attributes to the correct New Relic fields and also updates transaction names to include those attributes when the right values are present. If the right values are not available, the name provided through the OTel API will be used instead.

Closes: #3435 