### PR TITLE
Fix context bug

### DIFF
--- a/lib/new_relic/agent/opentelemetry/context/propagation/trace_propagator.rb
+++ b/lib/new_relic/agent/opentelemetry/context/propagation/trace_propagator.rb
@@ -27,6 +27,9 @@ module NewRelic
                 format: carrier_format,
                 trace_state_entry_key: Transaction::TraceContext::AccountHelpers.trace_state_entry_key
               )
+
+              return context if trace_context.nil?
+
               tp = trace_context.trace_parent
               span_context = ::OpenTelemetry::Trace::SpanContext.new(
                 trace_id: tp['trace_id'],


### PR DESCRIPTION
The agent would log a warning and in some cases log an error if trace context was nil and this method was called. Trace context can be nil if we're looking at a root span, so we allow that and just return the passed-in context. This leaves the error message for unexpected behavior.

It also allows the OTel propagation method to more closely match the behavior in our `TraceContext#parse` method to handle `nil` trace parents. 