### PR TITLE
Vendor detect parallel config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
   A new configuration option has been added, `error_collector.backtrace_truncate_location`, which allows the user to specify where in the backtrace to truncate when the number of frames exceeds `error_collector.max_backtrace_frames`. Options are `'top'` (removes frames from the beginning), `'middle'` (removes frames from the middle, preserving the beginning and end), or `'end'` (removes frames from the end). The default is `'middle'`. [PR#3424](https://github.com/newrelic/newrelic-ruby-agent/pull/3424)
 
+- **Feature: Add configuration option utilization.detect_in_parallel**
+
+  A new configuration option has been added, `utilization.detect_in_parallel`, which controls whether the agent uses threads when detecting cloud vendor information to speed up agent startup. When set to `false`, vendor detection runs sequentially without creating threads. The default is `true`. [PR#3439](https://github.com/newrelic/newrelic-ruby-agent/pull/3439)
+
 ## v10.1.0
 
 - **Feature: Add support for forking processes in Parallel gem instrumentation**

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2268,6 +2268,13 @@ module NewRelic
           :dynamic_name => true,
           :description => 'If `true`, the agent automatically detects that it is running in a Pivotal Cloud Foundry environment.'
         },
+        :'utilization.detect_in_parallel' => {
+          :default => true,
+          :public => true,
+          :type => Boolean,
+          :allowed_from_server => false,
+          :description => 'If `true`, the agent will perform environment detection in parallel to speed up agent startup time.'
+        },
         # Private
         :account_id => {
           :default => nil,

--- a/test/new_relic/agent/utilization_data_test.rb
+++ b/test/new_relic/agent/utilization_data_test.rb
@@ -301,6 +301,32 @@ module NewRelic::Agent
       end
     end
 
+    def test_uses_sequential_detection_when_detect_in_parallel_is_disabled
+      stub_aws_info
+
+      with_config(:'utilization.detect_in_parallel' => false, :'utilization.detect_docker' => false) do
+        utilization_data = UtilizationData.new
+
+        utilization_data.expects(:detect_vendors_sequential).once
+        utilization_data.expects(:detect_vendors_parallel).never
+
+        utilization_data.to_collector_hash
+      end
+    end
+
+    def test_uses_parallel_detection_when_detect_in_parallel_is_enabled
+      stub_aws_info
+
+      with_config(:'utilization.detect_in_parallel' => true, :'utilization.detect_docker' => false) do
+        utilization_data = UtilizationData.new
+
+        utilization_data.expects(:detect_vendors_parallel).once
+        utilization_data.expects(:detect_vendors_sequential).never
+
+        utilization_data.to_collector_hash
+      end
+    end
+
     # ---
 
     def stub_aws_info(response_code: '200', response_body: default_aws_response)

--- a/test/new_relic/agent/utilization_data_test.rb
+++ b/test/new_relic/agent/utilization_data_test.rb
@@ -327,6 +327,39 @@ module NewRelic::Agent
       end
     end
 
+    def test_sequential_detection_finds_aws_vendor
+      stub_aws_info
+
+      with_config(:'utilization.detect_in_parallel' => false, :'utilization.detect_docker' => false) do
+        utilization_data = UtilizationData.new
+
+        expected = {
+          :instanceId => 'i-08987cdeff7489fa7',
+          :instanceType => 'c4.2xlarge',
+          :availabilityZone => 'us-west-2c'
+        }
+
+        assert_equal expected, utilization_data.to_collector_hash[:vendors][:aws]
+      end
+    end
+
+    def test_sequential_detection_finds_ecs_vendor
+      stub_aws_info
+
+      # Stub ECS v4 detection to succeed
+      ecs_instance = mock('ecs')
+      ecs_instance.stubs(:detect).returns(true)
+      ecs_instance.stubs(:metadata).returns({ecsFargate: '1.4.0'})
+      Utilization::ECSV4.stubs(:new).returns(ecs_instance)
+
+      with_config(:'utilization.detect_in_parallel' => false, :'utilization.detect_docker' => false) do
+        utilization_data = UtilizationData.new
+        collector_hash = utilization_data.to_collector_hash
+
+        assert_equal({ecsFargate: '1.4.0'}, collector_hash[:vendors][:ecs])
+      end
+    end
+
     # ---
 
     def stub_aws_info(response_code: '200', response_body: default_aws_response)


### PR DESCRIPTION
Implements a customer request to opt in to sequential vendor metadata detection to avoid creating extra threads during the agent start up. 
Adds the config `utilization.detect_in_parallel` that when disables, uses the old logic of sequentially checking for vendor metadata. 