### PR TITLE
pin dalli test versions

### DIFF
--- a/lib/new_relic/agent/instrumentation/memcache/dalli.rb
+++ b/lib/new_relic/agent/instrumentation/memcache/dalli.rb
@@ -51,7 +51,7 @@ module NewRelic
           end
 
           def instrument_send_multiget
-            if supports_binary_protocol?
+            if supports_binary_protocol? 
               ::Dalli::Protocol::Binary
             else
               ::Dalli::Server

--- a/lib/new_relic/agent/instrumentation/memcache/dalli.rb
+++ b/lib/new_relic/agent/instrumentation/memcache/dalli.rb
@@ -51,7 +51,7 @@ module NewRelic
           end
 
           def instrument_send_multiget
-            if supports_binary_protocol? 
+            if supports_binary_protocol?
               ::Dalli::Protocol::Binary
             else
               ::Dalli::Server

--- a/test/multiverse/suites/memcache/Envfile
+++ b/test/multiverse/suites/memcache/Envfile
@@ -6,7 +6,7 @@ require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..', 'he
 
 # Dalli
 DALLI_VERSIONS = [
-  [nil],
+  ['< 5.0'],
   ['= 3.1.0']
 ]
 def gem_list(version = nil)


### PR DESCRIPTION
Looks like we'll need to make some changes to support Dalli 5.0, which has recently been released.

I created an issue to track adding that support here https://github.com/newrelic/newrelic-ruby-agent/issues/3446
For now, lets remove Dalli 5 from running in our CI until we add support. 