### PR TITLE
feat: add agent metadata action - step 1

### DIFF
--- a/.fleetControl/agentControl/agent-schema-for-agent-control.yml
+++ b/.fleetControl/agentControl/agent-schema-for-agent-control.yml
@@ -1,0 +1,107 @@
+# original source: https://github.com/newrelic/newrelic-agent-control/blob/main/agent-control/agent-type-registry/newrelic/com.newrelic.apm_ruby-0.1.0.yaml
+namespace: newrelic
+name: com.newrelic.apm_ruby
+version: 0.1.0
+variables:
+  k8s:
+    podLabelSelector:
+      description: "Pod label selector"
+      type: yaml
+      default: { }
+      required: false
+    containerSelector:
+      description: "Container selector"
+      type: yaml
+      default: { }
+      required: false
+    namespaceLabelSelector:
+      description: "Namespace label selector"
+      type: yaml
+      default: { }
+      required: false
+    # All 'agent' side-car related variables are flattened.
+    version:
+      description: "Ruby Agent init container version"
+      type: string
+      default: "latest"
+      required: false
+    env:
+      description: "environment variables to pass to Ruby agent"
+      type: yaml
+      default: [ ]
+      required: false
+    imagePullPolicy:
+      description: "image pull policy for the Ruby agent init container"
+      type: string
+      default: "Always"
+      required: false
+    resourceRequirements:
+      description: "resource requirements for the Ruby agent init container"
+      type: yaml
+      default: { }
+      required: false
+    securityContext:
+      description: "security context for the Ruby agent init container"
+      type: yaml
+      default: { }
+      required: false
+    # All health sidecar related variables are flattened and prefixed with "health_"
+    health_env:
+      description: "environment variables to pass to health sidecar"
+      type: yaml
+      default: [ ]
+      required: false
+    health_version:
+      description: "health sidecar image version"
+      type: string
+      default: "latest"
+      required: false
+    health_imagePullPolicy:
+      description: "image pull policy for the health sidecar"
+      type: string
+      default: "Always"
+      required: false
+    health_resourceRequirements:
+      description: "resource requirements for the health sidecar"
+      type: yaml
+      default: { }
+      required: false
+    health_securityContext:
+      description: "security context for the health sidecar"
+      type: yaml
+      default: { }
+      required: false
+deployment:
+  k8s:
+    health:
+      interval: 30s
+      initial_delay: 30s
+    objects:
+      instrumentation:
+        apiVersion: newrelic.com/v1beta3
+        kind: Instrumentation
+        metadata:
+          name: ${nr-sub:agent_id}
+          # APM CRs should be installed in "nr-ac:namespace"
+          # Due to a limitation in the k8s-agents-operator, Instrumentation CRs must be installed in the same namespace as the operator.
+          # Hence, the namespace is set to "nr-ac:namespace_agents".
+          # Reference: https://github.com/newrelic/k8s-agents-operator/blob/92c19208864f051f03f457ee04b772fca5042162/api/v1beta1/instrumentation_webhook.go#L110C27-L110C72
+          namespace: ${nr-ac:namespace_agents}
+        spec:
+          agent:
+            language: ruby
+            image: newrelic/newrelic-ruby-init:${nr-var:version}
+            env: ${nr-var:env}
+            imagePullPolicy: ${nr-var:imagePullPolicy}
+            resources: ${nr-var:resourceRequirements}
+            securityContext: ${nr-var:securityContext}
+          healthAgent:
+            image: newrelic/k8s-apm-agent-health-sidecar:${nr-var:health_version}
+            env: ${nr-var:health_env}
+            imagePullPolicy: ${nr-var:health_imagePullPolicy}
+            resources: ${nr-var:health_resourceRequirements}
+            securityContext: ${nr-var:health_securityContext}
+          podLabelSelector: ${nr-var:podLabelSelector}
+          namespaceLabelSelector: ${nr-var:namespaceLabelSelector}
+          containerSelector: ${nr-var:containerSelector}
+

--- a/.fleetControl/agentControlDefinitions.yml
+++ b/.fleetControl/agentControlDefinitions.yml
@@ -1,0 +1,5 @@
+agentControlDefinitions:
+  - platform: KUBERNETESCLUSTER
+    supportFromAgent: 1.0.0
+    supportFromAgentControl: 1.0.0
+    content: ./agentControl/agent-schema-for-agent-control.yml

--- a/.fleetControl/configurationDefinitions.yml
+++ b/.fleetControl/configurationDefinitions.yml
@@ -1,0 +1,6 @@
+configurationDefinitions:
+  - platform: KUBERNETESCLUSTER
+    description: Ruby agent configuration
+    type: agent-config
+    version: 1.0.0
+# will add schema information here later

--- a/.github/workflows/AgentMetadata.yml
+++ b/.github/workflows/AgentMetadata.yml
@@ -1,0 +1,105 @@
+name: Agent Metadata
+
+permissions:
+  contents: read
+
+on:
+  # Allows manual triggering with parameters
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version tag (e.g., v10.0.0)'
+        required: true
+        type: string
+      agent-type:
+        description: 'Agent type'
+        required: false
+        default: 'NRRubyAgent'
+        type: string
+      use-cache:
+        description: 'Use cache'
+        required: false
+        default: true
+        type: boolean
+  # commented items below pertain to future work
+  #      oci-registry:
+  #        description: 'OCI registry URL for binary uploads (e.g., ghcr.io/newrelic/agents). Leave empty to skip binary upload.'
+  #        required: false
+  #        default: ''
+  #        type: string
+  #      oci-username:
+  #        description: 'OCI registry username (required if oci-registry is set)'
+  #        required: false
+  #        default: ''
+  #        type: string
+  #      oci-password:
+  #        description: 'OCI registry password or token (required if oci-registry is set)'
+  #        required: false
+  #        default: ''
+  #        type: string
+  #      binaries:
+  #        description: 'JSON array with artifact definitions'
+  #        required: false
+  #        default: ''
+  #        type: string
+
+  # Allows calling from another workflow
+  workflow_call:
+    inputs:
+      version:
+        description: 'Version tag to test'
+        required: true
+        type: string
+      agent-type:
+        description: 'Agent type'
+        required: false
+        default: 'NRRubyAgent'
+        type: string
+      use-cache:
+        description: 'Use cache'
+        required: false
+        default: true
+        type: boolean
+    # commented items below pertain to future work
+    #      oci-registry:
+    #        description: 'OCI registry URL for binary uploads (e.g., ghcr.io/newrelic/agents). Leave empty to skip binary upload.'
+    #        required: false
+    #        default: ''
+    #        type: string
+    #      oci-username:
+    #        description: 'OCI registry username (required if oci-registry is set)'
+    #        required: false
+    #        default: ''
+    #        type: string
+    #      oci-password:
+    #        description: 'OCI registry password or token (required if oci-registry is set)'
+    #        required: false
+    #        default: ''
+    #        type: string
+    #      binaries:
+    #        description: 'JSON array with artifact definitions'
+    #        required: false
+    #        default: ''
+    #        type: string
+    secrets:
+      FC_SYS_ID_CLIENT_ID:
+        required: true
+      FC_SYS_ID_PR_KEY:
+        required: true
+      APM_CONTROL_NR_LICENSE_KEY_STAGING:
+        required: true
+
+jobs:
+  test-agent-metadata-action:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Run action
+        uses: newrelic/agent-metadata-action@v1.0.1
+        with:
+          newrelic-client-id: ${{ secrets.FC_SYS_ID_CLIENT_ID }}
+          newrelic-private-key: ${{ secrets.FC_SYS_ID_PR_KEY }}
+          apm-control-nr-license-key: ${{ secrets.APM_CONTROL_NR_LICENSE_KEY_STAGING }} # action app is instrumented and supported by APM Control team
+          agent-type: TestAgent #${{ inputs.agent-type }}
+          version: ${{ inputs.version }}
+          cache: ${{ inputs.use-cache }}


### PR DESCRIPTION
# Overview
This PR adds the ability for the NR agent team to send agent metadata and binaries to New Relic for use in fleets and other features. This will be triggered normally during a release. but if it fails, it will not fail the release. It can also be run on-demand for backfilling older agent versions, to make corrections, or to re-run the job after a failure.

GH action info: https://github.com/newrelic/agent-metadata-action/blob/main/README.md

Submitter Checklist:
- [ ] Include a link to the related GitHub issue, if applicable
- [ ] Add new tests for your change, if applicable

# Testing
This PR is step 1 that will use a`TestAgent` agent name instead of `NRRubyAgent`
This PR needs to be merged to main in order to run the new on-demand workflow
A later PR will add a step in the release and use the real agent name


# Reviewer Checklist
- [ ] Perform code review
- [ ] Confirm all checks passed
- [ ] Open a separate PR to add a CHANGELOG entry