### PR TITLE
feat: add agent metadata action - step 2

### DIFF
--- a/.github/workflows/AgentMetadata.yml
+++ b/.github/workflows/AgentMetadata.yml
@@ -100,6 +100,6 @@ jobs:
           newrelic-client-id: ${{ secrets.FC_SYS_ID_CLIENT_ID }}
           newrelic-private-key: ${{ secrets.FC_SYS_ID_PR_KEY }}
           apm-control-nr-license-key: ${{ secrets.APM_CONTROL_NR_LICENSE_KEY_STAGING }} # action app is instrumented and supported by APM Control team
-          agent-type: TestAgent #${{ inputs.agent-type }}
+          agent-type: ${{ inputs.agent-type }}
           version: ${{ inputs.version }}
           cache: ${{ inputs.use-cache }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,3 +60,13 @@ jobs:
 
     - name: Publish newrelic-infinite_tracing to rubygems.org
       run: ruby ./.github/workflows/scripts/rubygems-publish.rb infinite_tracing/newrelic-infinite_tracing
+
+  update-agent-metadata:
+    needs: [release]
+    uses: ./.github/workflows/AgentMetadata.yml
+    with:
+      version: ${{ github.event.release.tag_name }}
+    secrets:
+      FC_SYS_ID_CLIENT_ID: ${{ secrets.FC_SYS_ID_CLIENT_ID }}
+      FC_SYS_ID_PR_KEY: ${{ secrets.FC_SYS_ID_PR_KEY }}
+      APM_CONTROL_NR_LICENSE_KEY_STAGING: ${{ secrets.APM_CONTROL_NR_LICENSE_KEY_STAGING }}


### PR DESCRIPTION
### Overview
This PR completes the ability for the NR agent team to send agent metadata to New Relic for use in fleets and other features. This will be triggered normally during a release, but if it fails, it will not fail the release. It can also be run on-demand for backfilling older agent versions, to make corrections, or to re-run the job after a failure.

GH action info: https://github.com/newrelic/agent-metadata-action/blob/main/README.md

Submitter Checklist:
- [ ] Include a link to the related GitHub issue, if applicable
- [ ] Add new tests for your change, if applicable

# Testing
This work has been tested manually in: https://github.com/newrelic/newrelic-ruby-agent/pull/3448

# Reviewer Checklist
- [ ] Perform code review
- [ ] Confirm all checks passed
- [ ] Open a separate PR to add a CHANGELOG entry
