### PR TITLE
chore: Update metadata action version

### DIFF
--- a/.github/workflows/AgentMetadata.yml
+++ b/.github/workflows/AgentMetadata.yml
@@ -95,7 +95,7 @@ jobs:
     continue-on-error: true
     steps:
       - name: Run action
-        uses: newrelic/agent-metadata-action@v1.0.1
+        uses: newrelic/agent-metadata-action@v1.0.2
         with:
           newrelic-client-id: ${{ secrets.FC_SYS_ID_CLIENT_ID }}
           newrelic-private-key: ${{ secrets.FC_SYS_ID_PR_KEY }}


### PR DESCRIPTION
# Overview
The latest action version properly handles version tags that don't have a `v` prefix.

Submitter Checklist:
- [ ] Include a link to the related GitHub issue, if applicable
- [ ] Add new tests for your change, if applicable

# Testing
Originally, I created a test tag with a `v` prefix so the test worked but Ruby agent tags don't have that prefix. I have re-tested since updating to the latest action version and tags without the prefix now work properly.

# Reviewer Checklist
- [ ] Perform code review
- [ ] Confirm all checks passed
- [ ] Open a separate PR to add a CHANGELOG entry
