### PR TITLE
Finish OTel span before forcing finish

### DIFF
--- a/lib/new_relic/agent/opentelemetry/abstract_segment_patch.rb
+++ b/lib/new_relic/agent/opentelemetry/abstract_segment_patch.rb
@@ -12,6 +12,7 @@ module NewRelic
             if otel_span.respond_to?(:finish) && !otel_span.instance_variable_get(:@finished)
               begin
                 otel_span.finish
+
                 return if finished?
               rescue => e
                 NewRelic::Agent.logger.debug("Error finishing OpenTelemetry span during force_finish: #{e}")

--- a/lib/new_relic/agent/opentelemetry/abstract_segment_patch.rb
+++ b/lib/new_relic/agent/opentelemetry/abstract_segment_patch.rb
@@ -1,0 +1,27 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+module NewRelic
+  module Agent
+    module OpenTelemetry
+      module AbstractSegmentPatch
+        def force_finish
+          if instance_variable_defined?(:@otel_span)
+            otel_span = instance_variable_get(:@otel_span)
+            if otel_span.respond_to?(:finish) && !otel_span.instance_variable_get(:@finished)
+              begin
+                otel_span.finish
+                return if finished?
+              rescue => e
+                NewRelic::Agent.logger.debug("Error finishing OpenTelemetry span during force_finish: #{e}")
+              end
+            end
+          end
+
+          super
+        end
+      end
+    end
+  end
+end

--- a/lib/new_relic/agent/opentelemetry_bridge.rb
+++ b/lib/new_relic/agent/opentelemetry_bridge.rb
@@ -69,11 +69,13 @@ module NewRelic
         require_relative 'opentelemetry/transaction_patch'
         require_relative 'opentelemetry/context'
         require_relative 'opentelemetry/trace_patch'
+        require_relative 'opentelemetry/abstract_segment_patch'
 
         NewRelic::Agent.logger.warn('OpenTelemetry SDK gem is installed. This may interfere with New Relic instrumentation.') if defined?(OpenTelemetry::SDK)
 
         ::OpenTelemetry::Trace.singleton_class.prepend(NewRelic::Agent::OpenTelemetry::TracePatch)
         Transaction.prepend(OpenTelemetry::TransactionPatch)
+        Transaction::AbstractSegment.prepend(OpenTelemetry::AbstractSegmentPatch)
 
         ::OpenTelemetry.tracer_provider = OpenTelemetry::Trace::TracerProvider.new
         ::OpenTelemetry.propagation = OpenTelemetry::Context::Propagation::TracePropagator.new

--- a/test/multiverse/suites/hybrid_agent/abstract_segment_patch_test.rb
+++ b/test/multiverse/suites/hybrid_agent/abstract_segment_patch_test.rb
@@ -1,0 +1,69 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+module NewRelic
+  module Agent
+    module OpenTelemetry
+      class AbstractSegmentPatchTest < Minitest::Test
+        def setup
+          harvest_transaction_events!
+          harvest_span_events!
+        end
+
+        def test_force_finish_with_otel_span_that_cannot_finish_segment
+          in_transaction do |txn|
+            txn.stubs(:sampled?).returns(true)
+            segment = Tracer.start_segment(name: 'test_segment')
+            otel_span = segment.instance_variable_get(:@otel_span)
+
+            otel_span.stubs(:instance_variable_get).with(:@finished).returns(false)
+            otel_span.stubs(:finish).returns(nil)
+
+            segment.force_finish
+
+            assert_predicate segment, :finished?
+          end
+        end
+
+        def test_force_finish_with_successful_otel_span_finish
+          in_transaction do |txn|
+            txn.stubs(:sampled?).returns(true)
+            segment = Tracer.start_segment(name: 'test_segment')
+            otel_span = segment.instance_variable_get(:@otel_span)
+
+            otel_span.stubs(:instance_variable_get).with(:@finished).returns(false)
+            otel_span.stubs(:finish) do
+              segment.finish
+            end
+
+            refute_predicate segment, :finished?, 'Segment should start unfinished'
+
+            segment.force_finish
+
+            assert_predicate segment, :finished?, 'Segment should be finished by span.finish'
+          end
+        end
+
+        def test_force_finish_handles_otel_span_exceptions_gracefully
+          in_transaction do |txn|
+            txn.stubs(:sampled?).returns(true)
+            segment = Tracer.start_segment(name: 'test_segment')
+            otel_span = segment.instance_variable_get(:@otel_span)
+
+            otel_span.stubs(:instance_variable_get).with(:@finished).returns(false)
+            otel_span.stubs(:finish).raises(StandardError.new('Test exception'))
+
+            logger_mock = mock()
+            logger_mock.expects(:debug).with(regexp_matches(/Error finishing OpenTelemetry span during force_finish.*Test exception/))
+            NewRelic::Agent.stubs(:logger).returns(logger_mock)
+
+            segment.force_finish
+
+            assert_predicate segment, :finished?, 'Segment should still be finished via fallback after exception'
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
When replacing agent instrumentation with OTel's, we'd sometimes see a race condition where OTel spans finished asynchronously after New Relic transactions completed:
```
DEBUG : Segment: HTTP POST was unfinished at the end of transaction. Timing information for this segment's parent Middleware/Rack/Rack::Events/call in Controller/articles/create may be inaccurate.
```
This PR introduces a patch on Abstract Segment when the hybrid agent is enabled to finish OTel spans before forcing the NR segments to end.

closes #3140 