### PR TITLE
Release Change Proposals

### DIFF
--- a/.build_ignore
+++ b/.build_ignore
@@ -1,3 +1,4 @@
+.fleetControl
 .github/
 .gitignore
 .project

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -43,13 +43,3 @@ jobs:
         TITLE: "Prerelease ${{env.prerelease_tag}}"
         BODY: "Updates the version number, changelog, and newrelic.yml (if it needs updating). This is an automated PR."
         LABEL: prerelease
-
-    - name: Create pre release tag
-      uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # tag v2.5.0
-      with:
-        tag_name: ${{ env.prerelease_tag }}
-        name: ${{ env.prerelease_tag }}
-        target_commitish: prerelease_updates_${{ env.prerelease_tag }}
-        prerelease: true
-      env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/prerelease_tag.yml
+++ b/.github/workflows/prerelease_tag.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   create_prerelease_tag:
     if: ${{ (github.event.pull_request.merged == true) && (contains(github.event.pull_request.labels.*.name, 'prerelease')) }}
+    permissions:
+      contents: write
     runs-on: ubuntu-22.04
     steps:
     - name: Install Ruby 3.4

--- a/.github/workflows/prerelease_tag.yml
+++ b/.github/workflows/prerelease_tag.yml
@@ -1,0 +1,34 @@
+name: Create Release PR
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  create_prerelease_tag:
+    if: ${{ (github.event.pull_request.merged == true) && (contains(github.event.pull_request.labels.*.name, 'prerelease')) }}
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Install Ruby 3.4
+      uses: ruby/setup-ruby@8d27f39a5e7ad39aebbcbd1324f7af020229645c # tag v1.287.0
+      with:
+        ruby-version: 3.4
+
+    - name: Checkout code
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # tag v6.0.2
+
+    - run: bundle install
+
+    - name: Set prerelease tag env var
+      run: echo "prerelease_tag=$(bundle exec rake newrelic:version:current)-pre" >> $GITHUB_ENV
+
+    - name: Make tag
+      uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # tag v2.5.0
+      with:
+        tag_name: ${{ env.prerelease_tag }}
+        name: ${{ env.prerelease_tag }}
+        target_commitish: prerelease_updates_${{ env.prerelease_tag }}
+        prerelease: true
+      env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release_pr.yml
+++ b/.github/workflows/release_pr.yml
@@ -6,7 +6,7 @@ on:
       - closed
 
 jobs:
-  create_prerelease:
+  create_release_pr:
     if: ${{ (github.event.pull_request.merged == true) && (contains(github.event.pull_request.labels.*.name, 'prerelease')) }}
     runs-on: ubuntu-22.04
     permissions:


### PR DESCRIPTION
1. Previously, the prerelease tag would be created when the prerelease PR was opened. This means that changes to the agent after the prerelease PR was opened would not be reflected in the tag used for validation with internal apps.

Now, the tag will be created after the prerelease PR is merged.

2. There was a typo in the job name within release_pr.yml

3. The new .fleetControl folder doesn't need to be included in the distributed gem