### PR TITLE
Fix capitalization for OpenTelemetry heading

### DIFF
--- a/lib/tasks/config.rake
+++ b/lib/tasks/config.rake
@@ -32,7 +32,8 @@ namespace :newrelic do
       'slow_sql' => 'Slow SQL [#slow-sql]',
       'custom_insights_events' => 'Custom Events [#custom-events]',
       'ai_monitoring' => 'AI Monitoring [#ai-monitoring]',
-      'security_agent' => 'Security Agent [#security-agent]'
+      'security_agent' => 'Security Agent [#security-agent]',
+      'opentelemetry' => 'OpenTelemetry'
     }
 
     desc 'Describe available New Relic configuration settings'


### PR DESCRIPTION
Small typo noticed when reviewing the config docs PR.