### PR TITLE
Update forum.newrelic.com URLs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -178,15 +178,15 @@ opensource@newrelic.com.
 For more information about CLAs, please check out Alex Russell’s excellent post,
 [“Why Do I Need to Sign This?”](https://infrequently.org/2008/06/why-do-i-need-to-sign-this/).
 
-## Explorer's Hub
+## New Relic Support
 
 New Relic hosts and moderates an online forum where customers can interact with
 New Relic employees as well as other customers to get help and share best
 practices. Like all official New Relic open source projects, there's a related
-Community topic in the New Relic Explorers Hub. You can find this project's
+Community topic in the New Relic Support Forum. You can find this project's
 topic/threads under the "Ruby Agent" category here:
 
-[Explorer's Hub](https://forum.newrelic.com/s/category/Category__c/Default)
+[New Relic Support](https://support.newrelic.com/s/category/Category__c/Default)
 
 ## And Finally...
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This code is actively maintained by New Relic engineering teams and delivered he
 ## Supported environments
 
 An up-to-date list of Ruby versions and frameworks for the latest agent
-can be found on [our docs site](http://docs.newrelic.com/docs/ruby/supported-frameworks).
+can be found on [our docs site](https://docs.newrelic.com/docs/ruby/supported-frameworks).
 
 You can also monitor non-web applications. Refer to the "Other
 Environments" section below.
@@ -70,7 +70,7 @@ For complete documentation on installing the New Relic Ruby agent, see the follo
   * [Rails plugin installation](https://docs.newrelic.com/docs/agents/ruby-agent/installation/ruby-agent-installation-rails-plugin)
   * [AWS Lambda](https://docs.newrelic.com/docs/serverless-function-monitoring/aws-lambda-monitoring/instrument-lambda-function/instrument-your-own/)
   * [GAE Flexible Environment](https://docs.newrelic.com/docs/agents/ruby-agent/installation/install-new-relic-ruby-agent-gae-flexible-environment)
-  * [Pure Rack apps](http://docs.newrelic.com/docs/ruby/rack-middlewares)
+  * [Pure Rack apps](https://docs.newrelic.com/docs/ruby/rack-middlewares)
   * [Ruby agent and Heroku](https://docs.newrelic.com/docs/agents/ruby-agent/installation/ruby-agent-heroku)
   * [Background jobs](https://docs.newrelic.com/docs/agents/ruby-agent/background-jobs/monitor-ruby-background-processes)
 * [Configure the agent](https://docs.newrelic.com/docs/agents/ruby-agent/configuration/ruby-agent-configuration)
@@ -81,7 +81,7 @@ For complete documentation on installing the New Relic Ruby agent, see the follo
 
 Should you need assistance with New Relic products, you are in good hands with several support diagnostic tools and support channels.
 
-This [troubleshooting framework](https://knowledge.newrelic.com/s/article/Ruby-Troubleshooting-Framework-Install) steps you through common troubleshooting questions.
+This [troubleshooting guide](https://docs.newrelic.com/docs/apm/agents/ruby-agent/troubleshooting/no-data-appears-ruby/) walks you through common troubleshooting steps.
 
 New Relic offers NRDiag, [a client-side diagnostic utility](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics) that automatically detects common problems with New Relic agents. If NRDiag detects a problem, it suggests troubleshooting steps. NRDiag can also automatically attach troubleshooting data to a New Relic Support ticket.
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ For complete documentation on installing the New Relic Ruby agent, see the follo
 
 Should you need assistance with New Relic products, you are in good hands with several support diagnostic tools and support channels.
 
-This [troubleshooting framework](https://forum.newrelic.com/s/hubtopic/aAX8W0000008bSgWAI/ruby-troubleshooting-framework-install) steps you through common troubleshooting questions.
+This [troubleshooting framework](https://knowledge.newrelic.com/s/article/Ruby-Troubleshooting-Framework-Install) steps you through common troubleshooting questions.
 
 New Relic offers NRDiag, [a client-side diagnostic utility](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics) that automatically detects common problems with New Relic agents. If NRDiag detects a problem, it suggests troubleshooting steps. NRDiag can also automatically attach troubleshooting data to a New Relic Support ticket.
 
@@ -90,7 +90,7 @@ If the issue has been confirmed as a bug or is a Feature request, please file a 
 **Support channels**
 
 * [New Relic Documentation](https://docs.newrelic.com/docs/agents/ruby-agent): Comprehensive guidance for using our platform
-* [New Relic Community](https://forum.newrelic.com): The best place to engage in troubleshooting questions
+* [New Relic Support](https://support.newrelic.com): The best place to engage in troubleshooting questions
 * [New Relic University](https://learn.newrelic.com/): A range of online training for New Relic users of every level
 * [New Relic Technical Support](https://support.newrelic.com/) 24/7/365 ticketed support. Read more about our [Technical Support Offerings](https://docs.newrelic.com/docs/licenses/license-information/general-usage-licenses/support-plan).
 
@@ -126,7 +126,7 @@ The New Relic Ruby agent may use source code from third-party libraries. When us
 
 ## Thank you
 
-We always look forward to connecting with the community. We welcome [contributions](https://github.com/newrelic/newrelic-ruby-agent#contributing) to our source code and suggestions for improvements, and would love to hear about what you like and want to see in the future. 
+We always look forward to connecting with the community. We welcome [contributions](https://github.com/newrelic/newrelic-ruby-agent#contributing) to our source code and suggestions for improvements, and would love to hear about what you like and want to see in the future.
 
 Visit our [project board](https://github.com/orgs/newrelic/projects/84/) to see what's upcoming in a future release, what we're currently working on, and what we're planning next.
 


### PR DESCRIPTION
The forum subdomain has been retired. Now, the content can be found at support.newrelic.com.

In addition, the phrase "Explorer's Hub" has also been retired.