### PR TITLE
Remove straggling md5 require

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # New Relic Ruby Agent Release Notes
 
+## dev
+
+- **Security: Remove dead 'digest/md5' require for FIPS compliance**
+
+  In version 7.1.0 of the agent, MD5 usage was replaced with SHA1 for FIPS compliance. However, the old require for 'digest/md5' was not removed. We have removed the require to help our FIPS/FedRAMP users. Thank you to [ashleyboehs](https://github.com/ashleyboehs) for bringing this to our attention! [Issue#3469](https://github.com/newrelic/newrelic-ruby-agent/issues/3469) [PR#3470](https://github.com/newrelic/newrelic-ruby-agent/issues/3470)
+
 ## v10.2.0
 
 - **Feature: Introduce Hybrid Agent for OpenTelemetry Tracing Support**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## dev
 
-- **Security: Remove dead 'digest/md5' require for FIPS compliance**
+- **Bugfix: Remove dead 'digest/md5' require for FIPS/FedRAMP compliance**
 
-  In version 7.1.0 of the agent, MD5 usage was replaced with SHA1 for FIPS compliance. However, the old require for 'digest/md5' was not removed. We have removed the require to help our FIPS/FedRAMP users. Thank you to [ashleyboehs](https://github.com/ashleyboehs) for bringing this to our attention! [Issue#3469](https://github.com/newrelic/newrelic-ruby-agent/issues/3469) [PR#3470](https://github.com/newrelic/newrelic-ruby-agent/issues/3470)
+  In version 7.1.0 of the agent, MD5 usage was replaced with SHA1 for FIPS compliance [(PR)](https://github.com/newrelic/newrelic-ruby-agent/pull/686). However, the old require for 'digest/md5' was not removed. We have removed the require to help our FIPS/FedRAMP users. Thank you to [@ashleyboehs](https://github.com/ashleyboehs) for bringing this to our attention! [Issue#3469](https://github.com/newrelic/newrelic-ruby-agent/issues/3469) [PR#3470](https://github.com/newrelic/newrelic-ruby-agent/issues/3470)
 
 ## v10.2.0
 

--- a/lib/new_relic/agent/sql_sampler.rb
+++ b/lib/new_relic/agent/sql_sampler.rb
@@ -3,7 +3,6 @@
 # frozen_string_literal: true
 
 require 'zlib'
-require 'digest/md5'
 
 module NewRelic
   module Agent


### PR DESCRIPTION
Version 7.1.0 removed the MD5 code, but the require was left behind. Requiring the module can be flagged during compliance audits in strict FIPS-enforced or FEDRAMP environments.

Resolves #3469
