### PR TITLE
Add API `add_transaction_log_attributes`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # New Relic Ruby Agent Release Notes
 
+## dev
+
+- **Feature: Add new `NewRelic::Agent#add_custom_transaction_log_attributes` API**
+
+  A new API, `NewRelic::Agent#add_custom_transaction_log_attributes`, allows users to add transaction-scoped custom attributes to log events for the current transaction. These attributes will only be applied to logs created within the scope of the current transaction. [PR#3472](https://github.com/newrelic/newrelic-ruby-agent/pull/3472)
+
 ## v10.2.0
 
 - **Feature: Introduce Hybrid Agent for OpenTelemetry Tracing Support**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## dev
 
-- **Feature: Add new `NewRelic::Agent#add_custom_transaction_log_attributes` API**
+- **Feature: Add new `NewRelic::Agent#add_transaction_log_attributes` API**
 
-  A new API, `NewRelic::Agent#add_custom_transaction_log_attributes`, allows users to add transaction-scoped custom attributes to log events for the current transaction. These attributes will only be applied to logs created within the scope of the current transaction. [PR#3472](https://github.com/newrelic/newrelic-ruby-agent/pull/3472)
+  A new API, `NewRelic::Agent#add_transaction_log_attributes`, allows users to add transaction-scoped custom attributes to log events for the current transaction. These attributes will only be applied to logs created within the scope of the current transaction. [PR#3472](https://github.com/newrelic/newrelic-ruby-agent/pull/3472)
 
 ## v10.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## dev
 
-- **Feature: Add new `NewRelic::Agent#add_transaction_log_attributes` API**
-
 - **Feature: Add new `NewRelic::Agent.add_transaction_log_attributes` API**
 
   A new API, `NewRelic::Agent.add_transaction_log_attributes`, allows users to add transaction-scoped custom attributes to log events for the current transaction. These attributes will only be applied to logs created within the scope of the current transaction. [PR#3472](https://github.com/newrelic/newrelic-ruby-agent/pull/3472)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 - **Feature: Add new `NewRelic::Agent#add_transaction_log_attributes` API**
 
-  A new API, `NewRelic::Agent#add_transaction_log_attributes`, allows users to add transaction-scoped custom attributes to log events for the current transaction. These attributes will only be applied to logs created within the scope of the current transaction. [PR#3472](https://github.com/newrelic/newrelic-ruby-agent/pull/3472)
+- **Feature: Add new `NewRelic::Agent.add_transaction_log_attributes` API**
+
+  A new API, `NewRelic::Agent.add_transaction_log_attributes`, allows users to add transaction-scoped custom attributes to log events for the current transaction. These attributes will only be applied to logs created within the scope of the current transaction. [PR#3472](https://github.com/newrelic/newrelic-ruby-agent/pull/3472)
 
 ## v10.2.0
 

--- a/lib/new_relic/agent.rb
+++ b/lib/new_relic/agent.rb
@@ -921,6 +921,55 @@ module NewRelic
       end
     end
 
+    # Add transaction-scoped custom attributes to log events for the current transaction.
+    # These attributes will only be applied to logs created within the scope of the current transaction.
+    #
+    # @param [Hash] params    A Hash of attributes to attach to log
+    #                         events in the current transaction. The agent accepts
+    #                         up to 240 custom log event attributes per transaction.
+    #
+    #                         Keys will be coerced into Strings and must
+    #                         be less than 256 characters. Keys longer
+    #                         than 255 characters will be truncated.
+    #
+    #                         Values may be Strings, Symbols, numeric
+    #                         values or Booleans and must be less than
+    #                         4095 characters. If the value is a String
+    #                         or a Symbol, values longer than 4094
+    #                         characters will be truncated. If the value
+    #                         exceeds 4094 characters and is of a
+    #                         different class, the attribute pair will
+    #                         be dropped.
+    #
+    #                         This API can be called multiple times within
+    #                         a transaction. If the same key is passed more
+    #                         than once, the value associated with the last
+    #                         call will be preserved.
+    #
+    #                         Attribute pairs with empty or nil contents
+    #                         will be dropped.
+    #
+    #                         If called outside of a transaction context,
+    #                         the method will log a warning and return without
+    #                         adding attributes.
+    # @!scope class
+    # @api public
+    def add_custom_transaction_log_attributes(params)
+      record_api_supportability_metric(:add_custom_transaction_log_attributes)
+
+      unless params.is_a?(Hash)
+        ::NewRelic::Agent.logger.warn("Bad argument passed to #add_custom_transaction_log_attributes. Expected Hash but got #{params.class}")
+        return
+      end
+
+      transaction = Transaction.tl_current
+      if transaction
+        transaction.add_custom_transaction_log_attributes(params)
+      else
+        ::NewRelic::Agent.logger.warn('add_custom_transaction_log_attributes called outside of transaction context. Attributes will be ignored.')
+      end
+    end
+
     # Set the user id for the current transaction. When present, this value will be included in the agent attributes for transaction and error events as 'enduser.id'.
     #
     # @param [String] user_id    The user id to add to the current transaction attributes

--- a/lib/new_relic/agent.rb
+++ b/lib/new_relic/agent.rb
@@ -954,19 +954,19 @@ module NewRelic
     #                         adding attributes.
     # @!scope class
     # @api public
-    def add_custom_transaction_log_attributes(params)
-      record_api_supportability_metric(:add_custom_transaction_log_attributes)
+    def add_transaction_log_attributes(params)
+      record_api_supportability_metric(:add_transaction_log_attributes)
 
       unless params.is_a?(Hash)
-        ::NewRelic::Agent.logger.warn("Bad argument passed to #add_custom_transaction_log_attributes. Expected Hash but got #{params.class}")
+        ::NewRelic::Agent.logger.warn("Bad argument passed to #add_transaction_log_attributes. Expected Hash but got #{params.class}")
         return
       end
 
       transaction = Transaction.tl_current
       if transaction
-        transaction.add_custom_transaction_log_attributes(params)
+        transaction.add_transaction_log_attributes(params)
       else
-        ::NewRelic::Agent.logger.warn('add_custom_transaction_log_attributes called outside of transaction context. Attributes will be ignored.')
+        ::NewRelic::Agent.logger.warn('add_transaction_log_attributes called outside of transaction context. Attributes will be ignored.')
       end
     end
 

--- a/lib/new_relic/agent/log_event_aggregator.rb
+++ b/lib/new_relic/agent/log_event_aggregator.rb
@@ -154,8 +154,11 @@ module NewRelic
       def record_batch(txn, logs)
         # Ensure we have the same shared priority
         priority = LogPriority.priority_for(txn)
+        txn_attrs = txn.log_attributes&.custom_attributes
+
         logs.each do |log|
           log.first[PRIORITY_KEY] = priority
+          log.last.merge!(txn_attrs) if txn_attrs && !txn_attrs.empty?
         end
 
         @lock.synchronize do

--- a/lib/new_relic/agent/transaction.rb
+++ b/lib/new_relic/agent/transaction.rb
@@ -924,7 +924,7 @@ module NewRelic
         attributes.merge_custom_attributes(p)
       end
 
-      def add_custom_transaction_log_attributes(params)
+      def add_transaction_log_attributes(params)
         @log_attributes ||= LogEventAttributes.new
         @log_attributes.add_custom_attributes(params)
       end

--- a/lib/new_relic/agent/transaction.rb
+++ b/lib/new_relic/agent/transaction.rb
@@ -6,6 +6,7 @@ require 'new_relic/agent/instrumentation/queue_time'
 require 'new_relic/agent/transaction_metrics'
 require 'new_relic/agent/method_tracer_helpers'
 require 'new_relic/agent/attributes'
+require 'new_relic/agent/log_event_attributes'
 require 'new_relic/agent/transaction/request_attributes'
 require 'new_relic/agent/transaction/tracing'
 require 'new_relic/agent/transaction/distributed_tracer'
@@ -250,6 +251,7 @@ module NewRelic
         @starting_segment_key = current_segment_key
 
         @attributes = Attributes.new(NewRelic::Agent.instance.attribute_filter)
+        @log_attributes = nil
 
         merge_request_parameters(@filtered_params)
 
@@ -920,6 +922,15 @@ module NewRelic
 
       def add_custom_attributes(p)
         attributes.merge_custom_attributes(p)
+      end
+
+      def add_custom_transaction_log_attributes(params)
+        @log_attributes ||= LogEventAttributes.new
+        @log_attributes.add_custom_attributes(params)
+      end
+
+      def log_attributes
+        @log_attributes
       end
 
       def add_log_event(event)

--- a/lib/new_relic/supportability_helper.rb
+++ b/lib/new_relic/supportability_helper.rb
@@ -15,7 +15,7 @@ module NewRelic
       :add_custom_attributes,
       :add_custom_log_attributes,
       :add_custom_span_attributes,
-      :add_custom_transaction_log_attributes,
+      :add_transaction_log_attributes,
       :add_instrumentation,
       :add_method_tracer,
       :add_transaction_tracer,

--- a/lib/new_relic/supportability_helper.rb
+++ b/lib/new_relic/supportability_helper.rb
@@ -15,6 +15,7 @@ module NewRelic
       :add_custom_attributes,
       :add_custom_log_attributes,
       :add_custom_span_attributes,
+      :add_custom_transaction_log_attributes,
       :add_instrumentation,
       :add_method_tracer,
       :add_transaction_tracer,

--- a/test/new_relic/agent/log_event_aggregator_test.rb
+++ b/test/new_relic/agent/log_event_aggregator_test.rb
@@ -784,6 +784,29 @@ module NewRelic::Agent
       assert_labels(config, expected_label_attributes)
     end
 
+    def test_record_batch_with_transaction_attributes
+      in_transaction do |txn|
+        txn.add_custom_transaction_log_attributes({'txn1_key' => 'txn1_value', 'txn1_another_key' => 'txn1_another_value'})
+        @aggregator.record('Just some general information', 'INFO')
+      end
+
+      in_transaction do |txn|
+        txn.add_custom_transaction_log_attributes({'txn2_key' => 'txn2_value'})
+        @aggregator.record('Oh no!', 'FATAL')
+      end
+
+      _, events = @aggregator.harvest!
+
+      assert_equal(2, events.size)
+
+      fatal_event = events.find { |event| event[1]['message'] == 'Oh no!' }
+      info_event = events.find { |event| event[1]['message'] == 'Just some general information' }
+
+      assert_equal('txn1_value', info_event[1]['txn1_key'])
+      assert_equal('txn1_another_value', info_event[1]['txn1_another_key'])
+      assert_equal('txn2_value', fatal_event[1]['txn2_key'])
+    end
+
     private
 
     def assert_labels(config, expected_attributes = {})

--- a/test/new_relic/agent/log_event_aggregator_test.rb
+++ b/test/new_relic/agent/log_event_aggregator_test.rb
@@ -786,12 +786,12 @@ module NewRelic::Agent
 
     def test_record_batch_with_transaction_attributes
       in_transaction do |txn|
-        txn.add_custom_transaction_log_attributes({'txn1_key' => 'txn1_value', 'txn1_another_key' => 'txn1_another_value'})
+        txn.add_transaction_log_attributes({'txn1_key' => 'txn1_value', 'txn1_another_key' => 'txn1_another_value'})
         @aggregator.record('Just some general information', 'INFO')
       end
 
       in_transaction do |txn|
-        txn.add_custom_transaction_log_attributes({'txn2_key' => 'txn2_value'})
+        txn.add_transaction_log_attributes({'txn2_key' => 'txn2_value'})
         @aggregator.record('Oh no!', 'FATAL')
       end
 

--- a/test/new_relic/agent/log_event_aggregator_test.rb
+++ b/test/new_relic/agent/log_event_aggregator_test.rb
@@ -807,6 +807,21 @@ module NewRelic::Agent
       assert_equal('txn2_value', fatal_event[1]['txn2_key'])
     end
 
+    def test_multiple_logs_in_same_transaction_get_same_attributes
+      in_transaction do |txn|
+        txn.add_transaction_log_attributes({'user_id' => '12345'})
+        @aggregator.record('A debug message', 'DEBUG')
+        @aggregator.record('Here is some info', 'INFO')
+        @aggregator.record('Oh no!', 'WARN')
+      end
+
+      _, events = @aggregator.harvest!
+
+      assert_equal('12345', events[0][1]['user_id'])
+      assert_equal('12345', events[1][1]['user_id'])
+      assert_equal('12345', events[2][1]['user_id'])
+    end
+
     private
 
     def assert_labels(config, expected_attributes = {})

--- a/test/new_relic/agent/transaction_test.rb
+++ b/test/new_relic/agent/transaction_test.rb
@@ -1338,6 +1338,22 @@ module NewRelic::Agent
       end
     end
 
+    def test_log_attributes_lazy_initialization
+      in_transaction do |txn|
+        assert_nil txn.log_attributes
+      end
+    end
+
+    def test_add_custom_transaction_log_attributes_stores_attributes
+      in_transaction do |txn|
+        txn.add_custom_transaction_log_attributes({'key' => 'value', 'number' => 12345, :symbol_key => 'symbol_value'})
+
+        assert_equal 'value', txn.log_attributes.custom_attributes['key']
+        assert_equal 12345, txn.log_attributes.custom_attributes['number']
+        assert_equal 'symbol_value', txn.log_attributes.custom_attributes['symbol_key']
+      end
+    end
+
     def test_assigns_synthetics_to_intrinsic_attributes
       txn = in_transaction do |t|
         t.raw_synthetics_header = ''

--- a/test/new_relic/agent/transaction_test.rb
+++ b/test/new_relic/agent/transaction_test.rb
@@ -1344,9 +1344,9 @@ module NewRelic::Agent
       end
     end
 
-    def test_add_custom_transaction_log_attributes_stores_attributes
+    def test_add_transaction_log_attributes_stores_attributes
       in_transaction do |txn|
-        txn.add_custom_transaction_log_attributes({'key' => 'value', 'number' => 12345, :symbol_key => 'symbol_value'})
+        txn.add_transaction_log_attributes({'key' => 'value', 'number' => 12345, :symbol_key => 'symbol_value'})
 
         assert_equal 'value', txn.log_attributes.custom_attributes['key']
         assert_equal 12345, txn.log_attributes.custom_attributes['number']

--- a/test/new_relic/agent_test.rb
+++ b/test/new_relic/agent_test.rb
@@ -678,12 +678,12 @@ module NewRelic
       end
     end
 
-    def test_add_custom_transaction_log_attributes_logs_warning_if_argument_class_not_hash
+    def test_add_transaction_log_attributes_logs_warning_if_argument_class_not_hash
       logger = MiniTest::Mock.new
       logger.expect :warn, nil, [/Bad argument/]
 
       NewRelic::Agent.stub :logger, logger do
-        NewRelic::Agent.add_custom_transaction_log_attributes('this wont record')
+        NewRelic::Agent.add_transaction_log_attributes('this wont record')
         logger.verify
       end
     end

--- a/test/new_relic/agent_test.rb
+++ b/test/new_relic/agent_test.rb
@@ -678,6 +678,16 @@ module NewRelic
       end
     end
 
+    def test_add_custom_transaction_log_attributes_logs_warning_if_argument_class_not_hash
+      logger = MiniTest::Mock.new
+      logger.expect :warn, nil, [/Bad argument/]
+
+      NewRelic::Agent.stub :logger, logger do
+        NewRelic::Agent.add_custom_transaction_log_attributes('this wont record')
+        logger.verify
+      end
+    end
+
     def test_record_instrumentation_invocation
       library = 'NewRelicFly'
       dummy_engine = NewRelic::Agent.agent.stats_engine


### PR DESCRIPTION
New API to add transaction-scoped custom attributes to log events for the current transaction.

`NewRelic::Agent#add_transaction_log_attributes`

closes #3423