### PR TITLE
Add hybrid agent docs link to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 - **Feature: Introduce Hybrid Agent for OpenTelemetry Tracing Support**
 
-  OpenTelemetry Tracing APIs can now be translated into New Relic telemetry with the New Relic Ruby agent's new Hybrid Agent features. This allows the `newrelic_rpm` gem to behave similarly to an OpenTelemetry SDK, accepting OpenTelemetry API calls and turning them into New Relic Transactions and Segments with familiar attributes and names.
+  OpenTelemetry Tracing APIs can now be translated into New Relic telemetry with the New Relic Ruby agent's [new Hybrid Agent features](https://docs.newrelic.com/docs/apm/agents/manage-apm-agents/opentelemetry-api-support/). This allows the `newrelic_rpm` gem to behave similarly to an OpenTelemetry SDK, accepting OpenTelemetry API calls and turning them into New Relic Transactions and Segments with familiar attributes and names.
 
   The following configuration options relate to Hybrid Agent features:
 


### PR DESCRIPTION
Small PR to add a link to the docs. I'll open a separate PR to update the release notes on the docs website if we like this placement.