### PR TITLE
Add ignored_middleware_classes config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@
 
   The agent now supports Semantic Logger log forwarding and decoration for the `semantic_logger` gem versions 4.6.0+. If you were previously using Semantic Logger's built-in New Relic appender, it is recommended to choose one approach to avoid sending duplicate logs. New Relic's Semantic Logger instrumentation can be disabled by setting `instrumentation.semantic_logger` to `disabled`. [PR#3467](https://github.com/newrelic/newrelic-ruby-agent/pull/3467)
 
-  Thanks to [@jdelStrother](https://github.com/jdelStrother) for providing valuable feedback that helped shape this instrumentation. 
+  Thanks to [@jdelStrother](https://github.com/jdelStrother) for providing valuable feedback that helped shape this instrumentation.
+
+- **Feature: Add new 'instrumentation.rack.ignore_middlewares' configuration**
+
+  A new configuration option, `instrumentation.rack.ignore_middlewares`, allows users to exclude specific middlewares from instrumentation (ex. Rack::Cors). It defaults to an empty array. [Issue#1814](https://github.com/newrelic/newrelic-ruby-agent/issues/1814) [PR#3481](https://github.com/newrelic/newrelic-ruby-agent/pull/3481)
 
 - **Feature: Add new `NewRelic::Agent.add_transaction_log_attributes` API**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@
 
   Thanks to [@jdelStrother](https://github.com/jdelStrother) for providing valuable feedback that helped shape this instrumentation.
 
-- **Feature: Add new 'instrumentation.rack.ignore_middlewares' configuration**
+- **Feature: Add new 'ignored_middleware_classes' configuration**
 
-  A new configuration option, `instrumentation.rack.ignore_middlewares`, allows users to exclude specific middlewares from instrumentation (ex. Rack::Cors). It defaults to an empty array. [Issue#1814](https://github.com/newrelic/newrelic-ruby-agent/issues/1814) [PR#3481](https://github.com/newrelic/newrelic-ruby-agent/pull/3481)
+  A new configuration option, `ignored_middleware_classes`, allows users to exclude specific middlewares from instrumentation (ex. Rack::Cors). It defaults to an empty array. [Issue#1814](https://github.com/newrelic/newrelic-ruby-agent/issues/1814) [PR#3481](https://github.com/newrelic/newrelic-ruby-agent/pull/3481)
 
 - **Feature: Add new `NewRelic::Agent.add_transaction_log_attributes` API**
 

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -1452,6 +1452,13 @@ module NewRelic
           :allowed_from_server => false,
           :description => 'Ordinarily the agent reports dyno names with a trailing dot and process ID (for example, `worker.3`). You can remove this trailing data by specifying the prefixes you want to report without trailing data (for example, `worker`).'
         },
+        :ignored_middleware_classes => {
+          :default => [],
+          :public => true,
+          :type => Array,
+          :allowed_from_server => false,
+          :description => 'A list of middleware class or module names the agent should ignore. Example: ["Rack::Cors", "ActionDispatch::Reloader"]'
+        },
         # Infinite tracing
         :'infinite_tracing.trace_observer.host' => {
           :default => '',
@@ -1851,13 +1858,6 @@ module NewRelic
           :description => 'Controls auto-instrumentation of Rack. When enabled, the agent hooks into the ' \
                            '`to_app` method in `Rack::Builder` to find gems to instrument during ' \
                            'application startup. May be one of: `auto`, `prepend`, `chain`, `disabled`.'
-        },
-        :'instrumentation.rack.ignore_middlewares' => {
-          :default => [],
-          :public => true,
-          :type => Array,
-          :allowed_from_server => false,
-          :description => 'A list of Rack middleware class or module names the agent should ignore. Example: ["Rack::Cors", "Rack::]'
         },
         :'instrumentation.rack_urlmap' => {
           :default => 'auto',

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -1852,6 +1852,13 @@ module NewRelic
                            '`to_app` method in `Rack::Builder` to find gems to instrument during ' \
                            'application startup. May be one of: `auto`, `prepend`, `chain`, `disabled`.'
         },
+        :'instrumentation.rack.ignore_middlewares' => {
+          :default => [],
+          :public => true,
+          :type => Array,
+          :allowed_from_server => false,
+          :description => 'A list of Rack middleware class or module names the agent should ignore. Example: ["Rack::Cors", "Rack::]'
+        },
         :'instrumentation.rack_urlmap' => {
           :default => 'auto',
           :documentation_default => 'auto',

--- a/lib/new_relic/agent/instrumentation/middleware_proxy.rb
+++ b/lib/new_relic/agent/instrumentation/middleware_proxy.rb
@@ -46,7 +46,7 @@ module NewRelic
         def self.needs_wrapping?(target)
           (
             !target.respond_to?(:_nr_has_middleware_tracing) &&
-              !NewRelic::Agent.config[:'instrumentation.rack.ignore_middlewares'].include?(target.class.to_s) &&
+              !NewRelic::Agent.config[:ignored_middleware_classes].include?(target.class.to_s) &&
               !is_sinatra_app?(target)
           )
         end

--- a/lib/new_relic/agent/instrumentation/middleware_proxy.rb
+++ b/lib/new_relic/agent/instrumentation/middleware_proxy.rb
@@ -46,7 +46,8 @@ module NewRelic
         def self.needs_wrapping?(target)
           (
             !target.respond_to?(:_nr_has_middleware_tracing) &&
-            !is_sinatra_app?(target)
+              !NewRelic::Agent.config[:'instrumentation.rack.ignore_middlewares'].include?(target.class.to_s) &&
+              !is_sinatra_app?(target)
           )
         end
 

--- a/test/new_relic/agent/instrumentation/middleware_proxy_test.rb
+++ b/test/new_relic/agent/instrumentation/middleware_proxy_test.rb
@@ -130,7 +130,7 @@ class NewRelic::Agent::Instrumentation::MiddlewareProxyTest < Minitest::Test
   end
 
   def test_does_not_wrap_ignored_middleware
-    with_config(:'instrumentation.rack.ignore_middlewares' => ['Module']) do
+    with_config(:ignored_middleware_classes => ['Module']) do
       ignored_middleware = Module.new
 
       wrapped = NewRelic::Agent::Instrumentation::MiddlewareProxy.wrap(ignored_middleware)
@@ -140,7 +140,7 @@ class NewRelic::Agent::Instrumentation::MiddlewareProxyTest < Minitest::Test
   end
 
   def test_does_not_wrap_multiple_ignored_middlewares
-    with_config(:'instrumentation.rack.ignore_middlewares' => %w[First Second]) do
+    with_config(:ignored_middleware_classes => %w[First Second]) do
       first_ignored = First.new
       second_ignored = Second.new
       third_kept = Third.new

--- a/test/new_relic/agent/instrumentation/middleware_proxy_test.rb
+++ b/test/new_relic/agent/instrumentation/middleware_proxy_test.rb
@@ -4,6 +4,11 @@
 
 require_relative '../../../test_helper'
 
+# These classes are used in test_does_not_wrap_multiple_ignored_middlewares
+class First; end
+class Second; end
+class Third; end
+
 class NewRelic::Agent::Instrumentation::MiddlewareProxyTest < Minitest::Test
   def setup
     NewRelic::Agent.drop_buffered_data
@@ -122,6 +127,32 @@ class NewRelic::Agent::Instrumentation::MiddlewareProxyTest < Minitest::Test
     wrapped = NewRelic::Agent::Instrumentation::MiddlewareProxy.wrap(app)
 
     assert_same(app, wrapped)
+  end
+
+  def test_does_not_wrap_ignored_middleware
+    with_config(:'instrumentation.rack.ignore_middlewares' => ['Module']) do
+      ignored_middleware = Module.new
+
+      wrapped = NewRelic::Agent::Instrumentation::MiddlewareProxy.wrap(ignored_middleware)
+
+      assert_same(ignored_middleware, wrapped)
+    end
+  end
+
+  def test_does_not_wrap_multiple_ignored_middlewares
+    with_config(:'instrumentation.rack.ignore_middlewares' => %w[First Second]) do
+      first_ignored = First.new
+      second_ignored = Second.new
+      third_kept = Third.new
+
+      first_wrapped = NewRelic::Agent::Instrumentation::MiddlewareProxy.wrap(first_ignored)
+      second_wrapped = NewRelic::Agent::Instrumentation::MiddlewareProxy.wrap(second_ignored)
+      third_wrapped = NewRelic::Agent::Instrumentation::MiddlewareProxy.wrap(third_kept)
+
+      assert_same(first_ignored, first_wrapped)
+      assert_same(second_ignored, second_wrapped)
+      refute_same(third_kept, third_wrapped)
+    end
   end
 
   def test_should_wrap_non_instrumented_middlewares


### PR DESCRIPTION
This configuration option will allow users to supply a list of Rack middlewares for the agent to ignore. When the agent starts, it wraps middlewares that we want to instrument. Now, the new configuration will be taken into account during that wrapping process.

closes #1814
