### PR TITLE
Use Fiber ID for Falcon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 
 - **Bugfix: Fix "Unable to calculate elapsed transaction time" warnings when using Falcon web server**
 
-  The agent now uses `Fiber.current.object_id` instead of `Thread.current.object_id` to track transaction state when running under Falcon, preventing collisions from concurrent requests sharing the same thread. Also fixes a NameError: uninitialized constant `Async::HTTP::VERSION` when using Falcon. Thanks to [@97jaz](https://github.com/97jaz) and [@gsar](https://github.com/gsar) for bringing this to our attention. [PR#3483](https://github.com/newrelic/newrelic-ruby-agent/issues/3483)
+  The agent now uses `Fiber.current.object_id` instead of `Thread.current.object_id` to track transaction state when running under Falcon, preventing collisions from concurrent requests sharing the same thread. Also fixes a "NameError: uninitialized constant `Async::HTTP::VERSION`" when using Falcon. Thanks to [@97jaz](https://github.com/97jaz) and [@gsar](https://github.com/gsar) for bringing this to our attention. [PR#3483](https://github.com/newrelic/newrelic-ruby-agent/issues/3483)
 
 - **Bugfix: Fix typo in harvest.rb causing NoMethodError**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@
 
   Previously, the agent would cause a ~3 second shutdown delay when running the `rails test` command. The `Rails::Command::TestCommand` constant has been added to the default `autostart.denylisted_constants` list to prevent the agent from starting during Rails test runs. Thanks to [@varyform](https://github.com/varyform) for bringing this to our attention. [PR#3478](https://github.com/newrelic/newrelic-ruby-agent/issues/3478)
 
+- **Bugfix: Fix "Unable to calculate elapsed transaction time" warnings when using Falcon web server**
+
+  The agent now uses `Fiber.current.object_id` instead of `Thread.current.object_id` to track transaction state when running under Falcon, preventing collisions from concurrent requests sharing the same thread. Also fixes a NameError: uninitialized constant `Async::HTTP::VERSION` when using Falcon. Thanks to [@97jaz](https://github.com/97jaz) and [@gsar](https://github.com/gsar) for bringing this to our attention. [PR#3483](https://github.com/newrelic/newrelic-ruby-agent/issues/3483)
+
 ## v10.2.0
 
 - **Feature: Introduce Hybrid Agent for OpenTelemetry Tracing Support**

--- a/lib/new_relic/agent/instrumentation/async_http.rb
+++ b/lib/new_relic/agent/instrumentation/async_http.rb
@@ -10,7 +10,8 @@ DependencyDetection.defer do
   named :async_http
 
   depends_on do
-    defined?(Async::HTTP) &&
+    defined?(Async::HTTP)
+      defined?(Async::HTTP::VERSION) &&
       NewRelic::Helper.version_satisfied?(Async::HTTP::VERSION, '>=', '0.59.0') &&
       !defined?(Traces::Backend::NewRelic) # defined in the traces-backend-newrelic gem
   end

--- a/lib/new_relic/agent/instrumentation/async_http.rb
+++ b/lib/new_relic/agent/instrumentation/async_http.rb
@@ -10,7 +10,7 @@ DependencyDetection.defer do
   named :async_http
 
   depends_on do
-    defined?(Async::HTTP)
+    defined?(Async::HTTP) &&
       defined?(Async::HTTP::VERSION) &&
       NewRelic::Helper.version_satisfied?(Async::HTTP::VERSION, '>=', '0.59.0') &&
       !defined?(Traces::Backend::NewRelic) # defined in the traces-backend-newrelic gem

--- a/lib/new_relic/agent/opentelemetry/trace_patch.rb
+++ b/lib/new_relic/agent/opentelemetry/trace_patch.rb
@@ -9,7 +9,7 @@ module NewRelic
         def current_span(context = nil)
           return super if context
 
-          storage = otel_current_storage
+          storage = NewRelic::Agent::TransactionTimeAggregator.current_execution_context
           return super if storage[:nr_otel_recursion_guard]
 
           nr_span = storage[:nr_otel_current_span]
@@ -24,16 +24,6 @@ module NewRelic
         rescue => e
           NewRelic::Agent.logger.debug("Error in OpenTelemetry.current_span override, falling back to original implementation: #{e}")
           super
-        end
-
-        private
-
-        def otel_current_storage
-          if NewRelic::Agent.config[:dispatcher] == :falcon
-            Fiber.current
-          else
-            Thread.current
-          end
         end
       end
     end

--- a/lib/new_relic/agent/opentelemetry/trace_patch.rb
+++ b/lib/new_relic/agent/opentelemetry/trace_patch.rb
@@ -9,21 +9,31 @@ module NewRelic
         def current_span(context = nil)
           return super if context
 
-          thread = Thread.current
-          return super if thread[:nr_otel_recursion_guard]
+          storage = otel_current_storage
+          return super if storage[:nr_otel_recursion_guard]
 
-          nr_span = thread[:nr_otel_current_span]
+          nr_span = storage[:nr_otel_current_span]
           return nr_span if nr_span
 
           # Fallback with recursion protection
-          thread[:nr_otel_recursion_guard] = true
+          storage[:nr_otel_recursion_guard] = true
           result = super
-          thread[:nr_otel_recursion_guard] = nil
+          storage[:nr_otel_recursion_guard] = nil
 
           result
         rescue => e
           NewRelic::Agent.logger.debug("Error in OpenTelemetry.current_span override, falling back to original implementation: #{e}")
           super
+        end
+
+        private
+
+        def otel_current_storage
+          if NewRelic::Agent.config[:dispatcher] == :falcon
+            Fiber.current
+          else
+            Thread.current
+          end
         end
       end
     end

--- a/lib/new_relic/agent/opentelemetry/transaction_patch.rb
+++ b/lib/new_relic/agent/opentelemetry/transaction_patch.rb
@@ -10,7 +10,7 @@ module NewRelic
           @current_segment_lock.synchronize do
             if new_segment&.respond_to?(:transaction) && new_segment.transaction
               span = find_or_create_span(new_segment)
-              Thread.current[:nr_otel_current_span] = span
+              otel_current_storage[:nr_otel_current_span] = span
             end
           end
 
@@ -18,20 +18,28 @@ module NewRelic
         end
 
         def remove_current_segment_by_thread_id(id)
-          if id == Thread.current.object_id
-            Thread.current[:nr_otel_current_span] = nil
+          if id == NewRelic::Agent::TransactionTimeAggregator.current_execution_context_id
+            otel_current_storage[:nr_otel_current_span] = nil
           end
 
           super
         end
 
         def finish
-          Thread.current[:nr_otel_current_span] = nil
+          otel_current_storage[:nr_otel_current_span] = nil
 
           super
         end
 
         private
+
+        def otel_current_storage
+          if NewRelic::Agent.config[:dispatcher] == :falcon
+            Fiber.current
+          else
+            Thread.current
+          end
+        end
 
         def find_or_create_span(segment)
           if segment.instance_variable_defined?(:@otel_span)

--- a/lib/new_relic/agent/opentelemetry/transaction_patch.rb
+++ b/lib/new_relic/agent/opentelemetry/transaction_patch.rb
@@ -10,7 +10,7 @@ module NewRelic
           @current_segment_lock.synchronize do
             if new_segment&.respond_to?(:transaction) && new_segment.transaction
               span = find_or_create_span(new_segment)
-              otel_current_storage[:nr_otel_current_span] = span
+              NewRelic::Agent::TransactionTimeAggregator.current_execution_context[:nr_otel_current_span] = span
             end
           end
 
@@ -19,27 +19,19 @@ module NewRelic
 
         def remove_current_segment_by_thread_id(id)
           if id == NewRelic::Agent::TransactionTimeAggregator.current_execution_context_id
-            otel_current_storage[:nr_otel_current_span] = nil
+            NewRelic::Agent::TransactionTimeAggregator.current_execution_context[:nr_otel_current_span] = nil
           end
 
           super
         end
 
         def finish
-          otel_current_storage[:nr_otel_current_span] = nil
+          NewRelic::Agent::TransactionTimeAggregator.current_execution_context[:nr_otel_current_span] = nil
 
           super
         end
 
         private
-
-        def otel_current_storage
-          if NewRelic::Agent.config[:dispatcher] == :falcon
-            Fiber.current
-          else
-            Thread.current
-          end
-        end
 
         def find_or_create_span(segment)
           if segment.instance_variable_defined?(:@otel_span)

--- a/lib/new_relic/agent/transaction.rb
+++ b/lib/new_relic/agent/transaction.rb
@@ -247,7 +247,7 @@ module NewRelic
         @sampled = nil
         @priority = nil
 
-        @starting_thread_id = TransactionTimeAggregator.current_execution_context_id    
+        @starting_thread_id = TransactionTimeAggregator.current_execution_context_id
         @starting_segment_key = current_segment_key
 
         @attributes = Attributes.new(NewRelic::Agent.instance.attribute_filter)

--- a/lib/new_relic/agent/transaction.rb
+++ b/lib/new_relic/agent/transaction.rb
@@ -247,7 +247,7 @@ module NewRelic
         @sampled = nil
         @priority = nil
 
-        @starting_thread_id = Thread.current.object_id
+        @starting_thread_id = TransactionTimeAggregator.current_execution_context_id    
         @starting_segment_key = current_segment_key
 
         @attributes = Attributes.new(NewRelic::Agent.instance.attribute_filter)

--- a/lib/new_relic/agent/transaction/abstract_segment.rb
+++ b/lib/new_relic/agent/transaction/abstract_segment.rb
@@ -30,7 +30,7 @@ module NewRelic
         def initialize(name = nil, start_time = nil)
           @name = name
           @starting_segment_key = NewRelic::Agent::Tracer.current_segment_key
-          @thread_id = Thread.current.object_id
+          @thread_id = NewRelic::Agent::TransactionTimeAggregator.current_execution_context_id
           @transaction_name = nil
           @transaction = nil
           @guid = NewRelic::Agent::GuidGenerator.generate_guid

--- a/lib/new_relic/agent/transaction_time_aggregator.rb
+++ b/lib/new_relic/agent/transaction_time_aggregator.rb
@@ -74,18 +74,23 @@ module NewRelic
         result
       end
 
-      def current_execution_context_id
+      def current_execution_context
         if NewRelic::Agent.config[:dispatcher] == :falcon
-          Fiber.current.object_id
+          Fiber.current
         else
-          Thread.current.object_id
+          Thread.current
         end
+      end
+
+      def current_execution_context_id
+        current_execution_context.object_id
       end
 
       module_function :reset!,
         :transaction_start,
         :transaction_stop,
         :harvest!,
+        :current_execution_context,
         :current_execution_context_id
 
       class << self

--- a/lib/new_relic/agent/transaction_time_aggregator.rb
+++ b/lib/new_relic/agent/transaction_time_aggregator.rb
@@ -74,10 +74,19 @@ module NewRelic
         result
       end
 
+      def current_execution_context_id
+        if NewRelic::Agent.config[:dispatcher] == :falcon
+          Fiber.current.object_id
+        else
+          Thread.current.object_id
+        end
+      end
+
       module_function :reset!,
         :transaction_start,
         :transaction_stop,
-        :harvest!
+        :harvest!,
+        :current_execution_context_id
 
       class << self
         private
@@ -96,7 +105,7 @@ module NewRelic
         end
 
         def current_thread
-          Thread.current.object_id
+          TransactionTimeAggregator.current_execution_context_id
         end
 
         def thread_is_alive?(thread_id)

--- a/test/new_relic/agent/transaction_time_aggregator_test.rb
+++ b/test/new_relic/agent/transaction_time_aggregator_test.rb
@@ -135,4 +135,18 @@ class NewRelic::Agent::TransactionTimeAggregatorTest < Minitest::Test
 
     assert_equal 0, stats.size, 'Aggregator did not cull dead threads'
   end
+
+  def test_current_execution_context_id_returns_thread_id_by_default
+    result = NewRelic::Agent::TransactionTimeAggregator.current_execution_context_id
+
+    assert_equal Thread.current.object_id, result
+  end
+
+  def test_current_execution_context_id_returns_fiber_id_for_falcon
+    with_config(dispatcher: :falcon) do
+      result = NewRelic::Agent::TransactionTimeAggregator.current_execution_context_id
+
+      assert_equal Fiber.current.object_id, result
+    end
+  end
 end


### PR DESCRIPTION
Falcon uses fibers for concurrency. The agent's `TransactionTimeAggregator` was using `Thread.current.object_id` to track transaction state, causing collisions when multiple fibers on the same thread had overlapping transactions. Now when Falcon is the dispatcher, use `Fiber.current.object_id` instead.

Additionally, Falcon only loads `async/http/server`, not the full async-http gem, so `Async::HTTP::VERSION` may not be available. Added a `defined?` check to prevent the NameError.

closes #3482
closes #3190