### PR TITLE
WIP: Sidekiq force new transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 
 - **Feature: Add sidekiq.force_new_transaction configuration**
 
-  The `sidekiq.force_new_transaction` configuration option forces a new transaction to start when Sidekiq's server instrumentation is invoked to make sure every job starts its own transaction. This prevents Sidekiq jobs from being nested within web transactions that initiatied them. [PR#3489](https://github.com/newrelic/newrelic-ruby-agent/pull/3489)
+  The `sidekiq.force_new_transaction` configuration option forces a new transaction to start when Sidekiq's server instrumentation is invoked to make sure every job starts its own transaction. This prevents the duration of Sidekiq jobs from being included in the duration of the web transactions that started them. [PR#3489](https://github.com/newrelic/newrelic-ruby-agent/pull/3489)
 
 - **Bugfix: Provide config option to reduce cardinality of ActionCable broadcast metrics**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 
 - **Feature: Add sidekiq.force_new_transaction configuration**
 
-  The `sidekiq.force_new_transaction` configuration option forces a new transaction to start when Sidekiq's server instrumentation is invoked to make sure every job starts its own transaction. This prevents the duration of Sidekiq jobs from being included in the duration of the web transactions that started them. [PR#3489](https://github.com/newrelic/newrelic-ruby-agent/pull/3489)
+  The `sidekiq.force_new_transaction` configuration option forces a new transaction to start when Sidekiq's server instrumentation is invoked to make sure every job starts its own transaction. This prevents the duration of Sidekiq jobs from being included in the duration of the web transactions that started them. This is disabled by default. [PR#3489](https://github.com/newrelic/newrelic-ruby-agent/pull/3489)
 
 - **Bugfix: Provide config option to reduce cardinality of ActionCable broadcast metrics**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,13 +16,13 @@
 
   Thanks to [@jdelStrother](https://github.com/jdelStrother) for providing valuable feedback that helped shape this instrumentation.
 
-- **Feature: Add new 'ignored_middleware_classes' configuration**
-
-  A new configuration option, `ignored_middleware_classes`, allows users to exclude specific middlewares from instrumentation (ex. Rack::Cors). It defaults to an empty array. [Issue#1814](https://github.com/newrelic/newrelic-ruby-agent/issues/1814) [PR#3481](https://github.com/newrelic/newrelic-ruby-agent/pull/3481)
-
 - **Feature: Add new `NewRelic::Agent.add_transaction_log_attributes` API**
 
   A new API, `NewRelic::Agent.add_transaction_log_attributes`, allows users to add transaction-scoped custom attributes to log events for the current transaction. These attributes will only be applied to logs created within the scope of the current transaction. [PR#3472](https://github.com/newrelic/newrelic-ruby-agent/pull/3472)
+
+- **Feature: Add sidekiq.force_new_transaction configuration**
+
+  The `sidekiq.force_new_transaction` configuration option forces a new transaction to start when Sidekiq's server instrumentation is invoked to make sure every job starts its own transaction. This prevents Sidekiq jobs from being nested within web transactions that initiatied them. [PR#3489](https://github.com/newrelic/newrelic-ruby-agent/pull/3489)
 
 - **Bugfix: Provide config option to reduce cardinality of ActionCable broadcast metrics**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
 
   Thanks to [@jdelStrother](https://github.com/jdelStrother) for providing valuable feedback that helped shape this instrumentation.
 
+- **Feature: Add new 'ignored_middleware_classes' configuration**
+
+  A new configuration option, `ignored_middleware_classes`, allows users to exclude specific middlewares from instrumentation (ex. Rack::Cors). It defaults to an empty array. [Issue#1814](https://github.com/newrelic/newrelic-ruby-agent/issues/1814) [PR#3481](https://github.com/newrelic/newrelic-ruby-agent/pull/3481)
+
 - **Feature: Add new `NewRelic::Agent.add_transaction_log_attributes` API**
 
   A new API, `NewRelic::Agent.add_transaction_log_attributes`, allows users to add transaction-scoped custom attributes to log events for the current transaction. These attributes will only be applied to logs created within the scope of the current transaction. [PR#3472](https://github.com/newrelic/newrelic-ruby-agent/pull/3472)

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2143,7 +2143,7 @@ module NewRelic
           :public => true,
           :type => Boolean,
           :allowed_from_server => false,
-          :description => %Q(If `true`, the agent will force a new transaction to be started when Sidekiq's server instrumentation is invoked. This will prevent Sidekiq jobs from being nested within existing Web transactions.)
+          :description => %Q(If `true`, the agent forces a new transaction to start when Sidekiq's server instrumentation invokes. This prevents Sidekiq jobs from being nested within web transactions.)
         },
         # Slow SQL
         :'slow_sql.enabled' => {

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2138,6 +2138,13 @@ module NewRelic
           :allowed_from_server => false,
           :description => %Q(If `true`, the agent will ignore exceptions raised during Sidekiq's retry attempts and will only report the error if the job permanently fails.)
         },
+        :'sidekiq.force_new_transaction' => {
+          :default => false,
+          :public => true,
+          :type => Boolean,
+          :allowed_from_server => false,
+          :description => %Q(If `true`, the agent will force a new transaction to be started when Sidekiq's server instrumentation is invoked. This will prevent Sidekiq jobs from being nested within existing Web transactions.)
+        },
         # Slow SQL
         :'slow_sql.enabled' => {
           :default => value_of(:'transaction_tracer.enabled'),

--- a/lib/new_relic/agent/instrumentation/controller_instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/controller_instrumentation.rb
@@ -386,7 +386,7 @@ module NewRelic
             begin
               yield
             rescue => e
-              NewRelic::Agent.notice_error(e)
+              NewRelic::Agent.notice_error(e) unless trace_options[:notice_error] == false
               raise
             end
           ensure

--- a/lib/new_relic/agent/instrumentation/sidekiq/server.rb
+++ b/lib/new_relic/agent/instrumentation/sidekiq/server.rb
@@ -22,6 +22,7 @@ module NewRelic::Agent::Instrumentation::Sidekiq
       else
         self.class.default_trace_args(msg)
       end
+      trace_args[:notice_error] = false if NewRelic::Agent.config[:'sidekiq.ignore_retry_errors']
       trace_headers = msg.delete(NewRelic::NEWRELIC_KEY)
 
       execution_block = proc do
@@ -38,45 +39,12 @@ module NewRelic::Agent::Instrumentation::Sidekiq
         yield
       end
 
-      if NewRelic::Agent.config[:'sidekiq.ignore_retry_errors']
-        perform_action_with_newrelic_trace_without_error_reporting(trace_args, &execution_block)
-      else
-        perform_action_with_newrelic_trace(trace_args, &execution_block)
-      end
+      NewRelic::Agent::Tracer.current_transaction&.finish if NewRelic::Agent.config[:'sidekiq.force_new_transaction']
+
+      perform_action_with_newrelic_trace(trace_args, &execution_block)
     end
 
     private
-
-    # Version of perform_action_with_newrelic_trace that doesn't report errors
-    def perform_action_with_newrelic_trace_without_error_reporting(*args, &block)
-      NewRelic::Agent.record_api_supportability_metric(:perform_action_with_newrelic_trace_without_error_reporting)
-      state = NewRelic::Agent::Tracer.state
-      request = newrelic_request(args)
-      queue_start_time = detect_queue_start_time(request)
-
-      skip_tracing = do_not_trace? || !state.is_execution_traced?
-
-      if skip_tracing
-        state.current_transaction&.ignore!
-        NewRelic::Agent.disable_all_tracing { return yield }
-      end
-
-      trace_options = args.last.is_a?(Hash) ? args.last : NewRelic::EMPTY_HASH
-      category = trace_options[:category] || :controller
-      txn_options = create_transaction_options(trace_options, category, state, queue_start_time)
-
-      begin
-        finishable = NewRelic::Agent::Tracer.start_transaction_or_segment(
-          name: txn_options[:transaction_name],
-          category: category,
-          options: txn_options
-        )
-
-        yield
-      ensure
-        finishable&.finish
-      end
-    end
 
     def self.default_trace_args(msg)
       {

--- a/test/multiverse/suites/sidekiq/Envfile
+++ b/test/multiverse/suites/sidekiq/Envfile
@@ -5,7 +5,8 @@
 SIDEKIQ_VERSIONS = [
   [nil, 3.2],
   ['7.3.9', 2.7],
-  ['6.4.0'],
+  # 6.4.2 has a known incompatibility with Ruby 4.0's connection_pool gem
+  ['6.4.0', 2.6, 3.4],
   ['5.0.3', 2.6, 2.6]
 ]
 

--- a/test/multiverse/suites/sidekiq/sidekiq_force_new_transaction_test.rb
+++ b/test/multiverse/suites/sidekiq/sidekiq_force_new_transaction_test.rb
@@ -18,6 +18,7 @@ class SidekiqForceNewTransactionTest < Minitest::Test
 
   # TODO: Do we need to add active job to reproduce the behavior this feature intends to fix?
   # TODO: Do we need to add tests related to DT headers? Recheck what the customer's concern about that was
+  # TODO: Are we able to use perform_action_with_newrelic_trace or do we need to use start_new_transaction?
 
   def test_sidekiq_force_new_transaction_default_value
     refute NewRelic::Agent.config[:'sidekiq.force_new_transaction'],
@@ -39,8 +40,9 @@ class SidekiqForceNewTransactionTest < Minitest::Test
   end
 
   def test_sidekiq_job_added_to_existing_web_transaction_when_false
-    # TODO: MAJOR VERSION - remove this when Sidekiq v5 is no longer supported
-    skip 'Test requires Sidekiq v6+' unless Sidekiq::VERSION.split('.').first.to_i >= 6
+    # Sidekiq version 6.x's perform_inline invokes String#constantize, which is only
+    # delivered by ActiveSupport, which this test suite doesn't currently include.
+    skip 'Test requires Sidekiq v7+' unless NewRelic::Helper.version_satisfied?(Sidekiq::VERSION, '>=', '7.0.0')
 
     with_config(:'sidekiq.force_new_transaction' => false) do
       config = if Sidekiq::VERSION.split('.').first.to_i >= 7
@@ -79,8 +81,9 @@ class SidekiqForceNewTransactionTest < Minitest::Test
   end
 
   def test_sidekiq_job_not_added_to_existing_web_transaction_when_true
-    # TODO: MAJOR VERSION - remove this when Sidekiq v5 is no longer supported
-    skip 'Test requires Sidekiq v6+' unless Sidekiq::VERSION.split('.').first.to_i >= 6
+    # Sidekiq version 6.x's perform_inline invokes String#constantize, which is only
+    # delivered by ActiveSupport, which this test suite doesn't currently include.
+    skip 'Test requires Sidekiq v7+' unless NewRelic::Helper.version_satisfied?(Sidekiq::VERSION, '>=', '7.0.0')
 
     with_config(:'sidekiq.force_new_transaction' => true) do
       config = if Sidekiq::VERSION.split('.').first.to_i >= 7
@@ -102,8 +105,9 @@ class SidekiqForceNewTransactionTest < Minitest::Test
   end
 
   def test_sidekiq_job_part_of_new_transaction_when_true
-    # TODO: MAJOR VERSION - remove this when Sidekiq v5 is no longer supported
-    skip 'Test requires Sidekiq v6+' unless Sidekiq::VERSION.split('.').first.to_i >= 6
+    # Sidekiq version 6.x's perform_inline invokes String#constantize, which is only
+    # delivered by ActiveSupport, which this test suite doesn't currently include.
+    skip 'Test requires Sidekiq v7+' unless NewRelic::Helper.version_satisfied?(Sidekiq::VERSION, '>=', '7.0.0')
 
     with_config(:'sidekiq.force_new_transaction' => true) do
       config = if Sidekiq::VERSION.split('.').first.to_i >= 7

--- a/test/multiverse/suites/sidekiq/sidekiq_force_new_transaction_test.rb
+++ b/test/multiverse/suites/sidekiq/sidekiq_force_new_transaction_test.rb
@@ -1,0 +1,127 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+require_relative 'sidekiq_test_helpers'
+
+class SidekiqForceNewTransactionTest < Minitest::Test
+  include SidekiqTestHelpers
+
+  def setup
+    harvest_transaction_events!
+    harvest_span_events!
+  end
+
+  def teardown
+    mocha_teardown
+  end
+
+  # TODO: Do we need to add active job to reproduce the behavior this feature intends to fix?
+  # TODO: Do we need to add tests related to DT headers? Recheck what the customer's concern about that was
+
+  def test_sidekiq_force_new_transaction_default_value
+    refute NewRelic::Agent.config[:'sidekiq.force_new_transaction'],
+      'Expected sidekiq.force_new_transaction default to be false'
+  end
+
+  def test_sidekiq_force_new_transaction_configuration_can_be_set_to_true
+    with_config(:'sidekiq.force_new_transaction' => true) do
+      assert NewRelic::Agent.config[:'sidekiq.force_new_transaction'],
+        'Expected sidekiq.force_new_transaction to be true when configured'
+    end
+  end
+
+  def test_sidekiq_force_new_transaction_configuration_can_be_set_to_false
+    with_config(:'sidekiq.force_new_transaction' => false) do
+      refute NewRelic::Agent.config[:'sidekiq.force_new_transaction'],
+        'Expected sidekiq.force_new_transaction to be false when configured'
+    end
+  end
+
+  def test_sidekiq_job_added_to_existing_web_transaction_when_false
+    # TODO: MAJOR VERSION - remove this when Sidekiq v5 is no longer supported
+    skip 'Test requires Sidekiq v6+' unless Sidekiq::VERSION.split('.').first.to_i >= 6
+
+    with_config(:'sidekiq.force_new_transaction' => false) do
+      config = if Sidekiq::VERSION.split('.').first.to_i >= 7
+        Sidekiq.default_configuration
+      else
+        Sidekiq
+      end
+
+      t = in_web_transaction('web') do |txn|
+        NRDeadEndJob.perform_inline
+      end
+
+      # Do I need these if I harvest?
+      segment_names = t.segments.map(&:name)
+
+      assert_equal %w[web Nested/OtherTransaction/SidekiqJob/NRDeadEndJob/perform], segment_names
+
+      transactions = harvest_transaction_events!
+
+      assert_equal 1, transactions[0][:events_seen]
+      assert_equal 1, transactions[1].size
+
+      first_transaction = transactions[1][0]
+      # assert_equal 'web', first_transaction['name']
+
+      spans = harvest_span_events!
+
+      assert_equal 2, spans[1].size
+
+      # other possible span assertions:
+      # make sure the nr.entryPoint attribute is present on the web span
+      # make sure it isn't on the sidekiq span
+      # make sure the sidekiq span is the child of the web span
+      # could make sure they all have the same transaction id
+    end
+  end
+
+  def test_sidekiq_job_not_added_to_existing_web_transaction_when_true
+    # TODO: MAJOR VERSION - remove this when Sidekiq v5 is no longer supported
+    skip 'Test requires Sidekiq v6+' unless Sidekiq::VERSION.split('.').first.to_i >= 6
+
+    with_config(:'sidekiq.force_new_transaction' => true) do
+      config = if Sidekiq::VERSION.split('.').first.to_i >= 7
+        Sidekiq.default_configuration
+      else
+        Sidekiq
+      end
+
+      t = in_web_transaction('web') do |txn|
+        txn.stubs(:sampled?).returns(true)
+        NRDeadEndJob.perform_inline
+      end
+
+      segment_names = t.segments.map(&:name)
+
+      assert_equal %w[web], segment_names
+      # TODO: ADD MORE ASSERTIONS
+    end
+  end
+
+  def test_sidekiq_job_part_of_new_transaction_when_true
+    # TODO: MAJOR VERSION - remove this when Sidekiq v5 is no longer supported
+    skip 'Test requires Sidekiq v6+' unless Sidekiq::VERSION.split('.').first.to_i >= 6
+
+    with_config(:'sidekiq.force_new_transaction' => true) do
+      config = if Sidekiq::VERSION.split('.').first.to_i >= 7
+        Sidekiq.default_configuration
+      else
+        Sidekiq
+      end
+
+      t = in_web_transaction('web') do |txn|
+        txn.stubs(:sampled?).returns(true)
+        NRDeadEndJob.perform_inline
+      end
+
+      # Do I need to harvest?
+      segment_names = t.segments.map(&:name)
+
+      transactions = harvest_transaction_events!
+      # TODO: ADD MORE ASSERTIONS
+    end
+  end
+end

--- a/test/multiverse/suites/sidekiq/sidekiq_force_new_transaction_test.rb
+++ b/test/multiverse/suites/sidekiq/sidekiq_force_new_transaction_test.rb
@@ -35,81 +35,134 @@ class SidekiqForceNewTransactionTest < Minitest::Test
     end
   end
 
-  def test_sidekiq_job_added_to_existing_web_transaction_when_false
+  def test_sidekiq_job_added_as_nested_segment_when_force_new_false
     # Sidekiq version 6.x's perform_inline invokes String#constantize, which is only
     # delivered by ActiveSupport, which this test suite doesn't currently include.
     skip 'Test requires Sidekiq v7+' unless NewRelic::Helper.version_satisfied?(Sidekiq::VERSION, '>=', '7.0.0')
 
     with_config(:'sidekiq.force_new_transaction' => false) do
-      config = if Sidekiq::VERSION.split('.').first.to_i >= 7
-        Sidekiq.default_configuration
-      else
-        Sidekiq
-      end
+      txn = run_web_transaction_with_inline_job
 
-      t = in_web_transaction('web') do |txn|
-        NRDeadEndJob.perform_inline
-      end
+      segment_names = txn.segments.map(&:name)
+      expected_segments = %w[web Nested/OtherTransaction/SidekiqJob/NRDeadEndJob/perform]
 
-      segment_names = t.segments.map(&:name)
-
-      assert_equal %w[web Nested/OtherTransaction/SidekiqJob/NRDeadEndJob/perform], segment_names
-
-      transactions = harvest_transaction_events!
-
-      assert_equal 1, transactions[0][:events_seen]
-      assert_equal 1, transactions[1].size
-
-      first_transaction = transactions[1][0]
-      assert_equal 'web', first_transaction[0]['name']
-
-      _, spans = harvest_span_events!
-
-      assert_equal 2, spans[1].size
-      assert_equal 'web', spans[1][0]['name']
-      assert spans[1][0]['nr.entryPoint']
-
-      assert 'Nested/OtherTransaction/SidekiqJob/NRDeadEndJob/perform', spans[1][0]['name']
-      assert_equal spans[1][0]['transactionId'], spans[1][1]['transactionId']
+      assert_equal expected_segments, segment_names,
+        'Expected web transaction to contain nested Sidekiq job segment'
     end
   end
 
-  def test_sidekiq_job_not_added_to_existing_web_transaction_when_true
+  def test_single_transaction_created_when_force_new_false
+    # Sidekiq version 6.x's perform_inline invokes String#constantize, which is only
+    # delivered by ActiveSupport, which this test suite doesn't currently include.
+    skip 'Test requires Sidekiq v7+' unless NewRelic::Helper.version_satisfied?(Sidekiq::VERSION, '>=', '7.0.0')
+
+    with_config(:'sidekiq.force_new_transaction' => false) do
+      run_web_transaction_with_inline_job
+
+      transactions = harvest_transaction_events!
+
+      assert_equal 1, transactions[0][:events_seen], 'Expected exactly 1 transaction event'
+      assert_equal 1, transactions[1].size, 'Expected 1 transaction in the harvest'
+
+      transaction = transactions[1][0]
+
+      assert_equal 'web', transaction[0]['name'], 'Expected transaction name to be "web"'
+    end
+  end
+
+  def test_single_web_span_created_when_force_new_false
+    # Sidekiq version 6.x's perform_inline invokes String#constantize, which is only
+    # delivered by ActiveSupport, which this test suite doesn't currently include.
+    skip 'Test requires Sidekiq v7+' unless NewRelic::Helper.version_satisfied?(Sidekiq::VERSION, '>=', '7.0.0')
+
+    with_config(:'sidekiq.force_new_transaction' => false) do
+      run_web_transaction_with_inline_job
+
+      _, all_spans = harvest_span_events!
+      spans = all_spans[1].select { |span| span['name'] }
+
+      assert_equal 1, spans.size,
+        'Expected only 1 span (web entry point, sidekiq job is nested as a segment)'
+
+      web_span = spans[0]
+
+      assert_equal 'web', web_span['name'], 'Expected span to be named "web"'
+      assert web_span['nr.entryPoint'], 'Expected web span to be marked as entry point'
+    end
+  end
+
+  def test_web_transaction_excludes_sidekiq_segment_when_force_new_true
     # Sidekiq version 6.x's perform_inline invokes String#constantize, which is only
     # delivered by ActiveSupport, which this test suite doesn't currently include.
     skip 'Test requires Sidekiq v7+' unless NewRelic::Helper.version_satisfied?(Sidekiq::VERSION, '>=', '7.0.0')
 
     with_config(:'sidekiq.force_new_transaction' => true) do
-      config = if Sidekiq::VERSION.split('.').first.to_i >= 7
-        Sidekiq.default_configuration
-      else
-        Sidekiq
-      end
+      txn = run_web_transaction_with_inline_job
+      segment_names = txn.segments.map(&:name)
 
-      t = in_web_transaction('web') do |txn|
-        txn.stubs(:sampled?).returns(true)
-        NRDeadEndJob.perform_inline
-      end
+      assert_equal ['web'], segment_names,
+        'Expected web transaction to only contain web segment (not sidekiq job)'
+    end
+  end
+
+  def test_separate_transactions_for_web_and_sidekiq_when_force_new_true
+    skip 'Test requires Sidekiq v7+' unless NewRelic::Helper.version_satisfied?(Sidekiq::VERSION, '>=', '7.0.0')
+
+    with_config(:'sidekiq.force_new_transaction' => true) do
+      run_web_transaction_with_inline_job
 
       transactions = harvest_transaction_events!
 
-      assert_equal 2, transactions[0][:events_seen]
-      assert_equal 2, transactions[1].size
+      # TODO: Skeptical -- is this the right call? Should we have three transactions?
+      # Find distinct transaction names (filtering duplicates)
+      # binding.irb
+      transaction_names = transactions[1].map { |t| t[0]['name'] }.uniq
 
-      first_transaction = transactions[1][0]
-      assert_equal 'web', first_transaction['name']
+      assert_includes transaction_names, 'web', 'Expected to find web transaction'
+      assert transaction_names.any? { |name| name.include?('SidekiqJob/NRDeadEndJob/perform') }, 'Expected to find sidekiq transaction'
 
-      second_transaction = transactions[1][1]
-      assert_equal 'Nested/OtherTransaction/SidekiqJob/NRDeadEndJob/perform', second_transaction['name']
+      # Verify that web and sidekiq transactions have different names
+      web_transactions = transactions[1].select { |t| t[0]['name'] == 'web' }
+      sidekiq_transactions = transactions[1].select { |t| t[0]['name'].include?('SidekiqJob/NRDeadEndJob/perform') }
 
-      _, spans = harvest_span_events!
+      assert_predicate web_transactions, :any?, 'Expected at least one web transaction'
+      assert_predicate sidekiq_transactions, :any?, 'Expected at least one sidekiq transaction'
+    end
+  end
 
-      assert_equal 2, spans[1].size
-      assert_equal 'web', spans[1][1]['name']
-      assert spans[1][1]['nr.entryPoint']
+  def test_separate_spans_for_web_and_sidekiq_when_force_new_true
+    # Sidekiq version 6.x's perform_inline invokes String#constantize, which is only
+    # delivered by ActiveSupport, which this test suite doesn't currently include.
+    skip 'Test requires Sidekiq v7+' unless NewRelic::Helper.version_satisfied?(Sidekiq::VERSION, '>=', '7.0.0')
 
-      assert 'Nested/OtherTransaction/SidekiqJob/NRDeadEndJob/perform', spans[1][0]['name']
-      assert_equal spans[1][0]['transactionId'], spans[1][1]['transactionId']
+    with_config(:'sidekiq.force_new_transaction' => true) do
+      run_web_transaction_with_inline_job
+      _, all_spans = harvest_span_events!
+      spans = all_spans[1].select { |span| span['name'] }
+
+      sidekiq_span = spans.find { |s| s['name'] =~ /SidekiqJob\/NRDeadEndJob\/perform/ }
+
+      assert sidekiq_span, 'Expected to find sidekiq job span'
+      assert sidekiq_span['nr.entryPoint'],
+        'Expected sidekiq span to be marked as entry point (separate transaction)'
+
+      # TODO: Suspicious
+      # The web transaction may or may not create a span depending on sampling
+      # The key assertion is that the sidekiq job has its own span as a separate transaction
+      web_span = spans.find { |s| s['name'] == 'web' }
+      if web_span
+        refute_equal web_span['transactionId'], sidekiq_span['transactionId'],
+          'If web span exists, it should have a different transaction ID'
+      end
+    end
+  end
+
+  private
+
+  def run_web_transaction_with_inline_job
+    in_web_transaction('web') do |txn|
+      txn.stubs(:sampled?).returns(true)
+      NRDeadEndJob.perform_inline
     end
   end
 end

--- a/test/multiverse/suites/sidekiq/sidekiq_force_new_transaction_test.rb
+++ b/test/multiverse/suites/sidekiq/sidekiq_force_new_transaction_test.rb
@@ -16,10 +16,6 @@ class SidekiqForceNewTransactionTest < Minitest::Test
     mocha_teardown
   end
 
-  # TODO: Do we need to add active job to reproduce the behavior this feature intends to fix?
-  # TODO: Do we need to add tests related to DT headers? Recheck what the customer's concern about that was
-  # TODO: Are we able to use perform_action_with_newrelic_trace or do we need to use start_new_transaction?
-
   def test_sidekiq_force_new_transaction_default_value
     refute NewRelic::Agent.config[:'sidekiq.force_new_transaction'],
       'Expected sidekiq.force_new_transaction default to be false'
@@ -55,7 +51,6 @@ class SidekiqForceNewTransactionTest < Minitest::Test
         NRDeadEndJob.perform_inline
       end
 
-      # Do I need these if I harvest?
       segment_names = t.segments.map(&:name)
 
       assert_equal %w[web Nested/OtherTransaction/SidekiqJob/NRDeadEndJob/perform], segment_names
@@ -66,17 +61,16 @@ class SidekiqForceNewTransactionTest < Minitest::Test
       assert_equal 1, transactions[1].size
 
       first_transaction = transactions[1][0]
-      # assert_equal 'web', first_transaction['name']
+      assert_equal 'web', first_transaction[0]['name']
 
-      spans = harvest_span_events!
+      _, spans = harvest_span_events!
 
       assert_equal 2, spans[1].size
+      assert_equal 'web', spans[1][0]['name']
+      assert spans[1][0]['nr.entryPoint']
 
-      # other possible span assertions:
-      # make sure the nr.entryPoint attribute is present on the web span
-      # make sure it isn't on the sidekiq span
-      # make sure the sidekiq span is the child of the web span
-      # could make sure they all have the same transaction id
+      assert 'Nested/OtherTransaction/SidekiqJob/NRDeadEndJob/perform', spans[1][0]['name']
+      assert_equal spans[1][0]['transactionId'], spans[1][1]['transactionId']
     end
   end
 
@@ -97,35 +91,25 @@ class SidekiqForceNewTransactionTest < Minitest::Test
         NRDeadEndJob.perform_inline
       end
 
-      segment_names = t.segments.map(&:name)
-
-      assert_equal %w[web], segment_names
-      # TODO: ADD MORE ASSERTIONS
-    end
-  end
-
-  def test_sidekiq_job_part_of_new_transaction_when_true
-    # Sidekiq version 6.x's perform_inline invokes String#constantize, which is only
-    # delivered by ActiveSupport, which this test suite doesn't currently include.
-    skip 'Test requires Sidekiq v7+' unless NewRelic::Helper.version_satisfied?(Sidekiq::VERSION, '>=', '7.0.0')
-
-    with_config(:'sidekiq.force_new_transaction' => true) do
-      config = if Sidekiq::VERSION.split('.').first.to_i >= 7
-        Sidekiq.default_configuration
-      else
-        Sidekiq
-      end
-
-      t = in_web_transaction('web') do |txn|
-        txn.stubs(:sampled?).returns(true)
-        NRDeadEndJob.perform_inline
-      end
-
-      # Do I need to harvest?
-      segment_names = t.segments.map(&:name)
-
       transactions = harvest_transaction_events!
-      # TODO: ADD MORE ASSERTIONS
+
+      assert_equal 2, transactions[0][:events_seen]
+      assert_equal 2, transactions[1].size
+
+      first_transaction = transactions[1][0]
+      assert_equal 'web', first_transaction['name']
+
+      second_transaction = transactions[1][1]
+      assert_equal 'Nested/OtherTransaction/SidekiqJob/NRDeadEndJob/perform', second_transaction['name']
+
+      _, spans = harvest_span_events!
+
+      assert_equal 2, spans[1].size
+      assert_equal 'web', spans[1][1]['name']
+      assert spans[1][1]['nr.entryPoint']
+
+      assert 'Nested/OtherTransaction/SidekiqJob/NRDeadEndJob/perform', spans[1][0]['name']
+      assert_equal spans[1][0]['transactionId'], spans[1][1]['transactionId']
     end
   end
 end

--- a/test/multiverse/suites/sidekiq/sidekiq_force_new_transaction_test.rb
+++ b/test/multiverse/suites/sidekiq/sidekiq_force_new_transaction_test.rb
@@ -140,7 +140,7 @@ class SidekiqForceNewTransactionTest < Minitest::Test
       _, all_spans = harvest_span_events!
       spans = all_spans[1].select { |span| span['name'] }
 
-      sidekiq_span = spans.find { |s| s['name'] =~ /SidekiqJob\/NRDeadEndJob\/perform/ }
+      sidekiq_span = spans.find { |s| s['name'].include?('SidekiqJob/NRDeadEndJob/perform') }
 
       assert sidekiq_span, 'Expected to find sidekiq job span'
       assert sidekiq_span['nr.entryPoint'],

--- a/test/new_relic/agent/instrumentation/controller_instrumentation_test.rb
+++ b/test/new_relic/agent/instrumentation/controller_instrumentation_test.rb
@@ -357,6 +357,75 @@ module NewRelic::Agent::Instrumentation
       end
     end
 
+    def test_error_raised_and_noticed_if_notice_error_key_absent_from_trace_options
+      host_class = Class.new do
+        include ControllerInstrumentation
+
+        def doit
+          perform_action_with_newrelic_trace({}) do
+            raise UserError.new
+          end
+        end
+      end
+
+      NewRelic::Agent::Transaction.stubs(:start).returns(nil)
+
+      host = host_class.new
+      assert_raises(UserError) do
+        host.doit
+      end
+
+      _, errors = harvest_error_events!
+
+      assert_equal 1, errors.size
+    end
+
+    def test_error_raised_and_noticed_if_notice_error_key_true_in_trace_options
+      host_class = Class.new do
+        include ControllerInstrumentation
+
+        def doit
+          perform_action_with_newrelic_trace({:notice_error => true}) do
+            raise UserError.new
+          end
+        end
+      end
+
+      NewRelic::Agent::Transaction.stubs(:start).returns(nil)
+
+      host = host_class.new
+      assert_raises(UserError) do
+        host.doit
+      end
+
+      _, errors = harvest_error_events!
+
+      assert_equal 1, errors.size
+    end
+
+    def test_error_raised_and_not_noticed_if_notice_error_key_false_in_trace_options
+      host_class = Class.new do
+        include ControllerInstrumentation
+
+        def doit
+          perform_action_with_newrelic_trace({:notice_error => false}) do
+            raise UserError.new
+          end
+        end
+      end
+
+      NewRelic::Agent::Transaction.stubs(:start).returns(nil)
+
+      host = host_class.new
+      assert_raises(UserError) do
+        host.doit
+      end
+
+      _, errors = harvest_error_events!
+
+      assert_empty errors
+    end
+
     def test_should_not_set_request_path
       clazz = Class.new do
         include ControllerInstrumentation


### PR DESCRIPTION
This configuration option ends the current transaction if there is one, which forces a new transaction to start when
`perform_action_with_newrelic_trace` is called.

In addition, the `sidekiq.ignore_retry_errors` code has been refactored to toggle based on a key in the trace_options hash and removes the duplicated `perform_action_*` method from the Sidekiq server instrumentation.

Closes #3364 