### PR TITLE
Remove reference to deprecated ObjectSpace._id2ref

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## dev
 
+- **Bugfix: Remove usage of deprecated ObjectSpace._id2ref**
+
+  The agent now uses an alternative approach instead of the deprecated `ObjectSpace._id2ref` method, eliminating deprecation warnings when running on Ruby 4.0+. [PR#3490](https://github.com/newrelic/newrelic-ruby-agent/pull/3490)
+
 - **Feature: Add database query naming via SQL comments**
 
   Database queries can now be explicitly named using SQL comments. Queries can include `/* NewRelicQueryName: CustomName */` comments to assign stable names for better tracking and identification. This is especially useful for tracking specific database queries during performance regressions or incidents. [PR#3480](https://github.com/newrelic/newrelic-ruby-agent/pull/3480)

--- a/lib/new_relic/agent/transaction_time_aggregator.rb
+++ b/lib/new_relic/agent/transaction_time_aggregator.rb
@@ -118,7 +118,11 @@ module NewRelic
           require 'objspace'
 
           def thread_by_id(thread_id)
-            ObjectSpace._id2ref(thread_id)
+            obj = Thread.list.detect { |t| t.object_id == thread_id }
+            return obj if obj
+
+            # Thread.list is significantly faster than ObjectSpace.each_object, but Fibers do not have that method.
+            ObjectSpace.each_object(Fiber).detect { |f| f.object_id == thread_id }
           end
         end
 


### PR DESCRIPTION
resolves https://github.com/newrelic/newrelic-ruby-agent/issues/3417