### PR TITLE
Ensure message type is a string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## v10.3.0
 
-- **Bugfix: Remove usage of deprecated ObjectSpace._id2ref**
-
-  The agent now uses an alternative approach instead of the deprecated `ObjectSpace._id2ref` method, eliminating deprecation warnings when running on Ruby 4.0+. [PR#3490](https://github.com/newrelic/newrelic-ruby-agent/pull/3490)
-
 - **Feature: Add database query naming via SQL comments**
 
   Database queries can now be explicitly named using SQL comments. Queries can include `/* NewRelicQueryName: CustomName */` comments to assign stable names for better tracking and identification. This is especially useful for tracking specific database queries during performance regressions or incidents. [PR#3480](https://github.com/newrelic/newrelic-ruby-agent/pull/3480)
@@ -43,6 +39,14 @@
 - **Bugfix: Fix typo in harvest.rb causing NoMethodError**
 
   A typo in `lib/new_relic/agent/agent_helpers/harvest.rb` caused a `NoMethodError: undefined method 'agent' for NewRelic:Module`. Thanks to [@oakbow](https://github.com/oakbow) for reporting this issue. [PR#3484](https://github.com/newrelic/newrelic-ruby-agent/issues/3484)
+
+- **Bugfix: Remove usage of deprecated ObjectSpace._id2ref**
+
+  The agent now uses an alternative approach instead of the deprecated `ObjectSpace._id2ref` method, eliminating deprecation warnings when running on Ruby 4.0+. [PR#3490](https://github.com/newrelic/newrelic-ruby-agent/pull/3490)
+
+- **Bugfix: Fix NoMethoError in Logging instrumentation**
+
+  Previously, when the Logging gem instrumentation attempted to decorate local logs, it would raise a `NoMethodError` if it encountered a non-string object. This is now fixed. [PR#3501](https://github.com/newrelic/newrelic-ruby-agent/pull/3501)
 
 ## v10.2.0
 

--- a/lib/new_relic/agent/local_log_decorator.rb
+++ b/lib/new_relic/agent/local_log_decorator.rb
@@ -18,6 +18,7 @@ module NewRelic
           return
         end
 
+        message = message.to_s unless message.is_a?(String)
         formatted_metadata = " NR-LINKING|#{metadata[ENTITY_GUID_KEY]}|#{metadata[HOSTNAME_KEY]}|" \
                              "#{metadata[TRACE_ID_KEY]}|#{metadata[SPAN_ID_KEY]}|" \
                              "#{escape_entity_name(metadata[ENTITY_NAME_KEY])}|"

--- a/lib/new_relic/agent/log_event_aggregator.rb
+++ b/lib/new_relic/agent/log_event_aggregator.rb
@@ -454,6 +454,8 @@ module NewRelic
       end
 
       def truncate_message(message)
+        message = message.to_s unless message.is_a?(String)
+
         return message if message.bytesize <= MAX_BYTES
 
         message.byteslice(0...MAX_BYTES)

--- a/test/new_relic/agent/local_log_decorator_test.rb
+++ b/test/new_relic/agent/local_log_decorator_test.rb
@@ -122,6 +122,14 @@ module NewRelic::Agent
 
         assert_equal expected, hash, 'Expected no errors and no hash modifications for a frozen hash'
       end
+
+      def test_decorate_converts_exception_to_string
+        metadata_stubs
+        exception = RuntimeError.new('Something went wrong')
+        result = LocalLogDecorator.decorate(exception)
+
+        assert_equal "Something went wrong #{METADATA_STRING}", result
+      end
     end
   end
 end

--- a/test/new_relic/agent/log_event_aggregator_test.rb
+++ b/test/new_relic/agent/log_event_aggregator_test.rb
@@ -505,6 +505,13 @@ module NewRelic::Agent
       assert_equal(message, event[1]['message'])
     end
 
+    def test_truncate_message_converts_exception_to_string
+      exception = RuntimeError.new('Something went wrong')
+      result = @aggregator.send(:truncate_message, exception)
+
+      assert_equal('Something went wrong', result)
+    end
+
     def test_does_not_record_if_message_is_nil
       @aggregator.record(nil, 'DEBUG')
       _, events = @aggregator.harvest!


### PR DESCRIPTION
When Logging encounters an error (ie RuntimeError), the agent intercepts the event and when local log decoration is enabled, attempts to call the string method `partition` on the object. This would cause a `NoMethodError`.

Logging handles this by [turning](https://github.com/TwP/logging/blob/master/lib/logging/layout.rb#L152-L154) non-string objects into strings before passing it along to appenders. Since we hook in before logs have a chance to go through Logging's code, we should ensure we are working with strings before attempting to do anything too.