### PR TITLE
Stop HTTPX instrumentation crashes for nil segment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # New Relic Ruby Agent Release Notes
 
+## dev
+
+- **Bugfix: Prevent crashes during HTTPX segment creation**
+
+  Previously, if `start_external_request_segment` encountered an error and returned `nil`, the agent would trigger a `NoMethodError` when attempting to add headers to the missing segment. We've added a guard check to ensure the instrumentation handles these cases gracefully.
+
+  Bravo to [@thebravoman](https://github.com/thebravoman) for the report! [Issue#3509](https://github.com/newrelic/newrelic-ruby-agent/issues/3509) [PR#3510](https://github.com/newrelic/newrelic-ruby-agent/pull/3510)
+
 ## v10.3.0
 
 - **Feature: Add database query naming via SQL comments**

--- a/lib/new_relic/agent/instrumentation/httpx/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/httpx/instrumentation.rb
@@ -23,6 +23,11 @@ module NewRelic::Agent::Instrumentation::HTTPX
       uri: wrapped_request.uri,
       procedure: wrapped_request.method
     )
+
+    # If an exception occurs during segment creation, segment will be nil
+    # See: https://github.com/newrelic/newrelic-ruby-agent/issues/3509
+    return unless segment
+
     segment.add_request_headers(wrapped_request)
 
     request.on(:response) { nr_finish_segment.call(request, segment) }

--- a/test/multiverse/suites/httpx/httpx_instrumentation_test.rb
+++ b/test/multiverse/suites/httpx/httpx_instrumentation_test.rb
@@ -29,6 +29,17 @@ class HTTPXInstrumentationTest < Minitest::Test
     PhonySession.new.nr_finish_segment.call(nil, nil)
   end
 
+  # Regression test: https://github.com/newrelic/newrelic-ruby-agent/issues/3509
+  def test_nr_start_segment_does_not_raise_no_method_error
+    # raise an error while the start_external_request_segment method is running
+    # start_and_add_segment is called by start_external_request_segment
+    NewRelic::Agent::Tracer.stub(:start_and_add_segment, ->(arg1, arg2) { raise 'kaboom!' }) do
+      response = get_response
+
+      assert_kind_of HTTPX::Response, response
+    end
+  end
+
   def test_finish_with_error
     request = Minitest::Mock.new
     2.times { request.expect :response, :the_response }


### PR DESCRIPTION
Previously, if `start_external_request_segment` raised an error, segment would be `nil` and the instrumentation crashed with a `NoMethodError`. Now, we have a `nil` guard check to prevent crashes.

Resolves: #3509 