### PR TITLE
Refactor sidekiq.ignore_retry_errors

### DIFF
--- a/lib/new_relic/agent/instrumentation/controller_instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/controller_instrumentation.rb
@@ -386,7 +386,7 @@ module NewRelic
             begin
               yield
             rescue => e
-              NewRelic::Agent.notice_error(e)
+              NewRelic::Agent.notice_error(e) unless trace_options[:notice_error] == false
               raise
             end
           ensure

--- a/lib/new_relic/agent/instrumentation/sidekiq/server.rb
+++ b/lib/new_relic/agent/instrumentation/sidekiq/server.rb
@@ -22,6 +22,9 @@ module NewRelic::Agent::Instrumentation::Sidekiq
       else
         self.class.default_trace_args(msg)
       end
+
+      trace_args[:notice_error] = false if NewRelic::Agent.config[:'sidekiq.ignore_retry_errors']
+
       trace_headers = msg.delete(NewRelic::NEWRELIC_KEY)
 
       execution_block = proc do
@@ -38,45 +41,10 @@ module NewRelic::Agent::Instrumentation::Sidekiq
         yield
       end
 
-      if NewRelic::Agent.config[:'sidekiq.ignore_retry_errors']
-        perform_action_with_newrelic_trace_without_error_reporting(trace_args, &execution_block)
-      else
-        perform_action_with_newrelic_trace(trace_args, &execution_block)
-      end
+      perform_action_with_newrelic_trace(trace_args, &execution_block)
     end
 
     private
-
-    # Version of perform_action_with_newrelic_trace that doesn't report errors
-    def perform_action_with_newrelic_trace_without_error_reporting(*args, &block)
-      NewRelic::Agent.record_api_supportability_metric(:perform_action_with_newrelic_trace_without_error_reporting)
-      state = NewRelic::Agent::Tracer.state
-      request = newrelic_request(args)
-      queue_start_time = detect_queue_start_time(request)
-
-      skip_tracing = do_not_trace? || !state.is_execution_traced?
-
-      if skip_tracing
-        state.current_transaction&.ignore!
-        NewRelic::Agent.disable_all_tracing { return yield }
-      end
-
-      trace_options = args.last.is_a?(Hash) ? args.last : NewRelic::EMPTY_HASH
-      category = trace_options[:category] || :controller
-      txn_options = create_transaction_options(trace_options, category, state, queue_start_time)
-
-      begin
-        finishable = NewRelic::Agent::Tracer.start_transaction_or_segment(
-          name: txn_options[:transaction_name],
-          category: category,
-          options: txn_options
-        )
-
-        yield
-      ensure
-        finishable&.finish
-      end
-    end
 
     def self.default_trace_args(msg)
       {

--- a/test/new_relic/agent/instrumentation/controller_instrumentation_test.rb
+++ b/test/new_relic/agent/instrumentation/controller_instrumentation_test.rb
@@ -372,5 +372,74 @@ module NewRelic::Agent::Instrumentation
 
       assert_nil request_path
     end
+
+    def test_error_raised_and_noticed_if_notice_error_key_absent_from_trace_options
+      host_class = Class.new do
+        include ControllerInstrumentation
+
+        def doit
+          perform_action_with_newrelic_trace({}) do
+            raise UserError.new
+          end
+        end
+      end
+
+      NewRelic::Agent::Transaction.stubs(:start).returns(nil)
+
+      host = host_class.new
+      assert_raises(UserError) do
+        host.doit
+      end
+
+      _, errors = harvest_error_events!
+
+      assert_equal 1, errors.size
+    end
+
+    def test_error_raised_and_noticed_if_notice_error_key_true_in_trace_options
+      host_class = Class.new do
+        include ControllerInstrumentation
+
+        def doit
+          perform_action_with_newrelic_trace({:notice_error => true}) do
+            raise UserError.new
+          end
+        end
+      end
+
+      NewRelic::Agent::Transaction.stubs(:start).returns(nil)
+
+      host = host_class.new
+      assert_raises(UserError) do
+        host.doit
+      end
+
+      _, errors = harvest_error_events!
+
+      assert_equal 1, errors.size
+    end
+
+    def test_error_raised_and_not_noticed_if_notice_error_key_false_in_trace_options
+      host_class = Class.new do
+        include ControllerInstrumentation
+
+        def doit
+          perform_action_with_newrelic_trace({:notice_error => false}) do
+            raise UserError.new
+          end
+        end
+      end
+
+      NewRelic::Agent::Transaction.stubs(:start).returns(nil)
+
+      host = host_class.new
+      assert_raises(UserError) do
+        host.doit
+      end
+
+      _, errors = harvest_error_events!
+
+      assert_empty errors
+    end
   end
 end


### PR DESCRIPTION
Now, we use trace_args to pass a flag when errors should not be noticed. This could also be applied to other frameworks, but it currently is only assigned in Sidekiq server instrumentation.