### PR TITLE
Make Transaction#finish idempotent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
   Bravo to [@thebravoman](https://github.com/thebravoman) for the report! [Issue#3509](https://github.com/newrelic/newrelic-ruby-agent/issues/3509) [PR#3510](https://github.com/newrelic/newrelic-ruby-agent/pull/3510)
 
+- **Bugfix: Make Transaction#finish idempotent**
+
+  Previously, if the Transaction#finish method was called multiple times, more than one transaction could be created for the same operation. Now, a mutex protects calls to Transaction#finish to make sure finish operations only run once. [PR#3513](https://github.com/newrelic/newrelic-ruby-agent/pull/3513)
+
 ## v10.3.0
 
 - **Feature: Add database query naming via SQL comments**

--- a/lib/new_relic/agent/transaction.rb
+++ b/lib/new_relic/agent/transaction.rb
@@ -217,6 +217,7 @@ module NewRelic
         @current_segment_by_thread = {}
         @current_segment_lock = Mutex.new
         @segment_lock = Mutex.new
+        @finish_mutex = Mutex.new
         @segments = []
 
         self.default_name = options[:transaction_name]
@@ -554,24 +555,30 @@ module NewRelic
       end
 
       def finish
-        return unless state.is_execution_traced? && initial_segment
+        @finish_mutex.synchronize do
+          # Guard against double-finishing to prevent duplicate transaction recording
+          # This can occur in multi-threaded/fiber environments or when finish is called
+          # explicitly before the wrapping code calls it again (e.g., Tracer.in_transaction)
+          return unless state.is_execution_traced? && initial_segment
+          return if finished?
 
-        @end_time = Process.clock_gettime(Process::CLOCK_REALTIME)
-        @duration = @end_time - @start_time
-        freeze_name_and_execute_if_not_ignored
+          @end_time = Process.clock_gettime(Process::CLOCK_REALTIME)
+          @duration = @end_time - @start_time
+          freeze_name_and_execute_if_not_ignored
 
-        if nesting_max_depth == 1
-          initial_segment.name = @frozen_name
+          if nesting_max_depth == 1
+            initial_segment.name = @frozen_name
+          end
+
+          initial_segment.transaction_name = @frozen_name
+          assign_segment_dt_attributes
+          assign_agent_attributes
+          initial_segment.finish
+
+          NewRelic::Agent::TransactionTimeAggregator.transaction_stop(@end_time, @starting_thread_id)
+
+          commit!(initial_segment.name) unless @ignore_this_transaction
         end
-
-        initial_segment.transaction_name = @frozen_name
-        assign_segment_dt_attributes
-        assign_agent_attributes
-        initial_segment.finish
-
-        NewRelic::Agent::TransactionTimeAggregator.transaction_stop(@end_time, @starting_thread_id)
-
-        commit!(initial_segment.name) unless @ignore_this_transaction
       rescue => e
         NewRelic::Agent.logger.error('Exception during Transaction#finish', e)
         nil

--- a/test/new_relic/agent/transaction_test.rb
+++ b/test/new_relic/agent/transaction_test.rb
@@ -1900,5 +1900,80 @@ module NewRelic::Agent
       assert_nil txn.initial_segment
       refute_predicate txn, :finished?
     end
+
+    def test_finish_is_idempotent
+      txn = Tracer.start_transaction(name: 'test', category: :controller)
+      state = Tracer.state
+
+      # First finish should work
+      txn.finish
+
+      assert_predicate txn, :finished?
+
+      # Second finish should be a no-op (no exception raised)
+      txn.finish
+
+      assert_predicate txn, :finished?
+
+      state.reset
+    end
+
+    def test_finish_prevents_transaction_from_double_recording
+      txn = Tracer.start_transaction(name: 'test', category: :controller)
+      state = Tracer.state
+
+      txn.expects(:commit!).once
+
+      txn.finish
+      txn.finish
+
+      state.reset
+    end
+
+    def test_finish_is_thread_safe
+      txn = Tracer.start_transaction(name: 'test', category: :controller)
+      state = Tracer.state
+
+      txn.expects(:commit!).once
+
+      threads = Array.new(10) do
+        Thread.new { txn.finish }
+      end
+
+      threads.each(&:join)
+
+      state.reset
+    end
+
+    def test_finish_uses_mutex_for_thread_safety
+      txn = Tracer.start_transaction(name: 'test', category: :controller)
+      state = Tracer.state
+
+      mutex = txn.instance_variable_get(:@finish_mutex)
+
+      assert_kind_of Mutex, mutex, 'Transaction should have a @finish_mutex'
+
+      # Verify the mutex is used during finish by checking it's locked during execution
+      mutex_used = false
+      original_synchronize = mutex.method(:synchronize)
+      mutex.define_singleton_method(:synchronize) do |&block|
+        mutex_used = true
+        original_synchronize.call(&block)
+      end
+
+      txn.finish
+
+      assert mutex_used, 'Transaction#finish should use the mutex'
+
+      state.reset
+    end
+
+    def test_finish_with_no_initial_segment_returns_early
+      txn = Transaction.new(:web, {})
+
+      txn.finish
+
+      refute_predicate txn, :finished?
+    end
   end
 end


### PR DESCRIPTION
Previously, if `Transaction#finish` was called multiple times on the same transaction, multiple transactions could be created for one operation. Now, the `finish` method is protected by a mutex and an instance variable to make sure transactions are only finished once.