### PR TITLE
Fix bundling error for HTTP.rb suite with sqlite3

### DIFF
--- a/test/multiverse/suites/httprb/Envfile
+++ b/test/multiverse/suites/httprb/Envfile
@@ -25,6 +25,7 @@ def gem_list(httprb_version = nil)
     gem 'http'#{httprb_version}
     gem 'rack'
     gem 'ffi'#{ffi_version}
+    gem 'sqlite3'
   RB
 end
 


### PR DESCRIPTION
When trying to run HTTP.rb multiverse tests in both Ruby 2.6 (http version 5.3) and 4.0 (http version 6.0.2), the following error is raised: `gems/http-cookie-1.1.1/lib/http/cookie_jar/mozilla_store.rb:40:in `require': cannot load such file -- sqlite3 (LoadError)` 

Adding sqlite3 to the Envfile seems to solve the problem.

This seems related to [HTTP Cookie's](https://github.com/sparklemotion/http-cookie) 1.1.1 release, which came out today. I'm going to post on their GH repo as well to see if we can get a more permanent workaround.

Error stacktrace [(example)](https://github.com/newrelic/newrelic-ruby-agent/actions/runs/24032254543/job/70083490529?pr=3513#step:4:5684)
```
Use `bundle info [gemname]` to see where a bundled gem is installed.
/opt/hostedtoolcache/Ruby/2.6.10/x64/lib/ruby/gems/2.6.0/gems/http-cookie-1.1.1/lib/http/cookie_jar/mozilla_store.rb:40:in `require': cannot load such file -- sqlite3 (LoadError)
	from /opt/hostedtoolcache/Ruby/2.6.10/x64/lib/ruby/gems/2.6.0/gems/http-cookie-1.1.1/lib/http/cookie_jar/mozilla_store.rb:40:in `<class:MozillaStore>'
	from /opt/hostedtoolcache/Ruby/2.6.10/x64/lib/ruby/gems/2.6.0/gems/http-cookie-1.1.1/lib/http/cookie_jar/mozilla_store.rb:10:in `<class:CookieJar>'
	from /opt/hostedtoolcache/Ruby/2.6.10/x64/lib/ruby/gems/2.6.0/gems/http-cookie-1.1.1/lib/http/cookie_jar/mozilla_store.rb:4:in `<top (required)>'
	from /opt/hostedtoolcache/Ruby/2.6.10/x64/lib/ruby/gems/2.6.0/gems/http-cookie-1.1.1/lib/http/cookie_jar/abstract_store.rb:118:in `require'
	from /opt/hostedtoolcache/Ruby/2.6.10/x64/lib/ruby/gems/2.6.0/gems/http-cookie-1.1.1/lib/http/cookie_jar/abstract_store.rb:118:in `<top (required)>'
	from /opt/hostedtoolcache/Ruby/2.6.10/x64/lib/ruby/gems/2.6.0/gems/http-cookie-1.1.1/lib/http/cookie_jar.rb:325:in `require'
	from /opt/hostedtoolcache/Ruby/2.6.10/x64/lib/ruby/gems/2.6.0/gems/http-cookie-1.1.1/lib/http/cookie_jar.rb:325:in `<top (required)>'
	from /opt/hostedtoolcache/Ruby/2.6.10/x64/lib/ruby/gems/2.6.0/gems/http-5.3.1/lib/http/response.rb:10:in `require'
	from /opt/hostedtoolcache/Ruby/2.6.10/x64/lib/ruby/gems/2.6.0/gems/http-5.3.1/lib/http/response.rb:10:in `<top (required)>'
	from /opt/hostedtoolcache/Ruby/2.6.10/x64/lib/ruby/gems/2.6.0/gems/http-5.3.1/lib/http.rb:15:in `require'
	from /opt/hostedtoolcache/Ruby/2.6.10/x64/lib/ruby/gems/2.6.0/gems/http-5.3.1/lib/http.rb:15:in `<top (required)>'
	from /opt/hostedtoolcache/Ruby/2.6.10/x64/lib/ruby/site_ruby/2.6.0/bundler/runtime.rb:81:in `require'
	from /opt/hostedtoolcache/Ruby/2.6.10/x64/lib/ruby/site_ruby/2.6.0/bundler/runtime.rb:81:in `block (2 levels) in require'
	from /opt/hostedtoolcache/Ruby/2.6.10/x64/lib/ruby/site_ruby/2.6.0/bundler/runtime.rb:76:in `each'
	from /opt/hostedtoolcache/Ruby/2.6.10/x64/lib/ruby/site_ruby/2.6.0/bundler/runtime.rb:76:in `block in require'
	from /opt/hostedtoolcache/Ruby/2.6.10/x64/lib/ruby/site_ruby/2.6.0/bundler/runtime.rb:65:in `each'
	from /opt/hostedtoolcache/Ruby/2.6.10/x64/lib/ruby/site_ruby/2.6.0/bundler/runtime.rb:65:in `require'
	from /opt/hostedtoolcache/Ruby/2.6.10/x64/lib/ruby/site_ruby/2.6.0/bundler.rb:114:in `require'
	from /home/runner/work/newrelic-ruby-agent/newrelic-ruby-agent/test/multiverse/lib/multiverse/suite.rb:236:in `block in ensure_bundle'
	from /home/runner/work/newrelic-ruby-agent/newrelic-ruby-agent/test/multiverse/lib/multiverse/suite.rb:123:in `with_potentially_mismatched_bundler'
	from /home/runner/work/newrelic-ruby-agent/newrelic-ruby-agent/test/multiver
```