### PR TITLE
Update tokens for prerelease workflow

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -10,10 +10,10 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-    - name: Install Ruby 3.4
+    - name: Install Ruby 4.0
       uses: ruby/setup-ruby@3ff19f5e2baf30647122352b96108b1fbe250c64 # tag v1.299.0
       with:
-        ruby-version: 3.4
+        ruby-version: 4.0
 
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # tag v6.0.2
@@ -29,7 +29,7 @@ jobs:
     - name: Set tag name
       run: echo "prerelease_tag=$(bundle exec rake newrelic:version:current)-pre" >> $GITHUB_ENV
 
-    - name: Create pull request
+    - name: Push branch and create pull request
       run: |
         git checkout -b "prerelease_updates_${{ env.prerelease_tag }}"
         git add --all
@@ -37,9 +37,14 @@ jobs:
         git config --global user.name 'newrelic-ruby-agent-bot'
         git commit -m "bump version"
         git push --set-upstream origin "prerelease_updates_${{ env.prerelease_tag }}"
-        gh pr create --label $LABEL --title "$TITLE" --body "$BODY"
+        PR_URL=$(gh pr create --title "$TITLE" --body "$BODY")
+        echo "pr_url=$PR_URL" >> $GITHUB_ENV
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.NEWRELIC_RUBY_AGENT_BOT_TOKEN }}
         TITLE: "Prerelease ${{env.prerelease_tag}}"
         BODY: "Updates the version number, changelog, and newrelic.yml (if it needs updating). This is an automated PR."
-        LABEL: prerelease
+
+    - name: Add label to pull request
+      run: gh pr edit "${{ env.pr_url }}" --add-label prerelease
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
We want the CI to start running automatically when we create a prerelease PR. To do this, we need to create the PR with a bot user token. Previous attempts to use the bot token failed because the bot does not have permissions to update the PR to add a label. The `GITHUB_TOKEN` can add a label, but cannot start the CI on PRs it creates.

The solution is to make a new step to add the label that is separate from the step to create a branch and open a PR. The new step uses the GH token, whereas the branch/PR step use the bot token.

Closes #3236 

This was tested in https://github.com/newrelic/newrelic-ruby-agent/pull/3524

With the following workflow: 
```yml
name: Create Prerelease

on:
  workflow_dispatch:

jobs:
  create_prerelease:
    runs-on: ubuntu-22.04
    permissions:
      contents: write
      pull-requests: write
    steps:
    - name: Checkout code
      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # tag v6.0.2

    - name: Push test branch and create PR
      run: |
        git checkout -b "test-prerelease-tokens-$(date +%s)"
        echo "Test file for prerelease token validation" > test-prerelease.txt
        git add test-prerelease.txt
        git config --global user.email ${{ secrets.EMAIL }}
        git config --global user.name 'newrelic-ruby-agent-bot'
        git commit -m "test: verify bot token triggers CI"
        git push --set-upstream origin HEAD
        PR_URL=$(gh pr create --title "$TITLE" --body "$BODY")
        echo "pr_url=$PR_URL" >> $GITHUB_ENV
      env:
        GITHUB_TOKEN: ${{ secrets.NEWRELIC_RUBY_AGENT_BOT_TOKEN }}
        TITLE: "Test: Prerelease Token Switching"
        BODY: |
          This is a test PR to verify:
          * Bot token allows CI workflows to trigger
          * Default token can create and label PRs
          **This PR should be closed without merging.**
    - name: Add label to test PR
      run: gh pr edit "${{ env.pr_url }}" --add-label github
      env:
        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```