### PR TITLE
Small changes to config doc automation

### DIFF
--- a/lib/tasks/config.rake
+++ b/lib/tasks/config.rake
@@ -33,7 +33,7 @@ namespace :newrelic do
       'custom_insights_events' => 'Custom Events [#custom-events]',
       'ai_monitoring' => 'AI Monitoring [#ai-monitoring]',
       'security_agent' => 'Security Agent [#security-agent]',
-      'opentelemetry' => 'OpenTelemetry'
+      'opentelemetry' => 'OpenTelemetry [#opentelemetry]'
     }
 
     desc 'Describe available New Relic configuration settings'

--- a/lib/tasks/helpers/config.html.erb
+++ b/lib/tasks/helpers/config.html.erb
@@ -5,6 +5,8 @@ tags:
   - Ruby agent
   - Configuration
 metaDescription: 'APM for Ruby: how to configure the Ruby agent, including editing the config file and setting environment variables.'
+translate:
+  - jp
 redirects:
   - /docs/agents/ruby-agent/configuration/ruby-agent-configuration
   - /docs/ruby/ruby-agent-configuration


### PR DESCRIPTION
* There was a translate field added to the frontmatter
* The OpenTelemetry section was missing a jumplink tag

See: https://github.com/newrelic/docs-website/pull/23695