### PR TITLE
Reduce method calls by caching log level values

### DIFF
--- a/lib/new_relic/agent/log_event_aggregator.rb
+++ b/lib/new_relic/agent/log_event_aggregator.rb
@@ -53,6 +53,7 @@ module NewRelic
         @high_security = NewRelic::Agent.config[:high_security]
         @instrumentation_logger_enabled = NewRelic::Agent::Instrumentation::Logger.enabled?
         @attributes = NewRelic::Agent::LogEventAttributes.new
+        @severity_constant_cache = {}
 
         register_for_done_configuring(events)
       end
@@ -320,6 +321,8 @@ module NewRelic
           @seen = 0
           @seen_by_severity.clear
         end
+        @severity_constant_cache.clear
+        @configured_log_level_constant = nil
 
         super
       end
@@ -462,11 +465,11 @@ module NewRelic
       end
 
       def configured_log_level_constant
-        format_log_level_constant(NewRelic::Agent.config[LOG_LEVEL_KEY])
+        @configured_log_level_constant ||= format_log_level_constant(NewRelic::Agent.config[LOG_LEVEL_KEY])
       end
 
       def format_log_level_constant(log_level)
-        log_level.upcase.to_sym
+        @severity_constant_cache[log_level] ||= log_level.upcase.to_sym
       end
 
       def severity_too_low?(severity)

--- a/test/new_relic/agent/log_event_aggregator_test.rb
+++ b/test/new_relic/agent/log_event_aggregator_test.rb
@@ -596,9 +596,11 @@ module NewRelic::Agent
 
     def test_format_log_level_constant_caches_results
       result1 = @aggregator.send(:format_log_level_constant, 'debug')
+
       assert_equal :DEBUG, result1
 
       cache = @aggregator.instance_variable_get(:@severity_constant_cache)
+
       assert cache.key?('debug')
       assert_equal :DEBUG, cache['debug']
     end
@@ -611,14 +613,17 @@ module NewRelic::Agent
       assert_equal :DEBUG, debug_upper
 
       cache = @aggregator.instance_variable_get(:@severity_constant_cache)
-      assert_equal 2, cache.select { |k, v| v == :DEBUG }.size
+
+      assert_equal 2, cache.count { |k, v| v == :DEBUG }
     end
 
     def test_format_log_level_constant_handles_custom_levels
       custom = @aggregator.send(:format_log_level_constant, 'custom')
+
       assert_equal :CUSTOM, custom
 
       cache = @aggregator.instance_variable_get(:@severity_constant_cache)
+
       assert cache.key?('custom')
     end
 

--- a/test/new_relic/agent/log_event_aggregator_test.rb
+++ b/test/new_relic/agent/log_event_aggregator_test.rb
@@ -594,6 +594,34 @@ module NewRelic::Agent
       end
     end
 
+    def test_format_log_level_constant_caches_results
+      result1 = @aggregator.send(:format_log_level_constant, 'debug')
+      assert_equal :DEBUG, result1
+
+      cache = @aggregator.instance_variable_get(:@severity_constant_cache)
+      assert cache.key?('debug')
+      assert_equal :DEBUG, cache['debug']
+    end
+
+    def test_format_log_level_constant_handles_different_cases
+      debug_lower = @aggregator.send(:format_log_level_constant, 'debug')
+      debug_upper = @aggregator.send(:format_log_level_constant, 'DEBUG')
+
+      assert_equal :DEBUG, debug_lower
+      assert_equal :DEBUG, debug_upper
+
+      cache = @aggregator.instance_variable_get(:@severity_constant_cache)
+      assert_equal 2, cache.select { |k, v| v == :DEBUG }.size
+    end
+
+    def test_format_log_level_constant_handles_custom_levels
+      custom = @aggregator.send(:format_log_level_constant, 'custom')
+      assert_equal :CUSTOM, custom
+
+      cache = @aggregator.instance_variable_get(:@severity_constant_cache)
+      assert cache.key?('custom')
+    end
+
     def test_record_json_sets_severity_when_given_level
       @aggregator.record_logstasher_event({'level' => :warn, 'message' => 'yikes!'})
       _, events = @aggregator.harvest!


### PR DESCRIPTION
Previously, the agent called `upcase.to_sym` at twice on every log recorded -- once on the configured log level and once on the severity of the log event. Now, these method calls are reduced through caching.

* Memoize the `configured_log_level_constant`
* Create a cache using a hash for severity constants seen by the agent in `format_log_level_constant`
