### PR TITLE
Send download link to RubyGems version page

### DIFF
--- a/.github/workflows/scripts/generate_release_notes.rb
+++ b/.github/workflows/scripts/generate_release_notes.rb
@@ -56,7 +56,7 @@ class GenerateReleaseNotes
       subject: Ruby agent
       releaseDate: '#{Date.today}'
       version: #{NewRelic::VERSION::STRING}
-      downloadLink: https://rubygems.org/downloads/newrelic_rpm-#{NewRelic::VERSION::STRING}.gem
+      downloadLink: https://rubygems.org/gems/newrelic_rpm/versions/#{NewRelic::VERSION::STRING}
       features: #{metadata[:features]}
       bugs: #{metadata[:bugs]}
       security: #{metadata[:security]}

--- a/test/new_relic/github/workflows/scripts/generate_release_notes_test.rb
+++ b/test/new_relic/github/workflows/scripts/generate_release_notes_test.rb
@@ -120,7 +120,7 @@ module NewRelic
       assert_includes content, 'subject: Ruby agent'
       assert_includes content, "releaseDate: '#{Date.today}'"
       assert_includes content, "version: #{NewRelic::VERSION::STRING}"
-      assert_includes content, "downloadLink: https://rubygems.org/downloads/newrelic_rpm-#{NewRelic::VERSION::STRING}.gem"
+      assert_includes content, "downloadLink: https://rubygems.org/gems/newrelic_rpm/versions/#{NewRelic::VERSION::STRING}"
       assert_includes content, 'features: ["Add support for new framework"]'
       assert_includes content, 'bugs: ["Fix memory leak in instrumentation"]'
       assert_includes content, 'security: ["Address potential XSS vulnerability"]'


### PR DESCRIPTION
We don't recommend people download the agent gem directly from the docs page. If people want to do this, they can click the download link on RubyGems. If they want other information about that version, the RubyGems version page has lots of helpful links.