### PR TITLE
Add config `active_record_use_table_name`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # New Relic Ruby Agent Release Notes
 
+## dev
+
+- **Feature: Add active_record_use_table_name configuration option**
+
+  A new configuration option, `active_record_use_table_name`, uses an Active Record model's table name instead of its class name when naming metrics, spans, and transaction trace segments. This can particularly be helpful to reduce cardinality in applications using single-table inheritance. The option defaults to `false` to preserve existing behavior. [PR#3540](https://github.com/newrelic/newrelic-ruby-agent/pull/3540)
+
 ## v10.4.0
 
 - **Feature: Add Rails.event instrumentation for structured logging**

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -324,7 +324,7 @@ module NewRelic
           :public => true,
           :type => Boolean,
           :allowed_from_server => false,
-          :description => 'If `true`, the agent will use the Active Record model\'s table name instead of the class name when naming Active Record metrics, spans, and transaction trace segments. This can reduce metric cardinality when multiple models share a database table. Defaults to `false`.'
+          :description => 'If `true`, the agent will use the Active Record model\'s table name instead of the class name when naming Active Record metrics, spans, and transaction trace segments. This can reduce cardinality when multiple models share a database table. Defaults to `false`.'
         },
         :'ai_monitoring.enabled' => {
           :default => false,

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -319,6 +319,13 @@ module NewRelic
             \t\t- a.third.event
           DESCRIPTION
         },
+        :active_record_metrics_use_table_name => {
+          :default => false,
+          :public => true,
+          :type => Boolean,
+          :allowed_from_server => false,
+          :description => 'If `true`, the agent will use the Active Record model\'s table name instead of the class name when naming Active Record metrics. This can reduce metric cardinality when multiple models share a database table. Defaults to `false`.'
+        },
         :'ai_monitoring.enabled' => {
           :default => false,
           :public => true,

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -319,12 +319,12 @@ module NewRelic
             \t\t- a.third.event
           DESCRIPTION
         },
-        :active_record_metrics_use_table_name => {
+        :active_record_use_table_name => {
           :default => false,
           :public => true,
           :type => Boolean,
           :allowed_from_server => false,
-          :description => 'If `true`, the agent will use the Active Record model\'s table name instead of the class name when naming Active Record metrics. This can reduce metric cardinality when multiple models share a database table. Defaults to `false`.'
+          :description => 'If `true`, the agent will use the Active Record model\'s table name instead of the class name when naming Active Record metrics, spans, and transaction trace segments. This can reduce metric cardinality when multiple models share a database table. Defaults to `false`.'
         },
         :'ai_monitoring.enabled' => {
           :default => false,

--- a/lib/new_relic/agent/instrumentation/active_record_helper.rb
+++ b/lib/new_relic/agent/instrumentation/active_record_helper.rb
@@ -20,7 +20,7 @@ module NewRelic
         def instrument_save_methods
           ::ActiveRecord::Base.class_eval do
             def newrelic_model_collection_name
-              NewRelic::Agent::Instrumentation::ActiveRecordHelper.use_table_name? ? self.class.table_name : self.class.name
+              ::NewRelic::Agent.config[:active_record_use_table_name] ? self.class.table_name : self.class.name
             end
             private(:newrelic_model_collection_name)
 
@@ -45,7 +45,7 @@ module NewRelic
         def instrument_relation_methods
           ::ActiveRecord::Relation.class_eval do
             def newrelic_relation_collection_name
-              NewRelic::Agent::Instrumentation::ActiveRecordHelper.use_table_name? ? self.klass.table_name : self.name
+              ::NewRelic::Agent.config[:active_record_use_table_name] ? self.klass.table_name : self.name
             end
             private(:newrelic_relation_collection_name)
 
@@ -108,12 +108,6 @@ module NewRelic
         TABLE_NAME_CACHE = {}
         @table_name_cache_lock = Mutex.new
 
-        def use_table_name?
-          return @use_table_name if defined?(@use_table_name)
-
-          @use_table_name = NewRelic::Agent.config[:active_record_use_table_name]
-        end
-
         # convert vendor (makara, etc.) wrapper names to their bare names
         # ex: postgresql_makara -> postgresql
         def bare_adapter_name(adapter_name)
@@ -144,7 +138,7 @@ module NewRelic
           return unless splits.length == 2
 
           model_name = splits.first
-          return model_name unless use_table_name?
+          return model_name unless NewRelic::Agent.config[:active_record_use_table_name]
 
           table_name_for(model_name) || model_name
         end

--- a/lib/new_relic/agent/instrumentation/active_record_helper.rb
+++ b/lib/new_relic/agent/instrumentation/active_record_helper.rb
@@ -19,10 +19,15 @@ module NewRelic
 
         def instrument_save_methods
           ::ActiveRecord::Base.class_eval do
+            def newrelic_collection_name
+              ::NewRelic::Agent.config[:active_record_metrics_use_table_name] ? self.class.table_name : self.class.name
+            end
+            private :newrelic_collection_name
+
             alias_method(:save_without_newrelic, :save)
 
             def save(*args, &blk)
-              ::NewRelic::Agent.with_database_metric_name(self.class.name, nil, ACTIVE_RECORD) do
+              ::NewRelic::Agent.with_database_metric_name(newrelic_collection_name, nil, ACTIVE_RECORD) do
                 save_without_newrelic(*args, &blk)
               end
             end
@@ -30,7 +35,7 @@ module NewRelic
             alias_method(:save_without_newrelic!, :save!)
 
             def save!(*args, &blk)
-              ::NewRelic::Agent.with_database_metric_name(self.class.name, nil, ACTIVE_RECORD) do
+              ::NewRelic::Agent.with_database_metric_name(newrelic_collection_name, nil, ACTIVE_RECORD) do
                 save_without_newrelic!(*args, &blk)
               end
             end
@@ -39,10 +44,15 @@ module NewRelic
 
         def instrument_relation_methods
           ::ActiveRecord::Relation.class_eval do
+            def newrelic_collection_name
+              ::NewRelic::Agent.config[:active_record_metrics_use_table_name] ? self.klass.table_name : self.name
+            end
+            private :newrelic_collection_name
+
             alias_method(:update_all_without_newrelic, :update_all)
 
             def update_all(*args, &blk)
-              ::NewRelic::Agent.with_database_metric_name(self.name, nil, ACTIVE_RECORD) do
+              ::NewRelic::Agent.with_database_metric_name(newrelic_collection_name, nil, ACTIVE_RECORD) do
                 update_all_without_newrelic(*args, &blk)
               end
             end
@@ -51,13 +61,13 @@ module NewRelic
 
             if NewRelic::Helper.version_satisfied?(RUBY_VERSION, '<', '2.7.0')
               def delete_all(*args, &blk)
-                ::NewRelic::Agent.with_database_metric_name(self.name, nil, ACTIVE_RECORD) do
+                ::NewRelic::Agent.with_database_metric_name(newrelic_collection_name, nil, ACTIVE_RECORD) do
                   delete_all_without_newrelic(*args, &blk)
                 end
               end
             else
               def delete_all(*args, **kwargs, &blk)
-                ::NewRelic::Agent.with_database_metric_name(self.name, nil, ACTIVE_RECORD) do
+                ::NewRelic::Agent.with_database_metric_name(newrelic_collection_name, nil, ACTIVE_RECORD) do
                   delete_all_without_newrelic(*args, **kwargs, &blk)
                 end
               end
@@ -66,7 +76,7 @@ module NewRelic
             alias_method(:destroy_all_without_newrelic, :destroy_all)
 
             def destroy_all(*args, &blk)
-              ::NewRelic::Agent.with_database_metric_name(self.name, nil, ACTIVE_RECORD) do
+              ::NewRelic::Agent.with_database_metric_name(newrelic_collection_name, nil, ACTIVE_RECORD) do
                 destroy_all_without_newrelic(*args, &blk)
               end
             end
@@ -74,7 +84,7 @@ module NewRelic
             alias_method(:calculate_without_newrelic, :calculate)
 
             def calculate(*args, &blk)
-              ::NewRelic::Agent.with_database_metric_name(self.name, nil, ACTIVE_RECORD) do
+              ::NewRelic::Agent.with_database_metric_name(newrelic_collection_name, nil, ACTIVE_RECORD) do
                 calculate_without_newrelic(*args, &blk)
               end
             end
@@ -83,7 +93,7 @@ module NewRelic
               alias_method(:pluck_without_newrelic, :pluck)
 
               def pluck(*args, &blk)
-                ::NewRelic::Agent.with_database_metric_name(self.name, nil, ACTIVE_RECORD) do
+                ::NewRelic::Agent.with_database_metric_name(newrelic_collection_name, nil, ACTIVE_RECORD) do
                   pluck_without_newrelic(*args, &blk)
                 end
               end
@@ -95,6 +105,8 @@ module NewRelic
         ACTIVE_RECORD = 'ActiveRecord'.freeze
         OTHER = 'other'.freeze
         MAKARA_SUFFIX = '_makara'.freeze
+        TABLE_NAME_CACHE = {}
+        TABLE_NAME_CACHE_LOCK = Mutex.new
 
         # convert vendor (makara, etc.) wrapper names to their bare names
         # ex: postgresql_makara -> postgresql
@@ -123,9 +135,31 @@ module NewRelic
         end
 
         def model_from_splits(splits)
-          if splits.length == 2
-            splits.first
+          return unless splits.length == 2
+
+          model_name = splits.first
+          return model_name unless NewRelic::Agent.config[:active_record_metrics_use_table_name]
+
+          table_name_for(model_name) || model_name
+        end
+
+        def table_name_for(model_name)
+          return TABLE_NAME_CACHE[model_name] if TABLE_NAME_CACHE.key?(model_name)
+
+          TABLE_NAME_CACHE_LOCK.synchronize do
+            TABLE_NAME_CACHE[model_name] = resolve_table_name(model_name) unless TABLE_NAME_CACHE.key?(model_name)
+            TABLE_NAME_CACHE[model_name]
           end
+        end
+
+        def resolve_table_name(model_name)
+          klass = Object.const_get(model_name)
+          return nil unless klass.is_a?(Class)
+
+          klass.table_name
+        rescue => e
+          NewRelic::Agent.logger.debug("Failed to get table name for model #{model_name}: #{e}")
+          nil
         end
 
         def operation_from_splits(splits, sql)

--- a/lib/new_relic/agent/instrumentation/active_record_helper.rb
+++ b/lib/new_relic/agent/instrumentation/active_record_helper.rb
@@ -20,7 +20,7 @@ module NewRelic
         def instrument_save_methods
           ::ActiveRecord::Base.class_eval do
             def newrelic_collection_name
-              ::NewRelic::Agent.config[:active_record_metrics_use_table_name] ? self.class.table_name : self.class.name
+              ::NewRelic::Agent.config[:active_record_use_table_name] ? self.class.table_name : self.class.name
             end
             private(:newrelic_collection_name)
 
@@ -45,7 +45,7 @@ module NewRelic
         def instrument_relation_methods
           ::ActiveRecord::Relation.class_eval do
             def newrelic_collection_name
-              ::NewRelic::Agent.config[:active_record_metrics_use_table_name] ? self.klass.table_name : self.name
+              ::NewRelic::Agent.config[:active_record_use_table_name] ? self.klass.table_name : self.name
             end
             private(:newrelic_collection_name)
 
@@ -138,7 +138,7 @@ module NewRelic
           return unless splits.length == 2
 
           model_name = splits.first
-          return model_name unless NewRelic::Agent.config[:active_record_metrics_use_table_name]
+          return model_name unless NewRelic::Agent.config[:active_record_use_table_name]
 
           table_name_for(model_name) || model_name
         end

--- a/lib/new_relic/agent/instrumentation/active_record_helper.rb
+++ b/lib/new_relic/agent/instrumentation/active_record_helper.rb
@@ -20,7 +20,7 @@ module NewRelic
         def instrument_save_methods
           ::ActiveRecord::Base.class_eval do
             def newrelic_model_collection_name
-              ::NewRelic::Agent.config[:active_record_use_table_name] ? self.class.table_name : self.class.name
+              NewRelic::Agent::Instrumentation::ActiveRecordHelper.use_table_name? ? self.class.table_name : self.class.name
             end
             private(:newrelic_model_collection_name)
 
@@ -45,7 +45,7 @@ module NewRelic
         def instrument_relation_methods
           ::ActiveRecord::Relation.class_eval do
             def newrelic_relation_collection_name
-              ::NewRelic::Agent.config[:active_record_use_table_name] ? self.klass.table_name : self.name
+              NewRelic::Agent::Instrumentation::ActiveRecordHelper.use_table_name? ? self.klass.table_name : self.name
             end
             private(:newrelic_relation_collection_name)
 
@@ -108,6 +108,12 @@ module NewRelic
         TABLE_NAME_CACHE = {}
         @table_name_cache_lock = Mutex.new
 
+        def use_table_name?
+          return @use_table_name if defined?(@use_table_name)
+
+          @use_table_name = NewRelic::Agent.config[:active_record_use_table_name]
+        end
+
         # convert vendor (makara, etc.) wrapper names to their bare names
         # ex: postgresql_makara -> postgresql
         def bare_adapter_name(adapter_name)
@@ -138,7 +144,7 @@ module NewRelic
           return unless splits.length == 2
 
           model_name = splits.first
-          return model_name unless NewRelic::Agent.config[:active_record_use_table_name]
+          return model_name unless use_table_name?
 
           table_name_for(model_name) || model_name
         end

--- a/lib/new_relic/agent/instrumentation/active_record_helper.rb
+++ b/lib/new_relic/agent/instrumentation/active_record_helper.rb
@@ -22,7 +22,7 @@ module NewRelic
             def newrelic_collection_name
               ::NewRelic::Agent.config[:active_record_metrics_use_table_name] ? self.class.table_name : self.class.name
             end
-            private :newrelic_collection_name
+            private(:newrelic_collection_name)
 
             alias_method(:save_without_newrelic, :save)
 
@@ -47,7 +47,7 @@ module NewRelic
             def newrelic_collection_name
               ::NewRelic::Agent.config[:active_record_metrics_use_table_name] ? self.klass.table_name : self.name
             end
-            private :newrelic_collection_name
+            private(:newrelic_collection_name)
 
             alias_method(:update_all_without_newrelic, :update_all)
 

--- a/lib/new_relic/agent/instrumentation/active_record_helper.rb
+++ b/lib/new_relic/agent/instrumentation/active_record_helper.rb
@@ -106,7 +106,7 @@ module NewRelic
         OTHER = 'other'.freeze
         MAKARA_SUFFIX = '_makara'.freeze
         TABLE_NAME_CACHE = {}
-        TABLE_NAME_CACHE_LOCK = Mutex.new
+        @table_name_cache_lock = Mutex.new
 
         # convert vendor (makara, etc.) wrapper names to their bare names
         # ex: postgresql_makara -> postgresql
@@ -146,7 +146,7 @@ module NewRelic
         def table_name_for(model_name)
           return TABLE_NAME_CACHE[model_name] if TABLE_NAME_CACHE.key?(model_name)
 
-          TABLE_NAME_CACHE_LOCK.synchronize do
+          @table_name_cache_lock.synchronize do
             TABLE_NAME_CACHE[model_name] = resolve_table_name(model_name) unless TABLE_NAME_CACHE.key?(model_name)
             TABLE_NAME_CACHE[model_name]
           end

--- a/lib/new_relic/agent/instrumentation/active_record_helper.rb
+++ b/lib/new_relic/agent/instrumentation/active_record_helper.rb
@@ -19,15 +19,15 @@ module NewRelic
 
         def instrument_save_methods
           ::ActiveRecord::Base.class_eval do
-            def newrelic_collection_name
+            def newrelic_model_collection_name
               ::NewRelic::Agent.config[:active_record_use_table_name] ? self.class.table_name : self.class.name
             end
-            private(:newrelic_collection_name)
+            private(:newrelic_model_collection_name)
 
             alias_method(:save_without_newrelic, :save)
 
             def save(*args, &blk)
-              ::NewRelic::Agent.with_database_metric_name(newrelic_collection_name, nil, ACTIVE_RECORD) do
+              ::NewRelic::Agent.with_database_metric_name(newrelic_model_collection_name, nil, ACTIVE_RECORD) do
                 save_without_newrelic(*args, &blk)
               end
             end
@@ -35,7 +35,7 @@ module NewRelic
             alias_method(:save_without_newrelic!, :save!)
 
             def save!(*args, &blk)
-              ::NewRelic::Agent.with_database_metric_name(newrelic_collection_name, nil, ACTIVE_RECORD) do
+              ::NewRelic::Agent.with_database_metric_name(newrelic_model_collection_name, nil, ACTIVE_RECORD) do
                 save_without_newrelic!(*args, &blk)
               end
             end
@@ -44,15 +44,15 @@ module NewRelic
 
         def instrument_relation_methods
           ::ActiveRecord::Relation.class_eval do
-            def newrelic_collection_name
+            def newrelic_relation_collection_name
               ::NewRelic::Agent.config[:active_record_use_table_name] ? self.klass.table_name : self.name
             end
-            private(:newrelic_collection_name)
+            private(:newrelic_relation_collection_name)
 
             alias_method(:update_all_without_newrelic, :update_all)
 
             def update_all(*args, &blk)
-              ::NewRelic::Agent.with_database_metric_name(newrelic_collection_name, nil, ACTIVE_RECORD) do
+              ::NewRelic::Agent.with_database_metric_name(newrelic_relation_collection_name, nil, ACTIVE_RECORD) do
                 update_all_without_newrelic(*args, &blk)
               end
             end
@@ -61,13 +61,13 @@ module NewRelic
 
             if NewRelic::Helper.version_satisfied?(RUBY_VERSION, '<', '2.7.0')
               def delete_all(*args, &blk)
-                ::NewRelic::Agent.with_database_metric_name(newrelic_collection_name, nil, ACTIVE_RECORD) do
+                ::NewRelic::Agent.with_database_metric_name(newrelic_relation_collection_name, nil, ACTIVE_RECORD) do
                   delete_all_without_newrelic(*args, &blk)
                 end
               end
             else
               def delete_all(*args, **kwargs, &blk)
-                ::NewRelic::Agent.with_database_metric_name(newrelic_collection_name, nil, ACTIVE_RECORD) do
+                ::NewRelic::Agent.with_database_metric_name(newrelic_relation_collection_name, nil, ACTIVE_RECORD) do
                   delete_all_without_newrelic(*args, **kwargs, &blk)
                 end
               end
@@ -76,7 +76,7 @@ module NewRelic
             alias_method(:destroy_all_without_newrelic, :destroy_all)
 
             def destroy_all(*args, &blk)
-              ::NewRelic::Agent.with_database_metric_name(newrelic_collection_name, nil, ACTIVE_RECORD) do
+              ::NewRelic::Agent.with_database_metric_name(newrelic_relation_collection_name, nil, ACTIVE_RECORD) do
                 destroy_all_without_newrelic(*args, &blk)
               end
             end
@@ -84,7 +84,7 @@ module NewRelic
             alias_method(:calculate_without_newrelic, :calculate)
 
             def calculate(*args, &blk)
-              ::NewRelic::Agent.with_database_metric_name(newrelic_collection_name, nil, ACTIVE_RECORD) do
+              ::NewRelic::Agent.with_database_metric_name(newrelic_relation_collection_name, nil, ACTIVE_RECORD) do
                 calculate_without_newrelic(*args, &blk)
               end
             end
@@ -93,7 +93,7 @@ module NewRelic
               alias_method(:pluck_without_newrelic, :pluck)
 
               def pluck(*args, &blk)
-                ::NewRelic::Agent.with_database_metric_name(newrelic_collection_name, nil, ACTIVE_RECORD) do
+                ::NewRelic::Agent.with_database_metric_name(newrelic_relation_collection_name, nil, ACTIVE_RECORD) do
                   pluck_without_newrelic(*args, &blk)
                 end
               end

--- a/lib/new_relic/agent/instrumentation/active_record_prepend.rb
+++ b/lib/new_relic/agent/instrumentation/active_record_prepend.rb
@@ -42,7 +42,7 @@ module NewRelic
           private
 
           def newrelic_collection_name
-            ::NewRelic::Agent.config[:active_record_metrics_use_table_name] ? self.class.table_name : self.class.name
+            ::NewRelic::Agent.config[:active_record_use_table_name] ? self.class.table_name : self.class.name
           end
         end
 
@@ -69,7 +69,7 @@ module NewRelic
           private
 
           def newrelic_collection_name
-            ::NewRelic::Agent.config[:active_record_metrics_use_table_name] ? self.class.table_name : self.class.name
+            ::NewRelic::Agent.config[:active_record_use_table_name] ? self.class.table_name : self.class.name
           end
         end
 
@@ -107,7 +107,7 @@ module NewRelic
           private
 
           def newrelic_collection_name
-            ::NewRelic::Agent.config[:active_record_metrics_use_table_name] ? self.klass.table_name : self.name
+            ::NewRelic::Agent.config[:active_record_use_table_name] ? self.klass.table_name : self.name
           end
         end
       end

--- a/lib/new_relic/agent/instrumentation/active_record_prepend.rb
+++ b/lib/new_relic/agent/instrumentation/active_record_prepend.rb
@@ -3,6 +3,7 @@
 # frozen_string_literal: true
 
 require 'new_relic/agent/prepend_supportability'
+require 'new_relic/agent/instrumentation/active_record_helper'
 
 module NewRelic
   module Agent
@@ -42,7 +43,7 @@ module NewRelic
           private
 
           def newrelic_model_collection_name
-            ::NewRelic::Agent.config[:active_record_use_table_name] ? self.class.table_name : self.class.name
+            NewRelic::Agent::Instrumentation::ActiveRecordHelper.use_table_name? ? self.class.table_name : self.class.name
           end
         end
 
@@ -69,7 +70,7 @@ module NewRelic
           private
 
           def newrelic_model_collection_name
-            ::NewRelic::Agent.config[:active_record_use_table_name] ? self.class.table_name : self.class.name
+            NewRelic::Agent::Instrumentation::ActiveRecordHelper.use_table_name? ? self.class.table_name : self.class.name
           end
         end
 
@@ -107,7 +108,7 @@ module NewRelic
           private
 
           def newrelic_relation_collection_name
-            ::NewRelic::Agent.config[:active_record_use_table_name] ? self.klass.table_name : self.name
+            NewRelic::Agent::Instrumentation::ActiveRecordHelper.use_table_name? ? self.klass.table_name : self.name
           end
         end
       end

--- a/lib/new_relic/agent/instrumentation/active_record_prepend.rb
+++ b/lib/new_relic/agent/instrumentation/active_record_prepend.rb
@@ -13,26 +13,26 @@ module NewRelic
         module BaseExtensions
           if NewRelic::Helper.version_satisfied?(RUBY_VERSION, '<', '2.7.0')
             def save(*args, &blk)
-              ::NewRelic::Agent.with_database_metric_name(newrelic_collection_name, nil, ACTIVE_RECORD) do
+              ::NewRelic::Agent.with_database_metric_name(newrelic_model_collection_name, nil, ACTIVE_RECORD) do
                 super
               end
             end
 
             def save!(*args, &blk)
-              ::NewRelic::Agent.with_database_metric_name(newrelic_collection_name, nil, ACTIVE_RECORD) do
+              ::NewRelic::Agent.with_database_metric_name(newrelic_model_collection_name, nil, ACTIVE_RECORD) do
                 super
               end
             end
 
           else
             def save(*args, **kwargs, &blk)
-              ::NewRelic::Agent.with_database_metric_name(newrelic_collection_name, nil, ACTIVE_RECORD) do
+              ::NewRelic::Agent.with_database_metric_name(newrelic_model_collection_name, nil, ACTIVE_RECORD) do
                 super
               end
             end
 
             def save!(*args, **kwargs, &blk)
-              ::NewRelic::Agent.with_database_metric_name(newrelic_collection_name, nil, ACTIVE_RECORD) do
+              ::NewRelic::Agent.with_database_metric_name(newrelic_model_collection_name, nil, ACTIVE_RECORD) do
                 super
               end
             end
@@ -41,7 +41,7 @@ module NewRelic
 
           private
 
-          def newrelic_collection_name
+          def newrelic_model_collection_name
             ::NewRelic::Agent.config[:active_record_use_table_name] ? self.class.table_name : self.class.name
           end
         end
@@ -54,13 +54,13 @@ module NewRelic
           #
           if NewRelic::Helper.version_satisfied?(RUBY_VERSION, '<', '2.7.0')
             def touch(*args, **kwargs, &blk)
-              ::NewRelic::Agent.with_database_metric_name(newrelic_collection_name, nil, ACTIVE_RECORD) do
+              ::NewRelic::Agent.with_database_metric_name(newrelic_model_collection_name, nil, ACTIVE_RECORD) do
                 super
               end
             end
           else
             def touch(*args, **kwargs, &blk)
-              ::NewRelic::Agent.with_database_metric_name(newrelic_collection_name, nil, ACTIVE_RECORD) do
+              ::NewRelic::Agent.with_database_metric_name(newrelic_model_collection_name, nil, ACTIVE_RECORD) do
                 super
               end
             end
@@ -68,45 +68,45 @@ module NewRelic
 
           private
 
-          def newrelic_collection_name
+          def newrelic_model_collection_name
             ::NewRelic::Agent.config[:active_record_use_table_name] ? self.class.table_name : self.class.name
           end
         end
 
         module RelationExtensions
           def update_all(*args, &blk)
-            ::NewRelic::Agent.with_database_metric_name(newrelic_collection_name, nil, ACTIVE_RECORD) do
+            ::NewRelic::Agent.with_database_metric_name(newrelic_relation_collection_name, nil, ACTIVE_RECORD) do
               super
             end
           end
 
           def delete_all(*args, &blk)
-            ::NewRelic::Agent.with_database_metric_name(newrelic_collection_name, nil, ACTIVE_RECORD) do
+            ::NewRelic::Agent.with_database_metric_name(newrelic_relation_collection_name, nil, ACTIVE_RECORD) do
               super
             end
           end
 
           def destroy_all(*args, &blk)
-            ::NewRelic::Agent.with_database_metric_name(newrelic_collection_name, nil, ACTIVE_RECORD) do
+            ::NewRelic::Agent.with_database_metric_name(newrelic_relation_collection_name, nil, ACTIVE_RECORD) do
               super
             end
           end
 
           def calculate(*args, &blk)
-            ::NewRelic::Agent.with_database_metric_name(newrelic_collection_name, nil, ACTIVE_RECORD) do
+            ::NewRelic::Agent.with_database_metric_name(newrelic_relation_collection_name, nil, ACTIVE_RECORD) do
               super
             end
           end
 
           def pluck(*args, &blk)
-            ::NewRelic::Agent.with_database_metric_name(newrelic_collection_name, nil, ACTIVE_RECORD) do
+            ::NewRelic::Agent.with_database_metric_name(newrelic_relation_collection_name, nil, ACTIVE_RECORD) do
               super
             end
           end
 
           private
 
-          def newrelic_collection_name
+          def newrelic_relation_collection_name
             ::NewRelic::Agent.config[:active_record_use_table_name] ? self.klass.table_name : self.name
           end
         end

--- a/lib/new_relic/agent/instrumentation/active_record_prepend.rb
+++ b/lib/new_relic/agent/instrumentation/active_record_prepend.rb
@@ -13,30 +13,36 @@ module NewRelic
         module BaseExtensions
           if NewRelic::Helper.version_satisfied?(RUBY_VERSION, '<', '2.7.0')
             def save(*args, &blk)
-              ::NewRelic::Agent.with_database_metric_name(self.class.name, nil, ACTIVE_RECORD) do
+              ::NewRelic::Agent.with_database_metric_name(newrelic_collection_name, nil, ACTIVE_RECORD) do
                 super
               end
             end
 
             def save!(*args, &blk)
-              ::NewRelic::Agent.with_database_metric_name(self.class.name, nil, ACTIVE_RECORD) do
+              ::NewRelic::Agent.with_database_metric_name(newrelic_collection_name, nil, ACTIVE_RECORD) do
                 super
               end
             end
 
           else
             def save(*args, **kwargs, &blk)
-              ::NewRelic::Agent.with_database_metric_name(self.class.name, nil, ACTIVE_RECORD) do
+              ::NewRelic::Agent.with_database_metric_name(newrelic_collection_name, nil, ACTIVE_RECORD) do
                 super
               end
             end
 
             def save!(*args, **kwargs, &blk)
-              ::NewRelic::Agent.with_database_metric_name(self.class.name, nil, ACTIVE_RECORD) do
+              ::NewRelic::Agent.with_database_metric_name(newrelic_collection_name, nil, ACTIVE_RECORD) do
                 super
               end
             end
 
+          end
+
+          private
+
+          def newrelic_collection_name
+            ::NewRelic::Agent.config[:active_record_metrics_use_table_name] ? self.class.table_name : self.class.name
           end
         end
 
@@ -48,48 +54,60 @@ module NewRelic
           #
           if NewRelic::Helper.version_satisfied?(RUBY_VERSION, '<', '2.7.0')
             def touch(*args, **kwargs, &blk)
-              ::NewRelic::Agent.with_database_metric_name(self.class.name, nil, ACTIVE_RECORD) do
+              ::NewRelic::Agent.with_database_metric_name(newrelic_collection_name, nil, ACTIVE_RECORD) do
                 super
               end
             end
           else
             def touch(*args, **kwargs, &blk)
-              ::NewRelic::Agent.with_database_metric_name(self.class.name, nil, ACTIVE_RECORD) do
+              ::NewRelic::Agent.with_database_metric_name(newrelic_collection_name, nil, ACTIVE_RECORD) do
                 super
               end
             end
+          end
+
+          private
+
+          def newrelic_collection_name
+            ::NewRelic::Agent.config[:active_record_metrics_use_table_name] ? self.class.table_name : self.class.name
           end
         end
 
         module RelationExtensions
           def update_all(*args, &blk)
-            ::NewRelic::Agent.with_database_metric_name(self.name, nil, ACTIVE_RECORD) do
+            ::NewRelic::Agent.with_database_metric_name(newrelic_collection_name, nil, ACTIVE_RECORD) do
               super
             end
           end
 
           def delete_all(*args, &blk)
-            ::NewRelic::Agent.with_database_metric_name(self.name, nil, ACTIVE_RECORD) do
+            ::NewRelic::Agent.with_database_metric_name(newrelic_collection_name, nil, ACTIVE_RECORD) do
               super
             end
           end
 
           def destroy_all(*args, &blk)
-            ::NewRelic::Agent.with_database_metric_name(self.name, nil, ACTIVE_RECORD) do
+            ::NewRelic::Agent.with_database_metric_name(newrelic_collection_name, nil, ACTIVE_RECORD) do
               super
             end
           end
 
           def calculate(*args, &blk)
-            ::NewRelic::Agent.with_database_metric_name(self.name, nil, ACTIVE_RECORD) do
+            ::NewRelic::Agent.with_database_metric_name(newrelic_collection_name, nil, ACTIVE_RECORD) do
               super
             end
           end
 
           def pluck(*args, &blk)
-            ::NewRelic::Agent.with_database_metric_name(self.name, nil, ACTIVE_RECORD) do
+            ::NewRelic::Agent.with_database_metric_name(newrelic_collection_name, nil, ACTIVE_RECORD) do
               super
             end
+          end
+
+          private
+
+          def newrelic_collection_name
+            ::NewRelic::Agent.config[:active_record_metrics_use_table_name] ? self.klass.table_name : self.name
           end
         end
       end

--- a/lib/new_relic/agent/instrumentation/active_record_prepend.rb
+++ b/lib/new_relic/agent/instrumentation/active_record_prepend.rb
@@ -3,7 +3,6 @@
 # frozen_string_literal: true
 
 require 'new_relic/agent/prepend_supportability'
-require 'new_relic/agent/instrumentation/active_record_helper'
 
 module NewRelic
   module Agent
@@ -43,7 +42,7 @@ module NewRelic
           private
 
           def newrelic_model_collection_name
-            NewRelic::Agent::Instrumentation::ActiveRecordHelper.use_table_name? ? self.class.table_name : self.class.name
+            ::NewRelic::Agent.config[:active_record_use_table_name] ? self.class.table_name : self.class.name
           end
         end
 
@@ -70,7 +69,7 @@ module NewRelic
           private
 
           def newrelic_model_collection_name
-            NewRelic::Agent::Instrumentation::ActiveRecordHelper.use_table_name? ? self.class.table_name : self.class.name
+            ::NewRelic::Agent.config[:active_record_use_table_name] ? self.class.table_name : self.class.name
           end
         end
 
@@ -108,7 +107,7 @@ module NewRelic
           private
 
           def newrelic_relation_collection_name
-            NewRelic::Agent::Instrumentation::ActiveRecordHelper.use_table_name? ? self.klass.table_name : self.name
+            ::NewRelic::Agent.config[:active_record_use_table_name] ? self.klass.table_name : self.name
           end
         end
       end

--- a/test/multiverse/suites/active_record/active_record_test.rb
+++ b/test/multiverse/suites/active_record/active_record_test.rb
@@ -505,6 +505,47 @@ class ActiveRecordInstrumentationTest < Minitest::Test
     )
   end
 
+  def test_active_record_metrics_use_table_name_save_uses_table_name
+    with_config(active_record_metrics_use_table_name: true) do
+      in_web_transaction do
+        Animals::Dog.create!(name: 'Oliver')
+      end
+    end
+
+    assert_activerecord_metrics('animals', 'create')
+  end
+
+  def test_active_record_metrics_use_table_name_find_uses_table_name
+    with_config(active_record_metrics_use_table_name: true) do
+      in_web_transaction do
+        Animals::Dog.first
+      end
+    end
+
+    assert_activerecord_metrics('animals', 'find')
+  end
+
+  def test_active_record_metrics_use_table_name_update_uses_table_name
+    with_config(active_record_metrics_use_table_name: true) do
+      in_web_transaction do
+        Animals::Dog.update_all(name: 'Sammie')
+      end
+    end
+
+    assert_activerecord_metrics('animals', 'update')
+  end
+
+  def test_active_record_metrics_use_table_name_replaces_class_name
+    with_config(active_record_metrics_use_table_name: true) do
+      in_web_transaction do
+        Animals::Dog.first
+      end
+    end
+
+    assert_metrics_recorded(["Datastore/statement/#{current_product}/animals/find"])
+    assert_metrics_not_recorded(["Datastore/statement/#{current_product}/Animals::Dog/find"])
+  end
+
   ## helpers
 
   private

--- a/test/multiverse/suites/active_record/active_record_test.rb
+++ b/test/multiverse/suites/active_record/active_record_test.rb
@@ -505,14 +505,36 @@ class ActiveRecordInstrumentationTest < Minitest::Test
     )
   end
 
-  def test_active_record_use_table_name_save_uses_table_name
+  def test_active_record_use_table_name_calculate
     with_config(active_record_use_table_name: true) do
       in_web_transaction do
-        Animals::Dog.create!(name: 'Oliver')
+        Animals::Dog.count
       end
     end
 
-    assert_activerecord_metrics('animals', 'create')
+    assert_activerecord_metrics('animals', 'select')
+  end
+
+  def test_active_record_use_table_name_delete_all
+    with_config(active_record_use_table_name: true) do
+      in_web_transaction do
+        Animals::Dog.create!(name: 'Fido')
+        Animals::Dog.delete_all
+      end
+    end
+
+    assert_activerecord_metrics('animals', 'delete')
+  end
+
+  def test_active_record_use_table_name_destroy_all
+    with_config(active_record_use_table_name: true) do
+      in_web_transaction do
+        Animals::Dog.create!(name: 'Dolce')
+        Animals::Dog.destroy_all
+      end
+    end
+
+    assert_activerecord_metrics('animals', 'delete')
   end
 
   def test_active_record_use_table_name_find_uses_table_name
@@ -525,7 +547,51 @@ class ActiveRecordInstrumentationTest < Minitest::Test
     assert_activerecord_metrics('animals', 'find')
   end
 
-  def test_active_record_use_table_name_update_uses_table_name
+  def test_active_record_use_table_name_pluck
+    with_config(active_record_use_table_name: true) do
+      in_web_transaction do
+        Animals::Dog.pluck(:name)
+      end
+    end
+
+    assert_activerecord_metrics('animals', 'select')
+  end
+
+  def test_active_record_use_table_name_save
+    with_config(active_record_use_table_name: true) do
+      in_web_transaction do
+        dog = Animals::Dog.create!(name: 'Oliver')
+        dog.name = 'Sammie'
+        dog.save
+      end
+    end
+
+    assert_activerecord_metrics('animals', 'update')
+  end
+
+  # create! calls save!
+  def test_active_record_use_table_name_save_bang
+    with_config(active_record_use_table_name: true) do
+      in_web_transaction do
+        Animals::Dog.create!(name: 'Sam')
+      end
+    end
+
+    assert_activerecord_metrics('animals', 'create')
+  end
+
+  def test_active_record_use_table_name_touch
+    with_config(active_record_use_table_name: true) do
+      in_web_transaction do
+        dog = Animals::Dog.create!(name: 'Oliver')
+        dog.touch
+      end
+    end
+
+    assert_activerecord_metrics('animals', 'update')
+  end
+
+  def test_active_record_use_table_name_update_all
     with_config(active_record_use_table_name: true) do
       in_web_transaction do
         Animals::Dog.update_all(name: 'Sammie')

--- a/test/multiverse/suites/active_record/active_record_test.rb
+++ b/test/multiverse/suites/active_record/active_record_test.rb
@@ -554,10 +554,10 @@ class ActiveRecordInstrumentationTest < Minitest::Test
       end
     end
 
-    spans = harvest_span_events!
-    datastore_span = spans[1].find { |s| s[0]['name']&.include?('Datastore') }
+    expected = "Datastore/statement/#{current_product}/animals/find"
+    span_names = harvest_span_events![1].map { |s| s[0]['name'] }
 
-    assert_equal "Datastore/statement/#{current_product}/animals/find", datastore_span[0]['name']
+    assert_includes span_names, expected
   end
 
   def test_active_record_use_table_name_updates_transaction_trace_segment_name

--- a/test/multiverse/suites/active_record/active_record_test.rb
+++ b/test/multiverse/suites/active_record/active_record_test.rb
@@ -505,8 +505,8 @@ class ActiveRecordInstrumentationTest < Minitest::Test
     )
   end
 
-  def test_active_record_metrics_use_table_name_save_uses_table_name
-    with_config(active_record_metrics_use_table_name: true) do
+  def test_active_record_use_table_name_save_uses_table_name
+    with_config(active_record_use_table_name: true) do
       in_web_transaction do
         Animals::Dog.create!(name: 'Oliver')
       end
@@ -515,8 +515,8 @@ class ActiveRecordInstrumentationTest < Minitest::Test
     assert_activerecord_metrics('animals', 'create')
   end
 
-  def test_active_record_metrics_use_table_name_find_uses_table_name
-    with_config(active_record_metrics_use_table_name: true) do
+  def test_active_record_use_table_name_find_uses_table_name
+    with_config(active_record_use_table_name: true) do
       in_web_transaction do
         Animals::Dog.first
       end
@@ -525,8 +525,8 @@ class ActiveRecordInstrumentationTest < Minitest::Test
     assert_activerecord_metrics('animals', 'find')
   end
 
-  def test_active_record_metrics_use_table_name_update_uses_table_name
-    with_config(active_record_metrics_use_table_name: true) do
+  def test_active_record_use_table_name_update_uses_table_name
+    with_config(active_record_use_table_name: true) do
       in_web_transaction do
         Animals::Dog.update_all(name: 'Sammie')
       end
@@ -535,8 +535,8 @@ class ActiveRecordInstrumentationTest < Minitest::Test
     assert_activerecord_metrics('animals', 'update')
   end
 
-  def test_active_record_metrics_use_table_name_replaces_class_name
-    with_config(active_record_metrics_use_table_name: true) do
+  def test_active_record_use_table_name_replaces_class_name
+    with_config(active_record_use_table_name: true) do
       in_web_transaction do
         Animals::Dog.first
       end
@@ -544,6 +544,33 @@ class ActiveRecordInstrumentationTest < Minitest::Test
 
     assert_metrics_recorded(["Datastore/statement/#{current_product}/animals/find"])
     assert_metrics_not_recorded(["Datastore/statement/#{current_product}/Animals::Dog/find"])
+  end
+
+  def test_active_record_use_table_name_updates_span_name
+    with_config(active_record_use_table_name: true) do
+      in_web_transaction do |txn|
+        txn.stubs(:sampled?).returns(true)
+        Animals::Dog.first
+      end
+    end
+
+    spans = harvest_span_events!
+    datastore_span = spans[1].find { |s| s[0]['name']&.include?('Datastore') }
+
+    assert_equal "Datastore/statement/#{current_product}/animals/find", datastore_span[0]['name']
+  end
+
+  def test_active_record_use_table_name_updates_transaction_trace_segment_name
+    with_config(active_record_use_table_name: true) do
+      in_web_transaction do
+        Animals::Dog.first
+      end
+    end
+
+    metric = "Datastore/statement/#{current_product}/animals/find"
+    node = find_node_with_name(last_transaction_trace, metric)
+
+    assert_equal metric, node.metric_name
   end
 
   ## helpers

--- a/test/multiverse/suites/active_record/active_record_test.rb
+++ b/test/multiverse/suites/active_record/active_record_test.rb
@@ -14,6 +14,12 @@ class ActiveRecordInstrumentationTest < Minitest::Test
     NewRelic::Agent.drop_buffered_data
   end
 
+  def after_teardown
+    super
+    helper = NewRelic::Agent::Instrumentation::ActiveRecordHelper
+    helper.remove_instance_variable(:@use_table_name) if helper.instance_variable_defined?(:@use_table_name)
+  end
+
   def test_metrics_for_calculation_methods
     in_web_transaction do
       Order.count

--- a/test/multiverse/suites/active_record/active_record_test.rb
+++ b/test/multiverse/suites/active_record/active_record_test.rb
@@ -14,12 +14,6 @@ class ActiveRecordInstrumentationTest < Minitest::Test
     NewRelic::Agent.drop_buffered_data
   end
 
-  def after_teardown
-    super
-    helper = NewRelic::Agent::Instrumentation::ActiveRecordHelper
-    helper.remove_instance_variable(:@use_table_name) if helper.instance_variable_defined?(:@use_table_name)
-  end
-
   def test_metrics_for_calculation_methods
     in_web_transaction do
       Order.count

--- a/test/multiverse/suites/active_record/app/models/models.rb
+++ b/test/multiverse/suites/active_record/app/models/models.rb
@@ -32,3 +32,10 @@ end
 class Shipment < ActiveRecord::Base
   has_and_belongs_to_many :orders, :join_table => 'order_shipments'
 end
+
+class Animal < ActiveRecord::Base
+end
+
+module Animals
+  class Dog < Animal; end
+end

--- a/test/multiverse/suites/active_record/before_suite.rb
+++ b/test/multiverse/suites/active_record/before_suite.rb
@@ -35,5 +35,6 @@ class Minitest::Test
     Alias.delete_all
     Order.delete_all
     Shipment.delete_all
+    Animal.delete_all
   end
 end

--- a/test/multiverse/suites/active_record/db/migrate/20260420000000_create_animals.rb
+++ b/test/multiverse/suites/active_record/db/migrate/20260420000000_create_animals.rb
@@ -1,0 +1,18 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+require_relative '../../../../../../test/new_relic/multiverse_helpers'
+
+class CreateAnimals < current_active_record_migration_version
+  def self.up
+    create_table(:animals) do |t|
+      t.string(:type)
+      t.string(:name)
+    end
+  end
+
+  def self.down
+    drop_table(:animals)
+  end
+end

--- a/test/multiverse/suites/active_record/db/migrate/20260420000000_create_animals.rb
+++ b/test/multiverse/suites/active_record/db/migrate/20260420000000_create_animals.rb
@@ -9,6 +9,7 @@ class CreateAnimals < current_active_record_migration_version
     create_table(:animals) do |t|
       t.string(:type)
       t.string(:name)
+      t.timestamps
     end
   end
 

--- a/test/multiverse/suites/active_record_pg/active_record_test.rb
+++ b/test/multiverse/suites/active_record_pg/active_record_test.rb
@@ -634,7 +634,7 @@ class ActiveRecordInstrumentationTest < Minitest::Test
   def test_active_record_metrics_use_table_name_save_uses_table_name
     with_config(active_record_metrics_use_table_name: true) do
       in_web_transaction do
-        Dog.create!(name: 'Oliver')
+        Animals::Dog.create!(name: 'Oliver')
       end
     end
 
@@ -644,7 +644,7 @@ class ActiveRecordInstrumentationTest < Minitest::Test
   def test_active_record_metrics_use_table_name_find_uses_table_name
     with_config(active_record_metrics_use_table_name: true) do
       in_web_transaction do
-        Dog.first
+        Animals::Dog.first
       end
     end
 
@@ -654,11 +654,22 @@ class ActiveRecordInstrumentationTest < Minitest::Test
   def test_active_record_metrics_use_table_name_update_uses_table_name
     with_config(active_record_metrics_use_table_name: true) do
       in_web_transaction do
-        Dog.update_all(name: 'Sammie')
+        Animals::Dog.update_all(name: 'Sammie')
       end
     end
 
     assert_activerecord_metrics('animals', 'update')
+  end
+
+  def test_active_record_metrics_use_table_name_replaces_class_name
+    with_config(active_record_metrics_use_table_name: true) do
+      in_web_transaction do
+        Animals::Dog.first
+      end
+    end
+
+    assert_metrics_recorded(["Datastore/statement/#{current_product}/animals/find"])
+    assert_metrics_not_recorded(["Datastore/statement/#{current_product}/Animals::Dog/find"])
   end
 
   ## helpers

--- a/test/multiverse/suites/active_record_pg/active_record_test.rb
+++ b/test/multiverse/suites/active_record_pg/active_record_test.rb
@@ -680,10 +680,10 @@ class ActiveRecordInstrumentationTest < Minitest::Test
       end
     end
 
-    spans = harvest_span_events!
-    datastore_span = spans[1].find { |s| s[0]['name']&.include?('Datastore') }
+    expected = "Datastore/statement/#{current_product}/animals/find"
+    span_names = harvest_span_events![1].map { |s| s[0]['name'] }
 
-    assert_equal "Datastore/statement/#{current_product}/animals/find", datastore_span[0]['name']
+    assert_includes span_names, expected
   end
 
   def test_active_record_use_table_name_updates_transaction_trace_segment_name

--- a/test/multiverse/suites/active_record_pg/active_record_test.rb
+++ b/test/multiverse/suites/active_record_pg/active_record_test.rb
@@ -631,14 +631,44 @@ class ActiveRecordInstrumentationTest < Minitest::Test
     })
   end
 
-  def test_active_record_use_table_name_save_uses_table_name
+  def test_active_record_use_table_name_calculate
     with_config(active_record_use_table_name: true) do
       in_web_transaction do
-        Animals::Dog.create!(name: 'Oliver')
+        Animals::Dog.count
       end
     end
 
-    assert_activerecord_metrics('animals', 'create')
+    if active_record_version_at_least?(7)
+      assert_activerecord_metrics('animals', 'find')
+    else
+      assert_activerecord_metrics('animals', 'select')
+    end
+  end
+
+  def test_active_record_use_table_name_delete_all
+    with_config(active_record_use_table_name: true) do
+      in_web_transaction do
+        Animals::Dog.create!(name: 'Fido')
+        Animals::Dog.delete_all
+      end
+    end
+
+    assert_activerecord_metrics('animals', 'delete')
+  end
+
+  def test_active_record_use_table_name_destroy_all
+    with_config(active_record_use_table_name: true) do
+      in_web_transaction do
+        Animals::Dog.create!(name: 'Dolce')
+        Animals::Dog.destroy_all
+      end
+    end
+
+    if active_record_version_at_least?(7)
+      assert_activerecord_metrics('animals', 'destroy')
+    else
+      assert_activerecord_metrics('animals', 'delete')
+    end
   end
 
   def test_active_record_use_table_name_find_uses_table_name
@@ -651,7 +681,55 @@ class ActiveRecordInstrumentationTest < Minitest::Test
     assert_activerecord_metrics('animals', 'find')
   end
 
-  def test_active_record_use_table_name_update_uses_table_name
+  def test_active_record_use_table_name_pluck
+    with_config(active_record_use_table_name: true) do
+      in_web_transaction do
+        Animals::Dog.pluck(:name)
+      end
+    end
+
+    if active_record_version_at_least?(7)
+      assert_activerecord_metrics('animals', 'pluck')
+    else
+      assert_activerecord_metrics('animals', 'select')
+    end
+  end
+
+  def test_active_record_use_table_name_save
+    with_config(active_record_use_table_name: true) do
+      in_web_transaction do
+        dog = Animals::Dog.create!(name: 'Oliver')
+        dog.name = 'Sammie'
+        dog.save
+      end
+    end
+
+    assert_activerecord_metrics('animals', 'update')
+  end
+
+  # create! calls save!
+  def test_active_record_use_table_name_save_bang
+    with_config(active_record_use_table_name: true) do
+      in_web_transaction do
+        Animals::Dog.create!(name: 'Sam')
+      end
+    end
+
+    assert_activerecord_metrics('animals', 'create')
+  end
+
+  def test_active_record_use_table_name_touch
+    with_config(active_record_use_table_name: true) do
+      in_web_transaction do
+        dog = Animals::Dog.create!(name: 'Oliver')
+        dog.touch
+      end
+    end
+
+    assert_activerecord_metrics('animals', 'update')
+  end
+
+  def test_active_record_use_table_name_update_all
     with_config(active_record_use_table_name: true) do
       in_web_transaction do
         Animals::Dog.update_all(name: 'Sammie')

--- a/test/multiverse/suites/active_record_pg/active_record_test.rb
+++ b/test/multiverse/suites/active_record_pg/active_record_test.rb
@@ -631,8 +631,8 @@ class ActiveRecordInstrumentationTest < Minitest::Test
     })
   end
 
-  def test_active_record_metrics_use_table_name_save_uses_table_name
-    with_config(active_record_metrics_use_table_name: true) do
+  def test_active_record_use_table_name_save_uses_table_name
+    with_config(active_record_use_table_name: true) do
       in_web_transaction do
         Animals::Dog.create!(name: 'Oliver')
       end
@@ -641,8 +641,8 @@ class ActiveRecordInstrumentationTest < Minitest::Test
     assert_activerecord_metrics('animals', 'create')
   end
 
-  def test_active_record_metrics_use_table_name_find_uses_table_name
-    with_config(active_record_metrics_use_table_name: true) do
+  def test_active_record_use_table_name_find_uses_table_name
+    with_config(active_record_use_table_name: true) do
       in_web_transaction do
         Animals::Dog.first
       end
@@ -651,8 +651,8 @@ class ActiveRecordInstrumentationTest < Minitest::Test
     assert_activerecord_metrics('animals', 'find')
   end
 
-  def test_active_record_metrics_use_table_name_update_uses_table_name
-    with_config(active_record_metrics_use_table_name: true) do
+  def test_active_record_use_table_name_update_uses_table_name
+    with_config(active_record_use_table_name: true) do
       in_web_transaction do
         Animals::Dog.update_all(name: 'Sammie')
       end
@@ -661,8 +661,8 @@ class ActiveRecordInstrumentationTest < Minitest::Test
     assert_activerecord_metrics('animals', 'update')
   end
 
-  def test_active_record_metrics_use_table_name_replaces_class_name
-    with_config(active_record_metrics_use_table_name: true) do
+  def test_active_record_use_table_name_replaces_class_name
+    with_config(active_record_use_table_name: true) do
       in_web_transaction do
         Animals::Dog.first
       end
@@ -670,6 +670,33 @@ class ActiveRecordInstrumentationTest < Minitest::Test
 
     assert_metrics_recorded(["Datastore/statement/#{current_product}/animals/find"])
     assert_metrics_not_recorded(["Datastore/statement/#{current_product}/Animals::Dog/find"])
+  end
+
+  def test_active_record_use_table_name_updates_span_name
+    with_config(active_record_use_table_name: true) do
+      in_web_transaction do |txn|
+        txn.stubs(:sampled?).returns(true)
+        Animals::Dog.first
+      end
+    end
+
+    spans = harvest_span_events!
+    datastore_span = spans[1].find { |s| s[0]['name']&.include?('Datastore') }
+
+    assert_equal "Datastore/statement/#{current_product}/animals/find", datastore_span[0]['name']
+  end
+
+  def test_active_record_use_table_name_updates_transaction_trace_segment_name
+    with_config(active_record_use_table_name: true) do
+      in_web_transaction do
+        Animals::Dog.first
+      end
+    end
+
+    metric = "Datastore/statement/#{current_product}/animals/find"
+    node = find_node_with_name(last_transaction_trace, metric)
+
+    assert_equal metric, node.metric_name
   end
 
   ## helpers

--- a/test/multiverse/suites/active_record_pg/active_record_test.rb
+++ b/test/multiverse/suites/active_record_pg/active_record_test.rb
@@ -14,6 +14,12 @@ class ActiveRecordInstrumentationTest < Minitest::Test
     NewRelic::Agent.drop_buffered_data
   end
 
+  def after_teardown
+    super
+    helper = NewRelic::Agent::Instrumentation::ActiveRecordHelper
+    helper.remove_instance_variable(:@use_table_name) if helper.instance_variable_defined?(:@use_table_name)
+  end
+
   def test_metrics_for_calculation_methods
     in_web_transaction do
       Order.count

--- a/test/multiverse/suites/active_record_pg/active_record_test.rb
+++ b/test/multiverse/suites/active_record_pg/active_record_test.rb
@@ -631,6 +631,36 @@ class ActiveRecordInstrumentationTest < Minitest::Test
     })
   end
 
+  def test_active_record_metrics_use_table_name_save_uses_table_name
+    with_config(active_record_metrics_use_table_name: true) do
+      in_web_transaction do
+        Dog.create!(name: 'Oliver')
+      end
+    end
+
+    assert_activerecord_metrics('animals', 'create')
+  end
+
+  def test_active_record_metrics_use_table_name_find_uses_table_name
+    with_config(active_record_metrics_use_table_name: true) do
+      in_web_transaction do
+        Dog.first
+      end
+    end
+
+    assert_activerecord_metrics('animals', 'find')
+  end
+
+  def test_active_record_metrics_use_table_name_update_uses_table_name
+    with_config(active_record_metrics_use_table_name: true) do
+      in_web_transaction do
+        Dog.update_all(name: 'Sammie')
+      end
+    end
+
+    assert_activerecord_metrics('animals', 'update')
+  end
+
   ## helpers
   private
 

--- a/test/multiverse/suites/active_record_pg/active_record_test.rb
+++ b/test/multiverse/suites/active_record_pg/active_record_test.rb
@@ -14,12 +14,6 @@ class ActiveRecordInstrumentationTest < Minitest::Test
     NewRelic::Agent.drop_buffered_data
   end
 
-  def after_teardown
-    super
-    helper = NewRelic::Agent::Instrumentation::ActiveRecordHelper
-    helper.remove_instance_variable(:@use_table_name) if helper.instance_variable_defined?(:@use_table_name)
-  end
-
   def test_metrics_for_calculation_methods
     in_web_transaction do
       Order.count

--- a/test/multiverse/suites/active_record_pg/app/models/models.rb
+++ b/test/multiverse/suites/active_record_pg/app/models/models.rb
@@ -38,4 +38,6 @@ end
 class Animal < ActiveRecord::Base
 end
 
-class Dog < Animal; end
+module Animals
+  class Dog < Animal; end
+end

--- a/test/multiverse/suites/active_record_pg/app/models/models.rb
+++ b/test/multiverse/suites/active_record_pg/app/models/models.rb
@@ -34,3 +34,8 @@ end
 class Shipment < ActiveRecord::Base
   has_and_belongs_to_many :orders, :join_table => 'order_shipments'
 end
+
+class Animal < ActiveRecord::Base
+end
+
+class Dog < Animal; end

--- a/test/multiverse/suites/active_record_pg/before_suite.rb
+++ b/test/multiverse/suites/active_record_pg/before_suite.rb
@@ -39,5 +39,6 @@ class Minitest::Test
     Alias.delete_all if defined?(Alias)
     Order.delete_all if defined?(Order)
     Shipment.delete_all if defined?(Shipment)
+    Animal.delete_all if defined?(Animal)
   end
 end

--- a/test/multiverse/suites/active_record_pg/db/migrate/20260420000000_create_animals.rb
+++ b/test/multiverse/suites/active_record_pg/db/migrate/20260420000000_create_animals.rb
@@ -1,0 +1,18 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+require_relative '../../../../../../test/new_relic/multiverse_helpers'
+
+class CreateAnimals < current_active_record_migration_version
+  def self.up
+    create_table(:animals) do |t|
+      t.string(:type)
+      t.string(:name)
+    end
+  end
+
+  def self.down
+    drop_table(:animals)
+  end
+end

--- a/test/multiverse/suites/active_record_pg/db/migrate/20260420000000_create_animals.rb
+++ b/test/multiverse/suites/active_record_pg/db/migrate/20260420000000_create_animals.rb
@@ -9,6 +9,7 @@ class CreateAnimals < current_active_record_migration_version
     create_table(:animals) do |t|
       t.string(:type)
       t.string(:name)
+      t.timestamps
     end
   end
 

--- a/test/new_relic/agent/instrumentation/active_record_helper_test.rb
+++ b/test/new_relic/agent/instrumentation/active_record_helper_test.rb
@@ -17,9 +17,6 @@ module NewRelic::Agent::Instrumentation
   class ActiveRecordHelperTest < Minitest::Test
     def teardown
       ActiveRecordHelper::TABLE_NAME_CACHE.clear
-      if ActiveRecordHelper.instance_variable_defined?(:@use_table_name)
-        ActiveRecordHelper.remove_instance_variable(:@use_table_name)
-      end
     end
 
     def test_product_operation_collection_for_find

--- a/test/new_relic/agent/instrumentation/active_record_helper_test.rb
+++ b/test/new_relic/agent/instrumentation/active_record_helper_test.rb
@@ -159,5 +159,29 @@ module NewRelic::Agent::Instrumentation
         assert_equal 'Unresolvable::Model', collection
       end
     end
+
+    def test_model_from_splits_returns_nil_when_splits_length_is_not_two
+      assert_nil ActiveRecordHelper.model_from_splits([])
+      assert_nil ActiveRecordHelper.model_from_splits(['One'])
+      assert_nil ActiveRecordHelper.model_from_splits(['One', 'Two', 'Three'])
+    end
+
+    def test_model_from_splits_returns_model_name_when_config_is_disabled
+      with_config(active_record_use_table_name: false) do
+        assert_equal 'Animals::Dog', ActiveRecordHelper.model_from_splits(['Animals::Dog', 'Load'])
+      end
+    end
+
+    def test_model_from_splits_returns_table_name_when_config_is_enabled
+      with_config(active_record_use_table_name: true) do
+        assert_equal 'animals', ActiveRecordHelper.model_from_splits(['Animals::Dog', 'Load'])
+      end
+    end
+
+    def test_model_from_splits_falls_back_to_model_name_when_unresolvable
+      with_config(active_record_use_table_name: true) do
+        assert_equal 'Unresolvable::Model', ActiveRecordHelper.model_from_splits(['Unresolvable::Model', 'Load'])
+      end
+    end
   end
 end

--- a/test/new_relic/agent/instrumentation/active_record_helper_test.rb
+++ b/test/new_relic/agent/instrumentation/active_record_helper_test.rb
@@ -117,7 +117,7 @@ module NewRelic::Agent::Instrumentation
     end
 
     def test_table_name_result_is_stored_in_cache
-      with_config(active_record_metrics_use_table_name: true) do
+      with_config(active_record_use_table_name: true) do
         ActiveRecordHelper.product_operation_collection_for('Animals::Dog Load', nil, nil)
       end
 
@@ -128,7 +128,7 @@ module NewRelic::Agent::Instrumentation
       ActiveRecordHelper::TABLE_NAME_CACHE['Animals::Dog'] = 'animals'
 
       ActiveRecordHelper.stub(:resolve_table_name, ->(_) { raise 'should not be called' }) do
-        with_config(active_record_metrics_use_table_name: true) do
+        with_config(active_record_use_table_name: true) do
           _product, _operation, collection = ActiveRecordHelper.product_operation_collection_for('Animals::Dog Load', nil, nil)
 
           assert_equal 'animals', collection
@@ -137,7 +137,7 @@ module NewRelic::Agent::Instrumentation
     end
 
     def test_class_name_used_for_namespaced_model_by_default
-      with_config(active_record_metrics_use_table_name: false) do
+      with_config(active_record_use_table_name: false) do
         _product, _operation, collection = ActiveRecordHelper.product_operation_collection_for('Animals::Dog Load', nil, nil)
 
         assert_equal 'Animals::Dog', collection
@@ -145,7 +145,7 @@ module NewRelic::Agent::Instrumentation
     end
 
     def test_table_name_used_for_namespaced_model_when_configured
-      with_config(active_record_metrics_use_table_name: true) do
+      with_config(active_record_use_table_name: true) do
         _product, _operation, collection = ActiveRecordHelper.product_operation_collection_for('Animals::Dog Load', nil, nil)
 
         assert_equal 'animals', collection
@@ -153,7 +153,7 @@ module NewRelic::Agent::Instrumentation
     end
 
     def test_class_name_used_as_fallback_when_model_unresolvable
-      with_config(active_record_metrics_use_table_name: true) do
+      with_config(active_record_use_table_name: true) do
         _product, _operation, collection = ActiveRecordHelper.product_operation_collection_for('Unresolvable::Model Load', nil, nil)
 
         assert_equal 'Unresolvable::Model', collection

--- a/test/new_relic/agent/instrumentation/active_record_helper_test.rb
+++ b/test/new_relic/agent/instrumentation/active_record_helper_test.rb
@@ -5,8 +5,20 @@
 require_relative '../../../test_helper'
 require 'new_relic/agent/instrumentation/active_record_helper'
 
+module Animals
+  class Dog
+    def self.table_name
+      'animals'
+    end
+  end
+end
+
 module NewRelic::Agent::Instrumentation
   class ActiveRecordHelperTest < Minitest::Test
+    def teardown
+      ActiveRecordHelper::TABLE_NAME_CACHE.clear
+    end
+
     def test_product_operation_collection_for_find
       product, operation, collection = ActiveRecordHelper.product_operation_collection_for('Namespace::Model Load', nil, nil)
 
@@ -102,6 +114,49 @@ module NewRelic::Agent::Instrumentation
       adapter = NewRelic::Agent::Instrumentation::ActiveRecordHelper::InstanceIdentification.adapter_from_config(config)
 
       assert_equal :postgres, adapter
+    end
+
+    def test_table_name_result_is_stored_in_cache
+      with_config(active_record_metrics_use_table_name: true) do
+        ActiveRecordHelper.product_operation_collection_for('Animals::Dog Load', nil, nil)
+      end
+
+      assert ActiveRecordHelper::TABLE_NAME_CACHE.key?('Animals::Dog')
+    end
+
+    def test_cached_table_name_is_returned_without_resolving_again
+      ActiveRecordHelper::TABLE_NAME_CACHE['Animals::Dog'] = 'animals'
+
+      ActiveRecordHelper.stub(:resolve_table_name, ->(_) { raise 'should not be called' }) do
+        with_config(active_record_metrics_use_table_name: true) do
+          _product, _operation, collection = ActiveRecordHelper.product_operation_collection_for('Animals::Dog Load', nil, nil)
+          assert_equal 'animals', collection
+        end
+      end
+    end
+
+    def test_class_name_used_for_namespaced_model_by_default
+      with_config(active_record_metrics_use_table_name: false) do
+        _product, _operation, collection = ActiveRecordHelper.product_operation_collection_for('Animals::Dog Load', nil, nil)
+
+        assert_equal 'Animals::Dog', collection
+      end
+    end
+
+    def test_table_name_used_for_namespaced_model_when_configured
+      with_config(active_record_metrics_use_table_name: true) do
+        _product, _operation, collection = ActiveRecordHelper.product_operation_collection_for('Animals::Dog Load', nil, nil)
+
+        assert_equal 'animals', collection
+      end
+    end
+
+    def test_class_name_used_as_fallback_when_model_unresolvable
+      with_config(active_record_metrics_use_table_name: true) do
+        _product, _operation, collection = ActiveRecordHelper.product_operation_collection_for('Unresolvable::Model Load', nil, nil)
+
+        assert_equal 'Unresolvable::Model', collection
+      end
     end
   end
 end

--- a/test/new_relic/agent/instrumentation/active_record_helper_test.rb
+++ b/test/new_relic/agent/instrumentation/active_record_helper_test.rb
@@ -17,6 +17,9 @@ module NewRelic::Agent::Instrumentation
   class ActiveRecordHelperTest < Minitest::Test
     def teardown
       ActiveRecordHelper::TABLE_NAME_CACHE.clear
+      if ActiveRecordHelper.instance_variable_defined?(:@use_table_name)
+        ActiveRecordHelper.remove_instance_variable(:@use_table_name)
+      end
     end
 
     def test_product_operation_collection_for_find

--- a/test/new_relic/agent/instrumentation/active_record_helper_test.rb
+++ b/test/new_relic/agent/instrumentation/active_record_helper_test.rb
@@ -130,6 +130,7 @@ module NewRelic::Agent::Instrumentation
       ActiveRecordHelper.stub(:resolve_table_name, ->(_) { raise 'should not be called' }) do
         with_config(active_record_metrics_use_table_name: true) do
           _product, _operation, collection = ActiveRecordHelper.product_operation_collection_for('Animals::Dog Load', nil, nil)
+
           assert_equal 'animals', collection
         end
       end

--- a/test/new_relic/agent/instrumentation/active_record_helper_test.rb
+++ b/test/new_relic/agent/instrumentation/active_record_helper_test.rb
@@ -163,7 +163,7 @@ module NewRelic::Agent::Instrumentation
     def test_model_from_splits_returns_nil_when_splits_length_is_not_two
       assert_nil ActiveRecordHelper.model_from_splits([])
       assert_nil ActiveRecordHelper.model_from_splits(['One'])
-      assert_nil ActiveRecordHelper.model_from_splits(['One', 'Two', 'Three'])
+      assert_nil ActiveRecordHelper.model_from_splits(%w[One Two Three])
     end
 
     def test_model_from_splits_returns_model_name_when_config_is_disabled


### PR DESCRIPTION
Introduce new config `active_record_use_table_name` to use the Active Record model's table name instead of the class name when naming Active Record metrics, which also impacts span and segment names.

closes https://github.com/newrelic/newrelic-ruby-agent/issues/3465
