### PR TITLE
Update Dalli instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # New Relic Ruby Agent Release Notes
 
+## dev
+
+- **Feature: Add Dalli 5.0 support and fix meta protocol instrumentation**
+
+  The agent now supports Dalli 5.0+, which removed `Dalli::Protocol::Binary` in favor of the meta protocol exclusively. For Dalli 3.2.0+, `pipelined_get` instrumentation now correctly targets `Dalli::Protocol::Base` (where the method is defined) rather than `Dalli::Protocol::Binary`, fixing a gap where `get_multi` calls went uninstrumented when using the meta protocol. For Dalli 5.0+, the agent additionally instruments `Dalli::Protocol::Meta#read_multi_req`, which is invoked by Dalli's single-server `get_multi` optimizatio [PR#3541](https://github.com/newrelic/newrelic-ruby-agent/pull/3541)
+
 ## v10.4.0
 
 - **Feature: Add Rails.event instrumentation for structured logging**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - **Feature: Add Dalli 5.0 support and fix meta protocol instrumentation**
 
-  The agent now supports Dalli 5.0+, which removed `Dalli::Protocol::Binary` in favor of the meta protocol exclusively. For Dalli 3.2.0+, `pipelined_get` instrumentation now correctly targets `Dalli::Protocol::Base` (where the method is defined) rather than `Dalli::Protocol::Binary`, fixing a gap where `get_multi` calls went uninstrumented when using the meta protocol. For Dalli 5.0+, the agent additionally instruments `Dalli::Protocol::Meta#read_multi_req`, which is invoked by Dalli's single-server `get_multi` optimizatio [PR#3541](https://github.com/newrelic/newrelic-ruby-agent/pull/3541)
+  The agent now supports Dalli 5.0+, which removed `Dalli::Protocol::Binary` in favor of the meta protocol exclusively. For Dalli 3.2.0+, `pipelined_get` instrumentation now correctly targets `Dalli::Protocol::Base` (where the method is defined) rather than `Dalli::Protocol::Binary`, fixing a gap where `get_multi` calls went uninstrumented when using the meta protocol. For Dalli 5.0+, the agent additionally instruments `Dalli::Protocol::Meta#read_multi_req`, which is invoked by Dalli's single-server `get_multi` optimization. [PR#3541](https://github.com/newrelic/newrelic-ruby-agent/pull/3541)
 
 ## v10.4.0
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,8 +54,8 @@ services:
   memcached:
     image: memcached:1.6.12
     restart: always
-    expose:
-      - "11211"
+    ports:
+      - "11211:11211"
   mongodb:
     image: mongo:5.0.4
     restart: always

--- a/lib/new_relic/agent/instrumentation/memcache/dalli.rb
+++ b/lib/new_relic/agent/instrumentation/memcache/dalli.rb
@@ -16,6 +16,7 @@ module NewRelic
               instrument_methods(::Dalli::Client, dalli_methods)
               instrument_multi_method(:get_multi)
               instrument_send_multiget
+              instrument_read_multi_req if supports_read_multi_req?
               instrument_server_for_key
             else
               instrument_methods(::Dalli::Client, client_methods)
@@ -50,8 +51,22 @@ module NewRelic
             end
           end
 
+          def instrument_read_multi_req
+            ::Dalli::Protocol::Meta.class_eval do
+              include NewRelic::Agent::Instrumentation::Memcache::Tracer
+
+              alias_method(:read_multi_req_without_newrelic_trace, :read_multi_req)
+
+              def read_multi_req(keys)
+                send_multiget_with_newrelic_tracing(keys) { read_multi_req_without_newrelic_trace(keys) }
+              end
+            end
+          end
+
           def instrument_send_multiget
-            if supports_binary_protocol?
+            if supports_meta_protocol?
+              ::Dalli::Protocol::Base
+            elsif supports_binary_protocol?
               ::Dalli::Protocol::Binary
             else
               ::Dalli::Server

--- a/lib/new_relic/agent/instrumentation/memcache/helper.rb
+++ b/lib/new_relic/agent/instrumentation/memcache/helper.rb
@@ -7,6 +7,8 @@ module NewRelic::Agent::Instrumentation
     module Helper
       DATASTORE_INSTANCES_SUPPORTED_VERSION = Gem::Version.new('2.6.4')
       BINARY_PROTOCOL_SUPPORTED_VERSION = Gem::Version.new('3.0.2')
+      META_PROTOCOL_SUPPORTED_VERSION = Gem::Version.new('3.2.0')
+      READ_MULTI_SUPPORTED_VERSION = Gem::Version.new('5.0.0')
 
       def supports_datastore_instances?
         NewRelic::Helper.version_satisfied?(DATASTORE_INSTANCES_SUPPORTED_VERSION, '<=', ::Dalli::VERSION)
@@ -14,6 +16,14 @@ module NewRelic::Agent::Instrumentation
 
       def supports_binary_protocol?
         NewRelic::Helper.version_satisfied?(BINARY_PROTOCOL_SUPPORTED_VERSION, '<=', ::Dalli::VERSION)
+      end
+
+      def supports_meta_protocol?
+        NewRelic::Helper.version_satisfied?(META_PROTOCOL_SUPPORTED_VERSION, '<=', ::Dalli::VERSION)
+      end
+
+      def supports_read_multi_req?
+        NewRelic::Helper.version_satisfied?(READ_MULTI_SUPPORTED_VERSION, '<=', ::Dalli::VERSION)
       end
 
       def client_methods

--- a/lib/new_relic/agent/instrumentation/memcache/prepend.rb
+++ b/lib/new_relic/agent/instrumentation/memcache/prepend.rb
@@ -32,11 +32,15 @@ module NewRelic::Agent::Instrumentation
           yield(::Dalli::Client, dalli_client_prepender(dalli_methods))
           yield(::Dalli::Client, dalli_get_multi_prepender(:get_multi))
 
-          if supports_binary_protocol?
+          if supports_meta_protocol?
+            yield(::Dalli::Protocol::Base, dalli_server_prepender)
+          elsif supports_binary_protocol?
             yield(::Dalli::Protocol::Binary, dalli_server_prepender)
           else
             yield(::Dalli::Server, dalli_server_prepender)
           end
+
+          yield(::Dalli::Protocol::Meta, dalli_read_multi_req_prepender) if supports_read_multi_req?
 
           yield(::Dalli::Ring, dalli_ring_prepender)
         else
@@ -64,6 +68,17 @@ module NewRelic::Agent::Instrumentation
 
           define_method method_name do |*args, &block|
             get_multi_with_newrelic_tracing(method_name) { super(*args, &block) }
+          end
+        end
+      end
+
+      def dalli_read_multi_req_prepender
+        Module.new do
+          extend Helper
+          include NewRelic::Agent::Instrumentation::Memcache::Tracer
+
+          def read_multi_req(keys)
+            send_multiget_with_newrelic_tracing(keys) { super }
           end
         end
       end

--- a/test/multiverse/suites/memcache/Envfile
+++ b/test/multiverse/suites/memcache/Envfile
@@ -5,6 +5,8 @@
 require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..', 'helpers', 'docker'))
 
 # Dalli
+instrumentation_methods :chain, :prepend
+
 DALLI_VERSIONS = [
   ['>= 5.0', 3.3],
   ['< 5.0'],

--- a/test/multiverse/suites/memcache/Envfile
+++ b/test/multiverse/suites/memcache/Envfile
@@ -6,6 +6,7 @@ require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..', 'he
 
 # Dalli
 DALLI_VERSIONS = [
+  ['>= 5.0'],
   ['< 5.0'],
   ['= 3.1.0']
 ]

--- a/test/multiverse/suites/memcache/Envfile
+++ b/test/multiverse/suites/memcache/Envfile
@@ -6,7 +6,7 @@ require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..', 'he
 
 # Dalli
 DALLI_VERSIONS = [
-  ['>= 5.0'],
+  ['>= 5.0', 3.3],
   ['< 5.0'],
   ['= 3.1.0']
 ]

--- a/test/multiverse/suites/memcache/dalli_test.rb
+++ b/test/multiverse/suites/memcache/dalli_test.rb
@@ -10,7 +10,9 @@ if defined?(Dalli)
     include MemcacheTestCases
 
     MULTI_OPERATIONS = [:get_multi, :get_multi_cas]
-    DALLI_SERVER_PROTOCOL = if ::NewRelic::Agent::Instrumentation::Memcache::Dalli.supports_binary_protocol?
+    DALLI_SERVER_PROTOCOL = if ::NewRelic::Agent::Instrumentation::Memcache::Dalli.supports_meta_protocol?
+      ::Dalli::Protocol::Meta
+    elsif ::NewRelic::Agent::Instrumentation::Memcache::Dalli.supports_binary_protocol?
       ::Dalli::Protocol::Binary
     else
       ::Dalli::Server
@@ -113,7 +115,8 @@ if defined?(Dalli)
     end
   end
 
-  if NewRelic::Helper.version_satisfied?(Dalli::VERSION, '>=', '2.7')
+  if NewRelic::Helper.version_satisfied?(Dalli::VERSION, '>=', '2.7') &&
+      NewRelic::Helper.version_satisfied?(Dalli::VERSION, '<', '5.0')
     require 'dalli/cas/client'
     DependencyDetection.detect!
 

--- a/test/multiverse/suites/memcache/dalli_test.rb
+++ b/test/multiverse/suites/memcache/dalli_test.rb
@@ -54,6 +54,49 @@ if defined?(Dalli)
         end
       end
 
+      if ::NewRelic::Agent::Instrumentation::Memcache::Dalli.supports_read_multi_req?
+        # In dalli 5.0+, single-server get_multi uses the single_server_get_multi optimization,
+        # which calls read_multi_req on Dalli::Protocol::Meta directly instead of pipelined_get
+        # on Dalli::Protocol::Base. These tests explicitly exercise that path.
+
+        def test_get_multi_in_web_via_read_multi_req
+          keys = Array.new(3) { set_key_for_testcase }
+          expected_metrics = expected_web_metrics(:get_multi)
+
+          in_web_transaction("Controller/#{self.class}/action") do
+            @cache.get_multi(*keys)
+          end
+
+          assert_memcache_metrics_recorded expected_metrics
+        end
+
+        def test_get_multi_in_background_via_read_multi_req
+          keys = Array.new(3) { set_key_for_testcase }
+          expected_metrics = expected_bg_metrics(:get_multi)
+
+          in_background_transaction("OtherTransaction/Background/#{self.class}/bg_task") do
+            @cache.get_multi(*keys)
+          end
+
+          assert_memcache_metrics_recorded expected_metrics
+        end
+
+        def test_get_multi_with_multiple_keys_and_capture_memcache_keys_via_read_multi_req
+          with_config(:capture_memcache_keys => true) do
+            keys = Array.new(3) { set_key_for_testcase }
+
+            in_web_transaction("Controller/#{self.class}/action") do
+              @cache.get_multi(*keys)
+            end
+
+            trace = last_transaction_trace
+            segment = find_node_with_name(trace, 'Datastore/operation/Memcached/get_multi_request')
+
+            keys.each { |key| assert_includes segment[:statement], key }
+          end
+        end
+      end
+
       def test_assign_instance_to_with_ip_and_port
         segment = mock('datastore_segment')
         segment.expects(:set_instance_info).with('127.0.0.1', 11211)


### PR DESCRIPTION
Adds support for Dalli meta protocol. Also makes some updates for instrumenting new methods present in Dalli 5.0.

resolves https://github.com/newrelic/newrelic-ruby-agent/issues/3131 
resolves https://github.com/newrelic/newrelic-ruby-agent/issues/3446
resolves https://github.com/newrelic/newrelic-ruby-agent/issues/3453