### PR TITLE
Limit minitest version in slack notification tests

### DIFF
--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -299,7 +299,11 @@ jobs:
       - uses: ruby/setup-ruby@09a7688d3b55cf0e976497ff046b70949eeaccfd # tag v1.288.0
         with:
           ruby-version: 4.0.0
-      - run: gem install httparty minitest minitest-mock
+      - run: gem install httparty
+      # TODO: MAJOR VERSION - Remove this version constraint when we update the
+      # minitest version in the gemspec
+      - run: gem uninstall minitest # remove any other conflicting versions
+      - run: gem install minitest --version 5.3.3
       - name: Run Slack Notifications Tests
         run: |
           ruby test/new_relic/slack_notifications_test/slack_notifier_test.rb

--- a/test/new_relic/slack_notifications_test/gem_notifier_test.rb
+++ b/test/new_relic/slack_notifications_test/gem_notifier_test.rb
@@ -12,10 +12,8 @@ rescue LoadError
 end
 
 if defined?(HTTParty)
-  gem 'minitest'
-  gem 'minitest-mock'
+  gem 'minitest', "#{RUBY_VERSION >= '2.7.0' ? '5.3.3' : '4.7.5'}"
   require 'minitest/autorun'
-  require 'minitest/mock'
   require_relative '../../../.github/workflows/scripts/slack_notifications/gem_notifier'
 
   class GemNotifierTests < Minitest::Test

--- a/test/new_relic/slack_notifications_test/gem_notifier_test.rb
+++ b/test/new_relic/slack_notifications_test/gem_notifier_test.rb
@@ -12,7 +12,9 @@ rescue LoadError
 end
 
 if defined?(HTTParty)
-  gem 'minitest', "#{RUBY_VERSION >= '2.7.0' ? '5.3.3' : '4.7.5'}"
+  # TODO: MAJOR VERSION - Remove this version constraint when we update the
+  # minitest version in the gemspec
+  gem 'minitest', '5.3.3'
   require 'minitest/autorun'
   require_relative '../../../.github/workflows/scripts/slack_notifications/gem_notifier'
 

--- a/test/new_relic/slack_notifications_test/slack_notifier_test.rb
+++ b/test/new_relic/slack_notifications_test/slack_notifier_test.rb
@@ -12,10 +12,8 @@ rescue LoadError
 end
 
 if defined?(HTTParty)
-  gem 'minitest'
-  gem 'minitest-mock'
+  gem 'minitest', "#{RUBY_VERSION >= '2.7.0' ? '5.3.3' : '4.7.5'}"
   require 'minitest/autorun'
-  require 'minitest/mock'
   require_relative '../../../.github/workflows/scripts/slack_notifications/slack_notifier'
 
   class SlackNotifierTests < Minitest::Test

--- a/test/new_relic/slack_notifications_test/slack_notifier_test.rb
+++ b/test/new_relic/slack_notifications_test/slack_notifier_test.rb
@@ -12,7 +12,9 @@ rescue LoadError
 end
 
 if defined?(HTTParty)
-  gem 'minitest', "#{RUBY_VERSION >= '2.7.0' ? '5.3.3' : '4.7.5'}"
+  # TODO: MAJOR VERSION - Remove this version constraint when we update the
+  # minitest version in the gemspec
+  gem 'minitest', '5.3.3'
   require 'minitest/autorun'
   require_relative '../../../.github/workflows/scripts/slack_notifications/slack_notifier'
 


### PR DESCRIPTION
This allows us to avoid missing minitest-mock errors caused by the unscoped `gem 'minitest'` calls installing the latest version of minitest, which removed the minitest mock functionality.

Example error: 
```
/.../bundler/rubygems_integration.rb:215:in 'block (2 levels) in Kernel#replace_gem': 
minitest-mock is not part of the bundle. Add it to your Gemfile. (Gem::LoadError)
        from /.../test/new_relic/slack_notifications_test/slack_notifier_test.rb:16:in '<top (required)>'
```

✅ [Passing CI Cron result that runs the Slack Notification tests](https://github.com/newrelic/newrelic-ruby-agent/actions/runs/24836135800/job/72696876073)