### PR TITLE
Fix AgentVersion metric recording

### DIFF
--- a/lib/new_relic/agent/agent_helpers/startup.rb
+++ b/lib/new_relic/agent/agent_helpers/startup.rb
@@ -59,6 +59,7 @@ module NewRelic
             @harvest_samplers.load_samplers unless Agent.config[:disable_samplers]
           end
 
+          NewRelic::Agent.record_metric("Supportability/AgentVersion/newrelic_rpm/#{NewRelic::VERSION::STRING}", 0.0)
           connect_in_foreground if Agent.config[:sync_startup]
           start_worker_thread(options)
         end

--- a/lib/new_relic/control/instance_methods.rb
+++ b/lib/new_relic/control/instance_methods.rb
@@ -75,7 +75,6 @@ module NewRelic
         NewRelic::Agent.agent = NewRelic::Agent::Agent.instance
         init_instrumentation
         init_security_agent
-        report_agent_version_metric
       end
 
       def determine_env(options)
@@ -159,10 +158,6 @@ module NewRelic
 
       def stdout
         STDOUT
-      end
-
-      def report_agent_version_metric
-        NewRelic::Agent.record_metric_once("Supportability/AgentVersion/newrelic_rpm/#{NewRelic::VERSION::STRING}")
       end
     end
     include InstanceMethods

--- a/test/new_relic/control_test.rb
+++ b/test/new_relic/control_test.rb
@@ -142,7 +142,7 @@ class NewRelic::ControlTest < Minitest::Test
     end
   end
 
-  def test_init_plugin_records_agent_version_metric
+  def test_records_agent_version_metric_in_non_forking_environment
     reset_agent
 
     NewRelic::VERSION.stub_const(:STRING, '1.2.3') do
@@ -158,8 +158,35 @@ class NewRelic::ControlTest < Minitest::Test
     end
   end
 
+  def test_records_agent_version_metric_after_fork
+    reset_agent
+
+    NewRelic::VERSION.stub_const(:STRING, '1.2.3') do
+      with_config(:disable_samplers => true,
+        :disable_harvest_thread => true,
+        :agent_enabled          => true,
+        :monitor_mode           => true,
+        :license_key            => 'a' * 40,
+        :dispatcher             => :puma) do
+        NewRelic::Control.instance.init_plugin
+
+        # In a forking dispatcher, setup_and_start_agent is skipped in the master
+        # process, so the metric is not yet recorded.
+        assert_metrics_not_recorded('Supportability/AgentVersion/newrelic_rpm/1.2.3')
+
+        # After a worker forks, after_fork calls setup_and_start_agent in the child
+        # with a fresh stats engine. The metric must be recorded there so the
+        # worker's harvest thread can transmit it.
+        NewRelic::Agent.after_fork
+
+        assert_metrics_recorded('Supportability/AgentVersion/newrelic_rpm/1.2.3')
+      end
+    end
+  end
+
   def reset_agent
     NewRelic::Agent.shutdown
+    NewRelic::Agent.instance.stats_engine.reset!
     NewRelic::Agent.instance.instance_variable_get(:@harvest_samplers).clear
     NewRelic::Agent.instance.instance_variable_set(:@connect_state, :pending)
     NewRelic::Agent.instance.instance_variable_set(:@worker_thread, nil)


### PR DESCRIPTION
Previously, the `Supportability/AgentVersion/newrelic_rpm/#{verison}` supportability metric would not be recorded in environments with forking dispatchers because the stats engine gets replaced in the after_fork method, so the metric we tried to record would be lost before it could be sent up.

Now, the code the records the metric should only ever be hit once, so we don't need to use record_metric_once. After the worker forks, we'll run into the metric recording and it will be harvested.

This was tested with a Rails 8 app that used five Puma workers. The metric was recorded once.