### PR TITLE
Add Redis Datastore Translator

### DIFF
--- a/lib/new_relic/agent/opentelemetry/attribute_translator.rb
+++ b/lib/new_relic/agent/opentelemetry/attribute_translator.rb
@@ -24,15 +24,9 @@ module NewRelic
             'opentelemetry-instrumentation-redis' => RedisDatastoreTranslator
           },
           discriminating_attribute: {
-            'db.system' => {
-              'redis' => RedisDatastoreTranslator,
-              default: DatastoreTranslator
-            },
-            'db.system.name' => {
-              'redis' => RedisDatastoreTranslator,
-              default: DatastoreTranslator
-            }
-            # 'rpc.system' => {default: RpcTranslator},
+            'db.system' => DatastoreTranslator,
+            'db.system.name' => DatastoreTranslator
+            # 'rpc.system' => RpcTranslator,
           },
           span_kind: {
             client: HttpClientTranslator,
@@ -64,8 +58,7 @@ module NewRelic
             if TRANSLATOR_REGISTRY[:instrumentation_scope][instrumentation_scope]
               TRANSLATOR_REGISTRY[:instrumentation_scope][instrumentation_scope]
             elsif k = DISCRIMINATING_ATTRIBUTE_KEYS.find { |key| attributes.key?(key) }
-              entry = TRANSLATOR_REGISTRY[:discriminating_attribute][k]
-              entry[attributes[k]] || entry[:default]
+              TRANSLATOR_REGISTRY[:discriminating_attribute][k]
             elsif TRANSLATOR_REGISTRY[:span_kind][span_kind]
               TRANSLATOR_REGISTRY[:span_kind][span_kind]
             else

--- a/lib/new_relic/agent/opentelemetry/attribute_translator.rb
+++ b/lib/new_relic/agent/opentelemetry/attribute_translator.rb
@@ -3,6 +3,7 @@
 # frozen_string_literal: true
 
 require_relative 'translators/datastore_translator'
+require_relative 'translators/redis_datastore_translator'
 require_relative 'translators/http_client_translator'
 require_relative 'translators/http_server_translator'
 require_relative 'translators/generic_translator'
@@ -19,13 +20,19 @@ module NewRelic
             # pg instrumentation doesn't have db.system assigned when connect
             # spans start, so they would be incorrectly assigned
             # the HttpClientTranslator
-            'opentelemetry-instrumentation-pg' => DatastoreTranslator
-            # 'opentelemetry-instrumentation-redis' => RedisDatastoreTranslator,
+            'opentelemetry-instrumentation-pg' => DatastoreTranslator,
+            'opentelemetry-instrumentation-redis' => RedisDatastoreTranslator
           },
           discriminating_attribute: {
-            'db.system' => DatastoreTranslator,
-            'db.system.name' => DatastoreTranslator
-            # 'rpc.system' => RpcTranslator,
+            'db.system' => {
+              'redis' => RedisDatastoreTranslator,
+              default: DatastoreTranslator
+            },
+            'db.system.name' => {
+              'redis' => RedisDatastoreTranslator,
+              default: DatastoreTranslator
+            }
+            # 'rpc.system' => {default: RpcTranslator},
           },
           span_kind: {
             client: HttpClientTranslator,
@@ -57,7 +64,8 @@ module NewRelic
             if TRANSLATOR_REGISTRY[:instrumentation_scope][instrumentation_scope]
               TRANSLATOR_REGISTRY[:instrumentation_scope][instrumentation_scope]
             elsif k = DISCRIMINATING_ATTRIBUTE_KEYS.find { |key| attributes.key?(key) }
-              TRANSLATOR_REGISTRY[:discriminating_attribute][k]
+              entry = TRANSLATOR_REGISTRY[:discriminating_attribute][k]
+              entry[attributes[k]] || entry[:default]
             elsif TRANSLATOR_REGISTRY[:span_kind][span_kind]
               TRANSLATOR_REGISTRY[:span_kind][span_kind]
             else

--- a/lib/new_relic/agent/opentelemetry/trace/tracer.rb
+++ b/lib/new_relic/agent/opentelemetry/trace/tracer.rb
@@ -81,7 +81,11 @@ module NewRelic
                   start_time: start_timestamp
                 )
 
-                segment&._notice_sql(segment_api_params[:sql])
+                if segment_api_params[:sql]
+                  segment&._notice_sql(segment_api_params[:sql])
+                elsif segment_api_params[:nosql_statement]
+                  segment&.notice_nosql_statement(segment_api_params[:nosql_statement])
+                end
 
                 segment
               else

--- a/lib/new_relic/agent/opentelemetry/translators/attribute_mappings.rb
+++ b/lib/new_relic/agent/opentelemetry/translators/attribute_mappings.rb
@@ -97,6 +97,33 @@ module NewRelic
           }
         }.freeze
 
+        REDIS_MAPPINGS = { # v1.25, v1.17
+          'product' => {
+            otel_keys: ['db.system.name', 'db.system'],
+            segment_field: :product
+          },
+          'database_name' => {
+            otel_keys: ['db.namespace', 'db.name'],
+            segment_field: :database_name
+          },
+          'host' => {
+            otel_keys: ['server.address', 'net.peer.name'],
+            segment_field: :host
+          },
+          'port_path_or_id' => {
+            otel_keys: ['server.port', 'net.peer.port'],
+            segment_field: :port_path_or_id
+          },
+          'operation' => {
+            otel_keys: ['db.operation.name', 'db.operation'],
+            segment_field: :operation
+          },
+          'nosql_statement' => {
+            otel_keys: ['db.statement', 'db.query.text'],
+            segment_field: :nosql_statement
+          }
+        }.freeze
+
         HTTP_SERVER_MAPPINGS = { # v1.23, v1.20
           'http_response_code' => {
             otel_keys: ['http.response.status_code', 'http.status_code'],

--- a/lib/new_relic/agent/opentelemetry/translators/redis_datastore_translator.rb
+++ b/lib/new_relic/agent/opentelemetry/translators/redis_datastore_translator.rb
@@ -1,0 +1,19 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+require_relative 'datastore_translator'
+
+module NewRelic
+  module Agent
+    module OpenTelemetry
+      class RedisDatastoreTranslator < DatastoreTranslator
+        class << self
+          def mappings_hash
+            AttributeMappings::REDIS_MAPPINGS
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/multiverse/suites/hybrid_agent/attribute_translator_test.rb
+++ b/test/multiverse/suites/hybrid_agent/attribute_translator_test.rb
@@ -42,8 +42,6 @@ module NewRelic
           assert_same DatastoreTranslator, result[:translator]
         end
 
-        # TODO: Update this test to use a Redis-specific translator
-        # when we implement that translator
         def test_discriminating_attribute_takes_precedence_over_span_kind
           # :client span_kind maps to HttpClientTranslator,
           # but db.system discriminating attribute should win
@@ -53,7 +51,28 @@ module NewRelic
             name: 'SELECT'
           )
 
+          assert_same RedisDatastoreTranslator, result[:translator]
+        end
+
+        def test_non_specific_db_routes_to_generic_datastore_translator
+          result = AttributeTranslator.translate(
+            attributes: {'db.system' => 'some_database'},
+            span_kind: :client,
+            name: 'SELECT'
+          )
+
           assert_same DatastoreTranslator, result[:translator]
+        end
+
+        def test_redis_instrumentation_scope_routes_to_redis_translator
+          result = AttributeTranslator.translate(
+            instrumentation_scope: 'opentelemetry-instrumentation-redis',
+            attributes: {},
+            span_kind: :client,
+            name: 'GET'
+          )
+
+          assert_same RedisDatastoreTranslator, result[:translator]
         end
 
         def test_selects_http_client_translator_by_span_kind_client

--- a/test/multiverse/suites/hybrid_agent/attribute_translator_test.rb
+++ b/test/multiverse/suites/hybrid_agent/attribute_translator_test.rb
@@ -51,16 +51,6 @@ module NewRelic
             name: 'SELECT'
           )
 
-          assert_same RedisDatastoreTranslator, result[:translator]
-        end
-
-        def test_non_specific_db_routes_to_generic_datastore_translator
-          result = AttributeTranslator.translate(
-            attributes: {'db.system' => 'some_database'},
-            span_kind: :client,
-            name: 'SELECT'
-          )
-
           assert_same DatastoreTranslator, result[:translator]
         end
 

--- a/test/multiverse/suites/hybrid_agent/redis_mapping_test.rb
+++ b/test/multiverse/suites/hybrid_agent/redis_mapping_test.rb
@@ -8,7 +8,7 @@ module NewRelic
       module Trace
         class RedisMappingTest < Minitest::Test
           def setup
-            @tracer = NewRelic::Agent::OpenTelemetry::Trace::Tracer.new('OTelClient')
+            @tracer = NewRelic::Agent::OpenTelemetry::Trace::Tracer.new('opentelemetry-instrumentation-redis')
             harvest_span_events!
             harvest_transaction_events!
           end

--- a/test/multiverse/suites/hybrid_agent/redis_mapping_test.rb
+++ b/test/multiverse/suites/hybrid_agent/redis_mapping_test.rb
@@ -1,0 +1,185 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+module NewRelic
+  module Agent
+    module OpenTelemetry
+      module Trace
+        class RedisMappingTest < Minitest::Test
+          def setup
+            @tracer = NewRelic::Agent::OpenTelemetry::Trace::Tracer.new('OTelClient')
+            harvest_span_events!
+            harvest_transaction_events!
+          end
+
+          def teardown
+            mocha_teardown
+          end
+
+          def redis_v_1_17_attrs
+            {
+              'db.system' => 'redis',
+              'db.operation' => 'GET',
+              'db.name' => 'customers',
+              'db.statement' => 'SET user:42 some-secret',
+              'db.user' => 'default',
+              'net.peer.name' => 'redis.example',
+              'net.peer.port' => '6379'
+            }
+          end
+
+          def redis_v_1_25_attrs
+            {
+              'db.system.name' => 'redis',
+              'db.operation.name' => 'GET',
+              'db.query.text' => 'SET user:42 some-secret',
+              'db.user' => 'default',
+              'server.address' => 'redis.example',
+              'server.port' => '6379'
+            }
+          end
+
+          def start_redis_client_segment(attrs)
+            in_transaction(category: :web) do |txn|
+              txn.stubs(:sampled?).returns(true)
+
+              @tracer.in_span('GET', attributes: attrs.dup, kind: :client) do |span|
+                # noop
+              end
+            end
+          end
+
+          def test_redis_v_1_17_segment_properties
+            transaction = start_redis_client_segment(redis_v_1_17_attrs)
+
+            segment = transaction.segments[1]
+
+            assert_instance_of NewRelic::Agent::Transaction::DatastoreSegment, segment
+
+            assert_equal 'Datastore/operation/redis/GET', segment.name
+            assert_equal redis_v_1_17_attrs['net.peer.name'], segment.host
+          end
+
+          def test_redis_v_1_17_metrics
+            start_redis_client_segment(redis_v_1_17_attrs)
+
+            assert_metrics_recorded([
+              'Datastore/all',
+              'Datastore/allWeb',
+              'Datastore/instance/redis/redis.example/6379',
+              'Datastore/operation/redis/GET',
+              'Datastore/redis/all'
+            ])
+          end
+
+          def test_redis_v_1_17_intrinsic_attributes
+            start_redis_client_segment(redis_v_1_17_attrs)
+
+            spans = harvest_span_events!
+            span = spans[1][0]
+            intrinsics = span[0]
+
+            assert_equal redis_v_1_17_attrs['db.system'], intrinsics['component']
+            assert_equal 'client', intrinsics['span.kind']
+            assert_equal 'datastore', intrinsics['category']
+          end
+
+          def test_redis_v_1_17_agent_attributes
+            start_redis_client_segment(redis_v_1_17_attrs)
+
+            spans = harvest_span_events!
+            span = spans[1][0]
+            agent = span[2]
+
+            assert_equal redis_v_1_17_attrs['db.name'], agent['db.instance']
+            assert_equal "#{redis_v_1_17_attrs['net.peer.name']}:#{redis_v_1_17_attrs['net.peer.port']}", agent['peer.address']
+            assert_equal redis_v_1_17_attrs['net.peer.name'], agent['peer.hostname']
+            assert_equal redis_v_1_17_attrs['net.peer.name'], agent['server.address']
+            assert_equal redis_v_1_17_attrs['net.peer.port'], agent['server.port']
+            assert_equal redis_v_1_17_attrs['db.system'], agent['db.system']
+            # statement comes through via notice_nosql_statement (not SQL-obfuscated)
+            assert_equal redis_v_1_17_attrs['db.statement'], agent['db.statement']
+          end
+
+          def test_redis_v_1_17_custom_attributes
+            start_redis_client_segment(redis_v_1_17_attrs)
+
+            spans = harvest_span_events!
+            span = spans[1][0]
+            custom = span[1]
+
+            keys_assigned_elsewhere = %w[db.system db.name db.operation net.peer.name net.peer.port db.statement]
+
+            assert_empty custom.keys & keys_assigned_elsewhere
+            assert_equal redis_v_1_17_attrs['db.user'], custom['db.user']
+          end
+
+          def test_redis_v_1_25_segment_properties
+            transaction = start_redis_client_segment(redis_v_1_25_attrs)
+
+            segment = transaction.segments[1]
+
+            assert_instance_of NewRelic::Agent::Transaction::DatastoreSegment, segment
+
+            assert_equal 'Datastore/operation/redis/GET', segment.name
+            assert_equal redis_v_1_25_attrs['server.address'], segment.host
+          end
+
+          def test_redis_v_1_25_metrics
+            start_redis_client_segment(redis_v_1_25_attrs)
+
+            assert_metrics_recorded([
+              'Datastore/all',
+              'Datastore/allWeb',
+              'Datastore/instance/redis/redis.example/6379',
+              'Datastore/operation/redis/GET',
+              'Datastore/redis/all'
+            ])
+          end
+
+          def test_redis_v_1_25_intrinsic_attributes
+            start_redis_client_segment(redis_v_1_25_attrs)
+
+            spans = harvest_span_events!
+            span = spans[1][0]
+            intrinsics = span[0]
+
+            assert_equal redis_v_1_25_attrs['db.system.name'], intrinsics['component']
+            assert_equal 'client', intrinsics['span.kind']
+            assert_equal 'datastore', intrinsics['category']
+          end
+
+          def test_redis_v_1_25_agent_attributes
+            start_redis_client_segment(redis_v_1_25_attrs)
+
+            spans = harvest_span_events!
+            span = spans[1][0]
+            agent = span[2]
+
+            assert_equal "#{redis_v_1_25_attrs['server.address']}:#{redis_v_1_25_attrs['server.port']}", agent['peer.address']
+            assert_equal redis_v_1_25_attrs['server.address'], agent['peer.hostname']
+            assert_equal redis_v_1_25_attrs['server.address'], agent['server.address']
+            assert_equal redis_v_1_25_attrs['server.port'], agent['server.port']
+            assert_equal redis_v_1_25_attrs['db.system.name'], agent['db.system']
+            # statement comes through via notice_nosql_statement (not SQL-obfuscated)
+            assert_equal redis_v_1_25_attrs['db.query.text'], agent['db.statement']
+          end
+
+          def test_redis_v_1_25_custom_attributes
+            start_redis_client_segment(redis_v_1_25_attrs)
+
+            spans = harvest_span_events!
+            span = spans[1][0]
+            custom = span[1]
+
+            keys_assigned_elsewhere = %w[db.system.name db.operation.name db.query.text server.address server.port]
+
+            assert_empty custom.keys & keys_assigned_elsewhere
+            assert_equal redis_v_1_25_attrs['db.user'], custom['db.user']
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add Redis Datastore Translator. Redis closely mirrors the default datastore translator with the exception of it's mappings creating a nosql_statement vs a sql. Because of that, tracer code was also edit to allow for that difference. 

Part of https://github.com/newrelic/newrelic-ruby-agent/issues/3437