### PR TITLE
Resolve Rubocop Minitest warnings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -924,9 +924,28 @@ Security/IoMethods:
 Minitest/AssertOperator:
   Enabled: false
 
+Minitest/DuplicateTestRun:
+  Exclude:
+    # This is intentional, to run the same tests with different collector configurations
+    - 'test/multiverse/suites/rails/error_tracing_test.rb'
+    # This is intentional, to run the same tests with different app configurations
+    - 'test/multiverse/suites/sinatra/ignoring_test.rb'
+
+# We like using multiple assertions in a test
+Minitest/MultipleAssertions:
+  Enabled: false
+
 # Will incorrectly raise on test helper methods
 Minitest/TestMethodName:
   Enabled: false
+
+# Our Rails instrumentation tests are intentionally structured in a way
+# where some of the tests are in files that don't end in _test.rb
+# Performance suites don't use minitest and do not need _test.rb endings
+Minitest/TestFileName:
+  Exclude:
+    - 'test/new_relic/agent/instrumentation/rails/*'
+    - 'test/performance/suites/*'
 
 Style/AccessModifierDeclarations:
   Enabled: false

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -47,30 +47,6 @@ Lint/UselessConstantScoping:
 Metrics/AbcSize:
   Max: 87
 
-# Offense count: 4
-Minitest/DuplicateTestRun:
-  Exclude:
-    - 'test/multiverse/suites/rails/error_tracing_test.rb'
-    - 'test/multiverse/suites/sinatra/ignoring_test.rb'
-
-# Offense count: 341
-Minitest/MultipleAssertions:
-  Max: 28
-
-# Offense count: 19
-Minitest/TestFileName:
-  Enabled: false
-
-# Offense count: 7
-Minitest/UselessAssertion:
-  Exclude:
-    - 'test/intentional_fail.rb'
-    - 'test/multiverse/test/suite_examples/three/b/win_test.rb'
-    - 'test/new_relic/agent/agent_test.rb'
-    - 'test/new_relic/agent/apdex_from_server_test.rb'
-    - 'test/new_relic/agent/method_tracer_test.rb'
-    - 'test/new_relic/agent/stats_test.rb'
-
 # Offense count: 19
 # Configuration parameters: Mode, AllowedMethods, AllowedPatterns, AllowBangMethods, WaywardPredicates.
 # AllowedMethods: call

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -48,12 +48,6 @@ Metrics/AbcSize:
   Max: 87
 
 # Offense count: 4
-Minitest/AssertRaisesCompoundBody:
-  Exclude:
-    - 'test/new_relic/agent/collector_response_code_test.rb'
-    - 'test/new_relic/agent/new_relic_service_test.rb'
-
-# Offense count: 4
 Minitest/DuplicateTestRun:
   Exclude:
     - 'test/multiverse/suites/rails/error_tracing_test.rb'

--- a/newrelic_rpm.gemspec
+++ b/newrelic_rpm.gemspec
@@ -54,6 +54,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'feedjira', '3.2.1' unless ENV['CI']
   s.add_development_dependency 'httparty' unless ENV['CI'] # for perf tests and Gabby
+  # TODO: MAJOR VERSION - Remove support for Minitest 4.7.5 and all calls to
+  # skip_unless_minitest5_or_above when we drop support for Ruby 2.7
   s.add_development_dependency 'minitest', "#{RUBY_VERSION >= '2.7.0' ? '5.3.3' : '4.7.5'}"
   s.add_development_dependency 'minitest-stub-const', '0.6'
   s.add_development_dependency 'mocha', '~> 1.16'

--- a/test/intentional_fail.rb
+++ b/test/intentional_fail.rb
@@ -6,6 +6,6 @@ class IntentionalFail < Minitest::Test
   # This test suite is provided to facilitate testing that build scripts (e.g.
   # rake test) return the correct exit codes when tests fail.
   def test_fail
-    assert false
+    assert false # rubocop:disable Minitest/UselessAssertion
   end
 end

--- a/test/multiverse/test/suite_examples/three/b/win_test.rb
+++ b/test/multiverse/test/suite_examples/three/b/win_test.rb
@@ -5,6 +5,6 @@
 require 'test/unit'
 class ATest < Test::Unit::TestCase
   def test_success
-    assert 'This test is not failing!!!'
+    assert 'This test is not failing!!!' # rubocop:disable Minitest/UselessAssertion
   end
 end

--- a/test/new_relic/agent/agent_test.rb
+++ b/test/new_relic/agent/agent_test.rb
@@ -475,7 +475,6 @@ module NewRelic
         @agent.signal_connected
         thread.join
 
-        assert_equal error, error
         assert_kind_of NewRelic::Agent::AgentHelpers::Connect::WaitOnConnectTimeout, error
       end
 
@@ -496,7 +495,6 @@ module NewRelic
         @agent.stubs(:connected?).returns(false)
         thread.join
 
-        assert_equal error, error
         assert_kind_of NewRelic::Agent::AgentHelpers::Connect::WaitOnConnectTimeout, error
       end
 

--- a/test/new_relic/agent/apdex_from_server_test.rb
+++ b/test/new_relic/agent/apdex_from_server_test.rb
@@ -7,6 +7,6 @@ require_relative '../../test_helper'
 class NewRelic::Agent::ApdexFromServerTest < Minitest::Test
   def test_true
     # we need tests in this file - TBD
-    assert true
+    assert true # rubocop:disable Minitest/UselessAssertion
   end
 end

--- a/test/new_relic/agent/collector_response_code_test.rb
+++ b/test/new_relic/agent/collector_response_code_test.rb
@@ -60,8 +60,9 @@ module NewRelic
             # than testing it directly, we'll just assert that our service
             # call raises the right exception.
             #
+            @agent.error_collector.error_trace_aggregator.expects(:harvest!).returns(@errors)
+
             assert_raises(NewRelic::Agent::ForceRestartException) do
-              @agent.error_collector.error_trace_aggregator.expects(:harvest!).returns(@errors)
               @agent.send(:harvest_and_send_errors)
             end
           end

--- a/test/new_relic/agent/method_tracer_test.rb
+++ b/test/new_relic/agent/method_tracer_test.rb
@@ -429,7 +429,7 @@ class NewRelic::Agent::MethodTracerTest < Minitest::Test
         end
       end
 
-      assert false # should never get here
+      assert false # rubocop:disable Minitest/UselessAssertion -- should never get here
     rescue StandardError
     end
 

--- a/test/new_relic/agent/new_relic_service_test.rb
+++ b/test/new_relic/agent/new_relic_service_test.rb
@@ -493,8 +493,9 @@ class NewRelicServiceTest < Minitest::Test
       define_method(method_name) do
         @http_handle.respond_to(:metric_data, 'payload', :code => status_code)
 
+        stats_hash = NewRelic::Agent::StatsHash.new
+
         assert_raises exception_type do
-          stats_hash = NewRelic::Agent::StatsHash.new
           @service.metric_data(stats_hash)
         end
       end
@@ -570,8 +571,9 @@ class NewRelicServiceTest < Minitest::Test
     @http_handle.respond_to(:metric_data, 'payload', :code => 401)
 
     logger = with_array_logger(level = :error) do
+      stats_hash = NewRelic::Agent::StatsHash.new
+
       assert_raises NewRelic::Agent::ForceRestartException do
-        stats_hash = NewRelic::Agent::StatsHash.new
         @service.metric_data(stats_hash)
       end
     end
@@ -583,8 +585,9 @@ class NewRelicServiceTest < Minitest::Test
   def test_supportability_metrics_for_http_error_responses
     NewRelic::Agent.drop_buffered_data
     @http_handle.respond_to(:metric_data, 'bad format', :code => 400)
+    stats_hash = NewRelic::Agent::StatsHash.new
+
     assert_raises NewRelic::Agent::UnrecoverableServerException do
-      stats_hash = NewRelic::Agent::StatsHash.new
       @service.metric_data(stats_hash)
     end
 
@@ -611,8 +614,9 @@ class NewRelicServiceTest < Minitest::Test
     NewRelic::Agent.drop_buffered_data
 
     @http_handle.respond_to(:metric_data, 'bad format', :code => 400)
+    stats_hash = NewRelic::Agent::StatsHash.new
+
     assert_raises NewRelic::Agent::UnrecoverableServerException do
-      stats_hash = NewRelic::Agent::StatsHash.new
       @service.metric_data(stats_hash)
     end
 

--- a/test/new_relic/agent/stats_test.rb
+++ b/test/new_relic/agent/stats_test.rb
@@ -142,7 +142,7 @@ class NewRelic::Agent::StatsTest < Minitest::Test
       # the following should throw an exception because s1 is frozen
       s1.trace_call(20)
 
-      assert false
+      assert false # rubocop:disable Minitest/UselessAssertion -- this should never be hit
     rescue StandardError
       assert_predicate s1, :frozen?
       validate(stats: s1, count: 1, total: 10, min: 10, max: 10)


### PR DESCRIPTION
The commits can be stepped through to see individual changes.

Fixed:
* Minitest/UselessAssertion
* Minitest/AssertRaisesCompoundBody

Moved:
* Minitest/MultipleAssertions 👹 
* Minitest/DuplicateTestRuns (with an exclude list for our caveats, generally, I think we want to be warned if this happens)
* Minitest/TestFileName (same reasoning as above - exclude list + warnings if we do it again)

Added a comment for minitest upgrades when we drop 2.7

Resolves #1522