### PR TITLE
add elasticsearch 9 to docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,18 @@ services:
       - bootstrap.memory_lock=true
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
     mem_limit: 1g
+  elasticsearch9:
+    image: elasticsearch:9.0.2
+    ports:
+      - "9252:9252"
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+      - xpack.security.enrollment.enabled=false
+      - http.port=9252
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    mem_limit: 1g
   # this docker-compose service doesn't always work with "docker compose run opensearch"
   # the tests consistently work with:
   # docker run -it -p 9200:9200 -p 9600:9600 -e "discovery.type=single-node" --name opensearch-node opensearchproject/opensearch:1.3.18
@@ -101,6 +113,7 @@ services:
     depends_on:
       - elasticsearch7
       - elasticsearch8
+      - elasticsearch9
       # - opensearch
       - mysql
       - memcached


### PR DESCRIPTION
So it fails locally bc it's running elasticsearch 9, and we haven't added that to the docker compose
resolves https://github.com/newrelic/newrelic-ruby-agent/issues/1973