### PR TITLE
Fix access to agent_version job output

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
     needs: [release]
     uses: ./.github/workflows/agent_metadata.yml
     with:
-      version: ${{ needs.release.version.outputs.agent_version }}
+      version: ${{ needs.release.outputs.agent_version }}
     secrets:
       FC_SYS_ID_CLIENT_ID: ${{ secrets.FC_SYS_ID_CLIENT_ID }}
       FC_SYS_ID_PR_KEY: ${{ secrets.FC_SYS_ID_PR_KEY }}


### PR DESCRIPTION
Previously, we included the ID of the job from the output.

See step 4 on this doc: https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/pass-job-outputs#defining-and-using-job-outputs