### PR TITLE
Fix Rails 8.2+ test

### DIFF
--- a/test/multiverse/suites/rails_prepend/prepended_supportability_test.rb
+++ b/test/multiverse/suites/rails_prepend/prepended_supportability_test.rb
@@ -44,12 +44,17 @@ class PrependedSupportabilityMetricsTest < Minitest::Test
   def test_active_record_prepended_metrics
     # rails 5.0 prepends an anonymous module on to AR::Relation
     #
-    val = 1
-    val += 1 if ::Rails::VERSION::MAJOR.to_i == 5 and ::Rails::VERSION::MINOR.to_i == 0
+    ar_relation_prepended = 1
+    ar_relation_prepended += 1 if ::Rails::VERSION::MAJOR.to_i == 5 and ::Rails::VERSION::MINOR.to_i == 0
+
+    # rails 8.2 prepends Locking::Optimistic::DeferredTouch onto AR::Base
+    #
+    ar_base_prepended = 1
+    ar_base_prepended += 1 if ::Rails::VERSION::MAJOR.to_i == 8 && ::Rails::VERSION::MINOR.to_i >= 2
 
     assert_metrics_recorded({
-      'Supportability/PrependedModules/ActiveRecord::Base' => metric_values_for(1),
-      'Supportability/PrependedModules/ActiveRecord::Relation' => metric_values_for(val)
+      'Supportability/PrependedModules/ActiveRecord::Base' => metric_values_for(ar_base_prepended),
+      'Supportability/PrependedModules/ActiveRecord::Relation' => metric_values_for(ar_relation_prepended)
     })
   end
 


### PR DESCRIPTION
We test how many Rails prepends to a class, and Rails 8.2.0 [added](https://github.com/rails/rails/pull/57284/changes#diff-6545356dda7292c83a9374a31879a76d0e6c3c1fc95d3fc07d433c2ba98366ca) a new one. The update to the test mimics an existing pattern in the same test.  