### PR TITLE
RPC Attribute Mapping

### DIFF
--- a/lib/new_relic/agent/instrumentation/grpc/server/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/grpc/server/instrumentation.rb
@@ -35,6 +35,9 @@ module NewRelic
             process_distributed_tracing_headers(metadata)
 
             begin
+              # TODO: Check to see if we can get the response code in the gRPC response
+              # This would be used for to match the feature for hybrid agent attribute mapping
+              # we may need to save it in the grpc.statusCode attribute, which doesn't currently exist in the agent.
               yield
             rescue => e
               NewRelic::Agent.notice_error(e)

--- a/lib/new_relic/agent/instrumentation/grpc/server/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/grpc/server/instrumentation.rb
@@ -35,9 +35,11 @@ module NewRelic
             process_distributed_tracing_headers(metadata)
 
             begin
-              # TODO: Check to see if we can get the response code in the gRPC response
-              # This would be used for to match the feature for hybrid agent attribute mapping
-              # we may need to save it in the grpc.statusCode attribute, which doesn't currently exist in the agent.
+              # TODO: Check to see if we can get the response code in the
+              # gRPC response
+              # This would be used to match hybrid agent attributes.
+              # Currently, those values are saved in http.statusCode,
+              # but we could create a new attribute: grpc.statusCode.
               yield
             rescue => e
               NewRelic::Agent.notice_error(e)

--- a/lib/new_relic/agent/instrumentation/grpc/server/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/grpc/server/instrumentation.rb
@@ -35,11 +35,6 @@ module NewRelic
             process_distributed_tracing_headers(metadata)
 
             begin
-              # TODO: Check to see if we can get the response code in the
-              # gRPC response
-              # This would be used to match hybrid agent attributes.
-              # Currently, those values are saved in http.statusCode,
-              # but we could create a new attribute: grpc.statusCode.
               yield
             rescue => e
               NewRelic::Agent.notice_error(e)

--- a/lib/new_relic/agent/opentelemetry/attribute_translator.rb
+++ b/lib/new_relic/agent/opentelemetry/attribute_translator.rb
@@ -66,7 +66,7 @@ module NewRelic
               GenericTranslator
             end
 
-          translator.translate(attributes: attributes, name: name, instrumentation_scope: instrumentation_scope)
+          translator.translate(attributes: attributes, name: name, instrumentation_scope: instrumentation_scope, kind: span_kind)
         end
       end
     end

--- a/lib/new_relic/agent/opentelemetry/attribute_translator.rb
+++ b/lib/new_relic/agent/opentelemetry/attribute_translator.rb
@@ -7,6 +7,7 @@ require_relative 'translators/redis_datastore_translator'
 require_relative 'translators/http_client_translator'
 require_relative 'translators/http_server_translator'
 require_relative 'translators/generic_translator'
+require_relative 'translators/rpc_translator'
 
 module NewRelic
   module Agent
@@ -25,8 +26,8 @@ module NewRelic
           },
           discriminating_attribute: {
             'db.system' => DatastoreTranslator,
-            'db.system.name' => DatastoreTranslator
-            # 'rpc.system' => RpcTranslator,
+            'db.system.name' => DatastoreTranslator,
+            'rpc.system' => RpcTranslator
           },
           span_kind: {
             client: HttpClientTranslator,

--- a/lib/new_relic/agent/opentelemetry/trace/span.rb
+++ b/lib/new_relic/agent/opentelemetry/trace/span.rb
@@ -8,6 +8,7 @@ module NewRelic
       module Trace
         class Span < ::OpenTelemetry::Trace::Span
           attr_accessor :finishable
+          attr_writer :kind
           attr_writer :translator
           attr_reader :status
 
@@ -23,7 +24,7 @@ module NewRelic
             return if attributes.nil? || attributes.empty?
 
             if @translator
-              translated = @translator.translate(attributes: attributes)
+              translated = @translator.translate(attributes: attributes, kind: @kind)
               apply_translated_attributes(translated)
             else
               # fallback to adding all attributes to the span as custom

--- a/lib/new_relic/agent/opentelemetry/trace/tracer.rb
+++ b/lib/new_relic/agent/opentelemetry/trace/tracer.rb
@@ -63,9 +63,15 @@ module NewRelic
 
             case kind
             when :client
-              if segment_api_params[:uri] # HTTP Client
+              if segment_api_params[:uri] # HTTP Client and gRPC Client
                 NewRelic::Agent::Tracer.start_external_request_segment(
-                  library: @name,
+                  # should we just change this to library for
+                  # both the HTTP client and gRPC client spans
+                  # by updating the translator?
+                  # cuz I'm not sure if @name is exactly right
+                  # if the tracer has opentelemetry-instrumentation
+                  # in @name
+                  library: segment_api_params[:library] || @name,
                   uri: segment_api_params[:uri],
                   procedure: segment_api_params[:procedure],
                   start_time: start_timestamp

--- a/lib/new_relic/agent/opentelemetry/trace/tracer.rb
+++ b/lib/new_relic/agent/opentelemetry/trace/tracer.rb
@@ -35,6 +35,7 @@ module NewRelic
 
             otel_span.finishable = finishable
             otel_span.status = ::OpenTelemetry::Trace::Status.unset
+            otel_span.kind = kind
             otel_span.translator = translated[:translator]
             add_remote_context_to_otel_span(otel_span, parent_otel_context)
             otel_span.add_instrumentation_scope(@name, @version)

--- a/lib/new_relic/agent/opentelemetry/trace/tracer.rb
+++ b/lib/new_relic/agent/opentelemetry/trace/tracer.rb
@@ -66,12 +66,6 @@ module NewRelic
             when :client
               if segment_api_params[:uri] # HTTP Client and gRPC Client
                 NewRelic::Agent::Tracer.start_external_request_segment(
-                  # should we just change this to library for
-                  # both the HTTP client and gRPC client spans
-                  # by updating the translator?
-                  # cuz I'm not sure if @name is exactly right
-                  # if the tracer has opentelemetry-instrumentation
-                  # in @name
                   library: segment_api_params[:library] || @name,
                   uri: segment_api_params[:uri],
                   procedure: segment_api_params[:procedure],
@@ -108,7 +102,7 @@ module NewRelic
             segment_api_params = translated[:for_segment_api]
 
             case kind
-            when :server
+            when :server # HTTP or gRPC server calls
               nr_item = NewRelic::Agent::Tracer.start_transaction_or_segment(
                 name: segment_api_params[:name] || name,
                 category: :web

--- a/lib/new_relic/agent/opentelemetry/translators/attribute_mappings.rb
+++ b/lib/new_relic/agent/opentelemetry/translators/attribute_mappings.rb
@@ -151,7 +151,24 @@ module NewRelic
           }
         }.freeze
 
-        RPC_MAPPINGS = { # v1.23, v1.17 client
+        RPC_SERVER_MAPPINGS = { # v1.20
+          'http_response_code' => {
+            otel_keys: ['rpc.grpc.status_code'],
+            category: :instance_variable
+          },
+          'request.headers.host' => {
+            otel_keys: ['net.sock.peer.addr', 'server.address', 'net.peer.name'],
+            category: :agent,
+            destinations: DEFAULT_DESTINATIONS
+          },
+          'request.method' => {
+            otel_keys: ['rpc.method'],
+            category: :agent,
+            destinations: DEFAULT_DESTINATIONS
+          }
+        }.freeze
+
+        RPC_CLIENT_MAPPINGS = { # v1.17
           'http_status_code' => {
             otel_keys: ['rpc.grpc.status_code'],
             category: :instance_variable

--- a/lib/new_relic/agent/opentelemetry/translators/attribute_mappings.rb
+++ b/lib/new_relic/agent/opentelemetry/translators/attribute_mappings.rb
@@ -152,7 +152,7 @@ module NewRelic
         }.freeze
 
         RPC_SERVER_MAPPINGS = { # v1.20
-          'http_response_code' => {
+          'response_status' => {
             otel_keys: ['rpc.grpc.status_code'],
             category: :instance_variable
           },
@@ -169,7 +169,7 @@ module NewRelic
         }.freeze
 
         RPC_CLIENT_MAPPINGS = { # v1.17
-          'http_status_code' => {
+          'grpc_status_code' => {
             otel_keys: ['rpc.grpc.status_code'],
             category: :instance_variable
           },

--- a/lib/new_relic/agent/opentelemetry/translators/attribute_mappings.rb
+++ b/lib/new_relic/agent/opentelemetry/translators/attribute_mappings.rb
@@ -150,6 +150,36 @@ module NewRelic
             destinations: DEFAULT_DESTINATIONS
           }
         }.freeze
+
+        RPC_MAPPINGS = { # v1.23, v1.17 client
+          'http_status_code' => {
+            otel_keys: ['rpc.grpc.status_code'],
+            category: :instance_variable
+            # tbd
+          },
+          # the value closest to library in intention is rpc.system. however,
+          # to get the correct segment name, we need to set this to rpc.service
+          'library' => {
+            otel_keys: ['rpc.service'],
+            segment_field: :library
+          },
+          'procedure' => {
+            otel_keys: ['rpc.method'],
+            segment_field: :procedure
+          },
+          'host' => {
+            # traditional host keys aren't sent by otel grpc instrumentation
+            # so we use net.sock.peer.address to fill the host field
+            otel_keys: ['net.sock.peer.addr', 'server.address', 'net.peer.name'],
+            segment_field: :host
+          },
+          # not sent by gRPC OTel instrumentation, but can sometimes be gleaned
+          # by net.sock.peer.addr
+          'port' => {
+            otel_keys: ['server.port', 'net.peer.port'],
+            segment_field: :port
+          }
+        }.freeze
       end
     end
   end

--- a/lib/new_relic/agent/opentelemetry/translators/attribute_mappings.rb
+++ b/lib/new_relic/agent/opentelemetry/translators/attribute_mappings.rb
@@ -172,7 +172,6 @@ module NewRelic
           'http_status_code' => {
             otel_keys: ['rpc.grpc.status_code'],
             category: :instance_variable
-            # tbd
           },
           # the value closest to library in intention is rpc.system. however,
           # to get the correct segment name, we need to set this to rpc.service

--- a/lib/new_relic/agent/opentelemetry/translators/base_translator.rb
+++ b/lib/new_relic/agent/opentelemetry/translators/base_translator.rb
@@ -14,7 +14,7 @@ module NewRelic
           # This method should be redefined in child classes.
           # The body of the method should be the mappings constant defined in the
           #  AttributesMappings module for the attribute type being translated
-          def mappings_hash
+          def mappings_hash(kind)
             # no-op
             NewRelic::EMPTY_HASH
           end
@@ -28,11 +28,11 @@ module NewRelic
           #
           # @return [Hash] A hash with attributes divided into various categories for assignment on a New Relic
           # transaction or segment.
-          def translate(attributes: {}, name: nil, instrumentation_scope: nil)
+          def translate(attributes: {}, name: nil, instrumentation_scope: nil, kind: nil)
             working_attrs = attributes.dup # shallow copy
             result = {intrinsic: {}, agent: {}, custom: {}, for_segment_api: {}, instance_variable: {}, translator: self}
 
-            mappings_hash.each do |nr_key, mapping|
+            mappings_hash(kind).each do |nr_key, mapping|
               value = extract_first_present(working_attrs, mapping[:otel_keys])
               next unless value
 
@@ -54,7 +54,7 @@ module NewRelic
             # specialized attributes.
             # This method will augment the working result hash, so it does not
             # need to be merged.
-            add_specialized_attributes(result: result, name: name, attributes: attributes, instrumentation_scope: instrumentation_scope)
+            add_specialized_attributes(result: result, name: name, attributes: attributes, instrumentation_scope: instrumentation_scope, kind: kind)
 
             # Assign any remaining attributes as custom attributes
             result[:custom] = working_attrs
@@ -71,7 +71,7 @@ module NewRelic
           # @param [optional, String] instrumentation_scope The instrumentation scope provided to the translate method
           #
           # @return [Hash] The augmented result hash
-          def add_specialized_attributes(result: {}, name: nil, attributes: {}, instrumentation_scope: nil)
+          def add_specialized_attributes(result: {}, name: nil, attributes: {}, instrumentation_scope: nil, kind: nil)
             # no-op
             {}
           end

--- a/lib/new_relic/agent/opentelemetry/translators/datastore_translator.rb
+++ b/lib/new_relic/agent/opentelemetry/translators/datastore_translator.rb
@@ -9,11 +9,11 @@ module NewRelic
     module OpenTelemetry
       class DatastoreTranslator < BaseTranslator
         class << self
-          def mappings_hash
+          def mappings_hash(_kind)
             AttributeMappings::DATASTORE_MAPPINGS
           end
 
-          def add_specialized_attributes(result: {}, name: nil, attributes: nil, instrumentation_scope: nil)
+          def add_specialized_attributes(result: {}, name: nil, attributes: nil, instrumentation_scope: nil, kind: nil)
             operation = parse_operation(name, attributes)
             result[:for_segment_api][:operation] = operation if operation
 

--- a/lib/new_relic/agent/opentelemetry/translators/generic_translator.rb
+++ b/lib/new_relic/agent/opentelemetry/translators/generic_translator.rb
@@ -11,7 +11,7 @@ module NewRelic
       # because there are no known New Relic attributes to translate
       class GenericTranslator < BaseTranslator
         class << self
-          def mappings_hash
+          def mappings_hash(_kind)
             NewRelic::EMPTY_HASH
           end
         end

--- a/lib/new_relic/agent/opentelemetry/translators/http_client_translator.rb
+++ b/lib/new_relic/agent/opentelemetry/translators/http_client_translator.rb
@@ -9,11 +9,11 @@ module NewRelic
     module OpenTelemetry
       class HttpClientTranslator < BaseTranslator
         class << self
-          def mappings_hash
+          def mappings_hash(_kind)
             AttributeMappings::HTTP_CLIENT_MAPPINGS
           end
 
-          def add_specialized_attributes(result: {}, name: nil, attributes: nil, instrumentation_scope: nil)
+          def add_specialized_attributes(result: {}, name: nil, attributes: nil, instrumentation_scope: nil, kind: nil)
             uri = build_uri(attributes)
             result[:for_segment_api][:uri] = uri if uri
 

--- a/lib/new_relic/agent/opentelemetry/translators/http_server_translator.rb
+++ b/lib/new_relic/agent/opentelemetry/translators/http_server_translator.rb
@@ -9,11 +9,11 @@ module NewRelic
     module OpenTelemetry
       class HttpServerTranslator < BaseTranslator
         class << self
-          def mappings_hash
+          def mappings_hash(_kind)
             AttributeMappings::HTTP_SERVER_MAPPINGS
           end
 
-          def add_specialized_attributes(result: {}, name: nil, attributes: nil, instrumentation_scope: nil)
+          def add_specialized_attributes(result: {}, name: nil, attributes: nil, instrumentation_scope: nil, kind: nil)
             result[:for_segment_api][:name] = create_server_transaction_name(name, instrumentation_scope, attributes)
 
             result

--- a/lib/new_relic/agent/opentelemetry/translators/redis_datastore_translator.rb
+++ b/lib/new_relic/agent/opentelemetry/translators/redis_datastore_translator.rb
@@ -9,7 +9,7 @@ module NewRelic
     module OpenTelemetry
       class RedisDatastoreTranslator < DatastoreTranslator
         class << self
-          def mappings_hash
+          def mappings_hash(_kind)
             AttributeMappings::REDIS_MAPPINGS
           end
         end

--- a/lib/new_relic/agent/opentelemetry/translators/rpc_translator.rb
+++ b/lib/new_relic/agent/opentelemetry/translators/rpc_translator.rb
@@ -9,31 +9,47 @@ module NewRelic
     module OpenTelemetry
       class RpcTranslator < BaseTranslator
         class << self
-          def mappings_hash
-            AttributeMappings::RPC_MAPPINGS
+          def mappings_hash(kind)
+            kind == :client ? AttributeMappings::RPC_CLIENT_MAPPINGS : AttributeMappings::RPC_SERVER_MAPPINGS
           end
 
-          def add_specialized_attributes(result: {}, name: nil, attributes: nil, instrumentation_scope: nil)
-            uri = build_uri(attributes)
-            result[:for_segment_api][:uri] = uri if uri
+          def add_specialized_attributes(result: {}, name: nil, attributes: nil, instrumentation_scope: nil, kind: nil)
+            case kind
+            when :client
+              uri = build_uri(attributes)
+              result[:for_segment_api][:uri] = uri if uri
+            when :server
+              server_name = create_server_transaction_name(name: name, attributes: attributes, instrumentation_scope: instrumentation_scope) if name
+              result[:for_segment_api][:name] = server_name if server_name
+
+              uri = build_uri(attributes)
+              if uri
+                result[:agent]['request.uri'] = {value: uri, destinations: AttributeMappings::DEFAULT_DESTINATIONS}
+              end
+            end
 
             result
+          end
+
+          def create_server_transaction_name(name: nil, attributes: nil, instrumentation_scope: nil)
+            txn_name = name&.delete_prefix(NewRelic::SLASH)
+            Instrumentation::ControllerInstrumentation::TransactionNamer.name_for(nil, nil, :web, {class_name: instrumentation_scope, name: txn_name})
           end
 
           def build_uri(attributes)
             host = attributes['server.address'] || attributes['net.peer.name'] || attributes['net.sock.peer.addr']
             # in otel contrib's grpc instrumentation, the test example starts
             # with "dns:///", which can't be accurately parsed using ::URI.parse
-            host = host.gsub('dns:///', '') if host&.start_with?('dns:///')
+            host = host&.delete_prefix('dns:///')
             service = attributes['rpc.service']
             method = attributes['rpc.method']
 
-            return unless host && method
-
             if host && service && method
               "grpc://#{host}/#{service}/#{method}"
-            else
+            elsif host && method
               "grpc://#{host}/#{method}"
+            elsif service && method
+              "grpc://#{service}/#{method}"
             end
           end
         end

--- a/lib/new_relic/agent/opentelemetry/translators/rpc_translator.rb
+++ b/lib/new_relic/agent/opentelemetry/translators/rpc_translator.rb
@@ -38,11 +38,15 @@ module NewRelic
 
           def build_uri(attributes)
             host = attributes['server.address'] || attributes['net.peer.name'] || attributes['net.sock.peer.addr']
-            # in otel contrib's grpc instrumentation, the test example starts
-            # with "dns:///", which can't be accurately parsed using ::URI.parse
-            host = host&.delete_prefix('dns:///')
             service = attributes['rpc.service']
             method = attributes['rpc.method']
+
+            # return early if this method is called with an attributes
+            # hash that doesn't have the required values
+            return unless host || service || method
+
+            # strip scheme prefix (e.g. dns:///, xds:///) used by gRPC name resolvers
+            host = host&.sub(%r{\A\w+:///}, '')
 
             if host && service && method
               "grpc://#{host}/#{service}/#{method}"

--- a/lib/new_relic/agent/opentelemetry/translators/rpc_translator.rb
+++ b/lib/new_relic/agent/opentelemetry/translators/rpc_translator.rb
@@ -1,0 +1,43 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+require_relative 'base_translator'
+
+module NewRelic
+  module Agent
+    module OpenTelemetry
+      class RpcTranslator < BaseTranslator
+        class << self
+          def mappings_hash
+            AttributeMappings::RPC_MAPPINGS
+          end
+
+          def add_specialized_attributes(result: {}, name: nil, attributes: nil, instrumentation_scope: nil)
+            uri = build_uri(attributes)
+            result[:for_segment_api][:uri] = uri if uri
+
+            result
+          end
+
+          def build_uri(attributes)
+            host = attributes['server.address'] || attributes['net.peer.name'] || attributes['net.sock.peer.addr']
+            # in otel contrib's grpc instrumentation, the test example starts
+            # with "dns:///", which can't be accurately parsed using ::URI.parse
+            host = host.gsub('dns:///', '') if host&.start_with?('dns:///')
+            service = attributes['rpc.service']
+            method = attributes['rpc.method']
+
+            return unless host && method
+
+            if host && service && method
+              "grpc://#{host}/#{service}/#{method}"
+            else
+              "grpc://#{host}/#{method}"
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/new_relic/agent/span_event_primitive.rb
+++ b/lib/new_relic/agent/span_event_primitive.rb
@@ -27,6 +27,7 @@ module NewRelic
       DURATION_KEY = 'duration'
       NAME_KEY = 'name'
       CATEGORY_KEY = 'category'
+      GRPC_STATUS_CODE_KEY = 'grpc.statusCode'
       HTTP_URL_KEY = 'http.url'
       HTTP_METHOD_KEY = 'http.method'
       HTTP_REQUEST_METHOD_KEY = 'http.request.method'
@@ -79,6 +80,7 @@ module NewRelic
         intrinsics[HTTP_METHOD_KEY] = segment.procedure
         intrinsics[HTTP_REQUEST_METHOD_KEY] = segment.procedure
         intrinsics[HTTP_STATUS_CODE_KEY] = segment.http_status_code if segment.http_status_code
+        intrinsics[GRPC_STATUS_CODE_KEY] = segment.instance_variable_get(:@grpc_status_code) if segment.instance_variable_defined?(:@grpc_status_code)
         intrinsics[CATEGORY_KEY] = HTTP_CATEGORY
         intrinsics[SPAN_KIND_KEY] = CLIENT
         intrinsics[SERVER_ADDRESS_KEY] = segment.uri.host

--- a/lib/new_relic/agent/transaction.rb
+++ b/lib/new_relic/agent/transaction.rb
@@ -68,6 +68,7 @@ module NewRelic
         :jruby_cpu_start,
         :process_cpu_start,
         :http_response_code,
+        :response_status,
         :response_content_length,
         :response_content_type,
         :parent_span_id
@@ -631,6 +632,10 @@ module NewRelic
 
         if http_response_code
           add_agent_attribute(:'http.statusCode', http_response_code, default_destinations)
+        end
+
+        if response_status
+          add_agent_attribute(:'response.status', response_status, default_destinations)
         end
 
         if response_content_length

--- a/test/multiverse/suites/grpc/Envfile
+++ b/test/multiverse/suites/grpc/Envfile
@@ -8,7 +8,6 @@ end
 
 instrumentation_methods(:chain, :prepend)
 
-# TODO: permit testing of the nil (latest) version against Ruby 3.3+
 GRPC_VERSIONS = [
   [nil, 3.1],
   ['1.48.0', 2.6, 3.1]

--- a/test/multiverse/suites/grpc/Envfile
+++ b/test/multiverse/suites/grpc/Envfile
@@ -10,7 +10,7 @@ instrumentation_methods(:chain, :prepend)
 
 # TODO: permit testing of the nil (latest) version against Ruby 3.3+
 GRPC_VERSIONS = [
-  [nil, 2.6, 3.2],
+  [nil, 3.1],
   ['1.48.0', 2.6, 3.1]
 ]
 

--- a/test/multiverse/suites/hybrid_agent/attribute_translator_test.rb
+++ b/test/multiverse/suites/hybrid_agent/attribute_translator_test.rb
@@ -42,6 +42,25 @@ module NewRelic
           assert_same DatastoreTranslator, result[:translator]
         end
 
+        def test_selects_rpc_translator_by_discriminating_attribute_rpc_system
+          result = AttributeTranslator.translate(
+            attributes: {'rpc.system' => 'grpc'},
+            span_kind: :client
+          )
+
+          assert_same RpcTranslator, result[:translator]
+        end
+
+        def test_rpc_system_takes_precedence_over_span_kind
+          # :server span_kind would map to HttpServerTranslator, but rpc.system wins
+          result = AttributeTranslator.translate(
+            attributes: {'rpc.system' => 'grpc'},
+            span_kind: :server
+          )
+
+          assert_same RpcTranslator, result[:translator]
+        end
+
         def test_discriminating_attribute_takes_precedence_over_span_kind
           # :client span_kind maps to HttpClientTranslator,
           # but db.system discriminating attribute should win

--- a/test/multiverse/suites/hybrid_agent/rpc_mapping_test.rb
+++ b/test/multiverse/suites/hybrid_agent/rpc_mapping_test.rb
@@ -111,7 +111,7 @@ module NewRelic
             assert_equal attrs['rpc.service'], intrinsic['component']
             assert_equal attrs['rpc.method'], intrinsic['http.method']
             assert_equal attrs['rpc.method'], intrinsic['http.request.method']
-            assert_equal 0, intrinsic['http.statusCode']
+            assert_equal 0, intrinsic['grpc.statusCode']
             assert_equal 'http', intrinsic['category']
             assert_equal 'client', intrinsic['span.kind']
             # we intentionally pull out the dns:// prefix, so the attr doesn't
@@ -174,9 +174,8 @@ module NewRelic
             txns = harvest_transaction_events!
             txn = txns[1][0]
             agent = txn[2]
-            # we assign the status code as an instance variable rather than a
-            # direct agent attribute, the key is a symbolized string
-            assert_equal 0, agent[:'http.statusCode']
+
+            assert_equal 0, agent[:'response.status']
             assert_equal attrs['rpc.method'], agent['request.method']
             assert_equal 'grpc://proto.example.ExampleAPI/Example', agent['request.uri']
           end
@@ -200,7 +199,7 @@ module NewRelic
             span = spans[1][0]
             agent = span[2]
 
-            assert_equal 0, agent[:'http.statusCode']
+            assert_equal 0, agent[:'response.status']
           end
 
           def test_server_span_custom_attributes

--- a/test/multiverse/suites/hybrid_agent/rpc_mapping_test.rb
+++ b/test/multiverse/suites/hybrid_agent/rpc_mapping_test.rb
@@ -6,8 +6,6 @@ module NewRelic
   module Agent
     module OpenTelemetry
       module Trace
-        # This class only tests gRPC client instrumentation.
-        # OpenTelemetry Ruby does not have gRPC instrumentation for server calls.
         class RpcMappingTest < Minitest::Test
           def setup
             # tracer would likely be:

--- a/test/multiverse/suites/hybrid_agent/rpc_mapping_test.rb
+++ b/test/multiverse/suites/hybrid_agent/rpc_mapping_test.rb
@@ -1,0 +1,128 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+module NewRelic
+  module Agent
+    module OpenTelemetry
+      module Trace
+        # This class only tests gRPC client instrumentation.
+        # OpenTelemetry Ruby does not have gRPC instrumentation for server calls.
+        class RpcMappingTest < Minitest::Test
+          def setup
+            @tracer = NewRelic::Agent::OpenTelemetry::Trace::Tracer.new('OTelClient')
+            harvest_transaction_events!
+            harvest_span_events!
+          end
+
+          def teardown
+            mocha_teardown
+          end
+
+          # The name and attributes are based on gRPC client instrumentation
+          # in the opentelmetry-instrumentation-grpc gem
+          def span_name
+            'support.proto.PingServer/RequestResponsePing'
+          end
+
+          def req_attrs
+            {
+              'rpc.system' => 'grpc',
+              'rpc.service' => 'support.proto.PingServer',
+              'rpc.method' => 'RequestResponsePing',
+              'rpc.type' => 'request_response',
+              'net.sock.peer.addr' => 'dns:///localhost:63752'
+            }
+          end
+
+          # Using an array instead of a hash to mimic the instrumentation
+          # which calls set_attribute. That method requires two args,
+          # the key and the value.
+          def res_attrs
+            ['rpc.grpc.status_code', 0]
+          end
+
+          def run_grpc_client_segment
+            in_transaction(category: :web) do |txn|
+              txn.stubs(:sampled?).returns(true)
+
+              @tracer.in_span(span_name, attributes: req_attrs, kind: :client) do |span|
+                span.set_attribute(*res_attrs)
+              end
+            end
+          end
+
+          def test_segment_name
+            run_grpc_client_segment
+
+            spans = harvest_span_events!
+            span = spans[1][0]
+            intrinsics = span[0]
+
+            # This is the expected format in the spec
+            # External/${host}/${rpc.service}/${rpc.method}
+            # This means we intentionally set library to rpc.service in the start_external_request_segment
+            # API call.
+            assert_equal 'External/localhost/support.proto.PingServer/RequestResponsePing', intrinsics['name']
+          end
+
+          def test_transaction_metrics
+            run_grpc_client_segment
+
+            assert_metrics_recorded([
+              'External/allWeb',
+              'External/localhost/support.proto.PingServer/RequestResponsePing',
+              'WebTransactionTotalTime'
+            ])
+          end
+
+          def test_span_intrinsic_attributes
+            attrs = req_attrs
+            run_grpc_client_segment
+
+            spans = harvest_span_events!
+            span = spans[1][0]
+            intrinsic = span[0]
+
+            assert_equal attrs['rpc.service'], intrinsic['component']
+            assert_equal attrs['rpc.method'], intrinsic['http.method']
+            assert_equal attrs['rpc.method'], intrinsic['http.request.method']
+            assert_equal 0, intrinsic['http.statusCode']
+            assert_equal 'http', intrinsic['category']
+            assert_equal 'client', intrinsic['span.kind']
+            # we intentionally pull out the dns:// prefix, so the attr doesn't
+            # match what was provided by the API call
+            assert_equal 'localhost', intrinsic['server.address']
+            assert_equal 63752, intrinsic['server.port']
+          end
+
+          def test_span_agent_attributes
+            attrs = req_attrs
+            run_grpc_client_segment
+
+            spans = harvest_span_events!
+            span = spans[1][0]
+            agent = span[2]
+
+            assert_equal 'grpc://localhost:63752/support.proto.PingServer/RequestResponsePing', agent['http.url']
+          end
+
+          def test_span_custom_attributes
+            attrs = req_attrs
+            run_grpc_client_segment
+
+            spans = harvest_span_events!
+            span = spans[1][0]
+            custom = span[1]
+
+            keys_assigned_elsewhere = %w[rpc.method net.sock.peer.addr rpc.status_code rpc.service]
+
+            assert_empty custom.keys & keys_assigned_elsewhere
+            assert_equal attrs['rpc.system'], custom['rpc.system']
+            assert_equal attrs['rpc.type'], custom['rpc.type']
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/multiverse/suites/hybrid_agent/rpc_mapping_test.rb
+++ b/test/multiverse/suites/hybrid_agent/rpc_mapping_test.rb
@@ -10,6 +10,9 @@ module NewRelic
         # OpenTelemetry Ruby does not have gRPC instrumentation for server calls.
         class RpcMappingTest < Minitest::Test
           def setup
+            # tracer would likely be:
+            # opentelemetry-instrumentation-grpc
+            # opentelemetry-instrumentation-gruf
             @tracer = NewRelic::Agent::OpenTelemetry::Trace::Tracer.new('OTelClient')
             harvest_transaction_events!
             harvest_span_events!
@@ -19,13 +22,13 @@ module NewRelic
             mocha_teardown
           end
 
-          # The name and attributes are based on gRPC client instrumentation
-          # in the opentelmetry-instrumentation-grpc gem
-          def span_name
+          # The name and attributes for clients are based on gRPC client
+          # instrumentation in the opentelmetry-instrumentation-grpc gem
+          def client_span_name
             'support.proto.PingServer/RequestResponsePing'
           end
 
-          def req_attrs
+          def client_req_attrs
             {
               'rpc.system' => 'grpc',
               'rpc.service' => 'support.proto.PingServer',
@@ -35,25 +38,48 @@ module NewRelic
             }
           end
 
+          # The name and attributes for servers are based on the gruf server
+          # instrumentation in the opentelemetry-instrumentation-gruf gem
+          def server_span_name
+            '/proto.example.ExampleAPI/Example'
+          end
+
+          def server_req_attrs
+            {
+              'rpc.system' => 'grpc',
+              'rpc.service' => 'proto.example.ExampleAPI',
+              'rpc.method' => 'Example',
+              'rpc.type' => 'request_response'
+            }
+          end
+
           # Using an array instead of a hash to mimic the instrumentation
           # which calls set_attribute. That method requires two args,
-          # the key and the value.
+          # the key and the value. Both client and server instrumentation
+          # attach this value the same way.
           def res_attrs
             ['rpc.grpc.status_code', 0]
           end
 
-          def run_grpc_client_segment
+          def run_grpc_client_span
             in_transaction(category: :web) do |txn|
               txn.stubs(:sampled?).returns(true)
 
-              @tracer.in_span(span_name, attributes: req_attrs, kind: :client) do |span|
+              @tracer.in_span(client_span_name, attributes: client_req_attrs, kind: :client) do |span|
                 span.set_attribute(*res_attrs)
               end
             end
           end
 
-          def test_segment_name
-            run_grpc_client_segment
+          def run_grpc_server_span
+            span = @tracer.start_span(server_span_name, attributes: server_req_attrs, kind: :server)
+            span.finishable.stubs(:sampled?).returns(true)
+            span.set_attribute(*res_attrs)
+            span.finish
+          end
+
+          def test_client_segment_name
+            run_grpc_client_span
 
             spans = harvest_span_events!
             span = spans[1][0]
@@ -66,8 +92,8 @@ module NewRelic
             assert_equal 'External/localhost/support.proto.PingServer/RequestResponsePing', intrinsics['name']
           end
 
-          def test_transaction_metrics
-            run_grpc_client_segment
+          def test_client_transaction_metrics
+            run_grpc_client_span
 
             assert_metrics_recorded([
               'External/allWeb',
@@ -76,9 +102,9 @@ module NewRelic
             ])
           end
 
-          def test_span_intrinsic_attributes
-            attrs = req_attrs
-            run_grpc_client_segment
+          def test_client_span_intrinsic_attributes
+            attrs = client_req_attrs
+            run_grpc_client_span
 
             spans = harvest_span_events!
             span = spans[1][0]
@@ -96,9 +122,9 @@ module NewRelic
             assert_equal 63752, intrinsic['server.port']
           end
 
-          def test_span_agent_attributes
-            attrs = req_attrs
-            run_grpc_client_segment
+          def test_client_span_agent_attributes
+            attrs = client_req_attrs
+            run_grpc_client_span
 
             spans = harvest_span_events!
             span = spans[1][0]
@@ -107,9 +133,9 @@ module NewRelic
             assert_equal 'grpc://localhost:63752/support.proto.PingServer/RequestResponsePing', agent['http.url']
           end
 
-          def test_span_custom_attributes
-            attrs = req_attrs
-            run_grpc_client_segment
+          def test_client_span_custom_attributes
+            attrs = client_req_attrs
+            run_grpc_client_span
 
             spans = harvest_span_events!
             span = spans[1][0]
@@ -120,6 +146,79 @@ module NewRelic
             assert_empty custom.keys & keys_assigned_elsewhere
             assert_equal attrs['rpc.system'], custom['rpc.system']
             assert_equal attrs['rpc.type'], custom['rpc.type']
+          end
+
+          def test_server_transaction_name
+            run_grpc_server_span
+
+            txns = harvest_transaction_events!
+            txn = txns[1][0]
+            intrinsics = txn[0]
+
+            assert_equal 'Controller/OTelClient/proto.example.ExampleAPI/Example', intrinsics['name']
+          end
+
+          def test_server_transaction_metrics
+            run_grpc_server_span
+
+            assert_metrics_recorded([
+              'HttpDispatcher',
+              'WebTransactionTotalTime',
+              'Controller/OTelClient/proto.example.ExampleAPI/Example',
+              'WebTransactionTotalTime/Controller/OTelClient/proto.example.ExampleAPI/Example'
+            ])
+          end
+
+          def test_server_transaction_agent_attributes
+            attrs = server_req_attrs
+            run_grpc_server_span
+
+            txns = harvest_transaction_events!
+            txn = txns[1][0]
+            agent = txn[2]
+            # we assign the status code as an instance variable rather than a
+            # direct agent attribute, the key is a symbolized string
+            assert_equal 0, agent[:'http.statusCode']
+            assert_equal attrs['rpc.method'], agent['request.method']
+            assert_equal 'grpc://proto.example.ExampleAPI/Example', agent['request.uri']
+          end
+
+          def test_server_span_intrinsic_attributes
+            attrs = server_req_attrs
+            run_grpc_server_span
+
+            spans = harvest_span_events!
+            span = spans[1][0]
+            intrinsic = span[0]
+
+            assert_equal 'Controller/OTelClient/proto.example.ExampleAPI/Example', intrinsic['transaction.name']
+          end
+
+          def test_server_span_agent_attributes
+            attrs = server_req_attrs
+            run_grpc_server_span
+
+            spans = harvest_span_events!
+            span = spans[1][0]
+            agent = span[2]
+
+            assert_equal 0, agent[:'http.statusCode']
+          end
+
+          def test_server_span_custom_attributes
+            attrs = server_req_attrs
+            run_grpc_server_span
+
+            spans = harvest_span_events!
+            span = spans[1][0]
+            custom = span[1]
+
+            keys_assigned_elsewhere = %w[rpc.method net.sock.peer.addr rpc.status_code]
+
+            assert_empty custom.keys & keys_assigned_elsewhere
+            assert_equal attrs['rpc.system'], custom['rpc.system']
+            assert_equal attrs['rpc.type'], custom['rpc.type']
+            assert_equal attrs['rpc.service'], custom['rpc.service']
           end
         end
       end

--- a/test/multiverse/suites/hybrid_agent/rpc_mapping_test.rb
+++ b/test/multiverse/suites/hybrid_agent/rpc_mapping_test.rb
@@ -217,6 +217,35 @@ module NewRelic
             assert_equal attrs['rpc.type'], custom['rpc.type']
             assert_equal attrs['rpc.service'], custom['rpc.service']
           end
+
+          def test_client_span_non_ok_status_code
+            in_transaction(category: :web) do |txn|
+              txn.stubs(:sampled?).returns(true)
+
+              @tracer.in_span(client_span_name, attributes: client_req_attrs, kind: :client) do |span|
+                span.set_attribute('rpc.grpc.status_code', 14)
+              end
+            end
+
+            spans = harvest_span_events!
+            span = spans[1][0]
+            intrinsics = span[0]
+
+            assert_equal 14, intrinsics['grpc.statusCode']
+          end
+
+          def test_server_span_non_ok_status_code
+            span = @tracer.start_span(server_span_name, attributes: server_req_attrs, kind: :server)
+            span.finishable.stubs(:sampled?).returns(true)
+            span.set_attribute('rpc.grpc.status_code', 14)
+            span.finish
+
+            txns = harvest_transaction_events!
+            txn = txns[1][0]
+            agent = txn[2]
+
+            assert_equal 14, agent[:'response.status']
+          end
         end
       end
     end

--- a/test/multiverse/suites/hybrid_agent/rpc_translator_test.rb
+++ b/test/multiverse/suites/hybrid_agent/rpc_translator_test.rb
@@ -1,0 +1,220 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+module NewRelic
+  module Agent
+    module OpenTelemetry
+      class RpcTranslatorTest < Minitest::Test
+        def translator
+          RpcTranslator
+        end
+
+        def test_mappings_hash_returns_client_mappings_for_client_kind
+          assert_same AttributeMappings::RPC_CLIENT_MAPPINGS, translator.mappings_hash(:client)
+        end
+
+        def test_mappings_hash_returns_server_mappings_for_server_kind
+          assert_same AttributeMappings::RPC_SERVER_MAPPINGS, translator.mappings_hash(:server)
+        end
+
+        def test_build_uri_with_host_service_and_method
+          attrs = {
+            'server.address' => 'myhost.example.com',
+            'rpc.service' => 'MyService',
+            'rpc.method' => 'DoThing'
+          }
+
+          assert_equal 'grpc://myhost.example.com/MyService/DoThing', translator.build_uri(attrs)
+        end
+
+        def test_build_uri_with_host_and_method_only
+          attrs = {'server.address' => 'myhost.example.com', 'rpc.method' => 'DoThing'}
+
+          assert_equal 'grpc://myhost.example.com/DoThing', translator.build_uri(attrs)
+        end
+
+        def test_build_uri_with_service_and_method_only
+          attrs = {'rpc.service' => 'MyService', 'rpc.method' => 'DoThing'}
+
+          assert_equal 'grpc://MyService/DoThing', translator.build_uri(attrs)
+        end
+
+        def test_build_uri_returns_nil_when_no_relevant_attributes
+          assert_nil translator.build_uri({})
+        end
+
+        def test_build_uri_returns_nil_with_only_rpc_system
+          assert_nil translator.build_uri({'rpc.system' => 'grpc'})
+        end
+
+        def test_build_uri_strips_dns_scheme_prefix
+          attrs = {
+            'server.address' => 'dns:///localhost:50051',
+            'rpc.service' => 'MyService',
+            'rpc.method' => 'DoThing'
+          }
+
+          assert_equal 'grpc://localhost:50051/MyService/DoThing', translator.build_uri(attrs)
+        end
+
+        def test_build_uri_strips_xds_scheme_prefix
+          attrs = {
+            'server.address' => 'xds:///my-cluster',
+            'rpc.service' => 'MyService',
+            'rpc.method' => 'DoThing'
+          }
+
+          assert_equal 'grpc://my-cluster/MyService/DoThing', translator.build_uri(attrs)
+        end
+
+        def test_build_uri_leaves_plain_host_unchanged
+          attrs = {
+            'server.address' => 'localhost:50051',
+            'rpc.service' => 'MyService',
+            'rpc.method' => 'DoThing'
+          }
+
+          assert_equal 'grpc://localhost:50051/MyService/DoThing', translator.build_uri(attrs)
+        end
+
+        def test_build_uri_prefers_server_address_over_net_sock_peer_addr
+          attrs = {
+            'server.address' => 'preferred.example.com',
+            'net.sock.peer.addr' => 'fallback.example.com',
+            'rpc.service' => 'MyService',
+            'rpc.method' => 'DoThing'
+          }
+
+          assert_equal 'grpc://preferred.example.com/MyService/DoThing', translator.build_uri(attrs)
+        end
+
+        def test_build_uri_falls_back_to_net_peer_name
+          attrs = {
+            'net.peer.name' => 'legacy.example.com',
+            'rpc.service' => 'MyService',
+            'rpc.method' => 'DoThing'
+          }
+
+          assert_equal 'grpc://legacy.example.com/MyService/DoThing', translator.build_uri(attrs)
+        end
+
+        def test_build_uri_falls_back_to_net_sock_peer_addr
+          attrs = {
+            'net.sock.peer.addr' => 'sockaddr.example.com',
+            'rpc.service' => 'MyService',
+            'rpc.method' => 'DoThing'
+          }
+
+          assert_equal 'grpc://sockaddr.example.com/MyService/DoThing', translator.build_uri(attrs)
+        end
+
+        def test_create_server_transaction_name_strips_leading_slash
+          name = translator.create_server_transaction_name(
+            name: '/proto.example.Service/Method',
+            instrumentation_scope: 'OTelTracer'
+          )
+
+          assert_equal 'Controller/OTelTracer/proto.example.Service/Method', name
+        end
+
+        def test_create_server_transaction_name_without_leading_slash
+          name = translator.create_server_transaction_name(
+            name: 'proto.example.Service/Method',
+            instrumentation_scope: 'OTelTracer'
+          )
+
+          assert_equal 'Controller/OTelTracer/proto.example.Service/Method', name
+        end
+
+        def test_translate_client_routes_status_code_to_instance_variable
+          attrs = {'rpc.grpc.status_code' => 0}
+          result = translator.translate(attributes: attrs, kind: :client)
+
+          assert_equal 0, result[:instance_variable]['grpc_status_code']
+        end
+
+        def test_translate_client_routes_service_to_segment_api_library
+          attrs = {'rpc.service' => 'proto.example.MyService'}
+          result = translator.translate(attributes: attrs, kind: :client)
+
+          assert_equal 'proto.example.MyService', result[:for_segment_api][:library]
+        end
+
+        def test_translate_client_routes_method_to_segment_api_procedure
+          attrs = {'rpc.method' => 'DoThing'}
+          result = translator.translate(attributes: attrs, kind: :client)
+
+          assert_equal 'DoThing', result[:for_segment_api][:procedure]
+        end
+
+        def test_translate_client_routes_host_to_segment_api_host
+          attrs = {'net.sock.peer.addr' => 'dns:///localhost:50051'}
+          result = translator.translate(attributes: attrs, kind: :client)
+
+          assert_equal 'dns:///localhost:50051', result[:for_segment_api][:host]
+        end
+
+        def test_translate_client_builds_uri_in_segment_api
+          attrs = {
+            'server.address' => 'localhost:50051',
+            'rpc.service' => 'MyService',
+            'rpc.method' => 'DoThing'
+          }
+          result = translator.translate(attributes: attrs, kind: :client)
+
+          assert_equal 'grpc://localhost:50051/MyService/DoThing', result[:for_segment_api][:uri]
+        end
+
+        def test_translate_client_puts_unrecognized_attrs_in_custom
+          attrs = {'rpc.system' => 'grpc', 'rpc.type' => 'request_response'}
+          result = translator.translate(attributes: attrs, kind: :client)
+
+          assert_equal 'grpc', result[:custom]['rpc.system']
+          assert_equal 'request_response', result[:custom]['rpc.type']
+        end
+
+        def test_translate_server_routes_status_code_to_instance_variable
+          attrs = {'rpc.grpc.status_code' => 14}
+          result = translator.translate(attributes: attrs, kind: :server)
+
+          assert_equal 14, result[:instance_variable]['response_status']
+        end
+
+        def test_translate_server_routes_request_method_to_agent_attributes
+          attrs = {'rpc.method' => 'DoThing'}
+          result = translator.translate(attributes: attrs, kind: :server)
+
+          assert_equal 'DoThing', result[:agent]['request.method'][:value]
+        end
+
+        def test_translate_server_builds_uri_as_agent_attribute
+          attrs = {'rpc.service' => 'proto.example.Service', 'rpc.method' => 'Method'}
+          result = translator.translate(attributes: attrs, kind: :server)
+
+          assert_equal 'grpc://proto.example.Service/Method', result[:agent]['request.uri'][:value]
+        end
+
+        def test_translate_server_sets_transaction_name_in_segment_api
+          attrs = {'rpc.service' => 'proto.example.Service', 'rpc.method' => 'Method'}
+          result = translator.translate(
+            attributes: attrs,
+            name: '/proto.example.Service/Method',
+            instrumentation_scope: 'OTelTracer',
+            kind: :server
+          )
+
+          assert_equal 'Controller/OTelTracer/proto.example.Service/Method', result[:for_segment_api][:name]
+        end
+
+        def test_translate_server_puts_unrecognized_attrs_in_custom
+          attrs = {'rpc.system' => 'grpc', 'rpc.type' => 'request_response'}
+          result = translator.translate(attributes: attrs, kind: :server)
+
+          assert_equal 'grpc', result[:custom]['rpc.system']
+          assert_equal 'request_response', result[:custom]['rpc.type']
+        end
+      end
+    end
+  end
+end

--- a/test/new_relic/agent/span_event_primitive_test.rb
+++ b/test/new_relic/agent/span_event_primitive_test.rb
@@ -180,6 +180,47 @@ module NewRelic
           end
         end
 
+        def test_grpc_status_code_included_in_intrinsics_when_set
+          in_transaction do |txn|
+            NewRelic::Agent::Tracer.start_external_request_segment(
+              library: 'grpc',
+              uri: 'grpc://localhost:50051/MyService/DoThing',
+              procedure: 'DoThing'
+            )
+            txn.current_segment.instance_variable_set(:@grpc_status_code, 0)
+            intrinsics, _, _ = SpanEventPrimitive.for_external_request_segment(txn.current_segment)
+
+            assert_equal 0, intrinsics['grpc.statusCode']
+          end
+        end
+
+        def test_grpc_status_code_error_value_included_in_intrinsics
+          in_transaction do |txn|
+            NewRelic::Agent::Tracer.start_external_request_segment(
+              library: 'grpc',
+              uri: 'grpc://localhost:50051/MyService/DoThing',
+              procedure: 'DoThing'
+            )
+            txn.current_segment.instance_variable_set(:@grpc_status_code, 14)
+            intrinsics, _, _ = SpanEventPrimitive.for_external_request_segment(txn.current_segment)
+
+            assert_equal 14, intrinsics['grpc.statusCode']
+          end
+        end
+
+        def test_grpc_status_code_absent_from_intrinsics_when_not_set
+          in_transaction do |txn|
+            NewRelic::Agent::Tracer.start_external_request_segment(
+              library: 'Net::HTTP',
+              uri: 'https://example.com',
+              procedure: 'GET'
+            )
+            intrinsics, _, _ = SpanEventPrimitive.for_external_request_segment(txn.current_segment)
+
+            refute intrinsics.key?('grpc.statusCode')
+          end
+        end
+
         def test_doesnt_include_custom_attributes_in_event_when_configured_not_to
           with_config('span_events.attributes.enabled' => false) do
             with_segment do |segment|

--- a/test/new_relic/agent/transaction_test.rb
+++ b/test/new_relic/agent/transaction_test.rb
@@ -1462,6 +1462,26 @@ module NewRelic::Agent
       assert_equal 418, actual[:"http.statusCode"]
     end
 
+    def test_response_status_included_in_agent_attributes
+      txn = in_transaction do |t|
+        t.response_status = 0
+      end
+
+      actual = txn.attributes.agent_attributes_for(AttributeFilter::DST_TRANSACTION_TRACER)
+
+      assert_equal 0, actual[:'response.status']
+    end
+
+    def test_response_status_error_code_included_in_agent_attributes
+      txn = in_transaction do |t|
+        t.response_status = 14
+      end
+
+      actual = txn.attributes.agent_attributes_for(AttributeFilter::DST_TRANSACTION_TRACER)
+
+      assert_equal 14, actual[:'response.status']
+    end
+
     def test_trace_id
       txn = in_transaction {}
 


### PR DESCRIPTION
This PR provides support for OpenTelemetry spans that use RPC semantic conventions (specifically looking at gRPC and gruf instrumentations) to translate these conventions into their corresponding New Relic attributes. 

In addition, it adds the `kind` instance variable to spans. This should help us eventually add span kind to every OTel span.

Resolves #3438 