### PR TITLE
Fix Rails 8.2+ ActionCable subscriber test

### DIFF
--- a/test/new_relic/agent/instrumentation/rails/action_cable_subscriber.rb
+++ b/test/new_relic/agent/instrumentation/rails/action_cable_subscriber.rb
@@ -263,19 +263,28 @@ module NewRelic
             Rails::VERSION::MAJOR == 5 &&
             Rails::VERSION::MINOR == 0
 
-          config = MiniTest::Mock.new
-          config.expect(:log_tags, {})
-
           logger = ::Logger.new('/dev/null')
-
           server = MiniTest::Mock.new
-          server.expect(:worker_pool, 'dinosaur')
-          server.expect(:config, config)
-          server.expect(:logger, logger)
-          server.expect(:event_loop, nil)
 
-          env = {}
-          connection = TestConnection.new(server, env)
+          # Rails 8.2 changed ActionCable::Connection::Base#initialize from
+          # (server, env) to (server, socket)
+          rails_8_2_or_later = defined?(Rails::VERSION) && (
+            (Rails::VERSION::MAJOR == 8 && Rails::VERSION::MINOR >= 2)
+          )
+
+          if rails_8_2_or_later
+            socket = MiniTest::Mock.new
+            socket.expect(:logger, logger)
+            connection = TestConnection.new(server, socket)
+          else
+            config = MiniTest::Mock.new
+            config.expect(:log_tags, [])
+            server.expect(:worker_pool, 'dinosaur')
+            server.expect(:config, config)
+            server.expect(:logger, logger)
+            server.expect(:event_loop, nil)
+            connection = TestConnection.new(server, {})
+          end
           identifier = nil
 
           channel = TestChannel.new(connection, identifier)
@@ -290,7 +299,11 @@ module NewRelic
 
           assert_metrics_recorded metric_name
           assert find_node_with_name(last_transaction_trace, metric_name)
-          config.verify
+          if rails_8_2_or_later
+            socket.verify
+          else
+            config.verify
+          end
           server.verify
         end
 


### PR DESCRIPTION
Rails 8.2 [changed](https://github.com/rails/rails/pull/50979/changes#diff-9a03cea62f5541c014617147e47b7eee33e3717f826e59ba5a40e9171a479668R68) `ActionCable::Connection::Base#initialize` from `(server, env)` to `(server, socket)`

full ci run - https://github.com/newrelic/newrelic-ruby-agent/actions/runs/26655947958