### PR TITLE
AI Gem Summary

### DIFF
--- a/.github/workflows/scripts/slack_notifications/gem_notifier.rb
+++ b/.github/workflows/scripts/slack_notifications/gem_notifier.rb
@@ -7,25 +7,18 @@
 require 'time'
 require 'httparty'
 require_relative 'slack_notifier'
+require_relative 'gem_summary/instrumentation_agent'
 
 class GemNotifier < SlackNotifier
   SUPPORTED_GEMS_FILE = '.github/workflows/scripts/slack_notifications/supported_gems.txt'
 
   def self.check_for_updates(watched_gems)
-    return if verify_gem_list(watched_gems)
-
     watched_gems.each do |gem_name|
       gem_info = verify_gem(gem_name)
       versions = gem_versions(gem_info)
       send_slack_message(gem_message(gem_name, versions)) if gem_updated?(versions)
     end
     report_errors
-  end
-
-  private
-
-  def self.verify_gem_list(watched_gems)
-    abort("Nothing to see here! The 'watched_gems' array cannot be empty") if watched_gems.empty?
   end
 
   def self.verify_gem(gem_name)
@@ -70,11 +63,17 @@ class GemNotifier < SlackNotifier
     abort("Expected exactly 2 version numbers in the 'versions' array") unless versions.size == 2
     newest, previous = versions[0]['number'], versions[1]['number']
     alert_message = "A new gem version is out :sparkles: <#{interpolate_rubygems_url(gem_name)}|*#{gem_name}*>, #{previous} -> #{newest}"
-    action_url = action_url(gem_name)
-    action_message = "<#{action_url}|See more.>"
-    return alert_message if action_url.nil?
+    changelog_url = action_url(gem_name)
+    message = changelog_url.nil? ? alert_message : "#{alert_message}\n\n<#{changelog_url}|See more.>"
 
-    alert_message + "\n\n" + action_message
+    analysis = analyze_gem_update(gem_name, newest)
+    message += "\n\n*AI Summary:*\n#{analysis}" if analysis && !analysis.empty?
+
+    message
+  end
+
+  def self.analyze_gem_update(gem_name, version)
+    GemSummary::InstrumentationAgent.analyze(gem_name, version)
   end
 end
 

--- a/.github/workflows/scripts/slack_notifications/gem_summary/changelog_analyzer.rb
+++ b/.github/workflows/scripts/slack_notifications/gem_summary/changelog_analyzer.rb
@@ -1,0 +1,90 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+require 'httparty'
+require 'json'
+require 'yaml'
+
+module GemSummary
+  class ChangelogAnalyzer
+    MAX_LENGTH = 20_000 # Cap per-changelog length sent to Claude
+    GEM_CHANGELOG = YAML.safe_load_file(File.expand_path('gem_changelogs.yml', __dir__)).freeze
+
+    # Matches a version section header in a changelog. Three alternatives:
+    VERSION_HEADER = %r{
+      ^[#=]{1,2}.*\d+\.\d+       # markdown or rdoc header, e.g. "# 1.2.3", "== v1.2", "## Release 1.2.3"
+      |
+      ^v?\d+\.\d+                # setext-style version on its own line, e.g. "1.2.3", "v2.0" (followed by === underline)
+      |
+      ^\d{4}-\d{2}-\d{2}\s*\(    # date-prefixed entry, e.g. "2024-01-15 (v1.2.3)"
+    }x
+
+    class << self
+      def fetch_changelog(gem_name)
+        config = GEM_CHANGELOG[gem_name]
+        return nil if config.nil?
+
+        case config['type']
+        when 'releases' then fetch_releases(config['repo'])
+        when 'blob' then fetch_blob(config['repo'], config['path'], config['branch'])
+        end
+      rescue StandardError => e
+        puts "Warning: Failed to fetch changelog for #{gem_name}: #{e.message}"
+        nil
+      end
+
+      private
+
+      def fetch_releases(repo)
+        owner, name = repo.split('/')
+        url = "https://api.github.com/repos/#{owner}/#{name}/releases/latest"
+        headers = {'Accept' => 'application/vnd.github.v3+json'}
+        headers['Authorization'] = "token #{ENV['GITHUB_TOKEN']}" if ENV['GITHUB_TOKEN']
+
+        response = HTTParty.get(url, headers: headers, timeout: 30)
+        return nil unless response.success?
+
+        data = JSON.parse(response.body)
+        return nil if data['body'].to_s.empty?
+
+        truncate("Release #{data['tag_name']}:\n#{data['body']}")
+      end
+
+      def fetch_blob(repo, path, branch = nil)
+        # 'HEAD' lets raw.githubusercontent.com resolve to the repo's default branch.
+        branch ||= 'HEAD'
+        url = "https://raw.githubusercontent.com/#{repo}/#{branch}/#{path}"
+        response = HTTParty.get(url, timeout: 30, follow_redirects: true)
+        return nil unless response.success?
+
+        extract_latest_version(response.body)
+      end
+
+      # Walks the changelog line by line, capturing content between the first
+      # and second version headers.
+      def extract_latest_version(content)
+        return nil if content.nil?
+
+        result = nil
+        content.lines.each do |line|
+          if line.match?(VERSION_HEADER)
+            break if result
+
+            result = line
+          elsif result
+            result += line
+          end
+        end
+
+        truncate(result)
+      end
+
+      def truncate(content)
+        return nil if content.nil?
+
+        content.length > MAX_LENGTH ? content[0...MAX_LENGTH] + "\n[truncated]" : content
+      end
+    end
+  end
+end

--- a/.github/workflows/scripts/slack_notifications/gem_summary/claude_client.rb
+++ b/.github/workflows/scripts/slack_notifications/gem_summary/claude_client.rb
@@ -1,0 +1,57 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+require 'httparty'
+require 'json'
+
+module GemSummary
+  class ClaudeClient
+    MODEL = 'claude-4-7-opus'
+    MAX_TOKENS = 1000
+    MAX_RETRIES = 1
+
+    def initialize
+      @api_key = ENV['ANTHROPIC_API_KEY']
+      @api_endpoint = ENV['CLAUDE_API_ENDPOINT']
+    end
+
+    def send_message(prompt)
+      if @api_key.to_s.empty? || @api_endpoint.to_s.empty?
+        puts 'Warning: Claude API skipped — ANTHROPIC_API_KEY or CLAUDE_API_ENDPOINT not set'
+        return nil
+      end
+
+      retries = 0
+      begin
+        response = HTTParty.post(
+          @api_endpoint,
+          headers: {
+            'Content-Type' => 'application/json',
+            'Authorization' => "Bearer #{@api_key}"
+          },
+          body: {
+            model: MODEL,
+            max_tokens: MAX_TOKENS,
+            messages: [{role: 'user', content: prompt}]
+          }.to_json,
+          timeout: 30
+        )
+
+        status = response.code
+        return nil unless status == 200
+
+        JSON.parse(response.body).dig('content', 0, 'text')
+      rescue StandardError => e
+        retries += 1
+        if retries <= MAX_RETRIES
+          puts "Warning: Claude API error (attempt #{retries}): #{e.message}. Retrying..."
+          sleep(1)
+          retry
+        end
+        puts "Warning: Claude API error: #{e.message}"
+        nil
+      end
+    end
+  end
+end

--- a/.github/workflows/scripts/slack_notifications/gem_summary/gem_changelogs.yml
+++ b/.github/workflows/scripts/slack_notifications/gem_summary/gem_changelogs.yml
@@ -1,0 +1,72 @@
+# Changelog locations for gems the New Relic Ruby Agent tracks for updates.
+# Consumed by ChangelogAnalyzer.
+#
+# Entry shapes:
+#   type: releases   GitHub Releases API — returns the latest release notes
+#   type: blob       Raw file on GitHub — extracts the latest version section
+#   ~                No changelog available (non-GitHub, or repo has no changelog)
+#
+# When adding a gem here, also add a mapping in gem_instrumentation.yml
+# so the AI analysis has code to compare the changelog against.
+
+# --- GitHub Releases API ---------------------------------------------------
+# `activerecord` intentionally points at rails/rails — ActiveRecord ships from
+# the Rails monorepo. Both gem names appear in supported_gems.txt.
+grpc:         {type: releases, repo: grpc/grpc}
+logger:       {type: releases, repo: ruby/logger}
+mongo:        {type: releases, repo: mongodb/mongo-ruby-driver}
+rails:        {type: releases, repo: rails/rails}
+activerecord: {type: releases, repo: rails/rails}
+rake:         {type: releases, repo: ruby/rake}
+
+# --- AWS SDK family (same repo + branch, path differs) ---------------------
+aws-sdk-dynamodb: {type: blob, repo: aws/aws-sdk-ruby, branch: version-3, path: gems/aws-sdk-dynamodb/CHANGELOG.md}
+aws-sdk-firehose: {type: blob, repo: aws/aws-sdk-ruby, branch: version-3, path: gems/aws-sdk-firehose/CHANGELOG.md}
+aws-sdk-kinesis:  {type: blob, repo: aws/aws-sdk-ruby, branch: version-3, path: gems/aws-sdk-kinesis/CHANGELOG.md}
+aws-sdk-lambda:   {type: blob, repo: aws/aws-sdk-ruby, branch: version-3, path: gems/aws-sdk-lambda/CHANGELOG.md}
+aws-sdk-sqs:      {type: blob, repo: aws/aws-sdk-ruby, branch: version-3, path: gems/aws-sdk-sqs/CHANGELOG.md}
+
+# --- Standard CHANGELOG.md in repo root ------------------------------------
+concurrent-ruby: {type: blob, repo: ruby-concurrency/concurrent-ruby,   path: CHANGELOG.md}
+dalli:           {type: blob, repo: petergoldstein/dalli,               path: CHANGELOG.md}
+delayed_job:     {type: blob, repo: collectiveidea/delayed_job,         path: CHANGELOG.md}
+elasticsearch:   {type: blob, repo: elastic/elasticsearch-ruby,         path: CHANGELOG.md}
+ethon:           {type: blob, repo: typhoeus/ethon,                     path: CHANGELOG.md}
+grape:           {type: blob, repo: ruby-grape/grape,                   path: CHANGELOG.md}
+http:            {type: blob, repo: httprb/http,                        path: CHANGELOG.md}
+httpclient:      {type: blob, repo: nahi/httpclient,                    path: CHANGELOG.md}
+logstasher:      {type: blob, repo: shadabahmed/logstasher,             path: CHANGELOG.md}
+opensearch:      {type: blob, repo: opensearch-project/opensearch-ruby, path: CHANGELOG.md}
+parallel:        {type: blob, repo: grosser/parallel,                   path: CHANGELOG.md}
+rack:            {type: blob, repo: rack/rack,                          path: CHANGELOG.md}
+rdkafka:         {type: blob, repo: karafka/rdkafka-ruby,               path: CHANGELOG.md}
+redis:           {type: blob, repo: redis/redis-rb,                     path: CHANGELOG.md}
+ruby-kafka:      {type: blob, repo: zendesk/ruby-kafka,                 path: CHANGELOG.md}
+ruby-openai:     {type: blob, repo: alexrudall/ruby-openai,             path: CHANGELOG.md}
+semantic_logger: {type: blob, repo: reidmorrison/semantic_logger,       path: CHANGELOG.md}
+sinatra:         {type: blob, repo: sinatra/sinatra,                    path: CHANGELOG.md}
+stripe:          {type: blob, repo: stripe/stripe-ruby,                 path: CHANGELOG.md}
+tilt:            {type: blob, repo: rtomayko/tilt,                      path: CHANGELOG.md}
+typhoeus:        {type: blob, repo: typhoeus/typhoeus,                  path: CHANGELOG.md}
+yajl-ruby:       {type: blob, repo: brianmario/yajl-ruby,               path: CHANGELOG.md}
+
+# --- Non-standard paths or filenames ---------------------------------------
+activemerchant:           {type: blob, repo: activemerchant/active_merchant, path: CHANGELOG}
+async-http:               {type: blob, repo: socketry/async-http,            path: releases.md}
+bunny:                    {type: blob, repo: ruby-amqp/bunny,                path: ChangeLog.md}
+curb:                     {type: blob, repo: taf2/curb,                      path: ChangeLog.md}
+excon:                    {type: blob, repo: excon/excon,                    path: changelog.txt}
+httprb:                   {type: blob, repo: tommetge/httprb,                path: CHANGES}
+logging:                  {type: blob, repo: TwP/logging,                    path: History.txt}
+padrino:                  {type: blob, repo: padrino/padrino-framework,      path: CHANGES.rdoc}
+puma:                     {type: blob, repo: puma/puma,                      path: History.md}
+resque:                   {type: blob, repo: resque/resque,                  path: HISTORY.md}
+roda:                     {type: blob, repo: jeremyevans/roda,               path: CHANGELOG}
+sequel:                   {type: blob, repo: jeremyevans/sequel,             path: CHANGELOG}
+sidekiq:                  {type: blob, repo: sidekiq/sidekiq,                path: Changes.md}
+sidekiq-delay_extensions: {type: blob, repo: sidekiq/sidekiq,                path: Changes.md}
+view_component:           {type: blob, repo: ViewComponent/view_component,   path: docs/CHANGELOG.md}
+
+# --- No changelog available ------------------------------------------------
+httpx: ~       # Hosted on GitLab; changelog is an HTML page (honeyryderchuck.gitlab.io/httpx). No GitLab fetcher support yet.
+unicorn: ~     # Self-hosted at yhbt.net; no stable HTTPS URL for the NEWS file.

--- a/.github/workflows/scripts/slack_notifications/gem_summary/gem_instrumentation.yml
+++ b/.github/workflows/scripts/slack_notifications/gem_summary/gem_instrumentation.yml
@@ -1,0 +1,96 @@
+# Maps gem names to their New Relic Ruby Agent instrumentation code.
+# Consumed by GemInstrumentationMapper.
+#
+# Entry shapes:
+#   <string>    Directory name under lib/new_relic/agent/instrumentation/.
+#               instrumentation.rb and prepend.rb are looked up inside
+#               that directory.
+#   <list>      Explicit list of file paths, relative to
+#               lib/new_relic/agent/instrumentation/.
+#
+# When adding a new gem, also add a matching entry in gem_changelogs.yml so
+# the AI analysis has a changelog to compare against.
+
+# Directory mappings
+async-http:       async_http
+aws-sdk-firehose: aws_sdk_firehose
+aws-sdk-kinesis:  aws_sdk_kinesis
+aws-sdk-lambda:   aws_sdk_lambda
+bunny:            bunny
+concurrent-ruby:  concurrent_ruby
+curb:             curb
+delayed_job:      delayed_job
+elasticsearch:    elasticsearch
+ethon:            ethon
+excon:            excon
+grape:            grape
+httpclient:       httpclient
+httpx:            httpx
+logger:           logger
+logging:          logging
+logstasher:       logstasher
+opensearch:       opensearch
+padrino:          padrino
+parallel:         parallel
+rack:             rack
+rake:             rake
+rdkafka:          rdkafka
+redis:            redis
+resque:           resque
+roda:             roda
+ruby-kafka:       ruby_kafka
+ruby-openai:      ruby_openai
+semantic_logger:  semantic_logger
+sinatra:          sinatra
+tilt:             tilt
+typhoeus:         typhoeus
+view_component:   view_component
+
+# Non-obvious directory mappings
+aws-sdk-dynamodb: dynamodb
+aws-sdk-sqs:      aws_sqs
+http:             httprb
+httprb:           httprb
+
+# Explicit file lists
+activemerchant:
+  - active_merchant.rb
+activerecord:
+  - active_record.rb
+  - active_record_prepend.rb
+  - active_record_helper.rb
+dalli:
+  - memcache/instrumentation.rb
+  - memcache/prepend.rb
+  - memcache/dalli.rb
+mongo:
+  - mongo.rb
+  - mongodb_command_subscriber.rb
+rails:
+  - action_cable_subscriber.rb
+  - action_controller_subscriber.rb
+  - action_mailer_subscriber.rb
+  - action_view_subscriber.rb
+  - active_job.rb
+  - active_record_subscriber.rb
+  - active_storage_subscriber.rb
+sequel:
+  - sequel.rb
+  - sequel_helper.rb
+stripe:
+  - stripe.rb
+  - stripe_subscriber.rb
+
+# Nested directory file lists
+grpc:
+  - grpc/helper.rb
+  - grpc/client/instrumentation.rb
+  - grpc/client/prepend.rb
+  - grpc/server/instrumentation.rb
+  - grpc/server/rpc_server_prepend.rb
+sidekiq:
+  - sidekiq/client.rb
+  - sidekiq/server.rb
+sidekiq-delay_extensions:
+  - sidekiq/extensions/delayed_class.rb
+  - sidekiq/extensions/delay_extensions.rb

--- a/.github/workflows/scripts/slack_notifications/gem_summary/gem_instrumentation.yml
+++ b/.github/workflows/scripts/slack_notifications/gem_summary/gem_instrumentation.yml
@@ -22,7 +22,6 @@ curb:             curb
 delayed_job:      delayed_job
 elasticsearch:    elasticsearch
 ethon:            ethon
-excon:            excon
 grape:            grape
 httpclient:       httpclient
 httpx:            httpx
@@ -63,6 +62,9 @@ dalli:
   - memcache/instrumentation.rb
   - memcache/prepend.rb
   - memcache/dalli.rb
+excon:
+  - excon.rb
+  - excon/middleware.rb
 mongo:
   - mongo.rb
   - mongodb_command_subscriber.rb

--- a/.github/workflows/scripts/slack_notifications/gem_summary/gem_instrumentation_mapper.rb
+++ b/.github/workflows/scripts/slack_notifications/gem_summary/gem_instrumentation_mapper.rb
@@ -1,0 +1,32 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+require 'yaml'
+
+module GemSummary
+  class GemInstrumentationMapper
+    INSTRUMENTATION_FILES = %w[instrumentation.rb prepend.rb].freeze
+    INSTRUMENTATION_BASE_PATH = File.expand_path('../../../../../lib/new_relic/agent/instrumentation', __dir__)
+    GEM_TO_INSTRUMENTATION = YAML.safe_load_file(File.expand_path('gem_instrumentation.yml', __dir__)).freeze
+
+    def self.instrumentation_summary(gem_name)
+      value = GEM_TO_INSTRUMENTATION[gem_name]
+      return nil if value.nil?
+
+      files = value.is_a?(Array) ? value : INSTRUMENTATION_FILES.map { |filename| "#{value}/#{filename }" }
+
+      snippets = files.filter_map do |file|
+        path = File.join(INSTRUMENTATION_BASE_PATH, file)
+        unless File.exist?(path)
+          puts "Warning: instrumentation file not found at #{path} (referenced by gem_instrumentation.yml)"
+          next
+        end
+
+        "# === #{file} ===\n#{File.read(path)}"
+      end
+
+      snippets.empty? ? nil : snippets.join("\n\n")
+    end
+  end
+end

--- a/.github/workflows/scripts/slack_notifications/gem_summary/instrumentation_agent.rb
+++ b/.github/workflows/scripts/slack_notifications/gem_summary/instrumentation_agent.rb
@@ -1,0 +1,85 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+require_relative 'claude_client'
+require_relative 'changelog_analyzer'
+require_relative 'gem_instrumentation_mapper'
+
+module GemSummary
+  class InstrumentationAgent
+    PROMPT = <<~PROMPT
+      You're reviewing a new release of a gem the New Relic Ruby Agent
+      instruments. Compare the changelog against the methods we wrap.
+      Don't summarize what the gem does.
+
+      Gem: %<gem_name>s %<version>s
+
+      Methods and classes we currently wrap:
+      ```
+      %<code_snippet>s
+      ```
+
+      Changelog for this release:
+      ```
+      %<changelog>s
+      ```
+
+      Write a Slack-formatted summary. Use *single asterisks* for bold.
+
+      Rules:
+      - Max 4 bullets, each one sentence, ≤ 35 words.
+      - Every bullet MUST name a specific method, class, constant, hook,
+        notification event, or config option from the changelog.
+      - Prefix each bullet with its category in bold: *Breakage:*,
+        *Enhancement:*, or *Deprecation:*.
+      - *Breakage:* means our instrumentation actually breaks — a method we
+        wrap was removed, renamed, or had its signature changed. If a method
+        we wrap had internal changes but its signature is unchanged, that is
+        NOT breakage; omit the bullet entirely.
+      - *Enhancement:* means a public API, hook, notification, or config
+        option worth wrapping that our instrumentation doesn't already cover
+        (newly-added OR pre-existing). Briefly say why we'd want it. The
+        changelog item can be framed as a bug fix, security fix, or
+        refactor — what matters is whether the named method is something
+        we'd want to wrap and currently don't.
+      - Only omit a public method/hook from *Enhancement:* if our existing
+        instrumentation already covers it.
+      - *Deprecation:* means a method we wrap was marked deprecated.
+      - If a category has no real findings, skip it. Don't pad.
+      - Omit observational bullets. If a change neither breaks our wrapping
+        nor exposes a wrappable API we don't already cover, leave it out.
+      - Use the routine-release response ONLY when the changelog has zero
+        public API/method/hook activity — i.e. only docs, tests, CI, build
+        config, dependency bumps, or pure version bumps. Bug fixes and
+        security fixes that touch public behavior are NOT routine. When
+        you do use it, respond with exactly that single line — no
+        preamble, no narrative:
+        `No action needed — %<version>s is a routine release.`
+      - State findings directly with action verbs ("Wrap X", "Instrument Y").
+        Avoid hedging: "Consider," "may be worth," "could be useful," "may
+        affect instrumentation."
+      - Your response is a final answer, not a draft. Do not show your
+        reasoning. Do not narrate revisions.
+    PROMPT
+
+    def self.analyze(gem_name, version)
+      code_snippet = GemInstrumentationMapper.instrumentation_summary(gem_name)
+      return nil if code_snippet.nil?
+
+      changelog = ChangelogAnalyzer.fetch_changelog(gem_name)
+      return nil if changelog.nil?
+
+      prompt = format(PROMPT,
+        gem_name: gem_name,
+        version: version,
+        code_snippet: code_snippet,
+        changelog: changelog)
+
+      ClaudeClient.new.send_message(prompt)
+    rescue StandardError => e
+      puts "Warning: Analysis failed for #{gem_name}: #{e.message}"
+      nil
+    end
+  end
+end

--- a/.github/workflows/scripts/slack_notifications/slack_notifier.rb
+++ b/.github/workflows/scripts/slack_notifications/slack_notifier.rb
@@ -15,11 +15,9 @@ class SlackNotifier
                body: {text: message}.to_json}
     begin
       HTTParty.post(path, options)
-      puts "Gabbi DEBUG : path = >>#{path}<<, options = >>#{options}<<"
       sleep(1) # Pause to avoid Slack throttling
     rescue StandardError => e
       @@errors << e
-      puts "Gabbi DEBUG : errors = >>#{@@errors}<<"
     end
   end
 

--- a/.github/workflows/slack_notifications.yml
+++ b/.github/workflows/slack_notifications.yml
@@ -20,3 +20,5 @@ jobs:
         run: ruby .github/workflows/scripts/slack_notifications/gem_notifier.rb
         env:
           SLACK_GEM_NOTIFICATIONS_WEBHOOK: ${{ secrets.SLACK_GEM_NOTIFICATIONS_WEBHOOK }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          CLAUDE_API_ENDPOINT: ${{ secrets.CLAUDE_API_ENDPOINT }}

--- a/test/new_relic/slack_notifications_test/gem_notifier_test.rb
+++ b/test/new_relic/slack_notifications_test/gem_notifier_test.rb
@@ -111,16 +111,30 @@ if defined?(HTTParty)
 
     def test_gem_message_with_action_url
       GemNotifier.stub(:action_url, 'changelog.com') do
-        assert_equal 'A new gem version is out :sparkles: <https://rubygems.org/gems/fake_gem|*fake_gem*>, 1.1 -> 1.2' \
-        "\n\n<changelog.com|See more.>",
-          GemNotifier.gem_message('fake_gem', gem_versions_array)
+        GemNotifier.stub(:analyze_gem_update, nil) do
+          assert_equal 'A new gem version is out :sparkles: <https://rubygems.org/gems/fake_gem|*fake_gem*>, 1.1 -> 1.2' \
+          "\n\n<changelog.com|See more.>",
+            GemNotifier.gem_message('fake_gem', gem_versions_array)
+        end
       end
     end
 
     def test_gem_message_with_nil_action_url
       GemNotifier.stub(:action_url, nil) do
-        assert_equal 'A new gem version is out :sparkles: <https://rubygems.org/gems/fake_gem|*fake_gem*>, 1.1 -> 1.2',
-          GemNotifier.gem_message('fake_gem', gem_versions_array)
+        GemNotifier.stub(:analyze_gem_update, nil) do
+          assert_equal 'A new gem version is out :sparkles: <https://rubygems.org/gems/fake_gem|*fake_gem*>, 1.1 -> 1.2',
+            GemNotifier.gem_message('fake_gem', gem_versions_array)
+        end
+      end
+    end
+
+    def test_gem_message_appends_ai_summary_when_present
+      GemNotifier.stub(:action_url, 'changelog.com') do
+        GemNotifier.stub(:analyze_gem_update, '- *Enhancement:* New `Foo#bar` worth wrapping.') do
+          message = GemNotifier.gem_message('fake_gem', gem_versions_array)
+
+          assert_includes message, "*AI Summary:*\n- *Enhancement:* New `Foo#bar` worth wrapping."
+        end
       end
     end
   end

--- a/test/new_relic/slack_notifications_test/gem_summary/changelog_analyzer_test.rb
+++ b/test/new_relic/slack_notifications_test/gem_summary/changelog_analyzer_test.rb
@@ -1,0 +1,90 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+# HTTParty is only installed by the slack_notifications_tests CI job, not bundled with
+# the main test suite. This check ensures these tests run in that job but are skipped
+# when the test file is picked up by the glob pattern during regular test runs.
+begin
+  require 'httparty'
+rescue LoadError
+  nil
+end
+
+if defined?(HTTParty)
+  # TODO: MAJOR VERSION - Remove this version constraint when we update the
+  # minitest version in the gemspec
+  gem 'minitest', '5.3.3'
+  require 'minitest/autorun'
+  require_relative '../../../../.github/workflows/scripts/slack_notifications/gem_summary/changelog_analyzer'
+
+  class ChangelogAnalyzerTests < Minitest::Test
+    def successful_response(body)
+      response = Minitest::Mock.new
+      response.expect(:success?, true)
+      response.expect(:body, body)
+      response
+    end
+
+    def failed_response
+      response = Minitest::Mock.new
+      response.expect(:success?, false)
+      response
+    end
+
+    def test_fetch_changelog_returns_nil_for_unmapped_gem
+      assert_nil GemSummary::ChangelogAnalyzer.fetch_changelog('totally-fake-gem-name-12345')
+    end
+
+    def test_fetch_changelog_releases_type
+      body = JSON.dump('tag_name' => 'v7.1.0', 'body' => 'Release notes go here.')
+
+      HTTParty.stub(:get, successful_response(body)) do
+        # `rails` has type: releases in gem_changelogs.yml
+        result = GemSummary::ChangelogAnalyzer.fetch_changelog('rails')
+
+        assert_includes result, 'Release v7.1.0:'
+        assert_includes result, 'Release notes go here.'
+      end
+    end
+
+    def test_fetch_changelog_blob_type_extracts_latest_version_section
+      changelog = <<~MD
+        # Changelog
+
+        ## 5.4.1
+        - bug fix
+        - another fix
+
+        ## 5.4.0
+        - prior feature
+      MD
+
+      HTTParty.stub(:get, successful_response(changelog)) do
+        # `redis` has type: blob in gem_changelogs.yml
+        result = GemSummary::ChangelogAnalyzer.fetch_changelog('redis')
+
+        assert_includes result, '5.4.1'
+        assert_includes result, 'bug fix'
+        refute_includes result, 'prior feature'
+      end
+    end
+
+    def test_fetch_changelog_truncates_at_max_length
+      big_changelog = "## 1.0.0\n" + ('x' * (GemSummary::ChangelogAnalyzer::MAX_LENGTH + 100))
+
+      HTTParty.stub(:get, successful_response(big_changelog)) do
+        result = GemSummary::ChangelogAnalyzer.fetch_changelog('redis')
+
+        assert result.end_with?('[truncated]'), 'expected truncation marker'
+        assert result.length <= GemSummary::ChangelogAnalyzer::MAX_LENGTH + 20
+      end
+    end
+
+    def test_fetch_changelog_returns_nil_on_http_failure
+      HTTParty.stub(:get, failed_response) do
+        assert_nil GemSummary::ChangelogAnalyzer.fetch_changelog('redis')
+      end
+    end
+  end
+end

--- a/test/new_relic/slack_notifications_test/gem_summary/claude_client_test.rb
+++ b/test/new_relic/slack_notifications_test/gem_summary/claude_client_test.rb
@@ -1,0 +1,158 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+# HTTParty is only installed by the slack_notifications_tests CI job, not bundled with
+# the main test suite. This check ensures these tests run in that job but are skipped
+# when the test file is picked up by the glob pattern during regular test runs.
+begin
+  require 'httparty'
+rescue LoadError
+  nil
+end
+
+if defined?(HTTParty)
+  # TODO: MAJOR VERSION - Remove this version constraint when we update the
+  # minitest version in the gemspec
+  gem 'minitest', '5.3.3'
+  require 'minitest/autorun'
+  require_relative '../../../../.github/workflows/scripts/slack_notifications/gem_summary/claude_client'
+
+  class ClaudeClientTests < Minitest::Test
+    def setup
+      @original_key = ENV.delete('ANTHROPIC_API_KEY')
+      @original_endpoint = ENV.delete('CLAUDE_API_ENDPOINT')
+    end
+
+    def teardown
+      ENV['ANTHROPIC_API_KEY'] = @original_key if @original_key
+      ENV['CLAUDE_API_ENDPOINT'] = @original_endpoint if @original_endpoint
+    end
+
+    def with_credentials
+      ENV['ANTHROPIC_API_KEY'] = 'test-key'
+      ENV['CLAUDE_API_ENDPOINT'] = 'http://test/v1/messages'
+      yield
+    end
+
+    def successful_response(text = 'summary')
+      response = Minitest::Mock.new
+      response.expect(:code, 200)
+      response.expect(:body, JSON.dump('content' => [{'text' => text}]))
+      response
+    end
+
+    def response_with_code(code)
+      response = Minitest::Mock.new
+      response.expect(:code, code)
+      response
+    end
+
+    def response_with_body(body)
+      response = Minitest::Mock.new
+      response.expect(:code, 200)
+      response.expect(:body, body)
+      response
+    end
+
+    def test_send_message_returns_nil_when_credentials_missing
+      capture_io do
+        assert_nil GemSummary::ClaudeClient.new.send_message('prompt')
+      end
+    end
+
+    def test_send_message_returns_text_on_200
+      with_credentials do
+        HTTParty.stub(:post, successful_response('hello world')) do
+          assert_equal 'hello world', GemSummary::ClaudeClient.new.send_message('prompt')
+        end
+      end
+    end
+
+    def test_send_message_returns_nil_on_non_200_response
+      with_credentials do
+        HTTParty.stub(:post, response_with_code(401)) do
+          assert_nil GemSummary::ClaudeClient.new.send_message('prompt')
+        end
+      end
+    end
+
+    def test_send_message_returns_nil_on_unexpected_response_shape
+      with_credentials do
+        HTTParty.stub(:post, response_with_body(JSON.dump('error' => 'rate limited'))) do
+          assert_nil GemSummary::ClaudeClient.new.send_message('prompt')
+        end
+      end
+    end
+
+    def test_send_message_posts_request_with_expected_body_and_headers
+      captured_url = nil
+      captured_options = nil
+      stubbed_post = lambda do |url, options|
+        captured_url = url
+        captured_options = options
+        successful_response('ok')
+      end
+
+      with_credentials do
+        HTTParty.stub(:post, stubbed_post) do
+          GemSummary::ClaudeClient.new.send_message('hello prompt')
+        end
+      end
+
+      assert_equal 'http://test/v1/messages', captured_url
+      assert_equal 'application/json', captured_options[:headers]['Content-Type']
+      assert_equal 'Bearer test-key', captured_options[:headers]['Authorization']
+
+      body = JSON.parse(captured_options[:body])
+
+      assert_equal GemSummary::ClaudeClient::MODEL, body['model']
+      assert_equal GemSummary::ClaudeClient::MAX_TOKENS, body['max_tokens']
+      assert_equal [{'role' => 'user', 'content' => 'hello prompt'}], body['messages']
+    end
+
+    def test_send_message_retries_once_on_exception
+      call_count = 0
+      stubbed_post = lambda do |*_args, **_kwargs|
+        call_count += 1
+        raise StandardError, 'boom' if call_count == 1
+
+        successful_response('recovered')
+      end
+
+      with_credentials do
+        client = GemSummary::ClaudeClient.new
+        capture_io do
+          client.stub(:sleep, nil) do
+            HTTParty.stub(:post, stubbed_post) do
+              assert_equal 'recovered', client.send_message('prompt')
+            end
+          end
+        end
+      end
+
+      assert_equal 2, call_count
+    end
+
+    def test_send_message_returns_nil_after_retry_exhausted
+      call_count = 0
+      stubbed_post = lambda do |*_args, **_kwargs|
+        call_count += 1
+        raise StandardError, 'boom'
+      end
+
+      with_credentials do
+        client = GemSummary::ClaudeClient.new
+        capture_io do
+          client.stub(:sleep, nil) do
+            HTTParty.stub(:post, stubbed_post) do
+              assert_nil client.send_message('prompt')
+            end
+          end
+        end
+      end
+
+      assert_equal GemSummary::ClaudeClient::MAX_RETRIES + 1, call_count
+    end
+  end
+end

--- a/test/new_relic/slack_notifications_test/gem_summary/gem_instrumentation_mapper_test.rb
+++ b/test/new_relic/slack_notifications_test/gem_summary/gem_instrumentation_mapper_test.rb
@@ -1,0 +1,65 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+# HTTParty is only installed by the slack_notifications_tests CI job, not bundled with
+# the main test suite. This check ensures these tests run in that job but are skipped
+# when the test file is picked up by the glob pattern during regular test runs.
+begin
+  require 'httparty'
+rescue LoadError
+  nil
+end
+
+if defined?(HTTParty)
+  # TODO: MAJOR VERSION - Remove this version constraint when we update the
+  # minitest version in the gemspec
+  gem 'minitest', '5.3.3'
+  require 'minitest/autorun'
+  require_relative '../../../../.github/workflows/scripts/slack_notifications/gem_summary/gem_instrumentation_mapper'
+
+  class GemInstrumentationMapperTests < Minitest::Test
+    def test_summary_returns_nil_for_unmapped_gem
+      assert_nil GemSummary::GemInstrumentationMapper.instrumentation_summary('totally-fake-gem-name-12345')
+    end
+
+    def test_summary_string_entry_loads_instrumentation_and_prepend
+      # `redis: redis` is a string entry — looks up redis/instrumentation.rb and redis/prepend.rb.
+      result = GemSummary::GemInstrumentationMapper.instrumentation_summary('redis')
+
+      refute_nil result
+      assert_includes result, '# === redis/instrumentation.rb ==='
+      assert_includes result, '# === redis/prepend.rb ==='
+    end
+
+    def test_summary_array_entry_loads_listed_files
+      # `mongo` has an explicit array of files in gem_instrumentation.yml.
+      result = GemSummary::GemInstrumentationMapper.instrumentation_summary('mongo')
+
+      refute_nil result
+      assert_includes result, '# === mongo.rb ==='
+      assert_includes result, '# === mongodb_command_subscriber.rb ==='
+    end
+
+    def test_summary_returns_nil_when_no_files_exist
+      capture_io do
+        File.stub(:exist?, false) do
+          assert_nil GemSummary::GemInstrumentationMapper.instrumentation_summary('redis')
+        end
+      end
+    end
+
+    def test_summary_warns_when_referenced_file_is_missing
+      # Stub `redis/prepend.rb` missing but `redis/instrumentation.rb` present.
+      stubbed_exist = ->(path) { !path.end_with?('redis/prepend.rb') }
+      out, _err = capture_io do
+        File.stub(:exist?, stubbed_exist) do
+          GemSummary::GemInstrumentationMapper.instrumentation_summary('redis')
+        end
+      end
+
+      assert_includes out, 'instrumentation file not found'
+      assert_includes out, 'redis/prepend.rb'
+    end
+  end
+end

--- a/test/new_relic/slack_notifications_test/gem_summary/instrumentation_agent_test.rb
+++ b/test/new_relic/slack_notifications_test/gem_summary/instrumentation_agent_test.rb
@@ -49,11 +49,13 @@ if defined?(HTTParty)
 
     def test_analyze_sends_formatted_prompt_to_claude
       captured = []
+
       stub_pipeline(code: 'WRAPPED CODE', changelog: 'CHANGELOG BODY', captured: captured) do
         assert_equal 'summary', GemSummary::InstrumentationAgent.analyze('redis', '5.4.1')
       end
 
       prompt = captured.first
+
       assert_includes prompt, 'redis'
       assert_includes prompt, '5.4.1'
       assert_includes prompt, 'WRAPPED CODE'

--- a/test/new_relic/slack_notifications_test/gem_summary/instrumentation_agent_test.rb
+++ b/test/new_relic/slack_notifications_test/gem_summary/instrumentation_agent_test.rb
@@ -1,0 +1,69 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+# HTTParty is only installed by the slack_notifications_tests CI job, not bundled with
+# the main test suite. This check ensures these tests run in that job but are skipped
+# when the test file is picked up by the glob pattern during regular test runs.
+begin
+  require 'httparty'
+rescue LoadError
+  nil
+end
+
+if defined?(HTTParty)
+  # TODO: MAJOR VERSION - Remove this version constraint when we update the
+  # minitest version in the gemspec
+  gem 'minitest', '5.3.3'
+  require 'minitest/autorun'
+  require_relative '../../../../.github/workflows/scripts/slack_notifications/gem_summary/instrumentation_agent'
+
+  class InstrumentationAgentTests < Minitest::Test
+    def stub_pipeline(code: 'CODE', changelog: 'CHANGELOG', response: 'summary', captured: nil)
+      client = Object.new
+      client.define_singleton_method(:send_message) do |prompt|
+        captured << prompt if captured
+        response
+      end
+
+      GemSummary::ClaudeClient.stub(:new, client) do
+        GemSummary::GemInstrumentationMapper.stub(:instrumentation_summary, code) do
+          GemSummary::ChangelogAnalyzer.stub(:fetch_changelog, changelog) do
+            yield
+          end
+        end
+      end
+    end
+
+    def test_analyze_returns_nil_when_gem_not_instrumented
+      stub_pipeline(code: nil) do
+        assert_nil GemSummary::InstrumentationAgent.analyze('some-gem', '1.0.0')
+      end
+    end
+
+    def test_analyze_returns_nil_when_changelog_unavailable
+      stub_pipeline(changelog: nil) do
+        assert_nil GemSummary::InstrumentationAgent.analyze('some-gem', '1.0.0')
+      end
+    end
+
+    def test_analyze_sends_formatted_prompt_to_claude
+      captured = []
+      stub_pipeline(code: 'WRAPPED CODE', changelog: 'CHANGELOG BODY', captured: captured) do
+        assert_equal 'summary', GemSummary::InstrumentationAgent.analyze('redis', '5.4.1')
+      end
+
+      prompt = captured.first
+      assert_includes prompt, 'redis'
+      assert_includes prompt, '5.4.1'
+      assert_includes prompt, 'WRAPPED CODE'
+      assert_includes prompt, 'CHANGELOG BODY'
+    end
+
+    def test_analyze_returns_nil_when_claude_fails
+      stub_pipeline(response: nil) do
+        assert_nil GemSummary::InstrumentationAgent.analyze('redis', '5.4.1')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds AI-powered changelog analysis to the daily gem-update Slack notifier. When a watched gem releases a new version, `GemSummary::InstrumentationAgent` sends the changelog and our instrumentation source to Claude and appends a `*AI Summary:*` block to the Slack message highlighting breakage, enhancement opportunities, and deprecations.

Four classes under `.github/workflows/scripts/slack_notifications/gem_summary/`:
- `ClaudeClient` — HTTParty wrapper, env-driven, retries once.
- `ChangelogAnalyzer` — fetches latest version section via GitHub Releases API or raw blob.
- `GemInstrumentationMapper` — resolves gem name -> instrumentation source files.
- `InstrumentationAgent` — orchestrates the three and formats the prompt.