### PR TITLE
Add Span Links to hybrid agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## dev
 
+- **Feature: Span links are now supported for the Hybrid Agent**
+
+  Now, spans created by an OpenTelemetry API can have Span Links associated with them. Links can be added on a span's start, by passing them to the `links` argument, or by calling the `OpenTelemetry::Trace::Span#add_link` API. [PR#3586](https://github.com/newrelic/newrelic-ruby-agent/pull/3586)
+
 - **Bugfix: Fix `instrumentation.rails_event_logger: false` not disabling the instrumentation**
 
   Setting `instrumentation.rails_event_logger` to `false` was not disabling the Rails.event instrumentation as expected. The instrumentation would still be installed during Rails boot. This has been fixed. [PR#3564](https://github.com/newrelic/newrelic-ruby-agent/pull/3564)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - **Feature: Span links are now supported for the Hybrid Agent**
 
-  Now, spans created by an OpenTelemetry API can have Span Links associated with them. Links can be added on a span's start, by passing them to the `links` argument, or by calling the `OpenTelemetry::Trace::Span#add_link` API. [PR#3586](https://github.com/newrelic/newrelic-ruby-agent/pull/3586)
+  Spans created via the OpenTelemetry API can now have Span Links associated with them. Links can be added on a span's start, by passing them to the `links` argument, or by calling the `OpenTelemetry::Trace::Span#add_link` API. [PR#3586](https://github.com/newrelic/newrelic-ruby-agent/pull/3586)
 
 - **Bugfix: Fix `instrumentation.rails_event_logger: false` not disabling the instrumentation**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## dev
 
-- **Feature: Span links are now supported for the Hybrid Agent**
+- **Feature: Span Links are now supported for the Hybrid Agent**
 
-  Spans created via the OpenTelemetry API can now have Span Links associated with them. Links can be added on a span's start, by passing them to the `links` argument, or by calling the `OpenTelemetry::Trace::Span#add_link` API. [PR#3586](https://github.com/newrelic/newrelic-ruby-agent/pull/3586)
+  Spans created via the OpenTelemetry API can now have [Span Links](https://opentelemetry.io/docs/concepts/signals/traces/#span-links) associated with them. Links can be added on a span's start, by passing them to the `links` argument, or by calling the `OpenTelemetry::Trace::Span#add_link` API. [PR#3586](https://github.com/newrelic/newrelic-ruby-agent/pull/3586)
 
 - **Bugfix: Fix `instrumentation.rails_event_logger: false` not disabling the instrumentation**
 

--- a/lib/new_relic/agent/opentelemetry/trace/span.rb
+++ b/lib/new_relic/agent/opentelemetry/trace/span.rb
@@ -32,6 +32,13 @@ module NewRelic
             end
           end
 
+          def add_link(link)
+            return self unless recording?
+
+            finishable&.add_span_link(link)
+            self
+          end
+
           def apply_translated_attributes(translated)
             translated[:instance_variable].each do |key, value|
               sym_key = "@#{key}".to_sym

--- a/lib/new_relic/agent/opentelemetry/trace/tracer.rb
+++ b/lib/new_relic/agent/opentelemetry/trace/tracer.rb
@@ -40,6 +40,7 @@ module NewRelic
             add_remote_context_to_otel_span(otel_span, parent_otel_context)
             otel_span.add_instrumentation_scope(@name, @version)
             otel_span.apply_translated_attributes(translated)
+            links&.each { |link| otel_span.add_link(link) }
 
             otel_span
           end

--- a/lib/new_relic/agent/span_event_aggregator.rb
+++ b/lib/new_relic/agent/span_event_aggregator.rb
@@ -37,6 +37,13 @@ module NewRelic
         metadata, events = super
         span_links = []
         events.each do |event|
+          # Span events are normally [intrinsics, custom_attrs, agent_attrs].
+          # When a span has links, a 4th element is appended:
+          # [intrinsics, custom_attrs, agent_attrs, span_links]
+          #
+          # Span Links must be sent to the backend at the top level of the main
+          # payload, not nested inside an individual Span. This pulls them out
+          # be flattened into the final array: [Span, SpanLink, Span, SpanLink]
           span_links.concat(event.slice!(3)) if event.length > 3
         end
         [metadata, events.concat(span_links)]

--- a/lib/new_relic/agent/span_event_aggregator.rb
+++ b/lib/new_relic/agent/span_event_aggregator.rb
@@ -33,6 +33,15 @@ module NewRelic
       SUPPORTABILITY_TOTAL_SENT = 'Supportability/SpanEvent/TotalEventsSent'.freeze
       SUPPORTABILITY_DISCARDED = 'Supportability/SpanEvent/Discarded'.freeze
 
+      def harvest!
+        metadata, events = super
+        span_links = []
+        events.each do |event|
+          span_links.concat(event.slice!(3)) if event.length > 3
+        end
+        [metadata, events.concat(span_links)]
+      end
+
       def after_harvest(metadata)
         seen = metadata[:seen]
         sent = metadata[:captured]

--- a/lib/new_relic/agent/span_event_primitive.rb
+++ b/lib/new_relic/agent/span_event_primitive.rb
@@ -48,6 +48,13 @@ module NewRelic
       TRANSACTION_NAME_KEY = 'transaction.name'
       THREAD_ID_KEY = 'thread.id'
 
+      # Strings for static keys/values used by SpanLink events
+      SPAN_LINK_TYPE = 'SpanLink'
+      ID_KEY = 'id'
+      TRACE_ID_LINK_KEY = 'trace.id'
+      LINKED_SPAN_ID_KEY = 'linkedSpanId'
+      LINKED_TRACE_ID_KEY = 'linkedTraceId'
+
       # Strings for static values of the event structure
       EVENT_TYPE = 'Span'
       GENERIC_CATEGORY = 'generic'
@@ -70,7 +77,8 @@ module NewRelic
         intrinsics = intrinsics_for(segment)
         intrinsics[CATEGORY_KEY] = GENERIC_CATEGORY
 
-        [intrinsics, custom_attributes(segment), agent_attributes(segment)]
+        event = [intrinsics, custom_attributes(segment), agent_attributes(segment)]
+        attach_span_links(event, segment)
       end
 
       def for_external_request_segment(segment)
@@ -91,7 +99,8 @@ module NewRelic
           agent_attributes[HTTP_URL_KEY] = truncate(segment.uri)
         end
 
-        [intrinsics, custom_attributes(segment), agent_attributes.merge(agent_attributes(segment))]
+        event = [intrinsics, custom_attributes(segment), agent_attributes.merge(agent_attributes(segment))]
+        attach_span_links(event, segment)
       end
 
       def for_datastore_segment(segment)
@@ -129,10 +138,33 @@ module NewRelic
           agent_attributes[STACKTRACE_KEY] = segment.params[:backtrace]
         end
 
-        [intrinsics, custom_attributes(segment), agent_attributes.merge(agent_attributes(segment))]
+        event = [intrinsics, custom_attributes(segment), agent_attributes.merge(agent_attributes(segment))]
+        attach_span_links(event, segment)
       end
 
       private
+
+      def attach_span_links(event, segment)
+        links = for_span_links(segment)
+        links.empty? ? event : event << links
+      end
+
+      def for_span_links(segment)
+        return [] if segment.span_links.empty?
+
+        segment.span_links.map do |link|
+          ctx = link.span_context
+          intrinsics = {
+            TYPE_KEY => SPAN_LINK_TYPE,
+            TIMESTAMP_KEY => milliseconds_since_epoch(segment),
+            ID_KEY => segment.guid,
+            TRACE_ID_LINK_KEY => segment.transaction.trace_id,
+            LINKED_SPAN_ID_KEY => ctx.hex_span_id,
+            LINKED_TRACE_ID_KEY => ctx.hex_trace_id
+          }
+          [intrinsics, link.attributes.dup, {}]
+        end
+      end
 
       def intrinsics_for(segment)
         intrinsics = {

--- a/lib/new_relic/agent/transaction.rb
+++ b/lib/new_relic/agent/transaction.rb
@@ -480,6 +480,14 @@ module NewRelic
         initial_segment&.finished?
       end
 
+      def add_span_link(link)
+        initial_segment&.add_span_link(link)
+      end
+
+      def span_links
+        initial_segment&.span_links || NewRelic::EMPTY_ARRAY
+      end
+
       def create_initial_segment(options = {})
         segment = create_segment(@default_name, options)
         segment.record_scoped_metric = false

--- a/lib/new_relic/agent/transaction/abstract_segment.rb
+++ b/lib/new_relic/agent/transaction/abstract_segment.rb
@@ -109,7 +109,7 @@ module NewRelic
         end
 
         def span_links
-          @span_links || NewRelic::EMPTY_ARRAY
+          instance_variable_defined?(:@span_links) ? @span_links : NewRelic::EMPTY_ARRAY
         end
 
         def params

--- a/lib/new_relic/agent/transaction/abstract_segment.rb
+++ b/lib/new_relic/agent/transaction/abstract_segment.rb
@@ -26,6 +26,8 @@ module NewRelic
 
         CALLBACK = :@callback
         SEGMENT = 'segment'
+        MAX_SPAN_LINKS = 100
+        SPAN_LINKS_DROPPED_METRIC = 'Supportability/Ruby/SpanEvent/Links/Dropped'
 
         def initialize(name = nil, start_time = nil)
           @name = name
@@ -95,6 +97,19 @@ module NewRelic
           force_finish unless finished?
           record_exclusive_duration
           record_metrics if record_metrics?
+        end
+
+        def add_span_link(link)
+          @span_links ||= []
+          if @span_links.size >= MAX_SPAN_LINKS
+            NewRelic::Agent.record_metric(SPAN_LINKS_DROPPED_METRIC, 1)
+            return
+          end
+          @span_links << link
+        end
+
+        def span_links
+          @span_links || NewRelic::EMPTY_ARRAY
         end
 
         def params

--- a/test/multiverse/suites/hybrid_agent/span_test.rb
+++ b/test/multiverse/suites/hybrid_agent/span_test.rb
@@ -466,6 +466,93 @@ module NewRelic
 
             assert_equal 201, txn.http_response_code
           end
+
+          def test_add_link_stores_link_on_finishable
+            linked_ctx = ::OpenTelemetry::Trace::SpanContext.new(
+              trace_id: ['a' * 32].pack('H*'),
+              span_id: ['b' * 16].pack('H*')
+            )
+            link = ::OpenTelemetry::Trace::Link.new(linked_ctx)
+
+            span = @tracer.start_span('test_span', kind: :server)
+            span.add_link(link)
+            span.finish
+
+            assert_equal 1, span.finishable.span_links.length
+            assert_equal link, span.finishable.span_links.first
+          end
+
+          def test_add_link_is_noop_on_finished_span
+            span = @tracer.start_span('test_span', kind: :server)
+            span.finish
+
+            linked_ctx = ::OpenTelemetry::Trace::SpanContext.new(
+              trace_id: ['a' * 32].pack('H*'),
+              span_id: ['b' * 16].pack('H*')
+            )
+            link = ::OpenTelemetry::Trace::Link.new(linked_ctx)
+            result = span.add_link(link)
+
+            assert_equal span, result
+            assert_empty span.finishable.span_links
+          end
+
+          def test_start_span_with_links_parameter_processes_links
+            linked_ctx = ::OpenTelemetry::Trace::SpanContext.new(
+              trace_id: ['a' * 32].pack('H*'),
+              span_id: ['b' * 16].pack('H*')
+            )
+            link = ::OpenTelemetry::Trace::Link.new(linked_ctx)
+
+            span = @tracer.start_span('test_span', kind: :server, links: [link])
+            span.finish
+
+            assert_equal 1, span.finishable.span_links.length
+          end
+
+          def test_span_links_appear_in_harvested_events
+            linked_ctx = ::OpenTelemetry::Trace::SpanContext.new(
+              trace_id: ['abcd1234abcd1234abcd1234abcd1234'].pack('H*'),
+              span_id: ['1234abcd1234abcd'].pack('H*')
+            )
+            link = ::OpenTelemetry::Trace::Link.new(linked_ctx, {'custom_attr' => 'value'})
+
+            span = @tracer.start_span('test_span', kind: :server)
+            span.add_link(link)
+            span.finishable.stubs(:sampled?).returns(true)
+            span.finish
+
+            _, events = harvest_span_events!
+            span_link_events = events.select { |e| e[0]['type'] == 'SpanLink' }
+
+            assert_equal 1, span_link_events.length
+            intrinsics, user_attrs, _ = span_link_events[0]
+
+            assert_equal 'SpanLink', intrinsics['type']
+            assert_equal linked_ctx.hex_span_id, intrinsics['linkedSpanId']
+            assert_equal linked_ctx.hex_trace_id, intrinsics['linkedTraceId']
+            assert_equal 'value', user_attrs['custom_attr']
+          end
+
+          def test_span_link_drop_limit_records_supportability_metric
+            in_transaction do |txn|
+              txn.stubs(:sampled?).returns(true)
+              span = @tracer.start_span('test_span')
+
+              102.times do
+                ctx = ::OpenTelemetry::Trace::SpanContext.new(
+                  trace_id: ['a' * 32].pack('H*'),
+                  span_id: ['b' * 16].pack('H*')
+                )
+                span.add_link(::OpenTelemetry::Trace::Link.new(ctx))
+              end
+
+              assert_equal 100, span.finishable.span_links.length
+              span.finish
+            end
+
+            assert_metrics_recorded({'Supportability/Ruby/SpanEvent/Links/Dropped' => {call_count: 2}})
+          end
         end
       end
     end

--- a/test/new_relic/agent/span_event_aggregator_test.rb
+++ b/test/new_relic/agent/span_event_aggregator_test.rb
@@ -96,7 +96,7 @@ module NewRelic
         span_link_events = events.select { |e| e[0]['type'] == 'SpanLink' }
 
         assert_equal 1, span_events.length
-        assert_equal 3, span_events[0].length, 'span event should be 3-element tuple after harvest'
+        assert_equal 3, span_events[0].length
         assert_equal 1, span_link_events.length
         assert_equal 'abc', span_link_events[0][0]['linkedSpanId']
       end

--- a/test/new_relic/agent/span_event_aggregator_test.rb
+++ b/test/new_relic/agent/span_event_aggregator_test.rb
@@ -79,6 +79,86 @@ module NewRelic
 
       include NewRelic::CommonAggregatorTests
 
+      def test_harvest_extracts_span_links_from_events
+        guid = fake_guid(16)
+        span_link = [{'type' => 'SpanLink', 'linkedSpanId' => 'abc', 'linkedTraceId' => 'def'}, {}, {}]
+        event_with_links = [
+          {'type' => 'Span', 'name' => 'op', 'guid' => guid, 'traceId' => guid, 'priority' => 1.0,
+           'sampled' => false, 'timestamp' => 1000, 'duration' => 0.1, 'category' => 'generic'},
+          {},
+          {},
+          [span_link]
+        ]
+        @event_aggregator.record(event: event_with_links)
+        _, events = @event_aggregator.harvest!
+
+        span_events = events.select { |e| e[0]['type'] == 'Span' }
+        span_link_events = events.select { |e| e[0]['type'] == 'SpanLink' }
+
+        assert_equal 1, span_events.length
+        assert_equal 3, span_events[0].length, 'span event should be 3-element tuple after harvest'
+        assert_equal 1, span_link_events.length
+        assert_equal 'abc', span_link_events[0][0]['linkedSpanId']
+      end
+
+      def test_harvest_span_links_do_not_affect_span_event_count
+        2.times do
+          guid = fake_guid(16)
+          span_link = [{'type' => 'SpanLink', 'linkedSpanId' => 'abc', 'linkedTraceId' => 'def'}, {}, {}]
+          event_with_links = [
+            {'type' => 'Span', 'name' => 'op', 'guid' => guid, 'traceId' => guid, 'priority' => 1.0,
+             'sampled' => false, 'timestamp' => 1000, 'duration' => 0.1, 'category' => 'generic'},
+            {},
+            {},
+            [span_link]
+          ]
+          @event_aggregator.record(event: event_with_links)
+        end
+        metadata, events = @event_aggregator.harvest!
+
+        assert_equal 2, metadata[:events_seen], 'reservoir should only count span events, not span links'
+        assert_equal 4, events.length, '2 span events + 2 span link events'
+      end
+
+      def test_harvest_returns_events_unchanged_when_no_span_links
+        2.times { generate_event }
+        _, events = @event_aggregator.harvest!
+
+        events.each do |event|
+          assert_equal 3, event.length
+        end
+      end
+
+      def test_span_links_are_dropped_with_their_parent_span
+        with_config(:'span_events.max_samples_stored' => 1) do
+          span_link = [{'type' => 'SpanLink', 'linkedSpanId' => 'abc', 'linkedTraceId' => 'def'}, {}, {}]
+          low_priority_guid = fake_guid(16)
+          low_priority_span_with_link = [
+            {'type' => 'Span', 'name' => 'low', 'guid' => low_priority_guid, 'traceId' => low_priority_guid,
+             'priority' => 1.0, 'sampled' => false, 'timestamp' => 1000, 'duration' => 0.1, 'category' => 'generic'},
+            {},
+            {},
+            [span_link]
+          ]
+          high_priority_guid = fake_guid(16)
+          high_priority_span = [
+            {'type' => 'Span', 'name' => 'high', 'guid' => high_priority_guid, 'traceId' => high_priority_guid,
+             'priority' => 2.0, 'sampled' => false, 'timestamp' => 1000, 'duration' => 0.1, 'category' => 'generic'},
+            {},
+            {}
+          ]
+
+          @event_aggregator.record(event: low_priority_span_with_link)
+          @event_aggregator.record(event: high_priority_span)
+
+          _, events = @event_aggregator.harvest!
+
+          assert_equal 1, events.length, 'only the high-priority span should survive'
+          assert_equal 'high', events[0][0]['name']
+          assert_empty events.select { |e| e[0]['type'] == 'SpanLink' }, 'links from dropped span must not appear'
+        end
+      end
+
       def test_supportability_metrics_for_span_events
         # NOTE: with_config won't work here, as the underlying capacity value
         #       ends up inside of a cached callback, so we'll directly alter

--- a/test/new_relic/agent/span_event_primitive_test.rb
+++ b/test/new_relic/agent/span_event_primitive_test.rb
@@ -408,7 +408,76 @@ module NewRelic
           assert_equal thread_id, spans[1][0][0]['thread.id']
         end
 
+        def test_for_segment_returns_three_element_tuple_when_no_links
+          with_segment do |segment|
+            event = SpanEventPrimitive.for_segment(segment)
+
+            assert_equal 3, event.length
+          end
+        end
+
+        def test_for_segment_returns_four_element_tuple_when_links_present
+          link = stub_span_link('a' * 32, 'b' * 16)
+
+          with_segment do |segment|
+            segment.add_span_link(link)
+            event = SpanEventPrimitive.for_segment(segment)
+
+            assert_equal 4, event.length
+            assert_kind_of Array, event[3]
+          end
+        end
+
+        def test_for_span_links_returns_empty_when_no_links
+          with_segment do |segment|
+            result = SpanEventPrimitive.send(:for_span_links, segment)
+
+            assert_empty result
+          end
+        end
+
+        def test_for_span_links_returns_span_link_event_tuples
+          hex_trace_id = 'abcd1234abcd1234abcd1234abcd1234'
+          hex_span_id = '1234abcd1234abcd'
+          link = stub_span_link(hex_trace_id, hex_span_id, {'user_attr' => 'value'})
+
+          with_segment do |segment|
+            segment.add_span_link(link)
+            result = SpanEventPrimitive.send(:for_span_links, segment)
+
+            assert_equal 1, result.length
+            intrinsics, user_attrs, agent_attrs = result[0]
+
+            assert_equal 'SpanLink', intrinsics['type']
+            assert_equal segment.guid, intrinsics['id']
+            assert_equal segment.transaction.trace_id, intrinsics['trace.id']
+            assert_equal hex_span_id, intrinsics['linkedSpanId']
+            assert_equal hex_trace_id, intrinsics['linkedTraceId']
+            assert_kind_of Integer, intrinsics['timestamp']
+            assert_equal 'value', user_attrs['user_attr']
+            assert_empty(agent_attrs)
+          end
+        end
+
+        def test_for_span_links_link_attributes_are_included_as_user_attributes
+          link = stub_span_link('a' * 32, 'b' * 16, {'key1' => 'val1', 'key2' => 42})
+
+          with_segment do |segment|
+            segment.add_span_link(link)
+            result = SpanEventPrimitive.send(:for_span_links, segment)
+            _, user_attrs, _ = result[0]
+
+            assert_equal 'val1', user_attrs['key1']
+            assert_equal 42, user_attrs['key2']
+          end
+        end
+
         private
+
+        def stub_span_link(hex_trace_id, hex_span_id, attributes = {})
+          ctx = Struct.new(:hex_trace_id, :hex_span_id).new(hex_trace_id, hex_span_id)
+          Struct.new(:span_context, :attributes).new(ctx, attributes)
+        end
 
         def uri_for_testing
           URI.parse('https://newrelic.com')

--- a/test/new_relic/agent/span_event_primitive_test.rb
+++ b/test/new_relic/agent/span_event_primitive_test.rb
@@ -408,7 +408,7 @@ module NewRelic
           assert_equal thread_id, spans[1][0][0]['thread.id']
         end
 
-        def test_for_segment_returns_three_element_tuple_when_no_links
+        def test_for_segment_returns_three_element_array_when_no_links
           with_segment do |segment|
             event = SpanEventPrimitive.for_segment(segment)
 
@@ -416,7 +416,7 @@ module NewRelic
           end
         end
 
-        def test_for_segment_returns_four_element_tuple_when_links_present
+        def test_for_segment_returns_four_element_array_when_links_present
           link = stub_span_link('a' * 32, 'b' * 16)
 
           with_segment do |segment|
@@ -436,7 +436,7 @@ module NewRelic
           end
         end
 
-        def test_for_span_links_returns_span_link_event_tuples
+        def test_for_span_links_returns_span_link_event_harvest
           hex_trace_id = 'abcd1234abcd1234abcd1234abcd1234'
           hex_span_id = '1234abcd1234abcd'
           link = stub_span_link(hex_trace_id, hex_span_id, {'user_attr' => 'value'})

--- a/test/new_relic/agent/transaction_test.rb
+++ b/test/new_relic/agent/transaction_test.rb
@@ -1995,5 +1995,36 @@ module NewRelic::Agent
 
       refute_predicate txn, :finished?
     end
+
+    def test_span_links_returns_empty_array_when_no_links_added
+      in_transaction do |txn|
+        assert_equal NewRelic::EMPTY_ARRAY, txn.span_links
+      end
+    end
+
+    def test_span_links_returns_empty_array_without_initial_segment
+      txn = Transaction.new(:web, {})
+
+      assert_equal NewRelic::EMPTY_ARRAY, txn.span_links
+    end
+
+    def test_add_span_link_stores_link_on_initial_segment
+      stub_link = Struct.new(:span_context, :attributes).new(nil, {})
+
+      in_transaction do |txn|
+        txn.add_span_link(stub_link)
+
+        assert_equal 1, txn.span_links.length
+        assert_equal stub_link, txn.span_links.first
+        assert_equal txn.initial_segment.span_links, txn.span_links
+      end
+    end
+
+    def test_add_span_link_is_noop_without_initial_segment
+      txn = Transaction.new(:web, {})
+      stub_link = Struct.new(:span_context, :attributes).new(nil, {})
+
+      assert_nil txn.add_span_link(stub_link)
+    end
   end
 end


### PR DESCRIPTION
This PR allows Span Links to be sent with the associated Span when added to a Span on start with the `:link` argument or when they are added using the `OpenTelemetry::Trace::Span#add_link` API. This does not allow NR originated spans/transactions/etc. to add span links.

OTel documentation:
* https://opentelemetry.io/docs/concepts/signals/traces/#span-links
* https://opentelemetry.io/docs/specs/otel/trace/api/#add-link

Once we implement #3276, we will be able to automatically ingest span links from background job instrumentation (ex. active job, sidekiq, que, resque)

In the meantime, span links from messaging libraries like bunny, racecar, rdkafka, along with others, will be ingested.

Related Specs (internal)
* [otel_bridge: Tracing-API#span-links](https://source.datanerd.us/agents/agent-specs/blob/158bfbfe19a5d881c5b1ed7081f844744d2f6351/otel_bridge/Tracing-API.md#span-links)
* [Span Events#span-links](https://source.datanerd.us/agents/agent-specs/blob/ff6990f1c95a3999c3e5c18b53868c3410a8c2fe/Span-Events.md#spanlink-events)
* [Protocol Version 17: Span Event Data](https://source.datanerd.us/agents/agent-specs/blob/139a6bd0711e131b53fec378f0593700f52707cb/endpoints/protocol-version-17/span_event_data.md)

Closes #3460