### PR TITLE
Support OpenTelemetry::Tracer#start_root_span

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## dev
 
+- **Feature: Add support for OpenTelemetry::Tracer#start_root_span**
+
+  The `OpenTelemetry::Tracer#start_root_span` API can now be used to force a transaction to start for a given span, provided it has a `:server` or `:consumer` span kind. For any other span kinds, it will no-op. This method is most commonly used in background job instrumentation. [PR#3588](https://github.com/newrelic/newrelic-ruby-agent/pull/3588)
+
 - **Bugfix: Fix `instrumentation.rails_event_logger: false` not disabling the instrumentation**
 
   Setting `instrumentation.rails_event_logger` to `false` was not disabling the Rails.event instrumentation as expected. The instrumentation would still be installed during Rails boot. This has been fixed. [PR#3564](https://github.com/newrelic/newrelic-ruby-agent/pull/3564)

--- a/lib/new_relic/agent/opentelemetry/trace/tracer.rb
+++ b/lib/new_relic/agent/opentelemetry/trace/tracer.rb
@@ -57,6 +57,10 @@ module NewRelic
             span&.finish
           end
 
+          def start_root_span(name, attributes: nil, links: nil, start_timestamp: nil, kind: nil)
+            start_span(name, with_parent: ::OpenTelemetry::Context.empty, attributes: attributes, links: links, start_timestamp: start_timestamp, kind: kind)
+          end
+
           private
 
           def start_segment_from_otel(name:, translated: nil, start_timestamp: nil, kind: nil)

--- a/test/multiverse/suites/hybrid_agent/tracer_test.rb
+++ b/test/multiverse/suites/hybrid_agent/tracer_test.rb
@@ -190,6 +190,46 @@ module NewRelic
             assert_equal('red', span_attributes['strawberry'])
           end
 
+          def test_start_root_span_starts_transaction_with_valid_kind
+            # this is drawn from the Active Job instrumentation tests in
+            # opentelemetry-ruby-contrib/instrumentation/active_job
+            attrs = {
+              'code.namespace' => 'TestJob',
+              'messaging.system' => 'active_job',
+              'messaging.destination' => 'default',
+              'messaging.message.id' => '32de9ec6-e55c-4dbe-acd9-d632725ffb9e',
+              'messaging.active_job.adapter.name' => 'async',
+              'messaging.active_job.message.provider_job_id' => '3692e4e5-708c-4af6-a3ca-b431eaf1b3ef'
+            }
+
+            span = @tracer.start_root_span('default process', kind: :consumer, attributes: attrs)
+
+            assert_instance_of NewRelic::Agent::Transaction, span.finishable
+
+            initial_segment = span.finishable.initial_segment
+
+            assert_equal attrs, initial_segment.attributes.custom_attributes
+            assert_equal 'default process', initial_segment.name
+
+            span.finishable.stubs(:sampled?).returns(true)
+            span&.finish
+          end
+
+          def test_start_root_span_does_not_create_telemetry_without_valid_kind
+            # this is just an edge case. this is not used in any instrumentation
+            # the attempted span gets kicked out when the
+            # should_not_create_telemetry? method is called.
+            attrs = {'bing' => 'cherries'}
+
+            span = @tracer.start_root_span('Prunus avium', kind: :producer, attributes: attrs)
+
+            assert_instance_of ::OpenTelemetry::Trace::Span, span
+            assert_raises(NoMethodError) { span.finishable }
+            refute_predicate span.context, :valid?
+
+            span&.finish
+          end
+
           private
 
           def assert_logged(expected)


### PR DESCRIPTION
This method is most commonly used in background job instrumentation. [Example](https://github.com/open-telemetry/opentelemetry-ruby-contrib/blob/89f484cc0e087de03058bc1588a6adf69d1b17a3/instrumentation/sidekiq/lib/opentelemetry/instrumentation/sidekiq/middlewares/server/tracer_middleware.rb#L44) 

Closes #3276 