### PR TITLE
pin i18n if on ruby 3.1

### DIFF
--- a/test/environments/rails61/Gemfile
+++ b/test/environments/rails61/Gemfile
@@ -35,6 +35,11 @@ gem 'pry' if ENV['ENABLE_PRY']
 gem 'simplecov' if ENV['VERBOSE_TEST_OUTPUT']
 gem 'warning'
 
+# i18n 1.15.0+ is broken on Ruby 3.1 and will not be fixed, so pin below it
+if RUBY_VERSION.start_with?('3.1.')
+  gem 'i18n', '< 1.15.0'
+end
+
 if RUBY_VERSION.split('.')[0..1].join('.').to_f >= 3.4
   gem 'base64'
   gem 'bigdecimal'

--- a/test/environments/rails70/Gemfile
+++ b/test/environments/rails70/Gemfile
@@ -21,6 +21,11 @@ gem 'pry' if ENV['ENABLE_PRY']
 gem 'simplecov' if ENV['VERBOSE_TEST_OUTPUT']
 gem 'warning'
 
+# i18n 1.15.0+ is broken on Ruby 3.1 and will not be fixed, so pin below it
+if RUBY_VERSION.start_with?('3.1.')
+  gem 'i18n', '< 1.15.0'
+end
+
 if RUBY_VERSION.split('.')[0..1].join('.').to_f >= 3.4
   gem 'base64'
   gem 'bigdecimal'

--- a/test/environments/rails71/Gemfile
+++ b/test/environments/rails71/Gemfile
@@ -21,6 +21,11 @@ gem 'pry' if ENV['ENABLE_PRY']
 gem 'simplecov' if ENV['VERBOSE_TEST_OUTPUT']
 gem 'warning'
 
+# i18n 1.15.0+ is broken on Ruby 3.1 and will not be fixed, so pin below it
+if RUBY_VERSION.start_with?('3.1.')
+  gem 'i18n', '< 1.15.0'
+end
+
 if RUBY_VERSION.split('.')[0..1].join('.').to_f >= 3.4
   gem 'base64'
   gem 'bigdecimal'

--- a/test/environments/rails72/Gemfile
+++ b/test/environments/rails72/Gemfile
@@ -21,6 +21,11 @@ gem 'pry' if ENV['ENABLE_PRY']
 gem 'simplecov' if ENV['VERBOSE_TEST_OUTPUT']
 gem 'warning'
 
+# i18n 1.15.0+ is broken on Ruby 3.1 and will not be fixed, so pin below it
+if RUBY_VERSION.start_with?('3.1.')
+  gem 'i18n', '< 1.15.0'
+end
+
 if RUBY_VERSION.split('.')[0..1].join('.').to_f >= 3.4
   gem 'base64'
   gem 'bigdecimal'

--- a/test/multiverse/lib/multiverse/suite.rb
+++ b/test/multiverse/lib/multiverse/suite.rb
@@ -288,6 +288,9 @@ module Multiverse
         f.puts "gem 'webrick'"
         f.puts "gem 'warning'"
 
+        # i18n 1.15.0+ is broken on Ruby 3.1 and will not be fixed, so pin below it
+        f.puts "gem 'i18n', '< 1.15.0'" if RUBY_VERSION.start_with?('3.1.')
+
         if debug
           f.puts "gem 'pry', '~> 0.14'" if ENV['ENABLE_PRY']
           f.puts "gem 'pry-nav'" if ENV['ENABLE_PRY']

--- a/test/multiverse/suites/delayed_job/Envfile
+++ b/test/multiverse/suites/delayed_job/Envfile
@@ -26,7 +26,6 @@ if RUBY_VERSION >= '2.6.0'
   # top-level >= 0.3 dependency.
   gemfile <<~RB
     gem 'delayed_job'
-    gem 'i18n'
     #{boilerplate_gems}
     gem 'securerandom', '>= 0.3'
   RB
@@ -36,7 +35,6 @@ if RUBY_VERSION >= '2.6.0'
     gem 'delayed_job'
     gem 'delayed_job_active_record'
     gem 'activerecord', '~> 6.1.0'
-    gem 'i18n'
     #{boilerplate_gems}
   RB
 end
@@ -45,7 +43,6 @@ end
 gemfile <<~RB
   gem 'delayed_job', '~> 4.1.0'
   gem 'delayed_job_mongoid', '~> 2.3.0'
-  gem 'i18n', '~> 0.7.0'
   if RUBY_VERSION <= '2.6.0'
     gem 'minitest', '~> 4.7.5' # required for Rails < 4.1
     gem 'activesupport', '~> 3.2.22'


### PR DESCRIPTION
i18n 1.15.0 released on 3.1+, but is broken on 3.1. The fix they released for 1.15.1 was to simply bump the minimum required ruby version, so 3.1 will always be broken without us pinning it.

[ci cron ](https://github.com/newrelic/newrelic-ruby-agent/actions/runs/27776705525/job/82190781091)