### PR TITLE
Gate Lambda Release by successful release workflow

### DIFF
--- a/.github/workflows/lambda_release.yml
+++ b/.github/workflows/lambda_release.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   release:
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
The Lambda release workflow would incorrectly file if the release workflow completed, but failed. Now, it will only run if the release is successful. This is the pattern the GitHub docs recommend, so I think our best way to test it is during the release.

The original issue mentioned possibly updating `agent_metadata` too. Since it uses `workflow_run`, this is more complicated to get the input. I think we should make the smallest possible change for now, and we can look into refactoring later on.

Resolves #3569