### PR TITLE
Bump concurrent-ruby version

### DIFF
--- a/test/perfverse/rails7/Gemfile
+++ b/test/perfverse/rails7/Gemfile
@@ -11,4 +11,4 @@ gem 'rails', '~> 7.0.2', '>= 7.0.2.3'
 gem 'sprockets-rails'
 gem 'sqlite3', '~> 1.4'
 
-gem "concurrent-ruby", ">= 1.3.7"
+gem 'concurrent-ruby', '>= 1.3.7'

--- a/test/perfverse/rails7/Gemfile
+++ b/test/perfverse/rails7/Gemfile
@@ -11,6 +11,4 @@ gem 'rails', '~> 7.0.2', '>= 7.0.2.3'
 gem 'sprockets-rails'
 gem 'sqlite3', '~> 1.4'
 
-# https://github.com/rails/rails/issues/54260
-# https://stackoverflow.com/questions/79360526/uninitialized-constant-activesupportloggerthreadsafelevellogger-nameerror
-gem 'concurrent-ruby', '1.3.4'
+gem "concurrent-ruby", ">= 1.3.7"


### PR DESCRIPTION
Increasing to address dependabot vulnerabilities. 

See: https://github.com/newrelic/newrelic-ruby-agent/actions/runs/28060278946 

Should fix quotes before merge even though rubocop doesn't care.