### PR TITLE
Enable Style/SafeNavigation on Rubocop

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -76,15 +76,6 @@ Style/MapIntoArray:
     - 'lib/new_relic/agent/database/explain_plan_helpers.rb'
     - 'lib/tasks/helpers/format.rb'
 
-# Offense count: 2
-# This cop supports unsafe autocorrection (--autocorrect-all).
-# Configuration parameters: ConvertCodeThatCanStartToReturnNil, AllowedMethods, MaxChainLength.
-# AllowedMethods: present?, blank?, presence, try, try!
-Style/SafeNavigation:
-  Exclude:
-    - 'lib/new_relic/agent/instrumentation/active_record_helper.rb'
-    - 'lib/new_relic/agent/instrumentation/active_record_subscriber.rb'
-
 # Offense count: 4
 # Configuration parameters: Max.
 Style/SafeNavigationChainLength:

--- a/lib/new_relic/agent.rb
+++ b/lib/new_relic/agent.rb
@@ -645,8 +645,7 @@ module NewRelic
     #
     def after_fork(options = {})
       record_api_supportability_metric(:after_fork)
-      # the following line needs else branch coverage
-      agent.after_fork(options) if agent # rubocop:disable Style/SafeNavigation
+      agent&.after_fork(options)
     end
 
     # Shutdown the agent.  Call this before exiting.  Sends any queued data
@@ -668,8 +667,7 @@ module NewRelic
     # @!scope class
     # @api public
     def drop_buffered_data
-      # the following line needs else branch coverage
-      agent.drop_buffered_data if agent # rubocop:disable Style/SafeNavigation
+      agent&.drop_buffered_data
       record_api_supportability_metric(:drop_buffered_data)
     end
 

--- a/lib/new_relic/agent/commands/agent_command_router.rb
+++ b/lib/new_relic/agent/commands/agent_command_router.rb
@@ -29,10 +29,7 @@ module NewRelic
           @handlers['start_profiler'] = proc { |cmd| thread_profiler_session.handle_start_command(cmd) }
           @handlers['stop_profiler'] = proc { |cmd| thread_profiler_session.handle_stop_command(cmd) }
 
-          # the following statement needs else branch coverage
-          if event_listener # rubocop:disable Style/SafeNavigation
-            event_listener.subscribe(:before_shutdown, &method(:on_before_shutdown))
-          end
+          event_listener&.subscribe(:before_shutdown, &method(:on_before_shutdown))
         end
 
         def new_relic_service

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -100,8 +100,7 @@ module NewRelic
             end
 
             # If we're packaged for warbler, we can tell from GEM_HOME
-            # the following line needs else branch coverage
-            if ENV['GEM_HOME'] && ENV['GEM_HOME'].end_with?('.jar!') # rubocop:disable Style/SafeNavigation
+            if ENV['GEM_HOME']&.end_with?('.jar!')
               app_name = File.basename(ENV['GEM_HOME'], '.jar!')
               paths << File.join(ENV['GEM_HOME'], app_name, config_yaml)
               paths << File.join(ENV['GEM_HOME'], app_name, config_erb)

--- a/lib/new_relic/agent/heap.rb
+++ b/lib/new_relic/agent/heap.rb
@@ -26,8 +26,7 @@ module NewRelic
       def initialize(items = nil, &priority_fn)
         @items = []
         @priority_fn = priority_fn || ->(x) { x }
-        # the following line needs else branch coverage
-        items.each { |item| push(item) } if items # rubocop:disable Style/SafeNavigation
+        items&.each { |item| push(item) }
       end
 
       def [](index)

--- a/lib/new_relic/agent/instrumentation/action_controller_subscriber.rb
+++ b/lib/new_relic/agent/instrumentation/action_controller_subscriber.rb
@@ -90,8 +90,7 @@ module NewRelic
         end
 
         def queue_start(request)
-          # the following line needs else branch coverage
-          if request && request.respond_to?(:env) # rubocop:disable Style/SafeNavigation
+          if request&.respond_to?(:env)
             QueueTime.parse_frontend_timestamp(request.env, Process.clock_gettime(Process::CLOCK_REALTIME))
           end
         end

--- a/lib/new_relic/agent/instrumentation/active_record_helper.rb
+++ b/lib/new_relic/agent/instrumentation/active_record_helper.rb
@@ -322,7 +322,7 @@ module NewRelic
           private
 
           def postgres_unix_domain_socket_case?(host, adapter)
-            adapter == :postgres && host && host.start_with?(NewRelic::SLASH)
+            adapter == :postgres && host && host.start_with?(NewRelic::SLASH) # rubocop:disable Style/SafeNavigation
           end
 
           def mysql_default_case?(config, adapter)

--- a/lib/new_relic/agent/instrumentation/active_record_subscriber.rb
+++ b/lib/new_relic/agent/instrumentation/active_record_subscriber.rb
@@ -98,10 +98,12 @@ module NewRelic
         end
 
         def use_spec_config?(handler)
+          # rubocop:disable Style/SafeNavigation
           handler.respond_to?(:spec) &&
             handler.spec &&
             handler.spec.config &&
             handler.spec.config[:adapter].end_with?('makara')
+          # rubocop:enable Style/SafeNavigation
         end
 
         def start_segment(config, payload)

--- a/lib/new_relic/agent/instrumentation/controller_instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/controller_instrumentation.rb
@@ -238,8 +238,7 @@ module NewRelic
           end
 
           def self.prefix_for_category(txn, category = nil)
-            # the following line needs else branch coverage
-            category ||= (txn && txn.category) # rubocop:disable Style/SafeNavigation
+            category ||= txn&.category
             case category
             when :controller then ::NewRelic::Agent::Transaction::CONTROLLER_PREFIX
             when :web then ::NewRelic::Agent::Transaction::CONTROLLER_PREFIX
@@ -390,8 +389,7 @@ module NewRelic
               raise
             end
           ensure
-            # the following line needs else branch coverage
-            finishable.finish if finishable # rubocop:disable Style/SafeNavigation
+            finishable&.finish
           end
         end
 

--- a/lib/new_relic/agent/instrumentation/custom_events_subscriber.rb
+++ b/lib/new_relic/agent/instrumentation/custom_events_subscriber.rb
@@ -23,8 +23,7 @@ module NewRelic::Agent::Instrumentation
       NewRelic::Agent.notice_error(payload[:exception_object]) if payload.key?(:exception_object)
 
       finishable = pop_segment(id)
-      # the following line needs else branch coverage
-      finishable.finish if finishable # rubocop:disable Style/SafeNavigation
+      finishable&.finish
     rescue => e
       log_notification_error(e, name, 'finish')
     end

--- a/lib/new_relic/agent/instrumentation/excon/middleware.rb
+++ b/lib/new_relic/agent/instrumentation/excon/middleware.rb
@@ -49,8 +49,7 @@ module ::Excon
       end
 
       def finish_trace(datum) # THREAD_LOCAL_ACCESS
-        # The following line needs else branch coverage
-        segment = datum[:connection] && datum[:connection].instance_variable_get(TRACE_DATA_IVAR) # rubocop:disable Style/SafeNavigation
+        segment = datum[:connection]&.instance_variable_get(TRACE_DATA_IVAR)
         if segment
           begin
             segment.notice_error(datum[:error]) if datum[:error]

--- a/lib/new_relic/agent/instrumentation/redis/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/redis/instrumentation.rb
@@ -76,8 +76,7 @@ module NewRelic::Agent::Instrumentation
           self
         # redis-client gem v0.11+ (self is a RedisClient::Middlewares)
         elsif respond_to?(:client)
-          # The following line needs else branch coverage
-          client && client.config # rubocop:disable Style/SafeNavigation
+          client&.config
         # redis-client gem <0.11 (self is a RedisClient::Middlewares)
         elsif defined?(::RedisClient)
           ::RedisClient.config if ::RedisClient.respond_to?(:config)

--- a/lib/new_relic/agent/instrumentation/sinatra/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/sinatra/instrumentation.rb
@@ -47,8 +47,7 @@ module NewRelic::Agent::Instrumentation
 
       def try_to_use(app, clazz)
         install_lock.synchronize do
-          # The following line needs else branch coverage
-          has_middleware = app.middleware && app.middleware.any? { |info| info && info[0] == clazz } # rubocop:disable Style/SafeNavigation
+          has_middleware = app.middleware&.any? { |info| info && info[0] == clazz }
           app.use(clazz) unless has_middleware
         end
       end

--- a/lib/new_relic/agent/instrumentation/tilt/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/tilt/instrumentation.rb
@@ -36,8 +36,7 @@ module NewRelic
               raise
             end
           ensure
-            # The following line needs else branch coverage
-            finishable.finish if finishable # rubocop:disable Style/SafeNavigation
+            finishable&.finish
           end
         end
       end

--- a/lib/new_relic/agent/messaging.rb
+++ b/lib/new_relic/agent/messaging.rb
@@ -153,8 +153,7 @@ module NewRelic
         yield
       ensure
         begin
-          # the following line needs else branch coverage
-          txn.finish if txn # rubocop:disable Style/SafeNavigation
+          txn&.finish
         rescue => e
           NewRelic::Agent.logger.error('Error stopping Message Broker consume transaction', e)
         end
@@ -195,8 +194,7 @@ module NewRelic
         correlation_id: nil,
         exchange_type: nil)
 
-        # The following line needs else branch coverage
-        original_headers = headers.nil? ? nil : headers.dup # rubocop:disable Style/SafeNavigation
+        original_headers = headers&.dup
 
         segment = Tracer.start_message_broker_segment(
           action: :produce,

--- a/lib/new_relic/agent/pipe_service.rb
+++ b/lib/new_relic/agent/pipe_service.rb
@@ -89,8 +89,7 @@ module NewRelic
       end
 
       def write_to_pipe(endpoint, data)
-        # the following line needs else branch coverage
-        @pipe.write(marshal_payload([endpoint, data])) if @pipe # rubocop:disable Style/SafeNavigation
+        @pipe&.write(marshal_payload([endpoint, data]))
       end
     end
   end

--- a/lib/new_relic/agent/tracer.rb
+++ b/lib/new_relic/agent/tracer.rb
@@ -356,8 +356,7 @@ module NewRelic
 
           yield
         rescue => exception
-          # needs else branch coverage
-          segment.notice_error(exception) if segment&.is_a?(Transaction::AbstractSegment)
+          segment.notice_error(exception) if segment.is_a?(Transaction::AbstractSegment)
           raise
         end
 
@@ -489,8 +488,7 @@ module NewRelic
         end
 
         def pop_traced
-          # needs else branch coverage
-          @untraced.pop if @untraced # rubocop:disable Style/SafeNavigation
+          @untraced&.pop
         end
 
         def is_execution_traced?

--- a/lib/new_relic/agent/transaction.rb
+++ b/lib/new_relic/agent/transaction.rb
@@ -184,8 +184,7 @@ module NewRelic
 
       def add_agent_attribute(key, value, default_destinations)
         @attributes.add_agent_attribute(key, value, default_destinations)
-        # the following line needs else branch coverage
-        current_segment.add_agent_attribute(key, value) if current_segment # rubocop:disable Style/SafeNavigation
+        current_segment&.add_agent_attribute(key, value)
       end
 
       def self.merge_untrusted_agent_attributes(attributes, prefix, default_destinations)

--- a/lib/new_relic/agent/transaction_time_aggregator.rb
+++ b/lib/new_relic/agent/transaction_time_aggregator.rb
@@ -115,8 +115,7 @@ module NewRelic
 
         def thread_is_alive?(thread_id)
           thread = thread_by_id(thread_id)
-          # needs else branch coverage
-          thread && thread.alive? # rubocop:disable Style/SafeNavigation
+          thread&.alive?
         rescue StandardError
           false
         end

--- a/lib/new_relic/helper.rb
+++ b/lib/new_relic/helper.rb
@@ -63,8 +63,7 @@ module NewRelic
         raise NewRelic::CommandRunFailedError.new("Failed to run command '#{command}': #{message}")
       end
 
-      # needs else branch coverage
-      output.chomp if output # rubocop:disable Style/SafeNavigation
+      output&.chomp
     end
 
     # TODO: Open3 defers the actual execution of a binary to Process.spawn,

--- a/lib/new_relic/rack/browser_monitoring.rb
+++ b/lib/new_relic/rack/browser_monitoring.rb
@@ -111,7 +111,6 @@ module NewRelic
       end
 
       def html?(headers)
-        # needs else branch coverage
         headers[CONTENT_TYPE]&.match?(TEXT_HTML)
       end
 

--- a/test/multiverse/suites/excon/excon_test.rb
+++ b/test/multiverse/suites/excon/excon_test.rb
@@ -105,4 +105,10 @@ class ExconTest < Minitest::Test
 
     assert_equal('External/localhost/Excon/GET', last_node.metric_name)
   end
+
+  def test_finish_trace_with_nil_connection_does_not_raise
+    middleware = Excon::Middleware::NewRelicTracing.new(stub)
+    datum = {connection: nil}
+    middleware.send(:finish_trace, datum)
+  end
 end

--- a/test/multiverse/suites/redis/redis_instrumentation_test.rb
+++ b/test/multiverse/suites/redis/redis_instrumentation_test.rb
@@ -454,6 +454,22 @@ if NewRelic::Agent::Datastores::Redis.is_supported_version?
       end
     end
 
+    def test__nr_redis_client_config_with_nil_client
+      skip_unless_minitest5_or_above
+
+      client = FakeClient.new
+
+      client.stub :respond_to?, true, [:client] do
+        client.stub :client, nil do
+          Object.stub_const :RedisClient, nil do
+            assert_raises StandardError do
+              client.send(:_nr_redis_client_config)
+            end
+          end
+        end
+      end
+    end
+
     def test_call_pipelined_with_tracing_uses_a_nil_db_value_if_it_must
       client = FakeClient.new
       with_tracing_validator = proc do |*args|

--- a/test/multiverse/suites/tilt/tilt_instrumentation_test.rb
+++ b/test/multiverse/suites/tilt/tilt_instrumentation_test.rb
@@ -197,4 +197,12 @@ class TiltInstrumentationTest < Minitest::Test
     )
     String.any_instance.unstub(:split)
   end
+
+  def test_render_with_nil_finishable_does_not_raise
+    NewRelic::Agent::Tracer.stubs(:start_segment).returns(nil)
+
+    in_transaction do
+      Tilt.new('test.erb').render
+    end
+  end
 end

--- a/test/multiverse/suites/tilt/tilt_instrumentation_test.rb
+++ b/test/multiverse/suites/tilt/tilt_instrumentation_test.rb
@@ -88,6 +88,25 @@ class TiltInstrumentationTest < Minitest::Test
     assert_transaction_noticed_error txn, exception_class.name
   end
 
+  def test_finish_called_on_segment
+    mock_segment = stub_everything('segment')
+    mock_segment.expects(:finish).once
+    NewRelic::Agent::Tracer.stubs(:start_segment).returns(mock_segment)
+
+    in_transaction { haml_template }
+  end
+
+  def test_finish_called_on_segment_even_when_render_raises
+    mock_segment = stub_everything('segment')
+    mock_segment.expects(:finish).once
+    NewRelic::Agent::Tracer.stubs(:start_segment).returns(mock_segment)
+    Tilt::Template.any_instance.stubs(:evaluate).raises(TypeError)
+
+    assert_raises(TypeError) do
+      in_transaction { haml_template }
+    end
+  end
+
   def test_records_nothing_if_tracing_disabled
     NewRelic::Agent.disable_all_tracing do
       in_transaction do
@@ -196,13 +215,5 @@ class TiltInstrumentationTest < Minitest::Test
       long_non_nested_path
     )
     String.any_instance.unstub(:split)
-  end
-
-  def test_render_with_nil_finishable_does_not_raise
-    NewRelic::Agent::Tracer.stubs(:start_segment).returns(nil)
-
-    in_transaction do
-      Tilt.new('test.erb').render
-    end
   end
 end

--- a/test/new_relic/agent/commands/agent_command_router_test.rb
+++ b/test/new_relic/agent/commands/agent_command_router_test.rb
@@ -62,6 +62,12 @@ class AgentCommandRouterTest < Minitest::Test
     agent_commands.backtrace_service.worker_thread&.join
   end
 
+  def test_initialize_with_nil_event_listener
+    router = NewRelic::Agent::Commands::AgentCommandRouter.new(nil)
+
+    refute_nil router.handlers
+  end
+
   # General command routing
 
   def test_check_for_and_handle_agent_commands_dispatches_command

--- a/test/new_relic/agent/configuration/default_source_test.rb
+++ b/test/new_relic/agent/configuration/default_source_test.rb
@@ -122,6 +122,14 @@ module NewRelic::Agent::Configuration
       end
     end
 
+    def test_config_search_path_without_gem_home
+      with_environment('GEM_HOME' => nil) do
+        paths = DefaultSource.config_search_paths.call()
+
+        refute paths.any? { |p| p.include?('.jar!') }
+      end
+    end
+
     def test_agent_attribute_settings_convert_comma_delimited_strings_into_an_arrays
       types = %w[transaction_tracer. transaction_events. error_collector. browser_monitoring.]
       types << ''

--- a/test/new_relic/agent/heap_test.rb
+++ b/test/new_relic/agent/heap_test.rb
@@ -14,6 +14,12 @@ module NewRelic
         assert_equal [4, 8, 5, 12], heap.to_a
       end
 
+      def test_initialize_with_no_items
+        heap = Heap.new
+
+        assert_empty heap.to_a
+      end
+
       def test_tree_rebalanced_on_pop
         heap = Heap.new([12, 5, 4, 8])
         heap.pop

--- a/test/new_relic/agent/instrumentation/controller_instrumentation_test.rb
+++ b/test/new_relic/agent/instrumentation/controller_instrumentation_test.rb
@@ -252,6 +252,12 @@ module NewRelic::Agent::Instrumentation
       end
     end
 
+    def test_prefix_for_category_with_nil_txn_and_no_category
+      result = @txn_namer.prefix_for_category(nil)
+
+      assert_equal('/', result)
+    end
+
     def test_transaction_path_name
       result = @txn_namer.path_name(@object)
 
@@ -336,6 +342,21 @@ module NewRelic::Agent::Instrumentation
       host = host_class.new
       host.expects(:params).never
       host.doit
+    end
+
+    def test_nil_finishable_does_not_raise
+      host_class = Class.new do
+        include ControllerInstrumentation
+
+        def doit
+          perform_action_with_newrelic_trace do
+            # nothing
+          end
+        end
+      end
+
+      NewRelic::Agent::Tracer.stubs(:start_transaction_or_segment).returns(nil)
+      host_class.new.doit
     end
 
     class UserError < StandardError

--- a/test/new_relic/agent/instrumentation/rails/action_controller_subscriber.rb
+++ b/test/new_relic/agent/instrumentation/rails/action_controller_subscriber.rb
@@ -349,4 +349,8 @@ class NewRelic::Agent::Instrumentation::ActionControllerSubscriberTest < Minites
         attributes['code.namespace']
     end
   end
+
+  def test_queue_start_with_nil_request
+    assert_nil @subscriber.send(:queue_start, nil)
+  end
 end

--- a/test/new_relic/agent/instrumentation/rails/custom_events_subscriber_test.rb
+++ b/test/new_relic/agent/instrumentation/rails/custom_events_subscriber_test.rb
@@ -53,6 +53,13 @@ module NewRelic::Agent::Instrumentation
       logger.verify
     end
 
+    def test_finish_with_nil_finishable
+      SUBSCRIBER.stubs(:pop_segment).returns(nil)
+      in_transaction do
+        SUBSCRIBER.finish(NAME, ID, {})
+      end
+    end
+
     def test_finish
       in_transaction do |txn|
         started_segment = NewRelic::Agent::Tracer.start_transaction_or_segment(name: NAME, category: :testing)

--- a/test/new_relic/agent/instrumentation/sinatra_test.rb
+++ b/test/new_relic/agent/instrumentation/sinatra_test.rb
@@ -59,6 +59,14 @@ class NewRelic::Agent::Instrumentation::SinatraTest < Minitest::Test
     @app.route_eval_with_tracing
   end
 
+  def test_try_to_use_with_nil_middleware
+    fake_app = mock('app')
+    fake_app.stubs(:middleware).returns(nil)
+    fake_app.expects(:use).once
+
+    @app.try_to_use(fake_app, Class.new)
+  end
+
   def assert_transaction_name(expected, original)
     assert_equal expected, NewRelic::Agent::Instrumentation::Sinatra::TransactionNamer.transaction_name(original, nil)
   end

--- a/test/new_relic/agent/messaging_test.rb
+++ b/test/new_relic/agent/messaging_test.rb
@@ -163,6 +163,21 @@ module NewRelic
         assert txn.finished, 'Expected transaction to be finished'
       end
 
+      def test_wrap_message_broker_consume_transaction_with_nil_txn
+        NewRelic::Agent::Tracer.stubs(:start_transaction).raises(RuntimeError, 'simulated start failure')
+
+        yielded = false
+        NewRelic::Agent::Messaging.wrap_message_broker_consume_transaction(
+          library: 'AwesomeBunniez',
+          destination_type: :exchange,
+          destination_name: 'Default'
+        ) do
+          yielded = true
+        end
+
+        assert yielded, 'Expected block to be yielded even when txn is nil'
+      end
+
       def test_agent_attributes_assigned_for_generic_wrap_consume_transaction
         NewRelic::Agent.instance.span_event_aggregator.stubs(:enabled?).returns(true)
         NewRelic::Agent::Transaction.any_instance.stubs(:sampled?).returns(true)
@@ -335,6 +350,16 @@ module NewRelic
         )
 
         refute segment.params[:headers], 'expected no :headers key in segment params'
+      end
+
+      def test_start_amqp_publish_segment_with_nil_headers
+        segment = NewRelic::Agent::Messaging.start_amqp_publish_segment(
+          library: 'RabbitMQ',
+          destination_name: 'Default',
+          headers: nil
+        )
+
+        refute segment.params[:headers], 'expected no :headers key when headers is nil'
       end
 
       def test_headers_not_attached_to_segment_if_empty_on_consume

--- a/test/new_relic/agent/pipe_service_test.rb
+++ b/test/new_relic/agent/pipe_service_test.rb
@@ -37,6 +37,13 @@ class PipeServiceTest < Minitest::Test
     service.metric_data({})
   end
 
+  def test_write_to_pipe_with_nil_pipe_does_not_raise
+    service = NewRelic::Agent::PipeService.new(:non_existant)
+    service.instance_variable_set(:@pipe, nil)
+
+    assert_empty(service.metric_data({}))
+  end
+
   if NewRelic::LanguageSupport.can_fork?
 
     def test_metric_data

--- a/test/new_relic/agent/tracer_test.rb
+++ b/test/new_relic/agent/tracer_test.rb
@@ -532,6 +532,28 @@ module NewRelic
           Tracer.create_distributed_trace_payload
         end
       end
+
+      def test_capture_segment_error_with_nil_segment
+        error = RuntimeError.new('boom')
+        assert_raises(RuntimeError) do
+          Tracer.capture_segment_error(nil) { raise error }
+        end
+      end
+
+      def test_capture_segment_error_with_non_abstract_segment
+        error = RuntimeError.new('boom')
+        non_segment = Object.new
+        assert_raises(RuntimeError) do
+          Tracer.capture_segment_error(non_segment) { raise error }
+        end
+      end
+
+      def test_pop_traced_with_nil_untraced
+        state = Tracer::State.new
+        state.untraced = nil
+
+        assert_nil state.pop_traced
+      end
     end
   end
 end

--- a/test/new_relic/agent/transaction_test.rb
+++ b/test/new_relic/agent/transaction_test.rb
@@ -1328,6 +1328,16 @@ module NewRelic::Agent
       Transaction.add_agent_attribute(:foo, 'bar', AttributeFilter::DST_ALL)
     end
 
+    def test_adding_agent_attribute_with_nil_current_segment
+      in_transaction do |txn|
+        txn.stubs(:current_segment).returns(nil)
+        txn.add_agent_attribute(:foo, 'bar', AttributeFilter::DST_ALL)
+        actual = txn.attributes.agent_attributes_for(AttributeFilter::DST_TRANSACTION_TRACER)
+
+        assert_equal({:foo => 'bar'}, actual)
+      end
+    end
+
     def test_adding_intrinsic_attributes
       in_transaction do |txn|
         txn.attributes.add_intrinsic_attribute(:foo, 'bar')

--- a/test/new_relic/agent/transaction_time_aggregator_test.rb
+++ b/test/new_relic/agent/transaction_time_aggregator_test.rb
@@ -149,4 +149,11 @@ class NewRelic::Agent::TransactionTimeAggregatorTest < Minitest::Test
       assert_equal Fiber.current.object_id, result
     end
   end
+
+  def test_thread_is_alive_returns_falsy_when_thread_not_found
+    nonexistent_id = -1
+    result = NewRelic::Agent::TransactionTimeAggregator.send(:thread_is_alive?, nonexistent_id)
+
+    refute result
+  end
 end

--- a/test/new_relic/agent_test.rb
+++ b/test/new_relic/agent_test.rb
@@ -91,6 +91,18 @@ module NewRelic
       NewRelic::Agent.after_fork
     end
 
+    def test_after_fork_without_agent
+      with_unstarted_agent do
+        NewRelic::Agent.after_fork
+      end
+    end
+
+    def test_drop_buffered_data_without_agent
+      with_unstarted_agent do
+        NewRelic::Agent.drop_buffered_data
+      end
+    end
+
     def test_manual_start_default
       mock_control = mocked_control
       mock_control.expects(:init_plugin).with({:agent_enabled => true, :sync_startup => true})

--- a/test/new_relic/helper_test.rb
+++ b/test/new_relic/helper_test.rb
@@ -61,6 +61,14 @@ class HelperTest < Minitest::Test
     assert_equal result, stubbed
   end
 
+  def test_run_command_nil_output
+    NewRelic::Helper.stubs('executable_in_path?').returns(true)
+    Open3.stubs('capture2e').returns([nil, OpenStruct.new(success?: true)])
+    result = NewRelic::Helper.run_command('figlet Zoom Zoom')
+
+    assert_nil result
+  end
+
   def test_run_command_sad_unsuccessful
     NewRelic::Helper.stubs('executable_in_path?').returns(true)
     Open3.stubs('capture2e').returns([nil, OpenStruct.new(success?: false)])

--- a/test/new_relic/rack/browser_monitoring_test.rb
+++ b/test/new_relic/rack/browser_monitoring_test.rb
@@ -133,6 +133,10 @@ if defined?(Rack::Test)
       refute app.should_instrument?({}, 200, {'Content-Type' => 'text/xhtml'}), 'Expected not to instrument requests with content type other than text/html.'
     end
 
+    def test_should_not_instrument_when_content_type_missing
+      refute app.should_instrument?({}, 200, {})
+    end
+
     def test_should_not_instrument_when_content_disposition
       refute app.should_instrument?({}, 200, {'Content-Type' => 'text/html', 'Content-Disposition' => 'attachment; filename=test.html'})
     end


### PR DESCRIPTION
This cleans up some conditions and comments I added ages ago to help with our migration to the Safe Navigation Operator. 

* Remove most disables that just needed else branch coverage
* Add else branch coverage
* Migrate exclusions from TODO into code directly
* Style/SaveNavigation will be on by default

Wraps up https://github.com/newrelic/newrelic-ruby-agent/issues/1851
