### PR TITLE
Prototype: OpenTelemetry config support

### DIFF
--- a/lib/new_relic/agent/configuration/manager.rb
+++ b/lib/new_relic/agent/configuration/manager.rb
@@ -9,6 +9,7 @@ require 'new_relic/agent/configuration/default_source'
 require 'new_relic/agent/configuration/server_source'
 require 'new_relic/agent/configuration/environment_source'
 require 'new_relic/agent/configuration/high_security_source'
+require 'new_relic/agent/configuration/open_telemetry_source'
 
 module NewRelic
   module Agent
@@ -75,6 +76,7 @@ module NewRelic
           when :server then @server_source
           when :manual then @manual_source
           when :yaml then @yaml_source
+          when :open_telemetry then @otel_source
           when :default then @default_source
           end
 
@@ -88,6 +90,7 @@ module NewRelic
           when ServerSource then @server_source = nil
           when ManualSource then @manual_source = nil
           when YamlSource then @yaml_source = nil
+          when OpenTelemetrySource then @otel_source = nil
           when DefaultSource then @default_source = nil
           else
             @configs_for_testing.delete_if { |src, lvl| src == source }
@@ -110,6 +113,7 @@ module NewRelic
           when ServerSource then @server_source = source
           when ManualSource then @manual_source = source
           when YamlSource then @yaml_source = source
+          when OpenTelemetrySource then @otel_source = source
           when DefaultSource then @default_source = source
           else
             NewRelic::Agent.logger.warn("Invalid config format; config will be ignored: #{source}")
@@ -480,6 +484,7 @@ module NewRelic
           @server_source = nil
           @manual_source = nil
           @yaml_source = nil
+          @otel_source = OpenTelemetrySource.new
           @default_source = DefaultSource.new
 
           @configs_for_testing = []
@@ -531,6 +536,7 @@ module NewRelic
           @environment_source = nil
           @server_source = nil
           @manual_source = nil
+          @otel_source = nil
           @yaml_source = nil
           @default_source = nil
           @configs_for_testing = []
@@ -552,6 +558,7 @@ module NewRelic
             @server_source,
             @manual_source,
             @yaml_source,
+            @otel_source,
             @default_source]
 
           stack.compact!

--- a/lib/new_relic/agent/configuration/open_telemetry_source.rb
+++ b/lib/new_relic/agent/configuration/open_telemetry_source.rb
@@ -1,0 +1,65 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+module NewRelic
+  module Agent
+    module Configuration
+      # Maps a subset of OpenTelemetry environment variable configuration to
+      # New Relic configuration equivalents. Values are only considered when
+      # opentelemetry.enabled is true, so that applications that do not use
+      # the OTel bridge are unaffected.
+      class OpenTelemetrySource < DottedHash
+        OTEL_ENV_MAPPINGS = {
+          'OTEL_SERVICE_NAME' => :app_name,
+          'OTEL_LOG_LEVEL' => :log_level,
+          'OTEL_RESOURCE_ATTRIBUTES' => :labels,
+          'OTEL_BSP_MAX_EXPORT_BATCH_SIZE' => :'span_events.max_samples_stored',
+          'OTEL_BLRP_MAX_EXPORT_BATCH_SIZE' => :'application_logging.forwarding.max_samples_stored'
+        }.freeze
+
+        def initialize
+          @otel_values = {}
+
+          OTEL_ENV_MAPPINGS.each do |env_var, config_key|
+            raw = ENV[env_var]
+            next unless raw
+
+            @otel_values[config_key] = transform(config_key, raw)
+          end
+
+          super({})
+        end
+
+        def has_key?(key)
+          @otel_values.key?(key) && otel_enabled?
+        end
+
+        def [](key)
+          has_key?(key) ? @otel_values[key] : nil
+        end
+
+        private
+
+        def otel_enabled?
+          NewRelic::Agent.config[:'opentelemetry.enabled']
+        end
+
+        # Convert OTEL env var values to the format expected by NR config keys.
+        def transform(config_key, value)
+          case config_key
+          when :labels then otel_resource_attributes_to_nr_labels(value)
+          when :log_level then value.downcase
+          else value
+          end
+        end
+
+        # OTEL_RESOURCE_ATTRIBUTES: "key1=value1,key2=value2"
+        # NR labels:                "key1:value1;key2:value2"
+        def otel_resource_attributes_to_nr_labels(raw)
+          raw.split(',').map { |pair| pair.sub('=', ':') }.join(';')
+        end
+      end
+    end
+  end
+end

--- a/test/new_relic/agent/agent/connect_test.rb
+++ b/test/new_relic/agent/agent/connect_test.rb
@@ -27,6 +27,10 @@ class NewRelic::Agent::Agent::ConnectTest < Minitest::Test
     NewRelic::Agent.reset_config
   end
 
+  def teardown
+    mocha_teardown
+  end
+
   def control
     fake_control = OpenStruct.new('local_env' => OpenStruct.new('snapshot' => []))
     fake_control.instance_eval do

--- a/test/new_relic/agent/configuration/manager_test.rb
+++ b/test/new_relic/agent/configuration/manager_test.rb
@@ -197,7 +197,7 @@ module NewRelic::Agent::Configuration
       @manager.replace_or_add_config(new_config)
 
       assert_equal 'right', @manager[:test]
-      assert_equal 3, @manager.num_configs_for_testing
+      assert_equal 4, @manager.num_configs_for_testing
     end
 
     def test_registering_a_callback

--- a/test/new_relic/agent/configuration/open_telemetry_source_test.rb
+++ b/test/new_relic/agent/configuration/open_telemetry_source_test.rb
@@ -1,0 +1,198 @@
+# This file is distributed under New Relic's license terms.
+# See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
+# frozen_string_literal: true
+
+require_relative '../../../test_helper'
+require 'new_relic/agent/configuration/open_telemetry_source'
+
+module NewRelic::Agent::Configuration
+  class OpenTelemetrySourceTest < Minitest::Test
+    def teardown
+      NewRelic::Agent.config.reset_to_defaults
+    end
+
+    def with_otel_enabled
+      with_config(:'opentelemetry.enabled' => true) { yield }
+    end
+
+    def test_has_key_returns_false_when_opentelemetry_disabled
+      with_environment('OTEL_SERVICE_NAME' => 'my-service') do
+        source = OpenTelemetrySource.new
+
+        with_config(:'opentelemetry.enabled' => false) do
+          refute source.has_key?(:app_name)
+        end
+      end
+    end
+
+    def test_has_key_returns_false_when_env_var_absent
+      var_present = ENV.key?('OTEL_SERVICE_NAME')
+      if var_present
+        service_name = ENV['OTEL_SERVICE_NAME']
+        ENV.delete('OTEL_SERVICE_NAME')
+      end
+
+      source = OpenTelemetrySource.new
+
+      with_otel_enabled do
+        refute source.has_key?(:app_name)
+      end
+    ensure
+      ENV['OTEL_SERVICE_NAME'] = service_name if var_present
+    end
+
+    def test_has_key_returns_true_when_env_var_present_and_otel_enabled
+      with_environment('OTEL_SERVICE_NAME' => 'my-service') do
+        source = OpenTelemetrySource.new
+
+        with_otel_enabled do
+          assert source.has_key?(:app_name)
+        end
+      end
+    end
+
+    def test_source_does_not_expose_opentelemetry_enabled_key
+      source = OpenTelemetrySource.new
+
+      with_otel_enabled do
+        refute source.has_key?(:'opentelemetry.enabled')
+      end
+    end
+
+    def test_otel_service_name_maps_to_app_name
+      with_environment('OTEL_SERVICE_NAME' => 'my-otel-app') do
+        source = OpenTelemetrySource.new
+
+        with_otel_enabled do
+          assert_equal 'my-otel-app', source[:app_name]
+        end
+      end
+    end
+
+    def test_otel_log_level_maps_to_log_level
+      with_environment('OTEL_LOG_LEVEL' => 'DEBUG') do
+        source = OpenTelemetrySource.new
+
+        with_otel_enabled do
+          assert_equal 'debug', source[:log_level]
+        end
+      end
+    end
+
+    def test_otel_log_level_is_downcased
+      %w[DEBUG INFO WARN ERROR].each do |level|
+        with_environment('OTEL_LOG_LEVEL' => level) do
+          source = OpenTelemetrySource.new
+
+          with_otel_enabled do
+            assert_equal level.downcase, source[:log_level]
+          end
+        end
+      end
+    end
+
+    def test_otel_resource_attributes_maps_to_labels
+      with_environment('OTEL_RESOURCE_ATTRIBUTES' => 'service.name=frontend,team=platform') do
+        source = OpenTelemetrySource.new
+
+        with_otel_enabled do
+          assert_equal 'service.name:frontend;team:platform', source[:labels]
+        end
+      end
+    end
+
+    def test_otel_resource_attributes_single_pair
+      with_environment('OTEL_RESOURCE_ATTRIBUTES' => 'env=production') do
+        source = OpenTelemetrySource.new
+
+        with_otel_enabled do
+          assert_equal 'env:production', source[:labels]
+        end
+      end
+    end
+
+    def test_otel_bsp_max_export_batch_size_maps_to_span_events
+      with_environment('OTEL_BSP_MAX_EXPORT_BATCH_SIZE' => '500') do
+        source = OpenTelemetrySource.new
+
+        with_otel_enabled do
+          assert source.has_key?(:'span_events.max_samples_stored')
+          assert_equal '500', source[:'span_events.max_samples_stored']
+        end
+      end
+    end
+
+    def test_otel_blrp_max_export_batch_size_maps_to_log_forwarding
+      with_environment('OTEL_BLRP_MAX_EXPORT_BATCH_SIZE' => '2000') do
+        source = OpenTelemetrySource.new
+
+        with_otel_enabled do
+          assert source.has_key?(:'application_logging.forwarding.max_samples_stored')
+          assert_equal '2000', source[:'application_logging.forwarding.max_samples_stored']
+        end
+      end
+    end
+
+    def test_bracket_accessor_returns_nil_when_otel_disabled
+      with_environment('OTEL_SERVICE_NAME' => 'lost-service') do
+        source = OpenTelemetrySource.new
+
+        with_config(:'opentelemetry.enabled' => false) do
+          assert_nil source[:app_name]
+        end
+      end
+    end
+
+    def test_manager_includes_open_telemetry_source_in_stack
+      assert_includes NewRelic::Agent.config.config_classes_for_testing, OpenTelemetrySource
+    end
+
+    def test_otel_source_is_above_default_source_in_stack
+      # NewRelic::Agent.config.replace_or_add_config(DefaultSource.new)
+      classes = NewRelic::Agent.config.config_classes_for_testing
+
+      assert classes.index(OpenTelemetrySource) < classes.index(DefaultSource),
+        'OpenTelemetrySource should have higher priority than DefaultSource'
+    end
+
+    def test_otel_source_is_below_environment_source_in_stack
+      classes = NewRelic::Agent.config.config_classes_for_testing
+
+      assert classes.index(EnvironmentSource) < classes.index(OpenTelemetrySource),
+        'EnvironmentSource should have higher priority than OpenTelemetrySource'
+    end
+
+    def test_otel_source_is_below_yaml_source_in_stack
+      NewRelic::Agent.config.replace_or_add_config(YamlSource.new('test', 'test'))
+      classes = NewRelic::Agent.config.config_classes_for_testing
+
+      assert classes.index(YamlSource) < classes.index(OpenTelemetrySource),
+        'YamlSource should have higher priority than OpenTelemetrySource'
+    end
+
+    def test_otel_service_name_used_via_config_when_otel_enabled
+      with_environment('OTEL_SERVICE_NAME' => 'test-service') do
+        # Reinitialize so OpenTelemetrySource picks up the env var
+        NewRelic::Agent.config.replace_or_add_config(OpenTelemetrySource.new)
+
+        with_otel_enabled do
+          assert_equal ['test-service'], NewRelic::Agent.config[:app_name]
+        end
+      end
+    end
+
+    def test_nr_env_var_takes_precedence_over_otel_env_var
+      with_environment('OTEL_SERVICE_NAME' => 'from_otel') do
+        with_environment('NEW_RELIC_APP_NAME' => 'from_nr') do
+          # Reinitialize both sources to pick up both env vars
+          NewRelic::Agent.config.replace_or_add_config(EnvironmentSource.new)
+          NewRelic::Agent.config.replace_or_add_config(OpenTelemetrySource.new)
+
+          with_otel_enabled do
+            assert_equal ['from_nr'], NewRelic::Agent.config[:app_name]
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Allow some OpenTelemetry environment variables to be applied to New Relic configuration values at the lowest precedence, above only defaults.