### PR TITLE
Add server-side config for AI

### DIFF
--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -330,14 +330,14 @@ module NewRelic
           :default => false,
           :public => true,
           :type => Boolean,
-          :allowed_from_server => false,
+          :allowed_from_server => true,
           :description => 'If `false`, all LLM instrumentation (OpenAI only for now) will be disabled and no metrics, events, or spans will be sent. AI Monitoring is automatically disabled if `high_security` mode is enabled.'
         },
         :'ai_monitoring.record_content.enabled' => {
           :default => true,
           :public => true,
           :type => Boolean,
-          :allowed_from_server => false,
+          :allowed_from_server => true,
           :description => <<~DESCRIPTION
             If `false`, LLM instrumentation (OpenAI only for now) will not capture input and output content on specific LLM events.
 

--- a/lib/new_relic/agent/configuration/server_source.rb
+++ b/lib/new_relic/agent/configuration/server_source.rb
@@ -42,6 +42,7 @@ module NewRelic
           filter_keys(merged_settings)
 
           apply_feature_gates(merged_settings, connect_reply, existing_config)
+          apply_ai_monitoring_gate(merged_settings, connect_reply, existing_config)
 
           # The value under this key is a hash mapping transaction name strings
           # to apdex_t values. We don't want the nested hash to be flattened
@@ -153,6 +154,22 @@ module NewRelic
 
         def ungated_value(key, merged_settings, existing_config)
           merged_settings.has_key?(key) ? merged_settings[key] : existing_config[key.to_sym]
+        end
+
+        # `ai_monitoring.enabled` is gated by the `collect_ai` flag, but a value
+        # sent directly in the agent_config takes precedence over that gate.
+        def apply_ai_monitoring_gate(merged_settings, connect_reply, existing_config)
+          config_key = 'ai_monitoring.enabled'
+          gate_key = 'collect_ai'
+
+          if connect_reply['agent_config']&.has_key?(config_key)
+            merged_settings[config_key] = connect_reply['agent_config'][config_key]
+          elsif connect_reply.has_key?(gate_key)
+            allowed_by_server = connect_reply[gate_key]
+            requested_value = ungated_value(config_key, merged_settings, existing_config)
+            effective_value = (allowed_by_server && requested_value)
+            merged_settings[config_key] = effective_value
+          end
         end
       end
     end

--- a/lib/new_relic/agent/configuration/server_source.rb
+++ b/lib/new_relic/agent/configuration/server_source.rb
@@ -42,7 +42,6 @@ module NewRelic
           filter_keys(merged_settings)
 
           apply_feature_gates(merged_settings, connect_reply, existing_config)
-          apply_ai_monitoring_gate(merged_settings, connect_reply, existing_config)
 
           # The value under this key is a hash mapping transaction name strings
           # to apdex_t values. We don't want the nested hash to be flattened
@@ -140,7 +139,8 @@ module NewRelic
             'transaction_events.enabled' => 'collect_analytics_events',
             'custom_insights_events.enabled' => 'collect_custom_events',
             'error_collector.capture_events' => 'collect_error_events',
-            'span_events.enabled' => 'collect_span_events'
+            'span_events.enabled' => 'collect_span_events',
+            'ai_monitoring.enabled' => 'collect_ai'
           }
           gated_features.each do |config_key, gate_key|
             if connect_reply.has_key?(gate_key)
@@ -154,22 +154,6 @@ module NewRelic
 
         def ungated_value(key, merged_settings, existing_config)
           merged_settings.has_key?(key) ? merged_settings[key] : existing_config[key.to_sym]
-        end
-
-        # `ai_monitoring.enabled` is gated by the `collect_ai` flag, but a value
-        # sent directly in the agent_config takes precedence over that gate.
-        def apply_ai_monitoring_gate(merged_settings, connect_reply, existing_config)
-          config_key = 'ai_monitoring.enabled'
-          gate_key = 'collect_ai'
-
-          if connect_reply['agent_config']&.has_key?(config_key)
-            merged_settings[config_key] = connect_reply['agent_config'][config_key]
-          elsif connect_reply.has_key?(gate_key)
-            allowed_by_server = connect_reply[gate_key]
-            requested_value = ungated_value(config_key, merged_settings, existing_config)
-            effective_value = (allowed_by_server && requested_value)
-            merged_settings[config_key] = effective_value
-          end
         end
       end
     end

--- a/lib/new_relic/agent/instrumentation/ruby_openai.rb
+++ b/lib/new_relic/agent/instrumentation/ruby_openai.rb
@@ -38,7 +38,6 @@ end
 # enabled by server-side config after startup detection has run. Re-check the
 # dependency when the server source is applied.
 NewRelic::Agent.instance.events.subscribe(:server_source_configuration_added) do
-  binding.irb
   item = DependencyDetection.dependency_by_name(:'ruby_openai')
   item.execute if item && !item.executed && item.dependencies_satisfied?
 end

--- a/lib/new_relic/agent/instrumentation/ruby_openai.rb
+++ b/lib/new_relic/agent/instrumentation/ruby_openai.rb
@@ -38,6 +38,7 @@ end
 # enabled by server-side config after startup detection has run. Re-check the
 # dependency when the server source is applied.
 NewRelic::Agent.instance.events.subscribe(:server_source_configuration_added) do
+  binding.irb
   item = DependencyDetection.dependency_by_name(:'ruby_openai')
   item.execute if item && !item.executed && item.dependencies_satisfied?
 end

--- a/lib/new_relic/agent/instrumentation/ruby_openai.rb
+++ b/lib/new_relic/agent/instrumentation/ruby_openai.rb
@@ -33,3 +33,11 @@ DependencyDetection.defer do
     end
   end
 end
+
+# `ai_monitoring.enabled` gates this instrumentation at install time, but can be
+# enabled by server-side config after startup detection has run. Re-check the
+# dependency when the server source is applied.
+NewRelic::Agent.instance.events.subscribe(:server_source_configuration_added) do
+  item = DependencyDetection.dependency_by_name(:'ruby_openai')
+  item.execute if item && !item.executed && item.dependencies_satisfied?
+end

--- a/test/new_relic/agent/configuration/manager_test.rb
+++ b/test/new_relic/agent/configuration/manager_test.rb
@@ -61,6 +61,20 @@ module NewRelic::Agent::Configuration
       refute @manager['capture_params']
     end
 
+    def test_high_security_overrides_server_side_ai_monitoring_enabled
+      # in order of precedence
+      high_security = HighSecuritySource.new({})
+      server_source = ServerSource.new('agent_config' => {'ai_monitoring.enabled' => true})
+      manual_source = ManualSource.new(:'ai_monitoring.enabled' => true)
+
+      # load them out of order
+      @manager.replace_or_add_config(manual_source)
+      @manager.replace_or_add_config(server_source)
+      @manager.replace_or_add_config(high_security)
+
+      refute @manager[:'ai_monitoring.enabled']
+    end
+
     def test_identifying_config_source
       hash_source = {:foo => 'foo', :bar => 'default'}
       @manager.add_config_for_testing(hash_source, false)

--- a/test/new_relic/agent/configuration/server_source_test.rb
+++ b/test/new_relic/agent/configuration/server_source_test.rb
@@ -279,17 +279,17 @@ module NewRelic::Agent::Configuration
       assert @source[:'ai_monitoring.enabled']
     end
 
-    def test_should_enable_ai_monitoring_when_agent_config_overrides_collect_ai
+    def test_collect_ai_false_disables_ai_monitoring_even_when_agent_config_enables_it
       rsp = {
         'collect_ai' => false,
         'agent_config' => {'ai_monitoring.enabled' => true}
       }
       @source = ServerSource.new(rsp, {})
 
-      assert @source[:'ai_monitoring.enabled']
+      refute @source[:'ai_monitoring.enabled']
     end
 
-    def test_should_disable_ai_monitoring_when_agent_config_overrides_collect_ai
+    def test_collect_ai_true_disables_when_agent_config_ai_monitoring_is_false
       rsp = {
         'collect_ai' => true,
         'agent_config' => {'ai_monitoring.enabled' => false}
@@ -297,6 +297,16 @@ module NewRelic::Agent::Configuration
       @source = ServerSource.new(rsp, {})
 
       refute @source[:'ai_monitoring.enabled']
+    end
+
+    def test_collect_ai_true_enables_via_agent_config_over_locally_disabled
+      rsp = {
+        'collect_ai' => true,
+        'agent_config' => {'ai_monitoring.enabled' => true}
+      }
+      @source = ServerSource.new(rsp, {:'ai_monitoring.enabled' => false})
+
+      assert @source[:'ai_monitoring.enabled']
     end
 
     def test_should_set_ai_monitoring_record_content_when_server_says_to

--- a/test/new_relic/agent/configuration/server_source_test.rb
+++ b/test/new_relic/agent/configuration/server_source_test.rb
@@ -263,6 +263,56 @@ module NewRelic::Agent::Configuration
       assert @source[:'custom_insights_events.enabled']
     end
 
+    def test_should_disable_ai_monitoring_when_server_says_to
+      rsp = {'collect_ai' => false}
+      existing_config = {:'ai_monitoring.enabled' => true}
+      @source = ServerSource.new(rsp, existing_config)
+
+      refute @source[:'ai_monitoring.enabled']
+    end
+
+    def test_should_enable_ai_monitoring_when_server_says_to
+      rsp = {'collect_ai' => true}
+      existing_config = {:'ai_monitoring.enabled' => true}
+      @source = ServerSource.new(rsp, existing_config)
+
+      assert @source[:'ai_monitoring.enabled']
+    end
+
+    def test_should_enable_ai_monitoring_when_agent_config_overrides_collect_ai
+      rsp = {
+        'collect_ai' => false,
+        'agent_config' => {'ai_monitoring.enabled' => true}
+      }
+      @source = ServerSource.new(rsp, {})
+
+      assert @source[:'ai_monitoring.enabled']
+    end
+
+    def test_should_disable_ai_monitoring_when_agent_config_overrides_collect_ai
+      rsp = {
+        'collect_ai' => true,
+        'agent_config' => {'ai_monitoring.enabled' => false}
+      }
+      @source = ServerSource.new(rsp, {})
+
+      refute @source[:'ai_monitoring.enabled']
+    end
+
+    def test_should_set_ai_monitoring_record_content_when_server_says_to
+      rsp = {'agent_config' => {'ai_monitoring.record_content.enabled' => false}}
+      @source = ServerSource.new(rsp, {})
+
+      refute @source[:'ai_monitoring.record_content.enabled']
+    end
+
+    def test_should_not_set_ai_monitoring_when_no_server_keys_present
+      rsp = {'agent_config' => {'transaction_tracer.enabled' => true}}
+      @source = ServerSource.new(rsp, {:'ai_monitoring.enabled' => true})
+
+      refute @source.has_key?(:'ai_monitoring.enabled')
+    end
+
     def test_should_strip_non_ssc_keys
       rsp = {
         'agent_config' => {


### PR DESCRIPTION
Allow `ai_monitoring.enabled` and `ai_monitoring.record_content.enabled` to be set server-side.