### PR TITLE
Tidy up Puma instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - **Feature: Add Puma server-statistics instrumentation**
 
-  The agent now samples Puma's cluster-wide server statistics and reports them as `Ruby/Puma/*` timeslice metrics, including `backlog`, `running`, `pool_capacity`, `max_threads`, and `requests_count`. Statistics are sampled in single mode and in clustered mode when `preload_app!` is enabled. This instrumentation is disabled by default; enable it by setting `disable_puma_instrumentation` to `false`. When enabled, the agent starts a reporting thread in the Puma master process to deliver these metrics, which runs an additional agent connection alongside the Puma workers. The sampling interval is configurable via the new `puma.sample_rate` setting (default 60 seconds). Requires Puma 6.6 or later.
+  The agent now samples Puma's cluster-wide server statistics and reports them as `Ruby/Puma/*` timeslice metrics, including `backlog`, `running`, `pool_capacity`, `max_threads`, and `requests_count`. Statistics are sampled in single mode and in clustered mode when `preload_app!` is enabled. This instrumentation is disabled by default; enable it by setting `disable_puma_instrumentation` to `false`. When enabled, the agent starts a reporting thread in the Puma master process to deliver these metrics, which runs an additional agent connection alongside the Puma workers. The sampling interval is configurable via the new `puma.sample_rate` setting (default 60 seconds). Requires Puma 6.6 or later. See [our docs](https://docs.newrelic.com/docs/apm/agents/ruby-agent/instrumented-gems/puma-instrumentation/) for more information.
 
   Thanks so much to [@ashleyboehs](https://github.com/ashleyboehs) contributing this new feature. [PR#3578](https://github.com/newrelic/newrelic-ruby-agent/pull/3578)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 - **Feature: Add Puma server-statistics instrumentation**
 
-  The agent now samples Puma's cluster-wide server statistics and reports them as `Ruby/Puma/*` timeslice metrics, including `backlog`, `running`, `pool_capacity`, `max_threads`, and `requests_count`. Statistics are sampled in single mode and in clustered mode when `preload_app!` is enabled. The sampling interval is configurable via the new `puma.sample_rate` setting (default 60 seconds), and the instrumentation can be disabled with `disable_puma_instrumentation`. Requires Puma 6.6 or later. [PR#XXXX](https://github.com/newrelic/newrelic-ruby-agent/pull/XXXX)
+  The agent now samples Puma's cluster-wide server statistics and reports them as `Ruby/Puma/*` timeslice metrics, including `backlog`, `running`, `pool_capacity`, `max_threads`, and `requests_count`. Statistics are sampled in single mode and in clustered mode when `preload_app!` is enabled. The sampling interval is configurable via the new `puma.sample_rate` setting (default 60 seconds), and the instrumentation can be disabled with `disable_puma_instrumentation`. Requires Puma 6.6 or later.
+
+  Thanks so much to [@ashleyboehs](https://github.com/ashleyboehs) contributing this new feature. [PR#3578](https://github.com/newrelic/newrelic-ruby-agent/pull/3578)
 
 ## v10.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # New Relic Ruby Agent Release Notes
 
+## dev
+
+- **Feature: Add Puma server-statistics instrumentation**
+
+  The agent now samples Puma's cluster-wide server statistics and reports them as `Ruby/Puma/*` timeslice metrics, including `backlog`, `running`, `pool_capacity`, `max_threads`, and `requests_count`. Statistics are sampled in single mode and in clustered mode when `preload_app!` is enabled. The sampling interval is configurable via the new `puma.sample_rate` setting (default 60 seconds), and the instrumentation can be disabled with `disable_puma_instrumentation`. Requires Puma 6.6 or later. [PR#XXXX](https://github.com/newrelic/newrelic-ruby-agent/pull/XXXX)
+
 ## v10.6.0
 
 - **Feature: SpanLink events are now supported for the Hybrid Agent**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - **Feature: Add Puma server-statistics instrumentation**
 
-  The agent now samples Puma's cluster-wide server statistics and reports them as `Ruby/Puma/*` timeslice metrics, including `backlog`, `running`, `pool_capacity`, `max_threads`, and `requests_count`. Statistics are sampled in single mode and in clustered mode when `preload_app!` is enabled. The sampling interval is configurable via the new `puma.sample_rate` setting (default 60 seconds), and the instrumentation can be disabled with `disable_puma_instrumentation`. Requires Puma 6.6 or later.
+  The agent now samples Puma's cluster-wide server statistics and reports them as `Ruby/Puma/*` timeslice metrics, including `backlog`, `running`, `pool_capacity`, `max_threads`, and `requests_count`. Statistics are sampled in single mode and in clustered mode when `preload_app!` is enabled. This instrumentation is disabled by default; enable it by setting `disable_puma_instrumentation` to `false`. When enabled, the agent starts a reporting thread in the Puma master process to deliver these metrics, which runs an additional agent connection alongside the Puma workers. The sampling interval is configurable via the new `puma.sample_rate` setting (default 60 seconds). Requires Puma 6.6 or later.
 
   Thanks so much to [@ashleyboehs](https://github.com/ashleyboehs) contributing this new feature. [PR#3578](https://github.com/newrelic/newrelic-ruby-agent/pull/3578)
 

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2086,11 +2086,7 @@ module NewRelic
           :public => true,
           :type => Boolean,
           :allowed_from_server => false,
-          :description => <<~DESCRIPTION
-            If `true`, disables the Puma server-statistics instrumentation that samples `Ruby/Puma/*` metrics from the Puma master process.
-
-            When enabled, the agent starts its reporting thread in the Puma master so the sampled metrics are delivered. (The agent otherwise defers that thread under forking dispatchers such as Puma, leaving metrics sampled in the master buffered but never sent.) The Puma master then reports to New Relic as its own instance.
-          DESCRIPTION
+          :description => 'If `true`, disables the Puma server-statistics instrumentation that samples `Ruby/Puma/*` metrics from the Puma master process. When enabled, the Puma master appears in New Relic as its own reporting instance.'
         },
         :'puma.sample_rate' => {
           :default => 60,

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2088,7 +2088,7 @@ module NewRelic
           :description => 'If `true`, disables the Puma server-statistics instrumentation that samples ' \
             '`Ruby/Puma/*` metrics from the Puma master process. This instrumentation is disabled by ' \
             'default. When enabled, the agent starts a reporting thread in the Puma master process to ' \
-            'deliver these metrics.
+            'deliver these metrics.'
         },
         :'puma.sample_rate' => {
           :default => 60,

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2082,11 +2082,14 @@ module NewRelic
         },
         # Puma
         :disable_puma_instrumentation => {
-          :default => false,
+          :default => true,
           :public => true,
           :type => Boolean,
           :allowed_from_server => false,
-          :description => 'If `true`, disables the Puma server-statistics instrumentation that samples `Ruby/Puma/*` metrics from the Puma master process. When enabled, the Puma master appears in New Relic as its own reporting instance.'
+          :description => 'If `true`, disables the Puma server-statistics instrumentation that samples ' \
+            '`Ruby/Puma/*` metrics from the Puma master process. This instrumentation is disabled by ' \
+            'default. When enabled, the agent starts a reporting thread in the Puma master process to ' \
+            'deliver these metrics.
         },
         :'puma.sample_rate' => {
           :default => 60,

--- a/lib/new_relic/agent/instrumentation/puma.rb
+++ b/lib/new_relic/agent/instrumentation/puma.rb
@@ -4,44 +4,22 @@
 
 require 'new_relic/agent/puma_stats_sampler'
 
-# Agent-managed Puma server-statistics instrumentation.
-#
-# Puma exposes cluster-wide statistics only from its master process. When an
-# application runs with +preload_app!+ the agent is loaded in the master during
-# app preload, so this instrumentation installs there and samples the master's
-# stats on a background thread. Without +preload_app!+ the agent loads in each
-# worker instead of the master, where +#master?+ correctly declines so the
-# instrumentation no-ops. Single mode is one process and always samples.
-#
-# Detection reads the runner that +Puma::Launcher#initialize+ registers. When
-# Puma itself starts the application (the +puma+ and +pumactl+ CLIs) the runner
-# already exists at boot, so the instrumentation installs immediately. Entry
-# points that load the application first and construct the launcher afterward
-# (e.g. +rails server+) run detection before the runner exists; for those the
-# agent arms a one-shot interceptor on +Puma.stats_object=+ -- the setter the
-# launcher calls when it registers its runner -- so installation happens through
-# the same +#master?+ gate the instant the launcher appears.
 module NewRelic
   module Agent
     module Instrumentation
       module PumaStats
         module_function
 
-        # Puma stores the active runner (Puma::Cluster or Puma::Single) on the
-        # +Puma+ module when the launcher is constructed -- it is the only handle
-        # to the master's cluster-wide stats and lifecycle. Puma exposes the
-        # runner's *stats* publicly (+Puma.stats_hash+) but not the runner
-        # object, so reach it through the ivar the +stats_object=+ setter writes.
+        # Puma stores the runner via +Puma.stats_object=+. No public accessor,
+        # so read the ivar that the setter writes.
         def runner
           return nil unless defined?(::Puma) && ::Puma.instance_variable_defined?(:@get_stats)
 
           ::Puma.instance_variable_get(:@get_stats)
         end
 
-        # True only where the agent should sample: single mode (one process), or
-        # clustered mode with +preload_app!+ (the configuration where the agent
-        # is present in the master). In a non-preload deployment this runs in a
-        # worker, where +preload_app+ is false, so it declines.
+        # True only where the agent should sample: single mode (one process) or
+        # clustered with +preload_app!+ (where the agent is loaded in the master).
         def master?(runner)
           return false if runner.nil?
           return true if defined?(::Puma::Single) && runner.is_a?(::Puma::Single)
@@ -50,33 +28,39 @@ module NewRelic
           !!runner.options[:preload_app]
         end
 
-        # Runs at dependency-detection time. If Puma has already registered its
-        # runner (the +puma+/+pumactl+ boot order), install in the master right
-        # away. Otherwise the launcher does not exist yet (the +rails server+
-        # boot order), so arm the late interceptor instead and let it install
-        # when the runner registers.
         def install_or_arm
           current = runner
           current ? install_in_master(current) : arm_late_install
         end
 
-        # Installs the sampler when +runner+ is the master we should sample from,
-        # and declines otherwise. Shared by the eager detection path and the
-        # late +Puma.stats_object=+ interceptor.
         def install_in_master(runner)
-          return unless master?(runner)
+          unless master?(runner)
+            log_puma_6x_preload_warning(runner)
+            return
+          end
 
           NewRelic::Agent.logger.info('Installing Puma stats instrumentation')
           install(runner)
         end
 
+        # Puma 6.x doesn't apply +preload_app+ defaults from the config block,
+        # so a clustered 6.x app with +workers 2+ but no explicit +preload_app!(true)+
+        # 11silently gets no metrics.
+        def log_puma_6x_preload_warning(runner)
+          return unless runner&.respond_to?(:options)
+          return unless runner.options[:workers].to_i > 1 && !runner.options[:preload_app]
+          return unless defined?(::Puma::Const::VERSION) && ::Puma::Const::VERSION.start_with?('6.')
+
+          NewRelic::Agent.logger.warn(
+            'Did not install Puma instrumentation. Set preload_app!(true) explicitly in your puma.rb to enable Puma metrics.'
+          )
+        end
+
         # Prepends a one-shot interceptor on +Puma.stats_object=+ so the agent
-        # installs when a launcher registers its runner after detection already
-        # ran (the +rails server+ boot order). Prepending is idempotent, but the
-        # +@late_install_armed+ flag is the real gate: the interceptor only acts
-        # while armed and disarms itself on the first registration, so a later
-        # +stats_object=+ (e.g. a Puma hot restart) cannot start a second
-        # sampler, and an unarmed eager-path process is unaffected.
+        # installs when the launcher registers its runner (+rails server+ boot
+        # order). The prepend is permanent, so +@late_install_armed+ does the real
+        # gating: disarming it on the first registration keeps a Puma hot restart
+        # from starting a second sampler.
         def arm_late_install
           @late_install_armed = true
           ::Puma.singleton_class.prepend(StatsObjectRegistration)
@@ -91,15 +75,10 @@ module NewRelic
           install_in_master(runner)
         end
 
-        # Intercepts +Puma.stats_object=+, the setter +Puma::Launcher#initialize+
-        # calls to publish its runner. Prepended onto Puma's singleton class so
-        # +super+ performs Puma's own assignment before the agent reacts.
-        #
-        # The agent reaction runs inside Puma's launcher boot here, so it is
-        # wrapped so an agent-side failure can never escape into +stats_object=+
-        # and break Puma. (+super+ is left unguarded -- a failure there is Puma's
-        # own and must propagate.) This restores for the late path the error
-        # isolation the eager path gets for free from +DependencyDetection#execute+.
+        # Intercepts +Puma.stats_object=+ to install when a launcher registers
+        # its runner. +super+ runs Puma's own assignment unguarded; only the
+        # agent reaction is rescued, so an agent-side failure cannot escape
+        # into Puma's launcher boot.
         module StatsObjectRegistration
           def stats_object=(runner)
             super
@@ -111,9 +90,8 @@ module NewRelic
           end
         end
 
-        # Builds the sampler, registers a stop on Puma's lifecycle events, and
-        # runs the sampling loop on a background thread. Started in the master
-        # before workers fork, so forked workers do not inherit the thread.
+        # Started in the master before workers fork, so forked workers do not
+        # inherit the sampling thread.
         def install(runner)
           sampler = NewRelic::Agent::PumaStatsSampler.new(runner)
           register_stop(runner, sampler)
@@ -124,15 +102,11 @@ module NewRelic
           nil
         end
 
-        # Stops the sampler thread on Puma shutdown/restart. The runner does not
-        # expose its launcher (or the launcher's lifecycle events) publicly, so
-        # reach them through the +@launcher+ ivar. The launcher fires
-        # +:before_restart+/+:after_stopped+ (Puma 7+) or +:on_restart+/
-        # +:on_stopped+ (Puma 6.x); +Puma::Server+ separately fires
-        # +:state+ with +:stop+/+:halt+/+:restart+, the only shutdown signal in
-        # single mode (the clustered master runs no server, so it never fires
-        # +:state+). +stop+ is idempotent, so overlapping events for one
-        # shutdown are harmless.
+        # Stops the sampler on Puma shutdown/restart. Registers both Puma 7+
+        # events (+:before_restart+/+:after_stopped+) and Puma 6.x events
+        # (+:on_restart+/+:on_stopped+), plus +:state+ for single mode (the
+        # clustered master runs no +Puma::Server+). +stop+ is idempotent, so
+        # overlapping events are harmless.
         def register_stop(runner, sampler)
           launcher = runner.instance_variable_get(:@launcher)
           return unless launcher.respond_to?(:events)
@@ -149,31 +123,14 @@ module NewRelic
 end
 
 DependencyDetection.defer do
-  # Set +@name+ directly, as +sequel+ does, rather than calling +named+. The two
-  # are equivalent at runtime, but the orphan-config test treats a +named+ entry
-  # as a promise that +disable_<name>+ / +instrumentation.<name>+ config keys
-  # exist. This instrumentation defines neither; it gates on a dedicated
-  # +disable_puma_instrumentation+ via the explicit +depends_on+ below.
   @name = :puma
 
   depends_on do
-    defined?(Puma) && defined?(Puma::Launcher)
+    defined?(Puma) && defined?(Puma::Launcher) &&
+      NewRelic::Helper.version_satisfied?(Puma::Const::VERSION, '>=', '6.6.0') &&
+      !NewRelic::Agent.config[:disable_puma_instrumentation]
   end
 
-  depends_on do
-    # The cluster-wide stats and the launcher lifecycle events this samples are
-    # only reliable on Puma 6.6+ (the oldest line the suite exercises). Decline
-    # older versions rather than install against an unverified stats/event shape.
-    NewRelic::Helper.version_satisfied?(Puma::Const::VERSION, '>=', '6.6.0')
-  end
-
-  depends_on do
-    !NewRelic::Agent.config[:disable_puma_instrumentation]
-  end
-
-  # No +master?+ gate here: in the +rails server+ boot order the runner does
-  # not exist yet at detection time. install_or_arm installs in the master when
-  # the runner is already present and otherwise arms the late interceptor.
   executes do
     NewRelic::Agent::Instrumentation::PumaStats.install_or_arm
   end

--- a/lib/new_relic/agent/instrumentation/puma.rb
+++ b/lib/new_relic/agent/instrumentation/puma.rb
@@ -19,7 +19,7 @@ module NewRelic
         end
 
         # True only where the agent should sample: single mode (one process) or
-        # clustered with +preload_app!+ (where the agent is loaded in the master).
+        # clustered with +preload_app!+ (where the agent is loaded in the master process).
         def master?(runner) # :nodoc:
           return false if runner.nil?
           return true if defined?(::Puma::Single) && runner.is_a?(::Puma::Single)

--- a/lib/new_relic/agent/instrumentation/puma.rb
+++ b/lib/new_relic/agent/instrumentation/puma.rb
@@ -12,7 +12,7 @@ module NewRelic
 
         # Puma stores the runner via +Puma.stats_object=+. No public accessor,
         # so read the ivar that the setter writes.
-        def runner
+        def runner # :nodoc:
           return nil unless defined?(::Puma) && ::Puma.instance_variable_defined?(:@get_stats)
 
           ::Puma.instance_variable_get(:@get_stats)
@@ -20,7 +20,7 @@ module NewRelic
 
         # True only where the agent should sample: single mode (one process) or
         # clustered with +preload_app!+ (where the agent is loaded in the master).
-        def master?(runner)
+        def master?(runner) # :nodoc:
           return false if runner.nil?
           return true if defined?(::Puma::Single) && runner.is_a?(::Puma::Single)
           return false unless runner.respond_to?(:options)
@@ -28,12 +28,12 @@ module NewRelic
           !!runner.options[:preload_app]
         end
 
-        def install_or_arm
+        def install_or_arm # :nodoc:
           current = runner
           current ? install_in_master(current) : arm_late_install
         end
 
-        def install_in_master(runner)
+        def install_in_master(runner) # :nodoc:
           unless master?(runner)
             log_puma_6x_preload_warning(runner)
             return
@@ -45,8 +45,8 @@ module NewRelic
 
         # Puma 6.x doesn't apply +preload_app+ defaults from the config block,
         # so a clustered 6.x app with +workers 2+ but no explicit +preload_app!(true)+
-        # 11silently gets no metrics.
-        def log_puma_6x_preload_warning(runner)
+        # silently gets no metrics.
+        def log_puma_6x_preload_warning(runner) # :nodoc:
           return unless runner&.respond_to?(:options)
           return unless runner.options[:workers].to_i > 1 && !runner.options[:preload_app]
           return unless defined?(::Puma::Const::VERSION) && ::Puma::Const::VERSION.start_with?('6.')
@@ -61,14 +61,14 @@ module NewRelic
         # order). The prepend is permanent, so +@late_install_armed+ does the real
         # gating: disarming it on the first registration keeps a Puma hot restart
         # from starting a second sampler.
-        def arm_late_install
+        def arm_late_install # :nodoc:
           @late_install_armed = true
           ::Puma.singleton_class.prepend(StatsObjectRegistration)
         end
 
         # Invoked by the interceptor when Puma registers a runner. One-shot:
         # disarm before installing so the registration is handled exactly once.
-        def install_on_register(runner)
+        def install_on_register(runner) # :nodoc:
           return unless @late_install_armed
 
           @late_install_armed = false
@@ -79,7 +79,7 @@ module NewRelic
         # its runner. +super+ runs Puma's own assignment unguarded; only the
         # agent reaction is rescued, so an agent-side failure cannot escape
         # into Puma's launcher boot.
-        module StatsObjectRegistration
+        module StatsObjectRegistration # :nodoc:
           def stats_object=(runner)
             super
             begin
@@ -92,7 +92,7 @@ module NewRelic
 
         # Started in the master before workers fork, so forked workers do not
         # inherit the sampling thread.
-        def install(runner)
+        def install(runner) # :nodoc:
           sampler = NewRelic::Agent::PumaStatsSampler.new(runner)
           register_stop(runner, sampler)
           Thread.new { sampler.start }
@@ -107,7 +107,7 @@ module NewRelic
         # (+:on_restart+/+:on_stopped+), plus +:state+ for single mode (the
         # clustered master runs no +Puma::Server+). +stop+ is idempotent, so
         # overlapping events are harmless.
-        def register_stop(runner, sampler)
+        def register_stop(runner, sampler) # :nodoc:
           launcher = runner.instance_variable_get(:@launcher)
           return unless launcher.respond_to?(:events)
 

--- a/lib/new_relic/agent/puma_stats_sampler.rb
+++ b/lib/new_relic/agent/puma_stats_sampler.rb
@@ -6,81 +6,45 @@ require 'json'
 
 module NewRelic
   module Agent
-    # Samples Puma's clustered server statistics from the Puma master process
-    # and records them as New Relic timeslice metrics under +Ruby/Puma/*+.
+    # Samples Puma's clustered server statistics from the master process and
+    # records them as timeslice metrics under +Ruby/Puma/*+.
     #
-    # This class is driven by the Puma instrumentation defined in
-    # +lib/new_relic/agent/instrumentation/puma.rb+, which the agent installs
-    # automatically in the Puma master. It is intentionally *not* one of the
-    # agent's harvest-driven NewRelic::Agent::Sampler subclasses; see "Why the
-    # master process" below.
+    # Only the master exposes cluster-wide stats (per-worker thread-pool
+    # backlog, running threads, +pool_capacity+, +max_threads+,
+    # +requests_count+), so sampling happens there.
     #
-    # == Why the master process
+    # This class restarts the harvest thread in the master via
+    # +NewRelic::Agent.after_fork(force_reconnect: true)+ to deliver the
+    # sampled metrics. The master then reports to New Relic as its own
+    # instance.
     #
-    # Only the Puma master exposes cluster-wide statistics through its runner's
-    # +stats+ (per-worker thread-pool backlog, running threads, +pool_capacity+,
-    # configured max threads, and cumulative request count), surfaced publicly
-    # as +Puma.stats_hash+.
-    # Worker processes have no reliable handle to their own server statistics
-    # from a background thread (+Puma.stats_object=+ is called only in the master
-    # and +Puma::Server.current+ is request-thread-local), so sampling must
-    # happen in the master. That rules out a harvest-driven Sampler, whose
-    # +poll+ runs only on the per-worker harvest thread.
+    # Records only integer gauges/counters via +NewRelic::Agent.record_metric+
+    # (no request, query, or user data), so it is fully functional under High
+    # Security Mode.
     #
-    # == Why the harvest thread is restarted
-    #
-    # The agent intentionally defers starting its reporting (harvest) thread
-    # under forking dispatchers such as Puma, because the master forks workers
-    # that each start their own agent after forking. As a result, metrics
-    # recorded from the master are buffered but never sent. To deliver the
-    # sampled metrics, this class restarts the harvest thread in the master via
-    # the agent's own +NewRelic::Agent.after_fork(force_reconnect: true)+ entry
-    # point (the same call the agent's Harvester uses to recover in forked
-    # children). The master then reports to New Relic as its own instance. The
-    # whole instrumentation, this restart included, is turned off together via
-    # +disable_puma_instrumentation+.
-    #
-    # == High Security Mode
-    #
-    # Only +NewRelic::Agent.record_metric+ is used. No custom events or custom
-    # attributes are recorded, and the sampled values are integers with no
-    # request, query, or user data, so the instrumentation is fully functional
-    # under High Security Mode.
     class PumaStatsSampler
-      # Raised when Puma's +stats+ returns a Hash whose shape we don't
-      # recognize (no +:worker_status+ and no top-level worker keys). Lets
-      # +fetch_metrics+'s existing rescue route the case through the
-      # throttled sample-failure path instead of silently recording nothing.
+      # Raised on an unrecognized stats shape: neither +:worker_status+ nor any
+      # top-level worker keys. +fetch_metrics+ rescues it onto the throttled
+      # sample-failure path, so a bad shape surfaces in the log instead of
+      # silently recording nothing.
       class UnrecognizedStatsError < StandardError; end
 
       METRIC_NAMESPACE = 'Ruby/Puma'
-      # Per-worker keys reported by +Puma::Server#stats+ and surfaced through
-      # the master runner's stats (+Puma.stats_hash+). +requests_count+ is a
+      # Per-worker stat keys, summed across the cluster. +requests_count+ is a
       # cumulative counter (use +rate()+ in NRQL); the rest are point-in-time
-      # gauges. Keys are recorded under their Puma names (e.g. +pool_capacity+,
-      # the spare request capacity: idle threads plus unspawned threads still
-      # allowed up to +max_threads+) so the metrics line up with Puma's own docs.
+      # gauges. +pool_capacity+ is spare request capacity: idle threads plus
+      # unspawned threads still allowed up to +max_threads+.
       WORKER_STAT_KEYS = %i[backlog running pool_capacity max_threads requests_count].freeze
       # Runner metadata reported by +Puma::Runner#stats+ alongside (or, before
       # the runner's +Puma::Server+ exists, instead of) the per-worker keys.
       RUNNER_INFO_KEYS = %i[started_at versions].freeze
-      # Mirrors the +puma.sample_rate+ default in
-      # +lib/new_relic/agent/configuration/default_source.rb+; used only if that
-      # config value is missing or non-positive.
       DEFAULT_SAMPLE_RATE = 60
-      # When +stats+ fails repeatedly, log the first failure and then only every
-      # Nth occurrence to avoid flooding the Puma master log.
       LOG_FAILURE_INTERVAL = 10
-      # Floor on time between failure logs: even with exponential backoff
-      # suppressing per-iteration logs, a persistent failure is re-logged at
-      # least this often. Without the floor, reaching the 10th consecutive
-      # failure at the default 60 s sample rate takes ~55 min (60 + 120 + 240 +
-      # 6*480 seconds for the 9 waits between failures 1..10, with backoff
-      # capped at 2**3 = 8 intervals). The 300 s floor surfaces a re-log within
-      # ~7 min instead.
+      # Caps how long a persistent failure can go unlogged: forces a re-log once
+      # ~5 min have elapsed, instead of waiting for the backed-off "every Nth"
+      # cadence (~55 min at the default sample rate).
       LOG_FAILURE_TIME_FLOOR_SECONDS = 300
-      # Largest exponent used for exponential backoff after consecutive sampling
-      # failures, i.e. the wait grows up to 2**3 = 8 sample intervals.
+      # Caps backoff growth at 2**3 = 8 sample intervals.
       BACKOFF_EXPONENT_CAP = 3
 
       def initialize(stats_source)
@@ -96,52 +60,41 @@ module NewRelic
         @last_report_failure_logged_at = nil
       end
 
-      # Runs the sampling loop. Intended to be called on the background thread
-      # the instrumentation spawns in the master process. Blocks until #stop is
-      # called from a Puma lifecycle event (+:state+ in single mode,
-      # +:before_restart+ / +:after_stopped+ on the master in clustered mode).
-      # Single-shot: after the loop exits (cleanly or via the rescue path
-      # below) the sampler is done; the instrumentation instantiates one
-      # sampler per Puma boot, so #start is never re-entered on the same
-      # instance.
+      # Runs the sampling loop on the background thread the instrumentation
+      # spawns in the master. Blocks until #stop is called from a Puma lifecycle
+      # event. Single-shot: the instrumentation builds one sampler per Puma boot,
+      # so #start is never re-entered on the same instance.
       def start
         return unless ensure_master_is_reporting
 
         @lock.synchronize do
-          return if @stopped # #stop may have been called before we started
+          return if @stopped
 
           @running = true
           begin
             while @running
               sample
-              # Wait one interval (longer after repeated failures), releasing
-              # the lock, or until #stop signals us for immediate shutdown.
+              # Wait one interval (releases the lock); #stop wakes us early.
               # Re-check @running because the signal may have flipped it.
               @stop_signal.wait(@lock, next_wait_interval) if @running
             end
           ensure
-            # Keep the object's own state consistent if the loop aborts via
-            # an exception: @running is the loop's "still spinning" flag.
-            # #start's early-return reads @stopped (which #stop sets); the
-            # synchronize block doesn't touch @stopped on the rescue path,
-            # so that coordination stays coherent.
+            # Keep @running consistent if the loop aborts via an exception.
             @running = false
           end
         end
       rescue => e
-        # The instrumentation starts this loop on a bare +Thread.new+ with no
-        # rescue, so any exception escaping here would silently kill the
-        # sampler thread. Mirror +Threading::AgentThread.create+: log
-        # StandardError, log and re-raise Exception (so interrupts still
-        # propagate).
+        # The instrumentation starts this loop on a bare +Thread.new+, so an
+        # unhandled exception would silently kill the sampler thread. Log
+        # StandardError; log and re-raise Exception so interrupts still propagate.
         ::NewRelic::Agent.logger.error('NewRelic Puma stats sampler thread exited with error', e)
       rescue Exception => e
         ::NewRelic::Agent.logger.error('NewRelic Puma stats sampler thread exited with exception. Re-raising in case of interrupt.', e)
         raise
       end
 
-      # Signals the sampling loop to exit. Thread-safe: #stop runs on the Puma
-      # event thread while #start's loop runs on the background thread.
+      # Thread-safe: #stop runs on the Puma event thread, #start on the
+      # background thread.
       def stop
         @lock.synchronize do
           @running = false
@@ -159,11 +112,10 @@ module NewRelic
         report_metrics(metrics)
       end
 
-      # Fetches and aggregates Puma stats. Returns the metric Hash on success
-      # or nil if Puma's +stats+ call (or parsing/aggregation) raised. Failures
-      # here count toward the sampling backoff because they likely indicate
-      # Puma-side trouble. Returns nil rather than raising so #sample can keep
-      # the recording path separate.
+      # Fetches and aggregates Puma stats. Returns the metric Hash on success or
+      # nil on failure. Failures count toward the sampling backoff (likely
+      # Puma-side trouble). Returns nil rather than raising so #sample can route
+      # recording failures through their own counter.
       def fetch_metrics
         stats = @stats_source.stats
         # Newer Puma returns a Hash; older versions return a JSON string. Parse
@@ -179,26 +131,15 @@ module NewRelic
       end
 
       # Collapses Puma's stats into a flat metric => summed-value hash. Handles
-      # both clustered mode (a +:worker_status+ array) and single mode (the
-      # thread-pool keys at the top level). In clustered mode the per-worker
-      # values are summed, giving cluster-wide totals (e.g. +pool_capacity+
-      # becomes the cluster-wide spare thread capacity).
-      #
-      # Sparse data (a known shape with missing inner keys, e.g. a worker
-      # without +:last_status+) is tolerated and yields zeros for the absent
-      # metrics. A completely unrecognized shape (neither +:worker_status+
-      # nor any +WORKER_STAT_KEYS+ at the top level) raises so the caller
-      # surfaces it to operators instead of silently reporting nothing.
+      # clustered mode (sums across +:worker_status+) and single mode (top-level
+      # keys). Sparse data is tolerated; a completely unrecognized shape raises
+      # so operators see a clear signal instead of silent zero metrics.
       def aggregate(stats)
         metrics = Hash.new(0)
 
-        # +:worker_status: []+ (empty array) is intentionally a recognized
-        # shape: a clustered master observed before its workers have booted
-        # produces it briefly during startup. Tightening this to require a
-        # non-empty array would log an UnrecognizedStatsError on every Puma
-        # boot. The cost is at most one sample interval (default 60 s) of
-        # misleading-but-self-correcting zero metrics during boot, which is
-        # preferable to false-positive errors in normal operation.
+        # Empty +:worker_status+ is intentional: a clustered master sampled before
+        # its workers have spawned produces it briefly during boot. Requiring
+        # non-empty would log an UnrecognizedStatsError on every Puma boot.
         if stats[:worker_status]
           metrics[:workers] = stats[:workers].to_i
           stats[:worker_status].each do |worker|
@@ -212,14 +153,11 @@ module NewRelic
             metrics[key] += stats[key].to_i if stats.key?(key)
           end
         elsif !stats.empty? && (stats.keys - RUNNER_INFO_KEYS).empty?
-          # A single-mode runner sampled before its Puma::Server has started
-          # reports only runner metadata. The sampler is installed while Puma
-          # is still binding (before +start_server+), so the first sample can
-          # land in that window; like the empty +:worker_status+ above, it is
-          # a recognized boot shape with nothing to record yet. Deliberately
-          # strict (metadata keys only): a stats hash mixing metadata with
-          # unrecognized keys still raises, so a Puma release renaming the
-          # per-worker keys cannot be silently tolerated.
+          # A single-mode runner sampled before its Puma::Server exists reports
+          # only runner metadata: a recognized boot shape with nothing to record.
+          # Strict (metadata keys only) so that if a Puma release renames the
+          # per-worker keys, this branch still raises instead of silently treating
+          # the renamed stats as harmless metadata.
         else
           raise UnrecognizedStatsError,
             "Puma stats had neither :worker_status nor any of #{WORKER_STAT_KEYS.inspect} " \
@@ -230,18 +168,12 @@ module NewRelic
       end
 
       # Records the aggregated metrics. A failure here is the agent's metric
-      # store misbehaving, not Puma's; log it distinctly and do not count it
-      # toward the sampling backoff (which is for Puma-side trouble). A
-      # partial write is acceptable: any metric already recorded reaches New
-      # Relic on the next harvest. Logging is throttled like sample failures
-      # so a persistently broken metric store does not flood the master log
-      # every sample interval.
+      # store, not Puma's; log distinctly (throttled) and don't count against
+      # the sample backoff.
       #
-      # Asymmetry note: unlike +fetch_metrics+, this path does NOT extend
-      # +next_wait_interval+ on failure. Puma-side trouble is a signal to back
-      # off polling Puma; a metric-store outage isn't — keep sampling at the
-      # configured rate so recording resumes immediately once the store
-      # recovers. Don't "fix" this by merging the two counters.
+      # Asymmetry: this path does NOT extend +next_wait_interval+ on failure.
+      # A metric-store outage shouldn't slow Puma polling; recording should
+      # resume immediately on recovery. Don't "fix" this by merging counters.
       def report_metrics(metrics)
         metrics.each do |key, value|
           ::NewRelic::Agent.record_metric("#{METRIC_NAMESPACE}/#{key}", value)
@@ -262,11 +194,9 @@ module NewRelic
         @sample_rate * (2**exponent)
       end
 
-      # The master's agent never started its harvest thread (deferred for the
-      # forking dispatcher), so force it up so recorded metrics are delivered.
-      # Returns true if reporting is ready, false if the attempt failed, in
-      # which case the caller skips sampling rather than silently collecting
-      # metrics that will never be sent.
+      # Force the agent's harvest thread up in the master (normally deferred
+      # under forking dispatchers). Returns false on failure so the caller can
+      # skip sampling rather than buffer metrics that will never be sent.
       def ensure_master_is_reporting
         ::NewRelic::Agent.after_fork(force_reconnect: true)
         true
@@ -280,10 +210,7 @@ module NewRelic
       end
 
       # Logs the first failure, every Nth subsequent failure, and any failure
-      # that has not been logged in LOG_FAILURE_TIME_FLOOR_SECONDS. Without
-      # the time floor, exponential backoff stretches the "every Nth" cadence
-      # to ~14 minutes; the floor caps that at ~5-6 minutes so a persistent
-      # failure is re-surfaced even while backoff is sparse.
+      # not logged within LOG_FAILURE_TIME_FLOOR_SECONDS.
       def log_sample_failure(e)
         now = monotonic_now
         return unless should_log?(@consecutive_failures, @last_failure_logged_at, now)
@@ -297,8 +224,7 @@ module NewRelic
       end
 
       # Mirrors +log_sample_failure+ for record_metric failures, throttled
-      # against its own counter so a metric-store outage does not flood the
-      # master log at every sample interval.
+      # against its own counter to avoid flooding the master log.
       def log_report_failure(e)
         now = monotonic_now
         return unless should_log?(@consecutive_report_failures, @last_report_failure_logged_at, now)

--- a/lib/new_relic/agent/puma_stats_sampler.rb
+++ b/lib/new_relic/agent/puma_stats_sampler.rb
@@ -15,8 +15,7 @@ module NewRelic
     #
     # This class restarts the harvest thread in the master via
     # +NewRelic::Agent.after_fork(force_reconnect: true)+ to deliver the
-    # sampled metrics. The master then reports to New Relic as its own
-    # instance.
+    # sampled metrics. This starts an additional agent connection in the master.
     #
     # Records only integer gauges/counters via +NewRelic::Agent.record_metric+
     # (no request, query, or user data), so it is fully functional under High
@@ -30,6 +29,7 @@ module NewRelic
       class UnrecognizedStatsError < StandardError; end
 
       METRIC_NAMESPACE = 'Ruby/Puma'
+      INSTRUMENTATION_NAME = 'Puma'
       # Per-worker stat keys, summed across the cluster. +requests_count+ is a
       # cumulative counter (use +rate()+ in NRQL); the rest are point-in-time
       # gauges. +pool_capacity+ is spare request capacity: idle threads plus
@@ -66,6 +66,8 @@ module NewRelic
       # so #start is never re-entered on the same instance.
       def start
         return unless ensure_master_is_reporting
+
+        NewRelic::Agent.record_instrumentation_invocation(INSTRUMENTATION_NAME)
 
         @lock.synchronize do
           return if @stopped

--- a/newrelic.yml
+++ b/newrelic.yml
@@ -325,15 +325,6 @@ common: &default_settings
   # on the transaction may not reflect the altered value.
   # disable_middleware_instrumentation: false
 
-  # If true, disables the Puma server-statistics instrumentation that samples
-  # Ruby/Puma/* metrics from the Puma master process.
-  # 
-  # When enabled, the agent starts its reporting thread in the Puma master so the
-  # sampled metrics are delivered. (The agent otherwise defers that thread under
-  # forking dispatchers such as Puma, leaving metrics sampled in the master
-  # buffered but never sent.) The Puma master then reports to New Relic as its own
-  # instance.
-  # disable_puma_instrumentation: false
 
   # If true, disables agent middleware for Roda. This middleware is responsible
   # for advanced feature support such as page load timing and error collection.


### PR DESCRIPTION
- Disable by default
- Add supportability metric
- Add warning for users on 6.x who aren't calling preload
- Clean up comments