### PR TITLE
Fix CI for rails edge

### DIFF
--- a/.github/workflows/scripts/setup_bundler
+++ b/.github/workflows/scripts/setup_bundler
@@ -61,7 +61,7 @@ function install_ruby_version_specific_gems {
     gem install --default date:3.5.1
     gem install --default digest:3.1.0
     gem install --default digest:3.2.0
-    gem install --default erb:4.0.4
+    gem install --default erb:4.0.4.1
     gem install --default erb:5.0.2
     gem install --default erb:6.0.1
     gem install --default erb:6.0.4

--- a/.github/workflows/scripts/setup_bundler
+++ b/.github/workflows/scripts/setup_bundler
@@ -71,6 +71,7 @@ function install_ruby_version_specific_gems {
     gem install --default set:1.1.2
     gem install --default strscan:3.0.4
     gem install --default strscan:3.1.5
+    gem install --default strscan:3.1.8
 
     if [[ $RUBY_VERSION =~ ^(2\.|3\.[0-4]) ]]; then
     gem install --default logger:1.7.0

--- a/.github/workflows/scripts/setup_bundler
+++ b/.github/workflows/scripts/setup_bundler
@@ -56,6 +56,7 @@ function install_ruby_version_specific_gems {
     # The doubles below are needed for older Ruby versions, since the newer one won't install on the older Ruby versions
     gem install --default cgi:0.5.0
     gem install --default cgi:0.5.1
+    gem install --default cgi:0.5.2
     gem install --default date:3.4.1
     gem install --default date:3.5.1
     gem install --default digest:3.1.0
@@ -63,6 +64,7 @@ function install_ruby_version_specific_gems {
     gem install --default erb:4.0.4
     gem install --default erb:5.0.2
     gem install --default erb:6.0.1
+    gem install --default erb:6.0.4
 
     gem install --default securerandom:0.3.2
     gem install --default securerandom:0.4.1

--- a/test/multiverse/lib/multiverse/suite.rb
+++ b/test/multiverse/lib/multiverse/suite.rb
@@ -612,6 +612,7 @@ module Multiverse
     # Rails and minitest_tu_shim both want to do MiniTest::Unit.autorun for us
     # We can't sidestep, so just gut the method to avoid doubled test runs
     def prevent_minitest_auto_run
+      # TODO: OLD RUBIES - 2.6 - Remove this method when we drop support
       # MiniTest 4.x (absent on modern Minitest, which has no MiniTest::Unit)
       if defined?(::MiniTest::Unit)
         ::MiniTest::Unit.class_eval do

--- a/test/multiverse/lib/multiverse/suite.rb
+++ b/test/multiverse/lib/multiverse/suite.rb
@@ -328,6 +328,11 @@ module Multiverse
         require 'minitest/unit'
       end
       require 'minitest/mock'
+      # Minitest 5.25+ dropped the legacy camelCase `MiniTest` namespace that
+      # this harness references throughout. Recreate the alias ourselves so we
+      # keep supporting old and new Minitest alike. No-op where it still exists.
+      # (const_set, not `=`, since constant assignment isn't allowed in a method.)
+      Object.const_set(:MiniTest, ::Minitest) unless defined?(::MiniTest)
     end
 
     def print_environment
@@ -607,10 +612,12 @@ module Multiverse
     # Rails and minitest_tu_shim both want to do MiniTest::Unit.autorun for us
     # We can't sidestep, so just gut the method to avoid doubled test runs
     def prevent_minitest_auto_run
-      # MiniTest 4.x
-      ::MiniTest::Unit.class_eval do
-        def self.autorun
-          # NO-OP
+      # MiniTest 4.x (absent on modern Minitest, which has no MiniTest::Unit)
+      if defined?(::MiniTest::Unit)
+        ::MiniTest::Unit.class_eval do
+          def self.autorun
+            # NO-OP
+          end
         end
       end
 

--- a/test/multiverse/suites/rails/Envfile
+++ b/test/multiverse/suites/rails/Envfile
@@ -35,7 +35,9 @@ def minitest_rails_version(rails_version = nil)
   if rails_version && rails_version.include?('4.0.13')
     '4.2.0'
   else
-    '5.2.3'
+    # Rails edge (main) aliases assert_not_pattern to Minitest's refute_pattern,
+    # which was added in Minitest 5.16, so require at least that.
+    '>= 5.16'
   end
 end
 

--- a/test/multiverse/suites/rails/Envfile
+++ b/test/multiverse/suites/rails/Envfile
@@ -36,8 +36,10 @@ def minitest_rails_version(rails_version = nil)
     '4.2.0'
   else
     # Rails edge (main) aliases assert_not_pattern to Minitest's refute_pattern,
-    # which was added in Minitest 5.16, so require at least that.
-    '>= 5.16'
+    # which was added in Minitest 5.16, so require at least that. Cap below 6.0
+    # because Minitest 6 removed minitest/mock (now its own gem) and the legacy
+    # MiniTest namespace, both of which the multiverse harness still relies on.
+    '~> 5.16'
   end
 end
 

--- a/test/multiverse/suites/rails/Envfile
+++ b/test/multiverse/suites/rails/Envfile
@@ -34,12 +34,20 @@ end
 def minitest_rails_version(rails_version = nil)
   if rails_version && rails_version.include?('4.0.13')
     '4.2.0'
-  else
+  elsif RUBY_VERSION >= '3.3.0'
     # Rails edge (main) aliases assert_not_pattern to Minitest's refute_pattern,
-    # which was added in Minitest 5.16, so require at least that. Cap below 6.0
-    # because Minitest 6 removed minitest/mock (now its own gem) and the legacy
-    # MiniTest namespace, both of which the multiverse harness still relies on.
+    # which was added in Minitest 5.16, so require at least that. Rails edge only
+    # runs on Ruby >= 3.3 (see Multiverse::Envfile#unshift_rails_edge), so this is
+    # the only place the newer Minitest is needed. Cap below 6.0 because Minitest 6
+    # removed minitest/mock (now its own gem) and the legacy MiniTest namespace,
+    # both of which the multiverse harness still relies on.
     '~> 5.16'
+  else
+    # Older Rubies never run Rails edge, so keep the long-standing pin. Bumping
+    # Minitest here regresses Ruby 2.7: Minitest 5.25+ Mock#method_missing accepts
+    # **kwargs, so a symbol-keyed Hash passed to a mocked setter is split into
+    # kwargs under 2.7's argument semantics (activejob_test's code_information=).
+    '5.2.3'
   end
 end
 

--- a/test/multiverse/suites/rails/rails_event_logger_test.rb
+++ b/test/multiverse/suites/rails/rails_event_logger_test.rb
@@ -13,6 +13,7 @@ class RailsEventLoggerTest < Minitest::Test
     skip 'Rails.event requires Rails 8.1+' unless rails_event_available?
 
     @aggregator = NewRelic::Agent.agent.log_event_aggregator
+    @aggregator.reset!
   end
 
   def teardown

--- a/test/multiverse/suites/rails_prepend/Envfile
+++ b/test/multiverse/suites/rails_prepend/Envfile
@@ -18,7 +18,9 @@ unshift_rails_edge(RAILS_VERSIONS)
 def gem_list(rails_version = nil)
   # earlier thor errors, uncertain if they persist
   thor = "gem 'thor', '< 0.20.1'" if RUBY_PLATFORM == 'java' && rails_version && rails_version.include?('4')
-  minitest_version = rails_version && rails_version.include?('4.0') ? '4.2.0' : '5.2.3'
+  # Rails edge (main) aliases assert_not_pattern to Minitest's refute_pattern,
+  # which was added in Minitest 5.16, so require at least that.
+  minitest_version = rails_version && rails_version.include?('4.0') ? '4.2.0' : '5.16'
   <<~RB
     gem 'rails'#{rails_version}
     gem 'haml', '~> 6.0'


### PR DESCRIPTION
Rails edge changed something and now they reference refute_pattern from minitest but that's not in the minitest version we're running, so we need to bump minitest when we run rails edge. And then we needed to do other stuff to cope with the minitest version change

[ci cron run](https://github.com/newrelic/newrelic-ruby-agent/actions/runs/28539601901)