### PR TITLE
Fix intermittent rails suite failures

### DIFF
--- a/test/multiverse/suites/rails/rails3_app/my_app.rb
+++ b/test/multiverse/suites/rails/rails3_app/my_app.rb
@@ -63,6 +63,7 @@ if !defined?(MyApp)
     config.active_support.deprecation = :log
     config.secret_token = '49837489qkuweoiuoqwehisuakshdjksadhaisdy78o34y138974xyqp9rmye8yrpiokeuioqwzyoiuxftoyqiuxrhm3iou1hrzmjk'
     config.eager_load = false
+    config.enable_reloading = false if Rails::VERSION::STRING >= '7.2'
     config.filter_parameters += [:secret]
     config.secret_key_base = fake_guid(64)
     if Rails::VERSION::STRING >= '7.0.0'


### PR DESCRIPTION
So if the tests ran in a certain order, it would trigger rails to reload our test apps routes. But we don't define the routes normally (because test app), so instead of reloading, it just removes all the routes. Not ideal. There is a config to make it never do the route reloading though, so i added that config (only on rails 7.2+, which is the only versions that have this)