### PR TITLE
Add GCR hostname configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - **Feature: Report a unique hostname for Google Cloud Run instances**
 
-  The agent now detects Cloud Run and reports the GCP instance id as the hostname so individual instances can be distinguished. This is controlled by the new `utilization.gcp_cloud_run.use_instance_as_host` configuration option (default `true`). Set `utilization.gcp_cloud_run.include_revision_in_host` (default `false`) to `true` to report the hostname as `{K_REVISION}-{instance id}` instead. [Issue#3295](https://github.com/newrelic/newrelic-ruby-agent/issues/3295)
+  The agent now detects Cloud Run and reports the GCP instance id as the hostname so individual instances can be distinguished. This is controlled by the new `utilization.gcp_cloud_run.use_instance_as_host` configuration option (default `true`). Set `utilization.gcp_cloud_run.include_revision_in_host` (default `false`) to `true` to report the hostname as `{K_REVISION}-{instance id}` instead, where [`K_REVISION`](https://docs.cloud.google.com/run/docs/container-contract#env-vars) is the Cloud Run revision name. [Issue#3295](https://github.com/newrelic/newrelic-ruby-agent/issues/3295)
 
 ## v10.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - **Feature: Report a unique hostname for Google Cloud Run instances**
 
-  The agent now detects Cloud Run and reports the GCP instance id as the hostname so individual instances can be distinguished. This is controlled by the new `utilization.gcp_cloud_run.use_instance_as_host` configuration option (default `true`). Set `utilization.gcp_cloud_run.include_revision_in_host` (default `false`) to `true` to report the hostname as `{K_REVISION}-{instance id}` instead, where [`K_REVISION`](https://docs.cloud.google.com/run/docs/container-contract#env-vars) is the Cloud Run revision name. [Issue#3295](https://github.com/newrelic/newrelic-ruby-agent/issues/3295)
+  The agent now detects Cloud Run and reports the GCP instance id as the hostname so individual instances can be distinguished. Before this change, all Google Cloud Run hostnames were `localhost`. This feature is controlled by the new `utilization.gcp_cloud_run.use_instance_as_host` configuration option (default `true`). Set `utilization.gcp_cloud_run.include_revision_in_host` (default `false`) to `true` to report the hostname as `{K_REVISION}-{instance id}` instead, where [`K_REVISION`](https://docs.cloud.google.com/run/docs/container-contract#env-vars) is the Cloud Run revision name. Thank you to [@kawa-onushi](https://github.com/kawa-onushi) for suggesting this improvement. [Issue#3295](https://github.com/newrelic/newrelic-ruby-agent/issues/3295) [PR#3609](https://github.com/newrelic/newrelic-ruby-agent/pull/3609/)
 
 ## v10.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # New Relic Ruby Agent Release Notes
 
+## dev
+
+- **Feature: Report a unique hostname for Google Cloud Run instances**
+
+  The agent now detects Cloud Run and reports the GCP instance id as the hostname so individual instances can be distinguished. This is controlled by the new `utilization.gcp_cloud_run.use_instance_as_host` configuration option (default `true`). Set `utilization.gcp_cloud_run.include_revision_in_host` (default `false`) to `true` to report the hostname as `{K_REVISION}-{instance id}` instead. [Issue#3295](https://github.com/newrelic/newrelic-ruby-agent/issues/3295)
+
 ## v10.6.0
 
 - **Feature: SpanLink events are now supported for the Hybrid Agent**

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2351,6 +2351,20 @@ module NewRelic
           :dynamic_name => true,
           :description => 'If `true`, the agent automatically detects that it is running in an Google Cloud Platform environment.'
         },
+        :'utilization.gcp_cloud_run.use_instance_as_host' => {
+          :default => true,
+          :public => true,
+          :type => Boolean,
+          :allowed_from_server => false,
+          :description => 'If `true`, when the agent detects it is running on Google Cloud Run, it reports the GCP metadata instance id as the hostname rather than `localhost`. This allows individual Cloud Run instances to be distinguished in the New Relic UI.'
+        },
+        :'utilization.gcp_cloud_run.include_revision_in_host' => {
+          :default => false,
+          :public => true,
+          :type => Boolean,
+          :allowed_from_server => false,
+          :description => 'If `true`, when the agent detects it is running on Google Cloud Run, it prepends the `K_REVISION` environment variable value to the instance id to form the hostname (`{K_REVISION}-{instance id}`), which can be easier to identify in the New Relic UI. Has no effect unless `utilization.gcp_cloud_run.use_instance_as_host` is also `true`.'
+        },
         :'utilization.detect_kubernetes' => {
           :default => true,
           :public => true,

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -2356,14 +2356,14 @@ module NewRelic
           :public => true,
           :type => Boolean,
           :allowed_from_server => false,
-          :description => 'If `true`, when the agent detects it is running on Google Cloud Run, it reports the GCP metadata instance id as the hostname rather than `localhost`. This allows individual Cloud Run instances to be distinguished in the New Relic UI.'
+          :description => 'If `true`, the agent reports the GCP instance id as the hostname when running on Google Cloud Run.'
         },
         :'utilization.gcp_cloud_run.include_revision_in_host' => {
           :default => false,
           :public => true,
           :type => Boolean,
           :allowed_from_server => false,
-          :description => 'If `true`, when the agent detects it is running on Google Cloud Run, it prepends the `K_REVISION` environment variable value to the instance id to form the hostname (`{K_REVISION}-{instance id}`), which can be easier to identify in the New Relic UI. Has no effect unless `utilization.gcp_cloud_run.use_instance_as_host` is also `true`.'
+          :description => 'If `true`, the agent prepends the `K_REVISION` value to the GCP instance id to form the hostname (`{K_REVISION}-{instance id}`) on Google Cloud Run. Has no effect unless `utilization.gcp_cloud_run.use_instance_as_host` is also `true`.'
         },
         :'utilization.detect_kubernetes' => {
           :default => true,

--- a/lib/new_relic/agent/hostname.rb
+++ b/lib/new_relic/agent/hostname.rb
@@ -3,20 +3,58 @@
 # frozen_string_literal: true
 
 require 'socket'
+require 'net/http'
 require 'new_relic/helper'
 
 module NewRelic
   module Agent
     module Hostname
+      CLOUD_RUN_REVISION = 'K_REVISION'
+      GCP_INSTANCE_ID_URI = 'http://metadata.google.internal/computeMetadata/v1/instance/id'
+      GCP_METADATA_HEADERS = {'Metadata-Flavor' => 'Google'}.freeze
+
       def self.get
         dyno_name = ENV['DYNO']
         @hostname ||= if dyno_name && ::NewRelic::Agent.config[:'heroku.use_dyno_names']
           matching_prefix = heroku_dyno_name_prefix(dyno_name)
           dyno_name = "#{matching_prefix}.*" if matching_prefix
           dyno_name
+        elsif gcp_cloud_run?
+          gcp_cloud_run_host
         else
           Socket.gethostname.force_encoding(Encoding::UTF_8)
         end
+      end
+
+      def self.gcp_cloud_run?
+        ENV.key?(CLOUD_RUN_REVISION) &&
+          ::NewRelic::Agent.config[:'utilization.gcp_cloud_run.use_instance_as_host']
+      end
+
+      def self.gcp_cloud_run_host
+        instance_id = gcp_instance_id
+        return Socket.gethostname.force_encoding(Encoding::UTF_8) unless instance_id
+
+        if ::NewRelic::Agent.config[:'utilization.gcp_cloud_run.include_revision_in_host']
+          "#{ENV[CLOUD_RUN_REVISION]}-#{instance_id}"
+        else
+          instance_id
+        end
+      end
+
+      def self.gcp_instance_id
+        uri = URI(GCP_INSTANCE_ID_URI)
+        response = nil
+        Net::HTTP.start(uri.host, uri.port, open_timeout: 1, read_timeout: 1) do |http|
+          response = http.request(Net::HTTP::Get.new(uri, GCP_METADATA_HEADERS))
+        end
+        return unless response&.code == '200'
+
+        id = response.body.to_s.strip
+        id.empty? ? nil : id
+      rescue => e
+        NewRelic::Agent.logger.debug("Unable to fetch GCP Cloud Run instance id: #{e.class} - #{e.message}")
+        nil
       end
 
       # Pass '-f' to the external executable 'hostname' to request the fully

--- a/lib/new_relic/agent/hostname.rb
+++ b/lib/new_relic/agent/hostname.rb
@@ -3,7 +3,6 @@
 # frozen_string_literal: true
 
 require 'socket'
-require 'net/http'
 require 'new_relic/helper'
 
 module NewRelic
@@ -43,11 +42,7 @@ module NewRelic
       end
 
       def self.gcp_instance_id
-        uri = URI(GCP_INSTANCE_ID_URI)
-        response = nil
-        Net::HTTP.start(uri.host, uri.port, open_timeout: 1, read_timeout: 1) do |http|
-          response = http.request(Net::HTTP::Get.new(uri, GCP_METADATA_HEADERS))
-        end
+        response = NewRelic::Helper.fetch_metadata(GCP_INSTANCE_ID_URI, GCP_METADATA_HEADERS)
         return unless response&.code == '200'
 
         id = response.body.to_s.strip

--- a/lib/new_relic/agent/utilization/vendor.rb
+++ b/lib/new_relic/agent/utilization/vendor.rb
@@ -2,7 +2,7 @@
 # See https://github.com/newrelic/newrelic-ruby-agent/blob/main/LICENSE for complete details.
 # frozen_string_literal: true
 
-require 'net/http'
+require 'new_relic/helper'
 
 module NewRelic
   module Agent
@@ -75,12 +75,7 @@ module NewRelic
           processed_headers = headers
           raise if processed_headers.value?(:error)
 
-          response = nil
-          Net::HTTP.start(endpoint.host, endpoint.port, open_timeout: 1, read_timeout: 1) do |http|
-            req = Net::HTTP::Get.new(endpoint, processed_headers)
-            response = http.request(req)
-          end
-          response
+          NewRelic::Helper.fetch_metadata(endpoint, processed_headers)
         rescue
           NewRelic::Agent.logger.debug("#{vendor_name} environment not detected")
         end

--- a/lib/new_relic/helper.rb
+++ b/lib/new_relic/helper.rb
@@ -4,6 +4,7 @@
 
 require 'new_relic/language_support'
 require 'open3'
+require 'net/http'
 
 module NewRelic
   class CommandExecutableNotFoundError < StandardError; end
@@ -44,6 +45,13 @@ module NewRelic
 
     def time_to_millis(time)
       (time.to_f * 1000).round
+    end
+
+    def fetch_metadata(uri, headers)
+      uri = URI(uri)
+      Net::HTTP.start(uri.host, uri.port, open_timeout: 1, read_timeout: 1) do |http|
+        http.request(Net::HTTP::Get.new(uri, headers))
+      end
     end
 
     def run_command(command)

--- a/test/new_relic/agent/hostname_test.rb
+++ b/test/new_relic/agent/hostname_test.rb
@@ -80,6 +80,67 @@ module NewRelic
         end
       end
 
+      def test_gcp_cloud_run_reports_instance_id_as_host
+        NewRelic::Agent::Hostname.stubs(:gcp_instance_id).returns('1234567890')
+
+        with_cloud_run_env('gcr-test.1', :'utilization.gcp_cloud_run.use_instance_as_host' => true) do
+          assert_equal '1234567890', NewRelic::Agent::Hostname.get
+        end
+      end
+
+      def test_gcp_cloud_run_prepends_revision_when_configured
+        NewRelic::Agent::Hostname.stubs(:gcp_instance_id).returns('1234567890')
+
+        with_cloud_run_env('gcr-test.1',
+          :'utilization.gcp_cloud_run.use_instance_as_host' => true,
+          :'utilization.gcp_cloud_run.include_revision_in_host' => true) do
+          assert_equal 'gcr-test.1-1234567890', NewRelic::Agent::Hostname.get
+        end
+      end
+
+      def test_gcp_cloud_run_uses_socket_hostname_when_use_instance_as_host_disabled
+        NewRelic::Agent::Hostname.stubs(:gcp_instance_id).returns('1234567890')
+
+        with_cloud_run_env('gcr-test.1', :'utilization.gcp_cloud_run.use_instance_as_host' => false) do
+          assert_equal 'Rivendell', NewRelic::Agent::Hostname.get
+        end
+      end
+
+      def test_gcp_cloud_run_falls_back_to_socket_hostname_when_instance_id_unavailable
+        NewRelic::Agent::Hostname.stubs(:gcp_instance_id).returns(nil)
+
+        with_cloud_run_env('gcr-test.1', :'utilization.gcp_cloud_run.use_instance_as_host' => true) do
+          assert_equal 'Rivendell', NewRelic::Agent::Hostname.get
+        end
+      end
+
+      def test_gcp_instance_id_parses_successful_response
+        Net::HTTP.stubs(:start).yields(stub(request: stub(code: '200', body: "1234567890\n")))
+
+        assert_equal '1234567890', NewRelic::Agent::Hostname.gcp_instance_id
+      end
+
+      def test_gcp_instance_id_returns_nil_for_non_200_response
+        Net::HTTP.stubs(:start).yields(stub(request: stub(code: '404', body: 'nope')))
+
+        assert_nil NewRelic::Agent::Hostname.gcp_instance_id
+      end
+
+      def test_gcp_instance_id_returns_nil_on_connection_error
+        Net::HTTP.stubs(:start).raises(Errno::ECONNREFUSED)
+
+        assert_nil NewRelic::Agent::Hostname.gcp_instance_id
+      end
+
+      def with_cloud_run_env(revision, config_options)
+        with_config(config_options) do
+          ENV[NewRelic::Agent::Hostname::CLOUD_RUN_REVISION] = revision
+          yield
+        end
+      ensure
+        ENV.delete(NewRelic::Agent::Hostname::CLOUD_RUN_REVISION)
+      end
+
       def test_local_predicate_true_when_host_local
         hosts = %w[localhost 0.0.0.0 127.0.0.1 0:0:0:0:0:0:0:1
           0:0:0:0:0:0:0:0 ::1 ::]

--- a/test/new_relic/agent/hostname_test.rb
+++ b/test/new_relic/agent/hostname_test.rb
@@ -115,19 +115,19 @@ module NewRelic
       end
 
       def test_gcp_instance_id_parses_successful_response
-        Net::HTTP.stubs(:start).yields(stub(request: stub(code: '200', body: "1234567890\n")))
+        NewRelic::Helper.stubs(:fetch_metadata).returns(stub(code: '200', body: "1234567890\n"))
 
         assert_equal '1234567890', NewRelic::Agent::Hostname.gcp_instance_id
       end
 
       def test_gcp_instance_id_returns_nil_for_non_200_response
-        Net::HTTP.stubs(:start).yields(stub(request: stub(code: '404', body: 'nope')))
+        NewRelic::Helper.stubs(:fetch_metadata).returns(stub(code: '404', body: 'nope'))
 
         assert_nil NewRelic::Agent::Hostname.gcp_instance_id
       end
 
       def test_gcp_instance_id_returns_nil_on_connection_error
-        Net::HTTP.stubs(:start).raises(Errno::ECONNREFUSED)
+        NewRelic::Helper.stubs(:fetch_metadata).raises(Errno::ECONNREFUSED)
 
         assert_nil NewRelic::Agent::Hostname.gcp_instance_id
       end


### PR DESCRIPTION
Add option to report the GCP instance id as the hostname. Two new configs:
- `utilization.gcp_cloud_run.use_instance_as_host` (default `true`) - reports instance id
- `utilization.gcp_cloud_run.include_revision_in_host` (default `false`) reports {K_REVISION}-{instance id} 

Falls back to socket hostname on failure.

Closes #3295.

Example from playground application:
<img width="771" height="198" alt="Screenshot 2026-07-07 at 5 57 01 AM" src="https://github.com/user-attachments/assets/3403afa9-7d91-4988-a32b-ccf93bb29103" />
