### PR TITLE
fix for 7.2+ multi db explain plans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## dev
 
-- **Bugfix: Explain plans could target the wrong database and leave connections in a bad state in multi-database Rails apps (Rails >= 7.2)**
+- **Bugfix: Explain plans could target the wrong database in multi-database Rails apps (Rails >= 7.2)**
 
   On Rails 7.2+, the agent gathered explain plans using a connection from the app's default/shared pool rather than a dedicated one. This primarily affected multi-database apps. Explain plans could be generated against the wrong database, and a failed explain could leave a shared connection in a bad state, affecting unrelated requests. The agent now uses its own dedicated connection for explain plans, as it did before Rails 7.2, and resets or discards that connection whenever an explain attempt fails, so a bad connection is never reused. Thank you, [@masiafrest](https://github.com/masiafrest) for the detailed report! [Issue#3610](https://github.com/newrelic/newrelic-ruby-agent/issues/3610) [PR#3612](https://github.com/newrelic/newrelic-ruby-agent/pull/3612)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - **Bugfix: Explain plans could target the wrong database and leave connections in a bad state in multi-database Rails apps (Rails >= 7.2)**
 
-  On Rails 7.2+, the agent gathered explain plans using a connection from the app's default/shared pool rather than a dedicated one. This primarily affected multi-database apps, where explain plans could be generated against the wrong database, and a failed explain could leave a shared connection in a bad state, affecting unrelated requests. The agent now uses its own dedicated connection for explain plans, as it did before Rails 7.2, and resets or discards that connection whenever an explain attempt fails, so a bad connection is never reused. Thank you, [@masiafrest](https://github.com/masiafrest) for the detailed report! [Issue#3610](https://github.com/newrelic/newrelic-ruby-agent/issues/3610) [PR#3612](https://github.com/newrelic/newrelic-ruby-agent/pull/3612)
+  On Rails 7.2+, the agent gathered explain plans using a connection from the app's default/shared pool rather than a dedicated one. This primarily affected multi-database apps. Explain plans could be generated against the wrong database, and a failed explain could leave a shared connection in a bad state, affecting unrelated requests. The agent now uses its own dedicated connection for explain plans, as it did before Rails 7.2, and resets or discards that connection whenever an explain attempt fails, so a bad connection is never reused. Thank you, [@masiafrest](https://github.com/masiafrest) for the detailed report! [Issue#3610](https://github.com/newrelic/newrelic-ruby-agent/issues/3610) [PR#3612](https://github.com/newrelic/newrelic-ruby-agent/pull/3612)
 
 ## v10.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - **Bugfix: Explain plans could target the wrong database and leave connections in a bad state in multi-database Rails apps (Rails >= 7.2)**
 
-  On Rails 7.2+, the agent gathered explain plans using a connection from the app's default/shared pool rather than a dedicated one. This primarily affected multi-database apps, where explain plans could be generated against the wrong database, and a failed explain could leave a shared connection in a bad state, affecting unrelated requests. The agent now uses its own dedicated connection for explain plans, and resets or discards that connection whenever an explain attempt fails, so a bad connection is never reused. Thank you, [@masiafrest](https://github.com/masiafrest) for the detailed report! [Issue#3610](https://github.com/newrelic/newrelic-ruby-agent/issues/3610) [PR#3612](https://github.com/newrelic/newrelic-ruby-agent/pull/3612)
+  On Rails 7.2+, the agent gathered explain plans using a connection from the app's default/shared pool rather than a dedicated one. This primarily affected multi-database apps, where explain plans could be generated against the wrong database, and a failed explain could leave a shared connection in a bad state, affecting unrelated requests. The agent now uses its own dedicated connection for explain plans, as it did before Rails 7.2, and resets or discards that connection whenever an explain attempt fails, so a bad connection is never reused. Thank you, [@masiafrest](https://github.com/masiafrest) for the detailed report! [Issue#3610](https://github.com/newrelic/newrelic-ruby-agent/issues/3610) [PR#3612](https://github.com/newrelic/newrelic-ruby-agent/pull/3612)
 
 ## v10.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # New Relic Ruby Agent Release Notes
 
+## dev
+
+- **Bugfix: Explain plans could target the wrong database and leave connections in a bad state in multi-database Rails apps (Rails >= 7.2)**
+
+  On Rails 7.2+, the agent gathered explain plans using a connection from the app's default/shared pool rather than a dedicated one. This primarily affected multi-database apps, where explain plans could be generated against the wrong database, and a failed explain could leave a shared connection in a bad state, affecting unrelated requests. The agent now uses its own dedicated connection for explain plans, and resets or discards that connection whenever an explain attempt fails, so a bad connection is never reused. Thank you, [@masiafrest](https://github.com/masiafrest) for the detailed report! [Issue#3610](https://github.com/newrelic/newrelic-ruby-agent/issues/3610) [PR#3612](https://github.com/newrelic/newrelic-ruby-agent/pull/3612)
+
 ## v10.6.0
 
 - **Feature: SpanLink events are now supported for the Hybrid Agent**

--- a/lib/new_relic/agent/database.rb
+++ b/lib/new_relic/agent/database.rb
@@ -101,8 +101,13 @@ module NewRelic
       end
 
       def explain_this_using_with_connection(statement)
-        ::ActiveRecord::Base.with_connection do |conn|
-          conn.exec_query("EXPLAIN #{statement.sql}", "Explain #{statement.name}", statement.binds)
+        connection = get_connection(statement.config) do
+          ::ActiveRecord::ConnectionAdapters.resolve(statement.config[:adapter]).new(statement.config)
+        end
+        return unless connection
+
+        run_explain(statement.config, connection) do
+          connection.exec_query("EXPLAIN #{statement.sql}", "Explain #{statement.name}", statement.binds)
         end
       end
 
@@ -110,12 +115,24 @@ module NewRelic
         connection = get_connection(statement.config) do
           ::ActiveRecord::Base.send(:"#{statement.config[:adapter]}_connection", statement.config)
         end
+        return unless connection
 
-        if use_execute
-          connection.execute("EXPLAIN #{statement.sql}")
-        else
-          connection.exec_query("EXPLAIN #{statement.sql}", "Explain #{statement.name}", statement.binds)
+        run_explain(statement.config, connection) do
+          if use_execute
+            connection.execute("EXPLAIN #{statement.sql}")
+          else
+            connection.exec_query("EXPLAIN #{statement.sql}", "Explain #{statement.name}", statement.binds)
+          end
         end
+      end
+
+      # Ensures a connection that errors out while explaining a query never lingers in a bad
+      # transaction state for the next explain attempt against that same cached connection.
+      def run_explain(config, connection)
+        yield
+      rescue
+        ConnectionManager.instance.reset_or_discard_connection(config, connection)
+        raise
       end
 
       # ActiveRecord v7.2.0 introduced with_connection
@@ -211,6 +228,28 @@ module NewRelic
           rescue => e
             ::NewRelic::Agent.logger.error('Caught exception trying to get connection to DB for explain.', e)
             nil
+          end
+        end
+
+        # Tries to restore a connection to a clean, reusable state after a failed query
+        # (rolling back any open transaction), falling back to evicting it from the cache
+        # if it can't be reset.
+        def reset_or_discard_connection(config, connection)
+          connection.reset!
+        rescue
+          discard_connection(config)
+        end
+
+        # Evicts and disconnects a single cached connection, e.g. when it's been left in a bad
+        # state by a failed explain and shouldn't be reused for the next attempt.
+        def discard_connection(config)
+          @connections ||= {}
+          connection = @connections.delete(config)
+          return unless connection
+
+          begin
+            connection.disconnect!
+          rescue
           end
         end
 

--- a/lib/new_relic/agent/database.rb
+++ b/lib/new_relic/agent/database.rb
@@ -95,7 +95,7 @@ module NewRelic
         return unless connection
 
         run_explain(statement.config, connection) do
-          if use_execute && !supports_connection_adapters_resolve?
+          if use_execute # only used on rails 3
             connection.execute("EXPLAIN #{statement.sql}")
           else
             connection.exec_query("EXPLAIN #{statement.sql}", "Explain #{statement.name}", statement.binds)

--- a/lib/new_relic/agent/database.rb
+++ b/lib/new_relic/agent/database.rb
@@ -91,38 +91,27 @@ module NewRelic
       end
 
       def explain_this(statement, use_execute = false)
-        if supports_with_connection?
-          explain_this_using_with_connection(statement)
-        else
-          explain_this_using_adapter_connection(statement, use_execute)
+        connection = get_connection(statement.config) { new_explain_connection(statement.config) }
+        return unless connection
+
+        run_explain(statement.config, connection) do
+          if use_execute && !supports_connection_adapters_resolve?
+            connection.execute("EXPLAIN #{statement.sql}")
+          else
+            connection.exec_query("EXPLAIN #{statement.sql}", "Explain #{statement.name}", statement.binds)
+          end
         end
       rescue => e
         NewRelic::Agent.logger.error("Couldn't fetch the explain plan for statement: #{e}")
       end
 
-      def explain_this_using_with_connection(statement)
-        connection = get_connection(statement.config) do
-          ::ActiveRecord::ConnectionAdapters.resolve(statement.config[:adapter]).new(statement.config)
-        end
-        return unless connection
-
-        run_explain(statement.config, connection) do
-          connection.exec_query("EXPLAIN #{statement.sql}", "Explain #{statement.name}", statement.binds)
-        end
-      end
-
-      def explain_this_using_adapter_connection(statement, use_execute)
-        connection = get_connection(statement.config) do
-          ::ActiveRecord::Base.send(:"#{statement.config[:adapter]}_connection", statement.config)
-        end
-        return unless connection
-
-        run_explain(statement.config, connection) do
-          if use_execute
-            connection.execute("EXPLAIN #{statement.sql}")
-          else
-            connection.exec_query("EXPLAIN #{statement.sql}", "Explain #{statement.name}", statement.binds)
-          end
+      def new_explain_connection(config)
+        if supports_connection_adapters_resolve?
+          # Rails 7.2+
+          ::ActiveRecord::ConnectionAdapters.resolve(config[:adapter]).new(config)
+        else
+          # Rails <= 7.1
+          ::ActiveRecord::Base.send(:"#{config[:adapter]}_connection", config)
         end
       end
 
@@ -134,11 +123,10 @@ module NewRelic
         raise
       end
 
-      # ActiveRecord v7.2.0 introduced with_connection
-      def supports_with_connection?
-        return @supports_with_connection if defined?(@supports_with_connection)
+      def supports_connection_adapters_resolve?
+        return @supports_connection_adapters_resolve if defined?(@supports_connection_adapters_resolve)
 
-        @supports_with_connection = defined?(::ActiveRecord::VERSION::STRING) &&
+        @supports_connection_adapters_resolve = defined?(::ActiveRecord::VERSION::STRING) &&
           NewRelic::Helper.version_satisfied?(ActiveRecord::VERSION::STRING, '>=', '7.2.0')
       end
 

--- a/lib/new_relic/agent/database.rb
+++ b/lib/new_relic/agent/database.rb
@@ -126,8 +126,7 @@ module NewRelic
         end
       end
 
-      # Ensures a connection that errors out while explaining a query never lingers in a bad
-      # transaction state for the next explain attempt against that same cached connection.
+      # Resets the connection on error so it isn't reused while in a bad state
       def run_explain(config, connection)
         yield
       rescue
@@ -231,17 +230,13 @@ module NewRelic
           end
         end
 
-        # Tries to restore a connection to a clean, reusable state after a failed query
-        # (rolling back any open transaction), falling back to evicting it from the cache
-        # if it can't be reset.
+        # connection.reset! rolls back any open transaction; if that itself fails, evict it.
         def reset_or_discard_connection(config, connection)
           connection.reset!
         rescue
           discard_connection(config)
         end
 
-        # Evicts and disconnects a single cached connection, e.g. when it's been left in a bad
-        # state by a failed explain and shouldn't be reused for the next attempt.
         def discard_connection(config)
           @connections ||= {}
           connection = @connections.delete(config)

--- a/test/multiverse/suites/active_record_pg/active_record_test.rb
+++ b/test/multiverse/suites/active_record_pg/active_record_test.rb
@@ -463,6 +463,77 @@ class ActiveRecordInstrumentationTest < Minitest::Test
     end
   end
 
+  def test_resets_connection_after_failed_explain
+    with_config(:'transaction_tracer.explain_threshold' => -0.1) do
+      # first call: establish and cache the agent's dedicated explain connection
+      in_web_transaction { Order.first }
+      last_transaction_trace.prepare_to_send!
+
+      manager = NewRelic::Agent::Database::ConnectionManager.instance
+      connection = manager.instance_eval { @connections.values.first }
+
+      refute_nil connection, 'expected the agent to have cached a dedicated explain connection'
+
+      raw = connection.raw_connection
+      raw.query('BEGIN')
+      begin
+        raw.query('SELECT this_column_does_not_exist FROM orders')
+      rescue PG::Error
+      end
+
+      assert_equal(PG::PQTRANS_INERROR, raw.transaction_status,
+        'expected to have forced the connection into an aborted transaction')
+
+      # second call: explain fails against the still-poisoned connection, triggering a reset
+      in_web_transaction { Order.first }
+      last_transaction_trace.prepare_to_send!
+
+      assert_equal(PG::PQTRANS_IDLE, raw.transaction_status,
+        'expected the agent to reset the poisoned connection back to a clean state')
+
+      # third call: same connection, now healthy, should explain normally
+      in_web_transaction { Order.first }
+      sample = last_transaction_trace
+      metric = "Datastore/statement/#{current_product}/Order/find"
+      sql_node = find_node_with_name(sample, metric)
+      sample.prepare_to_send!
+
+      assert_same(connection, manager.instance_eval { @connections.values.first },
+        'expected the healed connection to still be the one cached and reused')
+      refute_nil(sql_node.params[:explain_plan],
+        "expected a real explain plan after the connection healed: #{sql_node}")
+    end
+  end
+
+  def test_discards_connection_when_it_cannot_be_reset
+    with_config(:'transaction_tracer.explain_threshold' => -0.1) do
+      in_web_transaction { Order.first }
+      last_transaction_trace.prepare_to_send!
+
+      manager = NewRelic::Agent::Database::ConnectionManager.instance
+      connection = manager.instance_eval { @connections.values.first }
+
+      refute_nil connection, 'expected the agent to have cached a dedicated explain connection'
+
+      connection.raw_connection.close
+
+      in_web_transaction { Order.first }
+      last_transaction_trace.prepare_to_send!
+
+      refute_same(connection, manager.instance_eval { @connections.values.first },
+        'expected the dead connection to be discarded and replaced')
+
+      in_web_transaction { Order.first }
+      sample = last_transaction_trace
+      metric = "Datastore/statement/#{current_product}/Order/find"
+      sql_node = find_node_with_name(sample, metric)
+      sample.prepare_to_send!
+
+      refute_nil(sql_node.params[:explain_plan],
+        "expected a real explain plan from the replacement connection: #{sql_node}")
+    end
+  end
+
   def test_sql_samplers_get_proper_metrics
     with_config(:'transaction_tracer.explain_threshold' => -0.1) do
       in_web_transaction do

--- a/test/new_relic/agent/database_test.rb
+++ b/test/new_relic/agent/database_test.rb
@@ -649,10 +649,8 @@ class NewRelic::Agent::DatabaseTest < Minitest::Test
     assert_nil statement.query_name
   end
 
-  # explain_this_using_with_connection (Rails >= 7.2) is expected to resolve a connection
-  # from the statement's own config (like the pre-7.2 adapter-connection path does), rather
-  # than ActiveRecord::Base.with_connection, which always checks out from the default pool
-  # and is unsafe in multi-database apps.
+  # with_connection resolves via statement.config, not ActiveRecord::Base.with_connection
+  # (which always uses the default pool and is unsafe in multi-database apps).
 
   def test_explain_using_with_connection_resolves_via_statement_config
     config = {:adapter => 'postgresql', :database => 'secondary'}
@@ -763,8 +761,7 @@ class NewRelic::Agent::DatabaseTest < Minitest::Test
     end
   end
 
-  # explain_this_using_adapter_connection (Rails < 7.2) already routes via statement.config;
-  # it just needs the same reset/discard-on-error safety net.
+  # adapter_connection already routes via statement.config; just needs the same safety net.
 
   def test_explain_using_adapter_connection_resets_connection_on_error
     config = {:adapter => 'postgresql', :database => 'secondary'}
@@ -815,10 +812,8 @@ class NewRelic::Agent::DatabaseTest < Minitest::Test
 
   private
 
-  # Defines a minimal top-level ActiveRecord module for the duration of the block, since
-  # this unit test suite runs without the real activerecord gem loaded. Also clears the
-  # ConnectionManager cache afterward so mock connections from one test never leak into
-  # another.
+  # Fakes ActiveRecord since this suite runs without the real gem loaded, and clears
+  # ConnectionManager's cache afterward so mock connections don't leak between tests.
   def with_fake_active_record(connection_adapters: Module.new, base: Class.new)
     ar_module = Module.new
     ar_module.const_set(:ConnectionAdapters, connection_adapters)

--- a/test/new_relic/agent/database_test.rb
+++ b/test/new_relic/agent/database_test.rb
@@ -823,11 +823,16 @@ class NewRelic::Agent::DatabaseTest < Minitest::Test
     ar_module = Module.new
     ar_module.const_set(:ConnectionAdapters, connection_adapters)
     ar_module.const_set(:Base, base)
+
+    had_active_record = Object.const_defined?(:ActiveRecord)
+    original_active_record = Object.const_get(:ActiveRecord) if had_active_record
+    Object.send(:remove_const, :ActiveRecord) if had_active_record
     Object.const_set(:ActiveRecord, ar_module)
 
     yield
   ensure
     Object.send(:remove_const, :ActiveRecord) if Object.const_defined?(:ActiveRecord)
+    Object.const_set(:ActiveRecord, original_active_record) if had_active_record
     NewRelic::Agent::Database::ConnectionManager.instance.instance_eval { @connections = {} }
   end
 end

--- a/test/new_relic/agent/database_test.rb
+++ b/test/new_relic/agent/database_test.rb
@@ -649,10 +649,7 @@ class NewRelic::Agent::DatabaseTest < Minitest::Test
     assert_nil statement.query_name
   end
 
-  # with_connection resolves via statement.config, not ActiveRecord::Base.with_connection
-  # (which always uses the default pool and is unsafe in multi-database apps).
-
-  def test_explain_using_with_connection_resolves_via_statement_config
+  def test_explain_this_resolves_via_statement_config
     config = {:adapter => 'postgresql', :database => 'secondary'}
     connection = mock('secondary db connection')
     connection.expects(:exec_query).with('EXPLAIN select 1', 'Explain SQL', nil).returns('a plan')
@@ -663,15 +660,17 @@ class NewRelic::Agent::DatabaseTest < Minitest::Test
     connection_adapters = mock('connection adapters module')
     connection_adapters.expects(:resolve).with('postgresql').returns(adapter_class)
 
+    NewRelic::Agent::Database.stubs(:supports_connection_adapters_resolve?).returns(true)
+
     with_fake_active_record(connection_adapters: connection_adapters) do
       statement = NewRelic::Agent::Database::Statement.new('select 1', config)
-      result = NewRelic::Agent::Database.explain_this_using_with_connection(statement)
+      result = NewRelic::Agent::Database.explain_this(statement)
 
       assert_equal 'a plan', result
     end
   end
 
-  def test_explain_using_with_connection_caches_connection_per_config
+  def test_explain_this_caches_connection_per_config
     config = {:adapter => 'postgresql', :database => 'secondary'}
     connection = mock('secondary db connection')
     connection.expects(:exec_query).twice.returns('a plan')
@@ -682,14 +681,16 @@ class NewRelic::Agent::DatabaseTest < Minitest::Test
     connection_adapters = mock('connection adapters module')
     connection_adapters.expects(:resolve).once.with('postgresql').returns(adapter_class)
 
+    NewRelic::Agent::Database.stubs(:supports_connection_adapters_resolve?).returns(true)
+
     with_fake_active_record(connection_adapters: connection_adapters) do
       statement = NewRelic::Agent::Database::Statement.new('select 1', config)
-      NewRelic::Agent::Database.explain_this_using_with_connection(statement)
-      NewRelic::Agent::Database.explain_this_using_with_connection(statement)
+      NewRelic::Agent::Database.explain_this(statement)
+      NewRelic::Agent::Database.explain_this(statement)
     end
   end
 
-  def test_explain_using_with_connection_routes_different_configs_independently
+  def test_explain_this_routes_different_configs_independently
     primary_config = {:adapter => 'postgresql', :database => 'primary'}
     secondary_config = {:adapter => 'postgresql', :database => 'secondary'}
 
@@ -705,16 +706,18 @@ class NewRelic::Agent::DatabaseTest < Minitest::Test
     connection_adapters = mock('connection adapters module')
     connection_adapters.stubs(:resolve).with('postgresql').returns(adapter_class)
 
+    NewRelic::Agent::Database.stubs(:supports_connection_adapters_resolve?).returns(true)
+
     with_fake_active_record(connection_adapters: connection_adapters) do
       primary_statement = NewRelic::Agent::Database::Statement.new('select 1', primary_config)
       secondary_statement = NewRelic::Agent::Database::Statement.new('select 2', secondary_config)
 
-      assert_equal 'primary plan', NewRelic::Agent::Database.explain_this_using_with_connection(primary_statement)
-      assert_equal 'secondary plan', NewRelic::Agent::Database.explain_this_using_with_connection(secondary_statement)
+      assert_equal 'primary plan', NewRelic::Agent::Database.explain_this(primary_statement)
+      assert_equal 'secondary plan', NewRelic::Agent::Database.explain_this(secondary_statement)
     end
   end
 
-  def test_explain_using_with_connection_resets_connection_on_error
+  def test_explain_this_resets_connection_on_error
     config = {:adapter => 'postgresql', :database => 'secondary'}
     connection = mock('secondary db connection')
     connection.expects(:exec_query).raises(StandardError.new('boom'))
@@ -726,16 +729,18 @@ class NewRelic::Agent::DatabaseTest < Minitest::Test
     connection_adapters = mock('connection adapters module')
     connection_adapters.stubs(:resolve).returns(adapter_class)
 
+    NewRelic::Agent::Database.stubs(:supports_connection_adapters_resolve?).returns(true)
+
     with_fake_active_record(connection_adapters: connection_adapters) do
       statement = NewRelic::Agent::Database::Statement.new('select 1', config)
 
-      assert_raises(StandardError) do
-        NewRelic::Agent::Database.explain_this_using_with_connection(statement)
-      end
+      # explain_this rescues and logs, so the error itself doesn't surface here -
+      # the mock's `reset!` expectation is what proves the recovery ran.
+      assert_nil NewRelic::Agent::Database.explain_this(statement)
     end
   end
 
-  def test_explain_using_with_connection_discards_connection_when_reset_fails
+  def test_explain_this_discards_connection_when_reset_fails
     config = {:adapter => 'postgresql', :database => 'secondary'}
     connection = mock('secondary db connection')
     connection.expects(:exec_query).raises(StandardError.new('boom'))
@@ -748,12 +753,12 @@ class NewRelic::Agent::DatabaseTest < Minitest::Test
     connection_adapters = mock('connection adapters module')
     connection_adapters.stubs(:resolve).returns(adapter_class)
 
+    NewRelic::Agent::Database.stubs(:supports_connection_adapters_resolve?).returns(true)
+
     with_fake_active_record(connection_adapters: connection_adapters) do
       statement = NewRelic::Agent::Database::Statement.new('select 1', config)
 
-      assert_raises(StandardError) do
-        NewRelic::Agent::Database.explain_this_using_with_connection(statement)
-      end
+      assert_nil NewRelic::Agent::Database.explain_this(statement)
 
       cached_connection = NewRelic::Agent::Database::ConnectionManager.instance.instance_eval { @connections[config] }
 
@@ -761,9 +766,9 @@ class NewRelic::Agent::DatabaseTest < Minitest::Test
     end
   end
 
-  # adapter_connection already routes via statement.config; just needs the same safety net.
+  # Same two cases, but forcing the pre-7.2 ActiveRecord::Base.send(:"#{adapter}_connection") path.
 
-  def test_explain_using_adapter_connection_resets_connection_on_error
+  def test_explain_this_resets_connection_on_error_with_legacy_adapter_connection
     config = {:adapter => 'postgresql', :database => 'secondary'}
     connection = mock('secondary db connection')
     connection.expects(:exec_query).raises(StandardError.new('boom'))
@@ -775,16 +780,16 @@ class NewRelic::Agent::DatabaseTest < Minitest::Test
     end
     base.stubs(:postgresql_connection).with(config).returns(connection)
 
+    NewRelic::Agent::Database.stubs(:supports_connection_adapters_resolve?).returns(false)
+
     with_fake_active_record(base: base) do
       statement = NewRelic::Agent::Database::Statement.new('select 1', config)
 
-      assert_raises(StandardError) do
-        NewRelic::Agent::Database.explain_this_using_adapter_connection(statement, false)
-      end
+      assert_nil NewRelic::Agent::Database.explain_this(statement)
     end
   end
 
-  def test_explain_using_adapter_connection_discards_connection_when_reset_fails
+  def test_explain_this_discards_connection_when_reset_fails_with_legacy_adapter_connection
     config = {:adapter => 'postgresql', :database => 'secondary'}
     connection = mock('secondary db connection')
     connection.expects(:exec_query).raises(StandardError.new('boom'))
@@ -797,12 +802,12 @@ class NewRelic::Agent::DatabaseTest < Minitest::Test
     end
     base.stubs(:postgresql_connection).with(config).returns(connection)
 
+    NewRelic::Agent::Database.stubs(:supports_connection_adapters_resolve?).returns(false)
+
     with_fake_active_record(base: base) do
       statement = NewRelic::Agent::Database::Statement.new('select 1', config)
 
-      assert_raises(StandardError) do
-        NewRelic::Agent::Database.explain_this_using_adapter_connection(statement, false)
-      end
+      assert_nil NewRelic::Agent::Database.explain_this(statement)
 
       cached_connection = NewRelic::Agent::Database::ConnectionManager.instance.instance_eval { @connections[config] }
 

--- a/test/new_relic/agent/database_test.rb
+++ b/test/new_relic/agent/database_test.rb
@@ -8,6 +8,7 @@ require 'new_relic/agent/database'
 class NewRelic::Agent::DatabaseTest < Minitest::Test
   def teardown
     NewRelic::Agent::Database::Obfuscator.instance.reset
+    NewRelic::Agent::Database::ConnectionManager.instance.instance_eval { @connections = {} }
   end
 
   def test_adapter_from_config_string
@@ -650,6 +651,8 @@ class NewRelic::Agent::DatabaseTest < Minitest::Test
   end
 
   def test_explain_this_resolves_via_statement_config
+    skip unless defined?(::ActiveRecord::Base)
+
     config = {:adapter => 'postgresql', :database => 'secondary'}
     connection = mock('secondary db connection')
     connection.expects(:exec_query).with('EXPLAIN select 1', 'Explain SQL', nil).returns('a plan')
@@ -657,20 +660,18 @@ class NewRelic::Agent::DatabaseTest < Minitest::Test
     adapter_class = mock('adapter class')
     adapter_class.expects(:new).with(config).returns(connection)
 
-    connection_adapters = mock('connection adapters module')
-    connection_adapters.expects(:resolve).with('postgresql').returns(adapter_class)
-
+    ::ActiveRecord::ConnectionAdapters.expects(:resolve).with('postgresql').returns(adapter_class)
     NewRelic::Agent::Database.stubs(:supports_connection_adapters_resolve?).returns(true)
 
-    with_fake_active_record(connection_adapters: connection_adapters) do
-      statement = NewRelic::Agent::Database::Statement.new('select 1', config)
-      result = NewRelic::Agent::Database.explain_this(statement)
+    statement = NewRelic::Agent::Database::Statement.new('select 1', config)
+    result = NewRelic::Agent::Database.explain_this(statement)
 
-      assert_equal 'a plan', result
-    end
+    assert_equal 'a plan', result
   end
 
   def test_explain_this_caches_connection_per_config
+    skip unless defined?(::ActiveRecord::Base)
+
     config = {:adapter => 'postgresql', :database => 'secondary'}
     connection = mock('secondary db connection')
     connection.expects(:exec_query).twice.returns('a plan')
@@ -678,19 +679,17 @@ class NewRelic::Agent::DatabaseTest < Minitest::Test
     adapter_class = mock('adapter class')
     adapter_class.expects(:new).once.with(config).returns(connection)
 
-    connection_adapters = mock('connection adapters module')
-    connection_adapters.expects(:resolve).once.with('postgresql').returns(adapter_class)
-
+    ::ActiveRecord::ConnectionAdapters.expects(:resolve).once.with('postgresql').returns(adapter_class)
     NewRelic::Agent::Database.stubs(:supports_connection_adapters_resolve?).returns(true)
 
-    with_fake_active_record(connection_adapters: connection_adapters) do
-      statement = NewRelic::Agent::Database::Statement.new('select 1', config)
-      NewRelic::Agent::Database.explain_this(statement)
-      NewRelic::Agent::Database.explain_this(statement)
-    end
+    statement = NewRelic::Agent::Database::Statement.new('select 1', config)
+    NewRelic::Agent::Database.explain_this(statement)
+    NewRelic::Agent::Database.explain_this(statement)
   end
 
   def test_explain_this_routes_different_configs_independently
+    skip unless defined?(::ActiveRecord::Base)
+
     primary_config = {:adapter => 'postgresql', :database => 'primary'}
     secondary_config = {:adapter => 'postgresql', :database => 'secondary'}
 
@@ -703,21 +702,19 @@ class NewRelic::Agent::DatabaseTest < Minitest::Test
     adapter_class.expects(:new).with(primary_config).returns(primary_connection)
     adapter_class.expects(:new).with(secondary_config).returns(secondary_connection)
 
-    connection_adapters = mock('connection adapters module')
-    connection_adapters.stubs(:resolve).with('postgresql').returns(adapter_class)
-
+    ::ActiveRecord::ConnectionAdapters.stubs(:resolve).with('postgresql').returns(adapter_class)
     NewRelic::Agent::Database.stubs(:supports_connection_adapters_resolve?).returns(true)
 
-    with_fake_active_record(connection_adapters: connection_adapters) do
-      primary_statement = NewRelic::Agent::Database::Statement.new('select 1', primary_config)
-      secondary_statement = NewRelic::Agent::Database::Statement.new('select 2', secondary_config)
+    primary_statement = NewRelic::Agent::Database::Statement.new('select 1', primary_config)
+    secondary_statement = NewRelic::Agent::Database::Statement.new('select 2', secondary_config)
 
-      assert_equal 'primary plan', NewRelic::Agent::Database.explain_this(primary_statement)
-      assert_equal 'secondary plan', NewRelic::Agent::Database.explain_this(secondary_statement)
-    end
+    assert_equal 'primary plan', NewRelic::Agent::Database.explain_this(primary_statement)
+    assert_equal 'secondary plan', NewRelic::Agent::Database.explain_this(secondary_statement)
   end
 
   def test_explain_this_resets_connection_on_error
+    skip unless defined?(::ActiveRecord::Base)
+
     config = {:adapter => 'postgresql', :database => 'secondary'}
     connection = mock('secondary db connection')
     connection.expects(:exec_query).raises(StandardError.new('boom'))
@@ -726,21 +723,19 @@ class NewRelic::Agent::DatabaseTest < Minitest::Test
     adapter_class = mock('adapter class')
     adapter_class.expects(:new).returns(connection)
 
-    connection_adapters = mock('connection adapters module')
-    connection_adapters.stubs(:resolve).returns(adapter_class)
-
+    ::ActiveRecord::ConnectionAdapters.stubs(:resolve).returns(adapter_class)
     NewRelic::Agent::Database.stubs(:supports_connection_adapters_resolve?).returns(true)
 
-    with_fake_active_record(connection_adapters: connection_adapters) do
-      statement = NewRelic::Agent::Database::Statement.new('select 1', config)
+    statement = NewRelic::Agent::Database::Statement.new('select 1', config)
 
-      # explain_this rescues and logs, so the error itself doesn't surface here -
-      # the mock's `reset!` expectation is what proves the recovery ran.
-      assert_nil NewRelic::Agent::Database.explain_this(statement)
-    end
+    # explain_this rescues and logs, so the error itself doesn't surface here -
+    # the mock's `reset!` expectation is what proves the recovery ran.
+    assert_nil NewRelic::Agent::Database.explain_this(statement)
   end
 
   def test_explain_this_discards_connection_when_reset_fails
+    skip unless defined?(::ActiveRecord::Base)
+
     config = {:adapter => 'postgresql', :database => 'secondary'}
     connection = mock('secondary db connection')
     connection.expects(:exec_query).raises(StandardError.new('boom'))
@@ -750,83 +745,54 @@ class NewRelic::Agent::DatabaseTest < Minitest::Test
     adapter_class = mock('adapter class')
     adapter_class.expects(:new).returns(connection)
 
-    connection_adapters = mock('connection adapters module')
-    connection_adapters.stubs(:resolve).returns(adapter_class)
-
+    ::ActiveRecord::ConnectionAdapters.stubs(:resolve).returns(adapter_class)
     NewRelic::Agent::Database.stubs(:supports_connection_adapters_resolve?).returns(true)
 
-    with_fake_active_record(connection_adapters: connection_adapters) do
-      statement = NewRelic::Agent::Database::Statement.new('select 1', config)
+    statement = NewRelic::Agent::Database::Statement.new('select 1', config)
 
-      assert_nil NewRelic::Agent::Database.explain_this(statement)
+    assert_nil NewRelic::Agent::Database.explain_this(statement)
 
-      cached_connection = NewRelic::Agent::Database::ConnectionManager.instance.instance_eval { @connections[config] }
+    cached_connection = NewRelic::Agent::Database::ConnectionManager.instance.instance_eval { @connections[config] }
 
-      assert_nil cached_connection
-    end
+    assert_nil cached_connection
   end
 
   # Same two cases, but forcing the pre-7.2 ActiveRecord::Base.send(:"#{adapter}_connection") path.
 
   def test_explain_this_resets_connection_on_error_with_legacy_adapter_connection
+    skip unless defined?(::ActiveRecord::Base)
+
     config = {:adapter => 'postgresql', :database => 'secondary'}
     connection = mock('secondary db connection')
     connection.expects(:exec_query).raises(StandardError.new('boom'))
     connection.expects(:reset!)
 
-    base = Class.new do
-      def self.postgresql_connection(config)
-      end
-    end
-    base.stubs(:postgresql_connection).with(config).returns(connection)
-
+    ::ActiveRecord::Base.stubs(:postgresql_connection).with(config).returns(connection)
     NewRelic::Agent::Database.stubs(:supports_connection_adapters_resolve?).returns(false)
 
-    with_fake_active_record(base: base) do
-      statement = NewRelic::Agent::Database::Statement.new('select 1', config)
+    statement = NewRelic::Agent::Database::Statement.new('select 1', config)
 
-      assert_nil NewRelic::Agent::Database.explain_this(statement)
-    end
+    assert_nil NewRelic::Agent::Database.explain_this(statement)
   end
 
   def test_explain_this_discards_connection_when_reset_fails_with_legacy_adapter_connection
+    skip unless defined?(::ActiveRecord::Base)
+
     config = {:adapter => 'postgresql', :database => 'secondary'}
     connection = mock('secondary db connection')
     connection.expects(:exec_query).raises(StandardError.new('boom'))
     connection.expects(:reset!).raises(StandardError.new('connection dead'))
     connection.expects(:disconnect!)
 
-    base = Class.new do
-      def self.postgresql_connection(config)
-      end
-    end
-    base.stubs(:postgresql_connection).with(config).returns(connection)
-
+    ::ActiveRecord::Base.stubs(:postgresql_connection).with(config).returns(connection)
     NewRelic::Agent::Database.stubs(:supports_connection_adapters_resolve?).returns(false)
 
-    with_fake_active_record(base: base) do
-      statement = NewRelic::Agent::Database::Statement.new('select 1', config)
+    statement = NewRelic::Agent::Database::Statement.new('select 1', config)
 
-      assert_nil NewRelic::Agent::Database.explain_this(statement)
+    assert_nil NewRelic::Agent::Database.explain_this(statement)
 
-      cached_connection = NewRelic::Agent::Database::ConnectionManager.instance.instance_eval { @connections[config] }
+    cached_connection = NewRelic::Agent::Database::ConnectionManager.instance.instance_eval { @connections[config] }
 
-      assert_nil cached_connection
-    end
-  end
-
-  private
-
-  # Fakes ActiveRecord for the duration of the block (this suite may run either without
-  # the real gem loaded, or under test:env with a real one already present), and clears
-  # ConnectionManager's cache afterward so mock connections don't leak between tests.
-  def with_fake_active_record(connection_adapters: Module.new, base: Class.new)
-    ar_module = Module.new
-    ar_module.const_set(:ConnectionAdapters, connection_adapters)
-    ar_module.const_set(:Base, base)
-
-    Object.stub_const(:ActiveRecord, ar_module) { yield }
-  ensure
-    NewRelic::Agent::Database::ConnectionManager.instance.instance_eval { @connections = {} }
+    assert_nil cached_connection
   end
 end

--- a/test/new_relic/agent/database_test.rb
+++ b/test/new_relic/agent/database_test.rb
@@ -648,4 +648,186 @@ class NewRelic::Agent::DatabaseTest < Minitest::Test
 
     assert_nil statement.query_name
   end
+
+  # explain_this_using_with_connection (Rails >= 7.2) is expected to resolve a connection
+  # from the statement's own config (like the pre-7.2 adapter-connection path does), rather
+  # than ActiveRecord::Base.with_connection, which always checks out from the default pool
+  # and is unsafe in multi-database apps.
+
+  def test_explain_using_with_connection_resolves_via_statement_config
+    config = {:adapter => 'postgresql', :database => 'secondary'}
+    connection = mock('secondary db connection')
+    connection.expects(:exec_query).with('EXPLAIN select 1', 'Explain SQL', nil).returns('a plan')
+
+    adapter_class = mock('adapter class')
+    adapter_class.expects(:new).with(config).returns(connection)
+
+    connection_adapters = mock('connection adapters module')
+    connection_adapters.expects(:resolve).with('postgresql').returns(adapter_class)
+
+    with_fake_active_record(connection_adapters: connection_adapters) do
+      statement = NewRelic::Agent::Database::Statement.new('select 1', config)
+      result = NewRelic::Agent::Database.explain_this_using_with_connection(statement)
+
+      assert_equal 'a plan', result
+    end
+  end
+
+  def test_explain_using_with_connection_caches_connection_per_config
+    config = {:adapter => 'postgresql', :database => 'secondary'}
+    connection = mock('secondary db connection')
+    connection.expects(:exec_query).twice.returns('a plan')
+
+    adapter_class = mock('adapter class')
+    adapter_class.expects(:new).once.with(config).returns(connection)
+
+    connection_adapters = mock('connection adapters module')
+    connection_adapters.expects(:resolve).once.with('postgresql').returns(adapter_class)
+
+    with_fake_active_record(connection_adapters: connection_adapters) do
+      statement = NewRelic::Agent::Database::Statement.new('select 1', config)
+      NewRelic::Agent::Database.explain_this_using_with_connection(statement)
+      NewRelic::Agent::Database.explain_this_using_with_connection(statement)
+    end
+  end
+
+  def test_explain_using_with_connection_routes_different_configs_independently
+    primary_config = {:adapter => 'postgresql', :database => 'primary'}
+    secondary_config = {:adapter => 'postgresql', :database => 'secondary'}
+
+    primary_connection = mock('primary connection')
+    primary_connection.expects(:exec_query).returns('primary plan')
+    secondary_connection = mock('secondary connection')
+    secondary_connection.expects(:exec_query).returns('secondary plan')
+
+    adapter_class = mock('adapter class')
+    adapter_class.expects(:new).with(primary_config).returns(primary_connection)
+    adapter_class.expects(:new).with(secondary_config).returns(secondary_connection)
+
+    connection_adapters = mock('connection adapters module')
+    connection_adapters.stubs(:resolve).with('postgresql').returns(adapter_class)
+
+    with_fake_active_record(connection_adapters: connection_adapters) do
+      primary_statement = NewRelic::Agent::Database::Statement.new('select 1', primary_config)
+      secondary_statement = NewRelic::Agent::Database::Statement.new('select 2', secondary_config)
+
+      assert_equal 'primary plan', NewRelic::Agent::Database.explain_this_using_with_connection(primary_statement)
+      assert_equal 'secondary plan', NewRelic::Agent::Database.explain_this_using_with_connection(secondary_statement)
+    end
+  end
+
+  def test_explain_using_with_connection_resets_connection_on_error
+    config = {:adapter => 'postgresql', :database => 'secondary'}
+    connection = mock('secondary db connection')
+    connection.expects(:exec_query).raises(StandardError.new('boom'))
+    connection.expects(:reset!)
+
+    adapter_class = mock('adapter class')
+    adapter_class.expects(:new).returns(connection)
+
+    connection_adapters = mock('connection adapters module')
+    connection_adapters.stubs(:resolve).returns(adapter_class)
+
+    with_fake_active_record(connection_adapters: connection_adapters) do
+      statement = NewRelic::Agent::Database::Statement.new('select 1', config)
+
+      assert_raises(StandardError) do
+        NewRelic::Agent::Database.explain_this_using_with_connection(statement)
+      end
+    end
+  end
+
+  def test_explain_using_with_connection_discards_connection_when_reset_fails
+    config = {:adapter => 'postgresql', :database => 'secondary'}
+    connection = mock('secondary db connection')
+    connection.expects(:exec_query).raises(StandardError.new('boom'))
+    connection.expects(:reset!).raises(StandardError.new('connection dead'))
+    connection.expects(:disconnect!)
+
+    adapter_class = mock('adapter class')
+    adapter_class.expects(:new).returns(connection)
+
+    connection_adapters = mock('connection adapters module')
+    connection_adapters.stubs(:resolve).returns(adapter_class)
+
+    with_fake_active_record(connection_adapters: connection_adapters) do
+      statement = NewRelic::Agent::Database::Statement.new('select 1', config)
+
+      assert_raises(StandardError) do
+        NewRelic::Agent::Database.explain_this_using_with_connection(statement)
+      end
+
+      cached_connection = NewRelic::Agent::Database::ConnectionManager.instance.instance_eval { @connections[config] }
+
+      assert_nil cached_connection
+    end
+  end
+
+  # explain_this_using_adapter_connection (Rails < 7.2) already routes via statement.config;
+  # it just needs the same reset/discard-on-error safety net.
+
+  def test_explain_using_adapter_connection_resets_connection_on_error
+    config = {:adapter => 'postgresql', :database => 'secondary'}
+    connection = mock('secondary db connection')
+    connection.expects(:exec_query).raises(StandardError.new('boom'))
+    connection.expects(:reset!)
+
+    base = Class.new do
+      def self.postgresql_connection(config)
+      end
+    end
+    base.stubs(:postgresql_connection).with(config).returns(connection)
+
+    with_fake_active_record(base: base) do
+      statement = NewRelic::Agent::Database::Statement.new('select 1', config)
+
+      assert_raises(StandardError) do
+        NewRelic::Agent::Database.explain_this_using_adapter_connection(statement, false)
+      end
+    end
+  end
+
+  def test_explain_using_adapter_connection_discards_connection_when_reset_fails
+    config = {:adapter => 'postgresql', :database => 'secondary'}
+    connection = mock('secondary db connection')
+    connection.expects(:exec_query).raises(StandardError.new('boom'))
+    connection.expects(:reset!).raises(StandardError.new('connection dead'))
+    connection.expects(:disconnect!)
+
+    base = Class.new do
+      def self.postgresql_connection(config)
+      end
+    end
+    base.stubs(:postgresql_connection).with(config).returns(connection)
+
+    with_fake_active_record(base: base) do
+      statement = NewRelic::Agent::Database::Statement.new('select 1', config)
+
+      assert_raises(StandardError) do
+        NewRelic::Agent::Database.explain_this_using_adapter_connection(statement, false)
+      end
+
+      cached_connection = NewRelic::Agent::Database::ConnectionManager.instance.instance_eval { @connections[config] }
+
+      assert_nil cached_connection
+    end
+  end
+
+  private
+
+  # Defines a minimal top-level ActiveRecord module for the duration of the block, since
+  # this unit test suite runs without the real activerecord gem loaded. Also clears the
+  # ConnectionManager cache afterward so mock connections from one test never leak into
+  # another.
+  def with_fake_active_record(connection_adapters: Module.new, base: Class.new)
+    ar_module = Module.new
+    ar_module.const_set(:ConnectionAdapters, connection_adapters)
+    ar_module.const_set(:Base, base)
+    Object.const_set(:ActiveRecord, ar_module)
+
+    yield
+  ensure
+    Object.send(:remove_const, :ActiveRecord) if Object.const_defined?(:ActiveRecord)
+    NewRelic::Agent::Database::ConnectionManager.instance.instance_eval { @connections = {} }
+  end
 end

--- a/test/new_relic/agent/database_test.rb
+++ b/test/new_relic/agent/database_test.rb
@@ -817,22 +817,16 @@ class NewRelic::Agent::DatabaseTest < Minitest::Test
 
   private
 
-  # Fakes ActiveRecord since this suite runs without the real gem loaded, and clears
+  # Fakes ActiveRecord for the duration of the block (this suite may run either without
+  # the real gem loaded, or under test:env with a real one already present), and clears
   # ConnectionManager's cache afterward so mock connections don't leak between tests.
   def with_fake_active_record(connection_adapters: Module.new, base: Class.new)
     ar_module = Module.new
     ar_module.const_set(:ConnectionAdapters, connection_adapters)
     ar_module.const_set(:Base, base)
 
-    had_active_record = Object.const_defined?(:ActiveRecord)
-    original_active_record = Object.const_get(:ActiveRecord) if had_active_record
-    Object.send(:remove_const, :ActiveRecord) if had_active_record
-    Object.const_set(:ActiveRecord, ar_module)
-
-    yield
+    Object.stub_const(:ActiveRecord, ar_module) { yield }
   ensure
-    Object.send(:remove_const, :ActiveRecord) if Object.const_defined?(:ActiveRecord)
-    Object.const_set(:ActiveRecord, original_active_record) if had_active_record
     NewRelic::Agent::Database::ConnectionManager.instance.instance_eval { @connections = {} }
   end
 end


### PR DESCRIPTION
changes the rails 7.2 explain plan logic to work similar to how it does on < 7.2. 

Prior to 7.2 we created our own connection for the explain plan, but in 7.2+ we used a connection from the shared connection pool (which, if there is multiple dbs, these are only to the primary db). So the explain plan would fail on multi db apps when explaining something from a different db, and then the connection just gets returned to the pool, all messed up. And then it gets reused, causing problems.

So now we don't use the connection pool, we do what we used to do and make our own connection (also we make the connection to the correct db if there are multiple). 
And I added a safety net for errors on the connection. Even though we aren't using the pool anymore so the connection shouldn't be shared anyways, still good to make sure we close things out well.

resolves https://github.com/newrelic/newrelic-ruby-agent/issues/3610

