### PR TITLE
fix intermittent CI failures

### DIFF
--- a/lib/new_relic/agent/utilization/pcf.rb
+++ b/lib/new_relic/agent/utilization/pcf.rb
@@ -17,7 +17,7 @@ module NewRelic
             return false unless pcf_keys_present?
 
             process_response(ENV)
-          rescue
+          rescue => e
             NewRelic::Agent.logger.error("Error occurred detecting: #{vendor_name}", e)
             record_supportability_metric
             false

--- a/lib/new_relic/agent/utilization/vendor.rb
+++ b/lib/new_relic/agent/utilization/vendor.rb
@@ -78,6 +78,7 @@ module NewRelic
           NewRelic::Helper.fetch_metadata(endpoint, processed_headers)
         rescue
           NewRelic::Agent.logger.debug("#{vendor_name} environment not detected")
+          nil
         end
 
         def prepare_response(response)

--- a/test/multiverse/suites/bunny/config/newrelic.yml
+++ b/test/multiverse/suites/bunny/config/newrelic.yml
@@ -16,4 +16,11 @@ development:
     enabled: true
     stack_trace_threshold: 0.5
     transaction_threshold: 1.0
+  utilization:
+    detect_aws: false
+    detect_azure: false
+    detect_docker: false
+    detect_gcp: false
+    detect_kubernetes: false
+    detect_pcf: false
 capture_params: false

--- a/test/multiverse/suites/sidekiq/sidekiq_test_helpers.rb
+++ b/test/multiverse/suites/sidekiq/sidekiq_test_helpers.rb
@@ -45,7 +45,15 @@ module SidekiqTestHelpers
 
   def process_queued_jobs
     NRDeadEndJob.class_variable_set(NRDeadEndJob::COMPLETION_VAR, false)
-    config = cli.instance_variable_defined?(:@config) ? cli.instance_variable_get(:@config) : Sidekiq.options
+    base_config = cli.instance_variable_defined?(:@config) ? cli.instance_variable_get(:@config) : Sidekiq.options
+
+    # Manager#quiet (below) doesn't block for worker threads to exit, so leftover threads
+    # from prior tests can intermittently exhaust Sidekiq v5/v6's shared connection pool.
+    config = if Sidekiq::VERSION.split('.').first.to_i < 7
+      base_config.merge(concurrency: 1)
+    else
+      base_config
+    end
 
     # TODO: MAJOR VERSION - remove this when Sidekiq v5 is no longer supported
     require 'sidekiq/launcher' if Sidekiq::VERSION.split('.').first.to_i < 6

--- a/test/multiverse/suites/unicorn/config/newrelic.yml
+++ b/test/multiverse/suites/unicorn/config/newrelic.yml
@@ -14,4 +14,11 @@ development:
     enabled: true
     stack_trace_threshold: 0.5
     transaction_threshold: 1.0
+  utilization:
+    detect_aws: false
+    detect_azure: false
+    detect_docker: false
+    detect_gcp: false
+    detect_kubernetes: false
+    detect_pcf: false
   capture_params: false

--- a/test/new_relic/agent/agent_test.rb
+++ b/test/new_relic/agent/agent_test.rb
@@ -838,12 +838,10 @@ module NewRelic
     class AgentStartingTest < Minitest::Test
       def test_abides_by_disabling_harvest_thread
         with_config(:disable_harvest_thread => true) do
-          threads_before = Thread.list.length
-
           agent = NewRelic::Agent::Agent.new
           agent.send(:start_worker_thread)
 
-          assert_equal threads_before, Thread.list.length
+          assert_nil Thread.list.find { |t| t[:newrelic_label] == 'Worker Loop' }
         end
       end
     end

--- a/test/new_relic/agent/instrumentation/net_instrumentation_test.rb
+++ b/test/new_relic/agent/instrumentation/net_instrumentation_test.rb
@@ -10,7 +10,8 @@ class NewRelic::Agent::Instrumentation::NetInstrumentationTest < Minitest::Test
   def setup
     NewRelic::Agent.manual_start(
       :"transaction_tracer.enabled" => true,
-      :encoding_key => 'gringletoes'
+      :encoding_key => 'gringletoes',
+      :disable_harvest_thread => true
     )
 
     @response ||= nil

--- a/test/new_relic/agent/transaction/segment_test.rb
+++ b/test/new_relic/agent/transaction/segment_test.rb
@@ -14,6 +14,7 @@ module NewRelic
           NewRelic::Agent.config.add_config_for_testing(@additional_config)
           NewRelic::Agent.config.notify_server_source_added
           nr_freeze_process_time
+          reset_buffers_and_caches
         end
 
         def teardown


### PR DESCRIPTION
it started with the bunny fix, but i saw like idk 3 intermittent failures before 11am so i just needed to do something. so I went through a bunch of our old failed jobs and decided to just try and fix a all of the recent intermittent failures i could find. lol. I found some of these several times (sidekiq i'm looking at you), but i know there are other ones that are less common that i didn't see today.

Fixed:
- the bunny/vendor log one
- the mock socket one
- the sidekiq timeout one
- one where the thread count changes but its not actually related to the harvest thread
- one that just needed the harvesters cleaned out before the test ran