### PR TITLE
Bugfix: FrozenError for erb 6.0.3 or higher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
   On Rails 7.2+, the agent gathered explain plans using a connection from the app's default/shared pool rather than a dedicated one. This primarily affected multi-database apps. Explain plans could be generated against the wrong database, and a failed explain could leave a shared connection in a bad state, affecting unrelated requests. The agent now uses its own dedicated connection for explain plans, as it did before Rails 7.2, and resets or discards that connection whenever an explain attempt fails, so a bad connection is never reused. Thank you, [@masiafrest](https://github.com/masiafrest) for the detailed report! [Issue#3610](https://github.com/newrelic/newrelic-ruby-agent/issues/3610) [PR#3612](https://github.com/newrelic/newrelic-ruby-agent/pull/3612)
 
+- **Bugfix: Browser monitoring instrumentation no longer fails with `FrozenError`**
+
+  When a response body's first fragment was a frozen `String` and there were multiple fragments, browser instrumentation hit a `FrozenError` and the browser timing header was never injected. This began appearing with `ERB` 6.0.3+, which started freezing more of its compiled strings. This issue is now fixed. Thank you to [@md5](https://github.com/md5) for reporting this issue! [Issue#3624](https://github.com/newrelic/newrelic-ruby-agent/issues/3624)[PR#3625](https://github.com/newrelic/newrelic-ruby-agent/pull/3625)
+
 ## v10.6.0
 
 - **Feature: SpanLink events are now supported for the Hybrid Agent**

--- a/lib/new_relic/rack/browser_monitoring.rb
+++ b/lib/new_relic/rack/browser_monitoring.rb
@@ -153,7 +153,7 @@ module NewRelic
 
       def gather_source(response)
         source = nil
-        response.each { |fragment| source ? (source << fragment.to_s) : (source = fragment.to_s) }
+        response.each { |fragment| source ? (source << fragment.to_s) : (source = fragment.to_s.dup) }
         source
       end
 

--- a/test/new_relic/rack/browser_monitoring_test.rb
+++ b/test/new_relic/rack/browser_monitoring_test.rb
@@ -260,6 +260,23 @@ if defined?(Rack::Test)
       assert_predicate last_response, :ok?
     end
 
+    def test_instruments_response_with_frozen_body_fragments
+      TestApp.next_response = ['<html><body>'.freeze, 'chocolate chip cookies are delicious</body></html>'.freeze]
+      NewRelic::Agent.stubs(:browser_timing_header).returns(RUM_PLACEHOLDER)
+
+      get('/')
+
+      assert_predicate last_response, :ok?
+      assert_includes(last_response.body, RUM_PLACEHOLDER)
+    end
+
+    def test_gather_source_handles_frozen_first_fragment
+      body = ['<html><body>'.freeze, 'peanut butter cookies are okay</body></html>'.freeze]
+      source = app.send(:gather_source, body)
+
+      assert_equal('<html><body>hi</body></html>', source)
+    end
+
     def test_content_length_set_when_we_modify_source
       original_headers = {
         'Content-Length' => '0',

--- a/test/new_relic/rack/browser_monitoring_test.rb
+++ b/test/new_relic/rack/browser_monitoring_test.rb
@@ -274,7 +274,7 @@ if defined?(Rack::Test)
       body = ['<html><body>'.freeze, 'peanut butter cookies are okay</body></html>'.freeze]
       source = app.send(:gather_source, body)
 
-      assert_equal('<html><body>hi</body></html>', source)
+      assert_equal('<html><body>peanut butter cookies are okay</body></html>', source)
     end
 
     def test_content_length_set_when_we_modify_source


### PR DESCRIPTION
ERB 6.0.3 made a change that freezes compiled strings. When trying to inject browser monitoring, if there was more than one fragment, we couldn't add secondary+ fragments to the first one since it was frozen. Now, we `dup` the first fragment to make it a mutable copy.

Closes #3624 