### PR TITLE
Small fixes

### DIFF
--- a/.github/workflows/config_docs.yml
+++ b/.github/workflows/config_docs.yml
@@ -1,9 +1,10 @@
 name: Update Config Docs
 
 on:
-  workflows: ["Release"]
-  types:
-    - completed
+  workflow_run:
+    workflows: ["Release"]
+    types:
+      - completed
   workflow_dispatch:
 
 env:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,8 +73,7 @@ services:
     restart: always
     volumes:
       - /data/db
-    expose:
-      - "27017"
+    ports: ["27017:27017"]
   postgres:
     image: postgres:14.2
     restart: always

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -718,7 +718,7 @@ module NewRelic
           :public => true,
           :type => Integer,
           :allowed_from_server => false,
-          :description => 'Defines the maximum number of frames in an error backtrace. Backtraces over this amount are truncated in the middle, preserving the beginning and the end of the stack trace.'
+          :description => 'Defines the maximum number of frames in an error backtrace. Backtraces over this amount are truncated in the middle by default, preserving the beginning and the end of the stack trace. See `error_collector.backtrace_truncate_location` to customize the truncation location.'
         },
         :'error_collector.backtrace_truncate_location' => {
           :default => 'middle',


### PR DESCRIPTION
A few lil changes based on some recent tinkering.

* Fix for docker-compose to run mongo tests locally (still worked with a Mongo playground too)
* Add info about truncation location to max_backtrace_frames config
* Config docs workflow syntax error