### PR TITLE
Use case-insensitive boolean config validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 
 - **Bugfix: Normalize boolean configuration values to allow all casing**
 
-  In version 9.x, the agent accepted capitalized boolean values, like "FALSE", and mixed-case values like "True". Version 10.0.0 included [PR#3341](https://github.com/newrelic/newrelic-ruby-agent/pull/3341), which unfortunately removed the case insensitive requirement. This caused users who had any casing besides all lowercase to have their configuration options fall back to the defaults. Now, the agent uses case-insensitive checks again. Our thanks go to [@willie](https://github.com/willie) for bringing this to our attention. [Issue#3632](https://github.com/newrelic/newrelic-ruby-agent/issues/3632) [PR#3633](https://github.com/newrelic/newrelic-ruby-agent/issues/3632)
+  In version 9.x, the agent accepted capitalized boolean values, like "FALSE", and mixed-case values like "True". Version 10.0.0 included [PR#3341](https://github.com/newrelic/newrelic-ruby-agent/pull/3341), which unintentionally removed the case-insensitive requirement. This caused users who had any casing besides all lowercase to have their configuration options fall back to the defaults. Now, the agent uses case-insensitive checks again. Our thanks go to [@willie](https://github.com/willie) for bringing this to our attention. [Issue#3632](https://github.com/newrelic/newrelic-ruby-agent/issues/3632) [PR#3633](https://github.com/newrelic/newrelic-ruby-agent/issues/3632)
 
 ## v10.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@
 
   When a response body's first fragment was a frozen `String` and there were multiple fragments, browser instrumentation hit a `FrozenError` and the browser timing header was never injected. This began appearing with `ERB` 6.0.3+, which started freezing more of its compiled strings. This issue is now fixed. Thank you to [@md5](https://github.com/md5) for reporting this issue! [Issue#3624](https://github.com/newrelic/newrelic-ruby-agent/issues/3624)[PR#3625](https://github.com/newrelic/newrelic-ruby-agent/pull/3625)
 
+- **Bugfix: Normalize boolean configuration values to allow all casing**
+
+  In version 9.x, the agent accepted capitalized boolean values, like "FALSE", and mixed-case values like "True". Version 10.0.0 included [PR#3341](https://github.com/newrelic/newrelic-ruby-agent/pull/3341), which unfortunately removed the case insensitive requirement. This caused users who had any casing besides all lowercase to have their configuration options fall back to the defaults. Now, the agent uses case-insensitive checks again. Our thanks go to [@willie](https://github.com/willie) for bringing this to our attention. [Issue#3632](https://github.com/newrelic/newrelic-ruby-agent/issues/3632) [PR#3633](https://github.com/newrelic/newrelic-ruby-agent/issues/3632)
+
 ## v10.6.0
 
 - **Feature: SpanLink events are now supported for the Hybrid Agent**

--- a/lib/new_relic/agent/configuration/manager.rb
+++ b/lib/new_relic/agent/configuration/manager.rb
@@ -217,7 +217,9 @@ module NewRelic
           return string_conversion(value) if STRINGLIKE_TYPES.include?(type) && STRINGLIKE_TYPES.include?(value.class)
 
           # convert bool to string for regex usage and bool hash lookup
-          value = value.to_s if type == Boolean
+          # normalize case for backwards-compatibility
+          # fixes: https://github.com/newrelic/newrelic-ruby-agent/issues/3632
+          value = value.to_s.downcase if type == Boolean
           if value.class != String
             return value if category == :test || likely_transformed_already?(key, value)
 

--- a/test/new_relic/agent/configuration/manager_test.rb
+++ b/test/new_relic/agent/configuration/manager_test.rb
@@ -596,6 +596,26 @@ module NewRelic::Agent::Configuration
       end
     end
 
+    def test_type_coercion_of_a_boolean_from_a_capitalized_string
+      key = :vm_performance_analysis
+      defaults = {key => {default: false, type: NewRelic::Agent::Configuration::Boolean}}
+      NewRelic::Agent::Configuration::Manager.stub_const(:DEFAULTS, defaults) do
+        value = @manager.type_coerce(key, 'ON', :manual)
+
+        assert_equal true, value # rubocop:disable Minitest/AssertTruthy
+      end
+    end
+
+    def test_type_coercion_of_a_boolean_from_a_mixed_case_string
+      key = :vm_performance_analysis
+      defaults = {key => {default: true, type: NewRelic::Agent::Configuration::Boolean}}
+      NewRelic::Agent::Configuration::Manager.stub_const(:DEFAULTS, defaults) do
+        value = @manager.type_coerce(key, 'fAlSe', :manual)
+
+        assert_equal false, value # rubocop:disable Minitest/RefuteFalse
+      end
+    end
+
     def test_type_coercion_of_an_integer_from_a_float
       key = :applied_jigawatts
       defaults = {key => {default: 0, type: Integer}}


### PR DESCRIPTION
In version 9.x, the agent accepted capitalized boolean values, like "FALSE", and mixed-case values like "True". Version 10.0.0 included #3341, which unintentionally removed the case-insensitive requirement. This caused users who had any casing besides all lowercase to have their configuration options fall back to the defaults. Now, the agent uses case-insensitive checks again. 

Resolves #3632