### PR TITLE
Fix intermittently failing `test_segment_can_disable_scoped_metric_recording`

### DIFF
--- a/test/new_relic/agent/transaction/segment_test.rb
+++ b/test/new_relic/agent/transaction/segment_test.rb
@@ -14,6 +14,7 @@ module NewRelic
           NewRelic::Agent.config.add_config_for_testing(@additional_config)
           NewRelic::Agent.config.notify_server_source_added
           nr_freeze_process_time
+          clear_metrics!
           reset_buffers_and_caches
         end
 
@@ -155,9 +156,6 @@ module NewRelic
         end
 
         def test_segment_can_disable_scoped_metric_recording
-          # TODO: Fix this test via Issue #2429
-          skip 'This test fails intermittently on multiple Ruby versions'
-
           in_transaction('test') do |txn|
             segment = Segment.new('Custom/simple/segment', 'Segment/all')
             segment.record_scoped_metric = false


### PR DESCRIPTION
Reset metrics between tests to avoid bleed over from other tests. Ran a few times and I think this should work, but we can keep an eye on the CI in case this starts failing again.

closes #2429