### PR TITLE
Bump actions/upload-artifact to 7.0.1

### DIFF
--- a/.github/actions/run_multiverse/action.yml
+++ b/.github/actions/run_multiverse/action.yml
@@ -65,7 +65,7 @@ runs:
 
     - name: Save coverage results
       if: ${{ inputs.pr-ci }} == 'true'
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # tag v4.6.2
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # tag v7.0.1
       with:
         name: coverage-report-multiverse-${{ inputs.ruby-version }}-${{ inputs.group }}
         path: lib/coverage_*/.resultset.json

--- a/.github/actions/run_perfverse/action.yml
+++ b/.github/actions/run_perfverse/action.yml
@@ -49,7 +49,7 @@ runs:
         ITERATIONS: ${{ inputs.iterations }}
 
     - name: Upload docker report
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # tag v4.6.2
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # tag v7.0.1
       with:
         if-no-files-found: error
         path: test/perfverse/docker_monitor/${{ inputs.docker_monitor_output_dir}}/

--- a/.github/actions/run_unit_tests/action.yml
+++ b/.github/actions/run_unit_tests/action.yml
@@ -82,7 +82,7 @@ runs:
         CI_FOR_PR: ${{ inputs.pr-ci}}
 
     - name: Save coverage results
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # tag v4.6.2
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # tag v7.0.1
       with:
         name: coverage-report-unit-tests-${{ inputs.ruby-version }}-${{ env.rails }}
         path: lib/coverage_*/.resultset.json


### PR DESCRIPTION
The action.yml files aren't updated by dependabot, so these were a few versions behind.
A bunch of Node 20 warnings in the CI output for Perfverse tipped me off.