### PR TITLE
Guard async HTTP segments

### DIFF
--- a/lib/new_relic/agent/instrumentation/async_http/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/async_http/instrumentation.rb
@@ -18,7 +18,7 @@ module NewRelic::Agent::Instrumentation
 
       begin
         response = nil
-        segment.add_request_headers(wrapped_request)
+        segment&.add_request_headers(wrapped_request)
 
         NewRelic::Agent.disable_all_tracing do
           response = NewRelic::Agent::Tracer.capture_segment_error(segment) do
@@ -27,7 +27,7 @@ module NewRelic::Agent::Instrumentation
         end
 
         wrapped_response = NewRelic::Agent::HTTPClients::AsyncHTTPResponse.new(response)
-        segment.process_response_headers(wrapped_response)
+        segment&.process_response_headers(wrapped_response)
         response
       ensure
         segment&.finish

--- a/test/multiverse/suites/async_http/async_http_instrumentation_test.rb
+++ b/test/multiverse/suites/async_http/async_http_instrumentation_test.rb
@@ -82,6 +82,18 @@ class AsyncHttpInstrumentationTest < Minitest::Test
     # so the errors will never end up on the transaction, only ever the async http segment
   end
 
+  def test_segment_might_fail_to_start
+    response = Object.new
+    client = Object.new
+    client.extend(NewRelic::Agent::Instrumentation::AsyncHttp)
+
+    NewRelic::Agent::Tracer.stub :start_external_request_segment, nil do
+      result = client.call_with_new_relic('GET', default_url) { response }
+
+      assert_same response, result
+    end
+  end
+
   def test_raw_synthetics_header_is_passed_along_if_present_array
     in_transaction do
       NewRelic::Agent::Tracer.current_transaction.raw_synthetics_header = 'boo'


### PR DESCRIPTION
# Overview

Ensure async HTTP instrumentation remains safe when `Tracer.start_external_request_segment` returns `nil` after handling an internal error.

The async HTTP instrumentation now uses nil-safe calls for request and response header processing, matching the existing Net::HTTP behavior. A regression test was added to verify that the original HTTP response is returned when segment creation fails.

Submitter Checklist:
- [ ] Include a link to the related GitHub issue, if applicable
- [x] Add new tests for your change, if applicable

# Testing

- `rake 'test:multiverse[async_http]'`
  - CHAIN: 44 runs, 104 assertions
  - PREPEND: 44 runs, 104 assertions
  - 0 failures, 0 errors

# Reviewer Checklist
- [ ] Perform code review
- [ ] Confirm all checks passed
- [ ] Open a separate PR to add a CHANGELOG entry