### PR TITLE
Fix ArgumentError on multi-key operations with dalli 5.1.0

### DIFF
--- a/lib/new_relic/agent/instrumentation/memcache/dalli.rb
+++ b/lib/new_relic/agent/instrumentation/memcache/dalli.rb
@@ -57,8 +57,9 @@ module NewRelic
 
               alias_method(:read_multi_req_without_newrelic_trace, :read_multi_req)
 
-              def read_multi_req(keys)
-                send_multiget_with_newrelic_tracing(keys) { read_multi_req_without_newrelic_trace(keys) }
+              # Dalli 5.1.0 added an optional options argument
+              def read_multi_req(keys, *args)
+                send_multiget_with_newrelic_tracing(keys) { read_multi_req_without_newrelic_trace(keys, *args) }
               end
             end
           end
@@ -74,10 +75,11 @@ module NewRelic
               include NewRelic::Agent::Instrumentation::Memcache::Tracer
 
               # Dalli - 3.1.0 renamed send_multiget to pipelined_get, but the method is otherwise the same
+              # Dalli 5.1.0 added an optional options argument to pipelined_get
               if NewRelic::Helper.version_satisfied?(::Dalli::VERSION, '>=', '3.1.0')
                 alias_method(:pipelined_get_without_newrelic_trace, :pipelined_get)
-                def pipelined_get(keys)
-                  send_multiget_with_newrelic_tracing(keys) { pipelined_get_without_newrelic_trace(keys) }
+                def pipelined_get(keys, *args)
+                  send_multiget_with_newrelic_tracing(keys) { pipelined_get_without_newrelic_trace(keys, *args) }
                 end
               else
                 alias_method(:send_multiget_without_newrelic_trace, :send_multiget)

--- a/lib/new_relic/agent/instrumentation/memcache/prepend.rb
+++ b/lib/new_relic/agent/instrumentation/memcache/prepend.rb
@@ -77,7 +77,8 @@ module NewRelic::Agent::Instrumentation
           extend Helper
           include NewRelic::Agent::Instrumentation::Memcache::Tracer
 
-          def read_multi_req(keys)
+          # Dalli 5.1.0 added an optional options argument
+          def read_multi_req(keys, *args)
             send_multiget_with_newrelic_tracing(keys) { super }
           end
         end
@@ -100,8 +101,9 @@ module NewRelic::Agent::Instrumentation
           include NewRelic::Agent::Instrumentation::Memcache::Tracer
 
           # Dalli - 3.1.0 renamed send_multiget to pipelined_get, but the method is otherwise the same
+          # Dalli 5.1.0 added an optional options argument to pipelined_get
           if NewRelic::Helper.version_satisfied?(::Dalli::VERSION, '>=', '3.1.0')
-            def pipelined_get(keys)
+            def pipelined_get(keys, *args)
               send_multiget_with_newrelic_tracing(keys) { super }
             end
           else

--- a/test/multiverse/suites/memcache/dalli_test.rb
+++ b/test/multiverse/suites/memcache/dalli_test.rb
@@ -81,6 +81,19 @@ if defined?(Dalli)
           assert_memcache_metrics_recorded expected_metrics
         end
 
+        # In dalli 5.1.0+, get_multi_cas routes through the pipelined getter, which calls
+        # pipelined_get on Dalli::Protocol::Base with an additional options argument.
+        def test_get_multi_cas_in_web_via_pipelined_get
+          keys = Array.new(3) { set_key_for_testcase }
+          expected_metrics = expected_web_metrics(:get_multi_cas)
+
+          in_web_transaction("Controller/#{self.class}/action") do
+            @cache.get_multi_cas(*keys)
+          end
+
+          assert_memcache_metrics_recorded expected_metrics
+        end
+
         def test_get_multi_with_multiple_keys_and_capture_memcache_keys_via_read_multi_req
           with_config(:capture_memcache_keys => true) do
             keys = Array.new(3) { set_key_for_testcase }


### PR DESCRIPTION
# Overview

Dalli 5.1.0 added an optional request options argument to `Dalli::Protocol::Meta#read_multi_req` and `Dalli::Protocol::Base#pipelined_get` and now always calls them with two arguments (petergoldstein/dalli#1147, petergoldstein/dalli#1154). The agent redefines both methods with a single `keys` parameter, so on dalli 5.1.0 every multi-key operation (`get_multi`, `get_multi_cas`, `get_multi_with_metadata`) raises:

```
ArgumentError: wrong number of arguments (given 2, expected 1)
  dalli-5.1.0/lib/dalli/protocol/base.rb:45:in 'request'
  newrelic_rpm-10.7.0/lib/new_relic/agent/instrumentation/memcache/prepend.rb:80:in 'read_multi_req'
```

This changes the four affected method definitions (the prepend and chain variants of `read_multi_req` and `pipelined_get`) to accept and forward any additional arguments. The tracing itself only uses `keys`, so behavior is unchanged on older dalli versions.

We hit this in production after upgrading to newrelic_rpm 10.7.0 alongside dalli 5.1.0.

Submitter Checklist:
- [ ] Include a link to the related GitHub issue, if applicable
- [x] Add new tests for your change, if applicable

# Testing

Without the fix, the memcache multiverse suite fails with 7 errors on dalli 5.1.0, reproducing the ArgumentError above. Added a `get_multi_cas` test to cover the `pipelined_get` path, which dalli 5.1.0 routes through the pipelined getter even with a single server (the existing tests cover the `read_multi_req` path).

Ran the memcache multiverse suite locally against dalli 5.1.0, 4.3.3, and 3.1.0 in both prepend and chain modes; all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
