### PR TITLE
Add safe navigation for segments & HTTP libraries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
   This fix updates Dalli instrumentation to accept and forward optional request options arguments in multi and pipelined operations. Our thanks go to [@dbackeus](https://github.com/dbackeus) for contributing a fix! [PR#3642](https://github.com/newrelic/newrelic-ruby-agent/pull/3642)
 
+- **Bugfix: Async::HTTP requests no longer raise `NoMethodError` when a segment fails to start**
+
+  If the agent encountered an internal error while creating the segment for an `Async::HTTP` request, the instrumentation went on to use that missing segment and could raise a `NoMethodError`. This is now fixed, thanks to [@ydah](https://github.com/ydah). [PR#3640](https://github.com/newrelic/newrelic-ruby-agent/pull/3640)
+
 ## v10.7.0
 
 - **Feature: Add transaction_tracer.cap_segment_artifacts configuration option**

--- a/lib/new_relic/agent/instrumentation/async_http/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/async_http/instrumentation.rb
@@ -6,7 +6,11 @@ require 'new_relic/agent/http_clients/async_http_wrappers'
 
 module NewRelic::Agent::Instrumentation
   module AsyncHttp
+    INSTRUMENTATION_NAME = 'AsyncHttp'
+
     def call_with_new_relic(method, url, headers = nil, body = nil)
+      NewRelic::Agent.record_instrumentation_invocation(INSTRUMENTATION_NAME)
+
       headers ||= {} # if it is nil, we need to make it a hash so we can insert headers
       wrapped_request = NewRelic::Agent::HTTPClients::AsyncHTTPRequest.new(self, method, url, headers)
 

--- a/lib/new_relic/agent/instrumentation/curb/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/curb/instrumentation.rb
@@ -101,7 +101,7 @@ module NewRelic
               procedure: wrapped_request.method
             )
 
-            segment.add_request_headers(wrapped_request)
+            segment&.add_request_headers(wrapped_request)
 
             # install all callbacks
             unless request._nr_instrumented

--- a/lib/new_relic/agent/instrumentation/ethon/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/ethon/instrumentation.rb
@@ -18,16 +18,16 @@ module NewRelic::Agent::Instrumentation
           procedure: wrapped_request.method,
           parent: parent
         )
-        segment.add_request_headers(wrapped_request)
+        segment&.add_request_headers(wrapped_request)
 
         callback = proc do
           wrapped_response = NewRelic::Agent::HTTPClients::EthonHTTPResponse.new(easy)
-          segment.process_response_headers(wrapped_response)
+          segment&.process_response_headers(wrapped_response)
 
           if easy.return_code != :ok
             e = NewRelic::Agent::NoticeableError.new(NOTICEABLE_ERROR_CLASS,
               "return_code: >>#{easy.return_code}<<, response_code: >>#{easy.response_code}<<")
-            segment.notice_error(e)
+            segment&.notice_error(e)
           end
 
           ::NewRelic::Agent::Transaction::Segment.finish(segment)

--- a/lib/new_relic/agent/instrumentation/excon/middleware.rb
+++ b/lib/new_relic/agent/instrumentation/excon/middleware.rb
@@ -28,7 +28,7 @@ module ::Excon
               procedure: wrapped_request.method
             )
 
-            segment.add_request_headers(wrapped_request)
+            segment&.add_request_headers(wrapped_request)
 
             datum[:connection].instance_variable_set(TRACE_DATA_IVAR, segment)
           end

--- a/lib/new_relic/agent/instrumentation/grpc/client/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/grpc/client/instrumentation.rb
@@ -22,7 +22,7 @@ module NewRelic
 
             segment = request_segment(method)
             request_wrapper = NewRelic::Agent::Instrumentation::GRPC::Client::RequestWrapper.new(@host)
-            segment.add_request_headers(request_wrapper)
+            segment&.add_request_headers(request_wrapper)
             metadata.merge!(request_wrapper.instance_variable_get(:@newrelic_metadata))
             grpc_message = nil
             grpc_status = 0

--- a/lib/new_relic/agent/instrumentation/httpclient/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/httpclient/instrumentation.rb
@@ -19,7 +19,7 @@ module NewRelic::Agent::Instrumentation
 
         begin
           response = nil
-          segment.add_request_headers(wrapped_request)
+          segment&.add_request_headers(wrapped_request)
 
           NewRelic::Agent::Tracer.capture_segment_error(segment) do
             yield
@@ -29,7 +29,7 @@ module NewRelic::Agent::Instrumentation
           connection.push(response)
 
           wrapped_response = ::NewRelic::Agent::HTTPClients::HTTPClientResponse.new(response)
-          segment.process_response_headers(wrapped_response)
+          segment&.process_response_headers(wrapped_response)
 
           response
         ensure

--- a/lib/new_relic/agent/instrumentation/httprb/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/httprb/instrumentation.rb
@@ -18,12 +18,12 @@ module NewRelic::Agent::Instrumentation
           procedure: wrapped_request.method
         )
 
-        segment.add_request_headers(wrapped_request)
+        segment&.add_request_headers(wrapped_request)
 
         response = NewRelic::Agent::Tracer.capture_segment_error(segment) { yield }
 
         wrapped_response = ::NewRelic::Agent::HTTPClients::HTTPResponse.new(response)
-        segment.process_response_headers(wrapped_response)
+        segment&.process_response_headers(wrapped_response)
 
         response
       ensure

--- a/lib/new_relic/agent/instrumentation/typhoeus/instrumentation.rb
+++ b/lib/new_relic/agent/instrumentation/typhoeus/instrumentation.rb
@@ -61,15 +61,15 @@ module NewRelic
             parent: parent
           )
 
-          segment.add_request_headers(wrapped_request)
+          segment&.add_request_headers(wrapped_request)
 
           callback = proc do
             wrapped_response = HTTPClients::TyphoeusHTTPResponse.new(request.response)
 
-            segment.process_response_headers(wrapped_response)
+            segment&.process_response_headers(wrapped_response)
 
             if request.response.code == 0
-              segment.notice_error(NoticeableError.new(NOTICEABLE_ERROR_CLASS, response_message(request.response)))
+              segment&.notice_error(NoticeableError.new(NOTICEABLE_ERROR_CLASS, response_message(request.response)))
             end
 
             ::NewRelic::Agent::Transaction::Segment.finish(segment)


### PR DESCRIPTION
Net_HTTP and AsyncHTTP have safe navs for segments. Update other HTTP libraries for the same safety. 

This also adds a CHANGELOG entry for the AsyncHTTP fix and a supportability metric for the instrumentation