### PR TITLE
Allowlists don't need to be case sensitive

### DIFF
--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -576,7 +576,7 @@ module NewRelic
           :public => true,
           :type => String,
           :allowed_from_server => true,
-          :allowlist => %w[obfuscated raw none off false],
+          :allowlist => ['obfuscated', 'raw', 'none', 'off', 'false', false],
           :description => <<~DESCRIPTION
             Obfuscation level for SQL queries reported in transaction trace nodes. By default, this is set to `obfuscated`, which strips out the numeric and string literals.
 
@@ -2197,7 +2197,7 @@ module NewRelic
           :public => true,
           :type => String,
           :allowed_from_server => true,
-          :allowlist => %w[obfuscated raw none off false],
+          :allowlist => ['obfuscated', 'raw', 'none', 'off', 'false', false],
           :description => 'Defines an obfuscation level for slow SQL queries. Valid options are `obfuscated`, `raw`, or `none`.'
         },
         :'slow_sql.use_longer_sql_id' => {

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -303,6 +303,7 @@ module NewRelic
           :public => true,
           :type => String,
           :allowed_from_server => false,
+          :allowlist => %w[debug info warn error],
           :description => 'Sets the level of detail of log messages. Possible log levels, in increasing verbosity, are: `error`, `warn`, `info` or `debug`.'
         },
         # General
@@ -575,6 +576,7 @@ module NewRelic
           :public => true,
           :type => String,
           :allowed_from_server => true,
+          :allowlist => ['obfuscated', 'raw', 'none', 'off'],
           :description => <<~DESCRIPTION
             Obfuscation level for SQL queries reported in transaction trace nodes. By default, this is set to `obfuscated`, which strips out the numeric and string literals.
 
@@ -769,9 +771,9 @@ module NewRelic
           :public => true,
           :type => String,
           :allowed_from_server => false,
-          :allowlist => %w[debug info warn error fatal unknown DEBUG INFO WARN ERROR FATAL UNKNOWN],
+          :allowlist => %w[debug info warn error fatal unknown],
           :description => <<~DESCRIPTION
-            Sets the minimum level a log event must have to be forwarded to New Relic. Logs at the configured level and any higher severity are forwarded, for example, `debug` forwards all log events, while `error` forwards only `error`, `fatal`, and `unknown` events. Valid values, lowest to highest severity: `debug`, `info`, `warn`, `error`, `fatal`, `unknown` (case-sensitive; uppercase forms are also accepted).
+            Sets the minimum level a log event must have to be forwarded to New Relic. Logs at the configured level and any higher severity are forwarded, for example, `debug` forwards all log events, while `error` forwards only `error`, `fatal`, and `unknown` events. Valid values, lowest to highest severity: `debug`, `info`, `warn`, `error`, `fatal`, `unknown` (case-insensitive).
 
             \tThis ordering is based on the integer values of Ruby's `Logger::Severity` constants (see https://github.com/ruby/logger/blob/113b82a06b3076b93a71cd467e1605b23afb3088/lib/logger/severity.rb).
           DESCRIPTION
@@ -2195,6 +2197,7 @@ module NewRelic
           :public => true,
           :type => String,
           :allowed_from_server => true,
+          :allowlist => ['obfuscated', 'raw', 'none', 'off'],
           :description => 'Defines an obfuscation level for slow SQL queries. Valid options are `obfuscated`, `raw`, or `none`.'
         },
         :'slow_sql.use_longer_sql_id' => {

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -576,7 +576,7 @@ module NewRelic
           :public => true,
           :type => String,
           :allowed_from_server => true,
-          :allowlist => ['obfuscated', 'raw', 'none', 'off', 'false', false],
+          :allowlist => %w[obfuscated raw none off false],
           :description => <<~DESCRIPTION
             Obfuscation level for SQL queries reported in transaction trace nodes. By default, this is set to `obfuscated`, which strips out the numeric and string literals.
 
@@ -2197,7 +2197,7 @@ module NewRelic
           :public => true,
           :type => String,
           :allowed_from_server => true,
-          :allowlist => ['obfuscated', 'raw', 'none', 'off', 'false', false],
+          :allowlist => %w[obfuscated raw none off false],
           :description => 'Defines an obfuscation level for slow SQL queries. Valid options are `obfuscated`, `raw`, or `none`.'
         },
         :'slow_sql.use_longer_sql_id' => {

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -303,8 +303,8 @@ module NewRelic
           :public => true,
           :type => String,
           :allowed_from_server => false,
-          :allowlist => %w[debug info warn error],
-          :description => 'Sets the level of detail of log messages. Possible log levels, in increasing verbosity, are: `error`, `warn`, `info` or `debug`.'
+          :allowlist => %w[debug info warn error fatal],
+          :description => 'Sets the level of detail of log messages. Possible log levels, in increasing verbosity, are: `fatal`, `error`, `warn`, `info` or `debug`.'
         },
         # General
         :active_support_custom_events_names => {
@@ -576,7 +576,7 @@ module NewRelic
           :public => true,
           :type => String,
           :allowed_from_server => true,
-          :allowlist => %w[obfuscated raw none off],
+          :allowlist => ['obfuscated', 'raw', 'none', 'off', 'false', false],
           :description => <<~DESCRIPTION
             Obfuscation level for SQL queries reported in transaction trace nodes. By default, this is set to `obfuscated`, which strips out the numeric and string literals.
 
@@ -2197,7 +2197,7 @@ module NewRelic
           :public => true,
           :type => String,
           :allowed_from_server => true,
-          :allowlist => %w[obfuscated raw none off],
+          :allowlist => ['obfuscated', 'raw', 'none', 'off', 'false', false],
           :description => 'Defines an obfuscation level for slow SQL queries. Valid options are `obfuscated`, `raw`, or `none`.'
         },
         :'slow_sql.use_longer_sql_id' => {

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -576,7 +576,7 @@ module NewRelic
           :public => true,
           :type => String,
           :allowed_from_server => true,
-          :allowlist => ['obfuscated', 'raw', 'none', 'off'],
+          :allowlist => %w[obfuscated raw none off],
           :description => <<~DESCRIPTION
             Obfuscation level for SQL queries reported in transaction trace nodes. By default, this is set to `obfuscated`, which strips out the numeric and string literals.
 
@@ -2197,7 +2197,7 @@ module NewRelic
           :public => true,
           :type => String,
           :allowed_from_server => true,
-          :allowlist => ['obfuscated', 'raw', 'none', 'off'],
+          :allowlist => %w[obfuscated raw none off],
           :description => 'Defines an obfuscation level for slow SQL queries. Valid options are `obfuscated`, `raw`, or `none`.'
         },
         :'slow_sql.use_longer_sql_id' => {

--- a/lib/new_relic/agent/configuration/manager.rb
+++ b/lib/new_relic/agent/configuration/manager.rb
@@ -275,7 +275,7 @@ module NewRelic
           return value if allowlist.include?(value)
 
           value = normalized_case_match(allowlist, value)
-          return value if value
+          return value unless value.nil?
 
           default_with_warning(key, value, 'Expected to receive a value found on the following list: ' \
                                ">>#{allowlist}<<, but received '#{value}'.")

--- a/lib/new_relic/agent/configuration/manager.rb
+++ b/lib/new_relic/agent/configuration/manager.rb
@@ -274,8 +274,17 @@ module NewRelic
           return value unless allowlist = default_source.allowlist_for(key)
           return value if allowlist.include?(value)
 
+          value = normalized_case_match(allowlist, value)
+          return value if value
+
           default_with_warning(key, value, 'Expected to receive a value found on the following list: ' \
                                ">>#{allowlist}<<, but received '#{value}'.")
+        end
+
+        def normalized_case_match(allowlist, value)
+          return unless STRINGLIKE_TYPES.include?(value.class)
+
+          allowlist.find { |allowlist_value| allowlist_value.to_s.casecmp?(value.to_s) }
         end
 
         def default_source

--- a/lib/new_relic/agent/configuration/manager.rb
+++ b/lib/new_relic/agent/configuration/manager.rb
@@ -280,6 +280,7 @@ module NewRelic
           default_with_warning(key, value, 'Expected to receive a value found on the following list: ' \
                                ">>#{allowlist}<<, but received '#{value}'.")
         end
+
         def normalized_case_match(allowlist, value)
           return unless STRINGLIKE_TYPES.include?(value.class)
 

--- a/lib/new_relic/agent/configuration/manager.rb
+++ b/lib/new_relic/agent/configuration/manager.rb
@@ -274,13 +274,12 @@ module NewRelic
           return value unless allowlist = default_source.allowlist_for(key)
           return value if allowlist.include?(value)
 
-          value = normalized_case_match(allowlist, value)
-          return value unless value.nil?
+          match = normalized_case_match(allowlist, value)
+          return match unless match.nil?
 
           default_with_warning(key, value, 'Expected to receive a value found on the following list: ' \
                                ">>#{allowlist}<<, but received '#{value}'.")
         end
-
         def normalized_case_match(allowlist, value)
           return unless STRINGLIKE_TYPES.include?(value.class)
 

--- a/test/new_relic/agent/agent_logger_test.rb
+++ b/test/new_relic/agent/agent_logger_test.rb
@@ -122,6 +122,17 @@ class AgentLoggerTest < Minitest::Test
     assert_equal Logger::INFO, NewRelic::Agent::AgentLogger.log_level_for(:unknown)
   end
 
+  def test_sets_log_level_when_the_configured_level_is_weirdly_cased
+    with_config(:log_level => 'DeBuG') do
+      override_logger = Logger.new($stderr)
+      override_logger.level = Logger::FATAL
+
+      NewRelic::Agent::AgentLogger.new('', override_logger)
+
+      assert_equal Logger::DEBUG, override_logger.level
+    end
+  end
+
   def test_sets_log_level
     with_config(:log_level => :debug) do
       override_logger = Logger.new($stderr)

--- a/test/new_relic/agent/configuration/default_source_test.rb
+++ b/test/new_relic/agent/configuration/default_source_test.rb
@@ -52,6 +52,15 @@ module NewRelic::Agent::Configuration
       end
     end
 
+    def test_allowlists_include_their_own_default_value
+      @defaults.each do |key, config_value|
+        next unless config_value[:allowlist]
+
+        assert_includes config_value[:allowlist], fetch_config_value(key),
+          "Expected the default value for #{key} to be on its own allowlist"
+      end
+    end
+
     def test_default_values_maps_keys_to_their_default_values
       default_values = @default_source.default_values
 
@@ -235,12 +244,52 @@ module NewRelic::Agent::Configuration
       end
     end
 
+    def test_allowlist_permits_valid_values_with_unexpected_casing
+      key = :'application_logging.forwarding.log_level'
+
+      with_config(key => 'WARN') do
+        assert_equal 'warn', NewRelic::Agent.config[key]
+      end
+    end
+
     def test_allowlist_blocks_invalid_values_and_uses_a_default
       key = :'application_logging.forwarding.log_level'
       default = ::NewRelic::Agent::Configuration::DefaultSource.default_for(key)
 
       with_config(key => 'bogus') do
         assert_equal default, NewRelic::Agent.config[key]
+      end
+    end
+
+    def test_log_level_allowlist_blocks_invalid_values_and_uses_a_default
+      with_config(:log_level => 'bogus') do
+        assert_equal 'info', NewRelic::Agent.config[:log_level]
+      end
+    end
+
+    def test_record_sql_allowlists_permit_the_values_database_recognizes
+      permitted = ['obfuscated', 'raw', 'none', 'off', 'false', false]
+
+      %i[transaction_tracer.record_sql slow_sql.record_sql].each do |key|
+        permitted.each do |value|
+          with_config(key => value) do
+            assert_equal value, NewRelic::Agent.config[key],
+              "Expected '#{key}' to permit '#{value}'"
+          end
+        end
+      end
+    end
+
+    def test_transaction_tracer_record_sql_allowlist_blocks_invalid_values_and_uses_a_default
+      with_config(:'transaction_tracer.record_sql' => 'bogus') do
+        assert_equal 'obfuscated', NewRelic::Agent.config[:'transaction_tracer.record_sql']
+      end
+    end
+
+    # slow_sql.record_sql defaults to the transaction_tracer.record_sql value
+    def test_slow_sql_record_sql_allowlist_blocks_invalid_values_and_uses_a_default
+      with_config(:'transaction_tracer.record_sql' => 'none', :'slow_sql.record_sql' => 'bogus') do
+        assert_equal 'none', NewRelic::Agent.config[:'slow_sql.record_sql']
       end
     end
 

--- a/test/new_relic/agent/configuration/default_source_test.rb
+++ b/test/new_relic/agent/configuration/default_source_test.rb
@@ -244,14 +244,6 @@ module NewRelic::Agent::Configuration
       end
     end
 
-    def test_allowlist_permits_valid_values_with_unexpected_casing
-      key = :'application_logging.forwarding.log_level'
-
-      with_config(key => 'WARN') do
-        assert_equal 'warn', NewRelic::Agent.config[key]
-      end
-    end
-
     def test_allowlist_blocks_invalid_values_and_uses_a_default
       key = :'application_logging.forwarding.log_level'
       default = ::NewRelic::Agent::Configuration::DefaultSource.default_for(key)
@@ -261,35 +253,32 @@ module NewRelic::Agent::Configuration
       end
     end
 
-    def test_log_level_allowlist_blocks_invalid_values_and_uses_a_default
-      with_config(:log_level => 'bogus') do
-        assert_equal 'info', NewRelic::Agent.config[:log_level]
-      end
-    end
+    def test_allowlisted_values_can_be_any_case
+      @defaults.each do |key, config_value|
+        next unless config_value[:allowlist]
 
-    def test_record_sql_allowlists_permit_the_values_database_recognizes
-      permitted = ['obfuscated', 'raw', 'none', 'off', 'false', false]
+        config_value[:allowlist].each do |value|
+          next unless value.is_a?(String) || value.is_a?(Symbol)
 
-      %i[transaction_tracer.record_sql slow_sql.record_sql].each do |key|
-        permitted.each do |value|
-          with_config(key => value) do
-            assert_equal value, NewRelic::Agent.config[key],
-              "Expected '#{key}' to permit '#{value}'"
+          value_swapcased = value.to_s.swapcase
+          standard = with_config(key => value) { NewRelic::Agent.config[key] }
+
+          with_config(key => value_swapcased) do
+            assert_equal standard, NewRelic::Agent.config[key], "Expected #{key} to treat '#{value_swapcased}' like '#{value}'"
           end
         end
       end
     end
 
-    def test_transaction_tracer_record_sql_allowlist_blocks_invalid_values_and_uses_a_default
-      with_config(:'transaction_tracer.record_sql' => 'bogus') do
-        assert_equal 'obfuscated', NewRelic::Agent.config[:'transaction_tracer.record_sql']
-      end
-    end
+    def test_a_value_that_is_not_on_an_allowlist_resolves_to_the_default
+      @defaults.each do |key, config_value|
+        next unless config_value[:allowlist]
 
-    # slow_sql.record_sql defaults to the transaction_tracer.record_sql value
-    def test_slow_sql_record_sql_allowlist_blocks_invalid_values_and_uses_a_default
-      with_config(:'transaction_tracer.record_sql' => 'none', :'slow_sql.record_sql' => 'bogus') do
-        assert_equal 'none', NewRelic::Agent.config[:'slow_sql.record_sql']
+        default = with_config(key => fetch_config_value(key)) { NewRelic::Agent.config[key] }
+
+        with_config(key => 'not_allowed') do
+          assert_equal default, NewRelic::Agent.config[key], "Expected #{key} to reject a value that is not on its allowlist"
+        end
       end
     end
 

--- a/test/new_relic/agent/configuration/manager_test.rb
+++ b/test/new_relic/agent/configuration/manager_test.rb
@@ -848,6 +848,19 @@ module NewRelic::Agent::Configuration
       end
     end
 
+    def test_enforce_allowlist_matches_a_value_without_regard_for_case
+      key = :guarded
+      allowlist = %w[debug info warn]
+
+      default_source = Object.new
+      default_source.stubs(:allowlist_for).returns(allowlist)
+      @manager.stubs(:default_source).returns(default_source)
+
+      value = @manager.enforce_allowlist(key, 'DeBuG')
+
+      assert_equal 'debug', value
+    end
+
     private
 
     def assert_parsed_labels(expected)

--- a/test/new_relic/agent/database_test.rb
+++ b/test/new_relic/agent/database_test.rb
@@ -11,6 +11,21 @@ class NewRelic::Agent::DatabaseTest < Minitest::Test
     NewRelic::Agent::Database::ConnectionManager.instance.instance_eval { @connections = {} }
   end
 
+  def test_record_sql_method_honors_values_regardless_of_case
+    {'Off' => :off, 'NoNe' => :off, 'fALSE' => :off, 'RAW' => :raw, 'obfuscated' => :obfuscated}.each do |value, expected|
+      with_config(:'transaction_tracer.record_sql' => value) do
+        assert_equal expected, NewRelic::Agent::Database.record_sql_method,
+          "Expected '#{value}' to be recognized as '#{expected}'"
+      end
+    end
+  end
+
+  def test_record_sql_method_falls_back_to_obfuscated_for_an_unrecognized_value
+    with_config(:'transaction_tracer.record_sql' => 'idk') do
+      assert_equal :obfuscated, NewRelic::Agent::Database.record_sql_method
+    end
+  end
+
   def test_adapter_from_config_string
     config = {:adapter => 'mysql'}
     statement = NewRelic::Agent::Database::Statement.new('some query', config)


### PR DESCRIPTION
Configs with allowlists now can pass through an additional screening that ignores case, making allowlists case-insensitive.

Adds allowlists for:
- log_level
- transaction_tracer.record_sql
- slow_sql.record_sql

closes #3613