### PR TITLE
Puma instrumentation works when Puma is lazy-loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # New Relic Ruby Agent Release Notes
 
+## dev
+
+- **Bugfix: Puma instrumentation works when Puma is lazy-loaded**
+
+  With `gem "puma", require: false`, Puma was not yet loaded when the agent's dependency check ran, so Puma instrumentation would fail to install. The agent now recognizes `Puma::RackHandler` as evidence that Puma is present, fixing this issue. Thank you [@jdelStrother](https://github.com/jdelStrother) for finding this issue and providing a solution! [PR#3650](https://github.com/newrelic/newrelic-ruby-agent/pull/3650)
+
 ## v10.7.1
 
 - **Feature: Add span.kind to background job libraries**

--- a/lib/new_relic/agent/instrumentation/puma.rb
+++ b/lib/new_relic/agent/instrumentation/puma.rb
@@ -126,9 +126,10 @@ DependencyDetection.defer do
   @name = :puma
 
   depends_on do
-    defined?(Puma) && defined?(Puma::Launcher) &&
-      NewRelic::Helper.version_satisfied?(Puma::Const::VERSION, '>=', '6.6.0') &&
-      !NewRelic::Agent.config[:disable_puma_instrumentation]
+  defined?(Puma) && (defined?(Puma::Launcher) || defined?(Puma::RackHandler)) &&
+    (defined?(Puma::Const) || require('puma/const')) &&
+    NewRelic::Helper.version_satisfied?(Puma::Const::VERSION, '>=', '6.6.0') &&
+    !NewRelic::Agent.config[:disable_puma_instrumentation]
   end
 
   executes do

--- a/lib/new_relic/agent/instrumentation/puma.rb
+++ b/lib/new_relic/agent/instrumentation/puma.rb
@@ -126,10 +126,10 @@ DependencyDetection.defer do
   @name = :puma
 
   depends_on do
-  defined?(Puma) && (defined?(Puma::Launcher) || defined?(Puma::RackHandler)) &&
-    (defined?(Puma::Const) || require('puma/const')) &&
-    NewRelic::Helper.version_satisfied?(Puma::Const::VERSION, '>=', '6.6.0') &&
-    !NewRelic::Agent.config[:disable_puma_instrumentation]
+    defined?(Puma) && (defined?(Puma::Launcher) || defined?(Puma::RackHandler)) &&
+      (defined?(Puma::Const) || require('puma/const')) &&
+      NewRelic::Helper.version_satisfied?(Puma::Const::VERSION, '>=', '6.6.0') &&
+      !NewRelic::Agent.config[:disable_puma_instrumentation]
   end
 
   executes do

--- a/test/multiverse/suites/puma/puma_instrumentation_test.rb
+++ b/test/multiverse/suites/puma/puma_instrumentation_test.rb
@@ -222,6 +222,23 @@ class PumaInstrumentationTest < Minitest::Test
     end
   end
 
+  # When `gem "puma", require: false`, Puma::RackHandler is defined 
+  # before Puma::Launcher loads
+  def test_dependency_satisfied_via_rack_handler_without_launcher
+    require 'rack/handler/puma'
+
+    item = DependencyDetection.dependency_by_name(:puma)
+    saved_launcher = Puma.send(:remove_const, :Launcher)
+
+    with_config(:disable_puma_instrumentation => false) do
+      assert_predicate item, :check_dependencies,
+        'expected :puma to be satisfied once Puma::RackHandler is defined, even without Puma::Launcher'
+    end
+  ensure
+    # Other tests in this file rely on  Puma::Launcher, so restore it
+    Puma.const_set(:Launcher, saved_launcher) if saved_launcher
+  end
+
   # --- install_or_arm decision -----------------------------------------------
 
   def test_install_or_arm_installs_in_master_when_runner_present

--- a/test/multiverse/suites/puma/puma_instrumentation_test.rb
+++ b/test/multiverse/suites/puma/puma_instrumentation_test.rb
@@ -222,7 +222,7 @@ class PumaInstrumentationTest < Minitest::Test
     end
   end
 
-  # When `gem "puma", require: false`, Puma::RackHandler is defined 
+  # When `gem "puma", require: false`, Puma::RackHandler is defined
   # before Puma::Launcher loads
   def test_dependency_satisfied_via_rack_handler_without_launcher
     require 'rack/handler/puma'


### PR DESCRIPTION
When Puma is lazy-loaded our original class checks to see if Puma was installed would failed. Now we check `Puma::RackHandler`, which is available when Puma is loaded in this way.

closes #3641