### PR TITLE
update syntax for backtrace stubs on ruby 3.4

### DIFF
--- a/test/agent_helper.rb
+++ b/test/agent_helper.rb
@@ -57,6 +57,11 @@ def last_traced_error
   harvest_error_traces!.last
 end
 
+# Ruby 3.4 changed backtraces/error messages from `method' to 'method' quoting
+def ruby_3_4_0_or_above?
+  NewRelic::Helper.version_satisfied?(RUBY_VERSION, '>=', '3.4.0')
+end
+
 def harvest_transaction_events!
   NewRelic::Agent.instance.transaction_event_aggregator.harvest!
 end

--- a/test/multiverse/suites/aws_sdk_lambda/aws_sdk_lambda_instrumentation_test.rb
+++ b/test/multiverse/suites/aws_sdk_lambda/aws_sdk_lambda_instrumentation_test.rb
@@ -84,14 +84,25 @@ class AwsSdkLambdaInstrumentationTest < Minitest::Test
     function_error = 'Unhandled'
     message = 'oh no'
     type = 'Function<RuntimeError>'
-    backtrace = ["/var/task/lambda_function.rb:4:in `lambda_handler'",
-      "/var/runtime/gems/aws_lambda_ric-3.0.0/lib/aws_lambda_ric/lambda_handler.rb:28:in `call_handler'",
-      "/var/runtime/gems/aws_lambda_ric-3.0.0/lib/aws_lambda_ric.rb:88:in `run_user_code'",
-      "/var/runtime/gems/aws_lambda_ric-3.0.0/lib/aws_lambda_ric.rb:66:in `start_runtime_loop'",
-      "/var/runtime/gems/aws_lambda_ric-3.0.0/lib/aws_lambda_ric.rb:49:in `run'",
-      "/var/runtime/gems/aws_lambda_ric-3.0.0/lib/aws_lambda_ric.rb:221:in `bootstrap_handler'",
-      "/var/runtime/gems/aws_lambda_ric-3.0.0/lib/aws_lambda_ric.rb:203:in `start'",
-      "/var/runtime/index.rb:4:in `<main>'"]
+    backtrace = if ruby_3_4_0_or_above?
+      ["/var/task/lambda_function.rb:4:in 'lambda_handler'",
+        "/var/runtime/gems/aws_lambda_ric-3.0.0/lib/aws_lambda_ric/lambda_handler.rb:28:in 'call_handler'",
+        "/var/runtime/gems/aws_lambda_ric-3.0.0/lib/aws_lambda_ric.rb:88:in 'run_user_code'",
+        "/var/runtime/gems/aws_lambda_ric-3.0.0/lib/aws_lambda_ric.rb:66:in 'start_runtime_loop'",
+        "/var/runtime/gems/aws_lambda_ric-3.0.0/lib/aws_lambda_ric.rb:49:in 'run'",
+        "/var/runtime/gems/aws_lambda_ric-3.0.0/lib/aws_lambda_ric.rb:221:in 'bootstrap_handler'",
+        "/var/runtime/gems/aws_lambda_ric-3.0.0/lib/aws_lambda_ric.rb:203:in 'start'",
+        "/var/runtime/index.rb:4:in '<main>'"]
+    else
+      ["/var/task/lambda_function.rb:4:in `lambda_handler'",
+        "/var/runtime/gems/aws_lambda_ric-3.0.0/lib/aws_lambda_ric/lambda_handler.rb:28:in `call_handler'",
+        "/var/runtime/gems/aws_lambda_ric-3.0.0/lib/aws_lambda_ric.rb:88:in `run_user_code'",
+        "/var/runtime/gems/aws_lambda_ric-3.0.0/lib/aws_lambda_ric.rb:66:in `start_runtime_loop'",
+        "/var/runtime/gems/aws_lambda_ric-3.0.0/lib/aws_lambda_ric.rb:49:in `run'",
+        "/var/runtime/gems/aws_lambda_ric-3.0.0/lib/aws_lambda_ric.rb:221:in `bootstrap_handler'",
+        "/var/runtime/gems/aws_lambda_ric-3.0.0/lib/aws_lambda_ric.rb:203:in `start'",
+        "/var/runtime/index.rb:4:in `<main>'"]
+    end
     payload = StringIO.new(JSON.generate({'errorMessage' => message, 'errorType' => type, 'stackTrace' => backtrace}))
     response = {status_code: 200, function_error: function_error, payload: payload}
 
@@ -143,5 +154,9 @@ class AwsSdkLambdaInstrumentationTest < Minitest::Test
     assert_equal 1, segments.size, "Expected to find exactly 1 Lambda client segment, found #{segments.size}"
 
     segments.first
+  end
+
+  def ruby_3_4_0_or_above?
+    NewRelic::Helper.version_satisfied?(RUBY_VERSION, '>=', '3.4.0')
   end
 end

--- a/test/multiverse/suites/aws_sdk_lambda/aws_sdk_lambda_instrumentation_test.rb
+++ b/test/multiverse/suites/aws_sdk_lambda/aws_sdk_lambda_instrumentation_test.rb
@@ -155,8 +155,4 @@ class AwsSdkLambdaInstrumentationTest < Minitest::Test
 
     segments.first
   end
-
-  def ruby_3_4_0_or_above?
-    NewRelic::Helper.version_satisfied?(RUBY_VERSION, '>=', '3.4.0')
-  end
 end

--- a/test/new_relic/agent/stats_engine/stats_hash_test.rb
+++ b/test/new_relic/agent/stats_engine/stats_hash_test.rb
@@ -199,8 +199,4 @@ class NewRelic::Agent::StatsHashTest < Minitest::Test
     hash = stats_hash.instance_variable_get(:@unscoped)
     hash.default_proc = proc { raise exception }
   end
-
-  def ruby_3_4_0_or_above?
-    NewRelic::Helper.version_satisfied?(RUBY_VERSION, '>=', '3.4.0')
-  end
 end

--- a/test/new_relic/agent/stats_engine/stats_hash_test.rb
+++ b/test/new_relic/agent/stats_engine/stats_hash_test.rb
@@ -194,8 +194,13 @@ class NewRelic::Agent::StatsHashTest < Minitest::Test
   DEFAULT_SPEC = NewRelic::MetricSpec.new('foo')
 
   def fake_borked_default_proc(stats_hash)
-    exception = NoMethodError.new("borked default proc gives a NoMethodError on `yield'")
+    message = ruby_3_4_0_or_above? ? "borked default proc gives a NoMethodError on 'yield'" : "borked default proc gives a NoMethodError on `yield'"
+    exception = NoMethodError.new(message)
     hash = stats_hash.instance_variable_get(:@unscoped)
     hash.default_proc = proc { raise exception }
+  end
+
+  def ruby_3_4_0_or_above?
+    NewRelic::Helper.version_satisfied?(RUBY_VERSION, '>=', '3.4.0')
   end
 end

--- a/test/new_relic/agent/threading/backtrace_node_test.rb
+++ b/test/new_relic/agent/threading/backtrace_node_test.rb
@@ -235,15 +235,5 @@ module NewRelic::Agent::Threading
 
       assert_equal(MAX_THREAD_PROFILE_DEPTH, root.flattened.size)
     end
-
-    private
-
-    # TODO: OLD RUBIES < 3.4
-    # Ruby 3.4 introduced a new format for backtraces
-    # These tests have examples with the old the and new formats
-    # When we drop support for Ruby 3.3, we can remove the condition
-    def ruby_3_4_0_or_above?
-      NewRelic::Helper.version_satisfied?(RUBY_VERSION, '>=', '3.4.0')
-    end
   end
 end

--- a/test/new_relic/agent/threading/thread_profile_test.rb
+++ b/test/new_relic/agent/threading/thread_profile_test.rb
@@ -248,14 +248,6 @@ if NewRelic::Agent::Threading::BacktraceService.is_supported?
 
         count
       end
-
-      # TODO: OLD RUBIES < 3.4
-      # Ruby 3.4 introduced a new format for backtraces
-      # These tests have examples with the old the and new formats
-      # When we drop support for Ruby 3.3, we can remove the condition
-      def ruby_3_4_0_or_above?
-        NewRelic::Helper.version_satisfied?(RUBY_VERSION, '>=', '3.4.0')
-      end
     end
   end
 end

--- a/test/new_relic/http_client_test_cases.rb
+++ b/test/new_relic/http_client_test_cases.rb
@@ -263,8 +263,9 @@ module HttpClientTestCases
 
   def test_doesnt_affect_the_request_if_an_exception_is_raised_while_setting_up_tracing
     res = nil
+    message = ruby_3_4_0_or_above? ? "undefined method 'push_scope'" : "undefined method `push_scope'"
     NewRelic::Agent.instance.stats_engine.stubs(:push_scope)
-      .raises(NoMethodError, "undefined method `push_scope'")
+      .raises(NoMethodError, message)
 
     in_transaction { res = get_response }
 
@@ -273,12 +274,17 @@ module HttpClientTestCases
 
   def test_doesnt_affect_the_request_if_an_exception_is_raised_while_finishing_tracing
     res = nil
+    message = ruby_3_4_0_or_above? ? "undefined method 'pop_scope'" : "undefined method `pop_scope'"
     NewRelic::Agent.instance.stats_engine.stubs(:pop_scope)
-      .raises(NoMethodError, "undefined method `pop_scope'")
+      .raises(NoMethodError, message)
 
     in_transaction { res = get_response }
 
     assert_equal NewRelic::FakeExternalServer::STATUS_MESSAGE, body(res)
+  end
+
+  def ruby_3_4_0_or_above?
+    NewRelic::Helper.version_satisfied?(RUBY_VERSION, '>=', '3.4.0')
   end
 
   def test_doesnt_misbehave_when_transaction_tracing_is_disabled

--- a/test/new_relic/http_client_test_cases.rb
+++ b/test/new_relic/http_client_test_cases.rb
@@ -283,10 +283,6 @@ module HttpClientTestCases
     assert_equal NewRelic::FakeExternalServer::STATUS_MESSAGE, body(res)
   end
 
-  def ruby_3_4_0_or_above?
-    NewRelic::Helper.version_satisfied?(RUBY_VERSION, '>=', '3.4.0')
-  end
-
   def test_doesnt_misbehave_when_transaction_tracing_is_disabled
     # The error should have any other consequence other than logging the error, so
     # this will capture logs


### PR DESCRIPTION
resolves https://github.com/newrelic/newrelic-ruby-agent/issues/2990