### PR TITLE
Add support for `browser_monitoring.version` config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - **Feature: Add `browser_monitoring.version` configuration option**
 
-  Customers can now pin the exact browser agent loader version New Relic injects by setting the new `browser_monitoring.version` configuration option. See the [browser agent EOL policy](https://docs.newrelic.com/docs/browser/browser-monitoring/getting-started/browser-agent-eol-policy/) for which versions are currently available and supported. 
+  Customers can now pin the exact browser agent loader version New Relic injects by setting the new `browser_monitoring.version` configuration option. See the [browser agent EOL policy](https://docs.newrelic.com/docs/browser/browser-monitoring/getting-started/browser-agent-eol-policy/) for which versions are currently available and supported.
 
 - **Bugfix: DelayedJob instrumentation no longer reinstalls itself on every worker under prepend mode**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## dev
 
+- **Feature: Add `browser_monitoring.version` configuration option**
+
+  Customers can now pin the exact browser agent loader version New Relic injects by setting the new `browser_monitoring.version` configuration option. See the [browser agent EOL policy](https://docs.newrelic.com/docs/browser/browser-monitoring/getting-started/browser-agent-eol-policy/) for which versions are currently available and supported. 
+
 - **Bugfix: DelayedJob instrumentation no longer reinstalls itself on every worker under prepend mode**
 
   When DelayedJob instrumentation is installed via prepend (the default), creating more than one `Delayed::Worker` in the same process caused the agent to log "Installing DelayedJob instrumentation" and reinitialize the plugin again for each additional worker. This was harmless but noisy; it's now only done once per process, matching the existing chain-instrumentation behavior. [PR#3654](https://github.com/newrelic/newrelic-ruby-agent/pull/3654)

--- a/lib/new_relic/agent/configuration/default_source.rb
+++ b/lib/new_relic/agent/configuration/default_source.rb
@@ -736,6 +736,13 @@ module NewRelic
           :allowed_from_server => false,
           :description => 'If `true`, enables auto-injection of [Content Security Policy Nonce](https://content-security-policy.com/nonce/) in browser monitoring scripts. For now, auto-injection only works with Rails 5.2+.'
         },
+        :'browser_monitoring.version' => {
+          :default => '',
+          :public => true,
+          :type => String,
+          :allowed_from_server => false,
+          :description => 'Pin the version of the browser agent loader that New Relic injects, such as `1.317.0`. When unset, New Relic injects the latest available version. See the [browser agent EOL policy](/docs/browser/browser-monitoring/getting-started/browser-agent-eol-policy/) for which versions are currently available and supported.'
+        },
         # Transaction events
         :'transaction_events.enabled' => {
           :default => true,

--- a/lib/new_relic/agent/javascript_instrumentor.rb
+++ b/lib/new_relic/agent/javascript_instrumentor.rb
@@ -29,7 +29,6 @@ module NewRelic
       end
 
       def warn_if_requested_version_not_used
-        binding.irb
         return if missing_config?(:'browser_monitoring.version')
         return unless missing_config?(:js_agent_loader)
 

--- a/lib/new_relic/agent/javascript_instrumentor.rb
+++ b/lib/new_relic/agent/javascript_instrumentor.rb
@@ -24,6 +24,19 @@ module NewRelic
         if !NewRelic::Agent.config[:'rum.enabled']
           NewRelic::Agent.logger.debug('Real User Monitoring is disabled for this agent. Edit your configuration to change this.')
         end
+
+        warn_if_requested_version_not_used
+      end
+
+      def warn_if_requested_version_not_used
+        binding.irb
+        return if missing_config?(:'browser_monitoring.version')
+        return unless missing_config?(:js_agent_loader)
+
+        requested_version = NewRelic::Agent.config[:'browser_monitoring.version']
+        NewRelic::Agent.logger.warn("Requested browser_monitoring.version '#{requested_version}' did not return a " \
+          "browser agent loader; please ensure '#{requested_version}' is available and supported. No browser " \
+          'monitoring will be injected for this connect.')
       end
 
       def enabled?

--- a/test/new_relic/agent/javascript_instrumentor_test.rb
+++ b/test/new_relic/agent/javascript_instrumentor_test.rb
@@ -69,6 +69,13 @@ class NewRelic::Agent::JavaScriptInstrumentorTest < Minitest::Test
     end
   end
 
+  def test_warns_when_requested_version_did_not_return_a_loader
+    with_config(:'browser_monitoring.version' => '1.317.0', :js_agent_loader => '') do
+      expects_logging(:warn, includes('1.317.0'))
+      instrumentor.warn_if_requested_version_not_used
+    end
+  end
+
   def test_browser_timing_header_without_beacon
     with_config(:beacon => '') do
       in_transaction do


### PR DESCRIPTION
Adds support for new configuration option, `browser_monitoring.version`. 

Customers may specificy which version of the browser agent to use. If the specified version cannot be resolved (out of support, malformed, etc.), browser monitoring will not be installed. See the [browser agent EOL policy](https://docs.newrelic.com/docs/browser/browser-monitoring/getting-started/browser-agent-eol-policy/) for the latest supported versions. 

If unset, the latest browser monitoring version will be used (default).