### PR TITLE
Fix ci. again.

### DIFF
--- a/.github/workflows/scripts/setup_bundler
+++ b/.github/workflows/scripts/setup_bundler
@@ -75,7 +75,7 @@ function install_ruby_version_specific_gems {
 
     # TODO: remove if once elasticsearch works with json 3.0+
     if [[ "$MULTIVERSE_GROUP" != "services_elasticsearch" ]]; then
-      gem install --default json:3.0.1
+      gem install --default json:3.0.2
     fi
 
     if [[ $RUBY_VERSION =~ ^(2\.|3\.[0-4]) ]]; then

--- a/test/new_relic/metric_spec_test.rb
+++ b/test/new_relic/metric_spec_test.rb
@@ -48,28 +48,24 @@ class NewRelic::MetricSpecTest < Minitest::Test
   end
 
   # test to make sure the MetricSpec class can serialize to json
-  if defined?(::ActiveSupport)
-    def test_json
-      spec = NewRelic::MetricSpec.new('controller', 'metric#find')
+  def test_json
+    spec = NewRelic::MetricSpec.new('controller', 'metric#find')
 
-      import = ::ActiveSupport::JSON.decode(spec.to_json)
+    import = ::JSON.parse(spec.to_json)
 
-      compare_spec(spec, import)
+    compare_spec(spec, import)
 
-      stats = NewRelic::Agent::Stats.new
+    stats = NewRelic::Agent::Stats.new
 
-      import = ::ActiveSupport::JSON.decode(stats.to_json)
+    import = ::JSON.parse(stats.to_json)
 
-      compare_stat(stats, import)
+    compare_stat(stats, import)
 
-      metric_data = NewRelic::MetricData.new(spec, stats)
+    metric_data = NewRelic::MetricData.new(spec, stats)
 
-      import = ::ActiveSupport::JSON.decode(metric_data.to_json)
+    import = ::JSON.parse(metric_data.to_json)
 
-      compare_metric_data(metric_data, import)
-    end
-  else
-    puts "Skipping `test_json` in #{File.basename(__FILE__)} because ActiveSupport is unavailable" if ENV['VERBOSE_TEST_OUTPUT']
+    compare_metric_data(metric_data, import)
   end
 
   def test_initialize_truncates_name_and_scope


### PR DESCRIPTION
So this test was weird, we were using activesupport to decode it but we could just use json directly. turns out it's because the test is just super old. There is no reason it needs to be activesupport decode specifically. 
I have no idea why this test was passing yesterday when I fixed this stuff. Its haunted.

[full ci run](https://github.com/newrelic/newrelic-ruby-agent/actions/runs/34370698670)